### PR TITLE
fix(rp2040): make PIO loopback capture deterministic

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -123,6 +123,10 @@ class Args:
     rp_spi_index: int
     rp_spi_public_api: bool
     rp_spi_chipset: str
+    # RP PIO TX engine used by --flex-io on RP2040/RP2350.
+    rp_pio_index: int
+    # Select both PIO TX engines for a parallel RP run.
+    rp_pio_both: bool
 
     # LPC845 fault emit validation (#3302).
     fault_emit_test: bool
@@ -309,6 +313,18 @@ See Also:
             "--flex-io",
             action="store_true",
             help="Test only FlexIO clockless driver (Teensy 4.x only; requires --tx-pin in {6-13,32})",
+        )
+        driver_group.add_argument(
+            "--rp-pio-index",
+            type=int,
+            choices=(0, 1),
+            default=1,
+            help="RP2040/RP2350 PIO engine for --flex-io (default: 1).",
+        )
+        driver_group.add_argument(
+            "--rp-pio-both",
+            action="store_true",
+            help="RP2040/RP2350: select PIO0 and PIO1 together (requires --flex-io --parallel).",
         )
         driver_group.add_argument(
             "--flexio",
@@ -875,6 +891,8 @@ See Also:
             rp_spi_index=parsed.rp_spi_index,
             rp_spi_public_api=parsed.rp_spi_public_api,
             rp_spi_chipset=parsed.rp_spi_chipset,
+            rp_pio_index=parsed.rp_pio_index,
+            rp_pio_both=parsed.rp_pio_both,
             fault_emit_test=parsed.fault_emit_test,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -282,6 +282,9 @@ def display_pattern_details(result: dict[str, Any]) -> None:
         raw_edges = pat.get("rawEdgesAfterWait")
         if capture_wait is not None or raw_edges is not None:
             print(f"    RX wait/raw:      {capture_wait}/{raw_edges}")
+        begin_error = pat.get("rxBeginError")
+        if begin_error:
+            print(f"    RX begin error:   {begin_error}")
         decode_ok = pat.get("decodeOk")
         decode_error = pat.get("decodeError")
         decode_bytes = pat.get("decodeBytes")

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -78,17 +78,21 @@ def _is_teensy4_environment(final_environment: str | None) -> bool:
     )
 
 
-def _driver_name_for_environment(driver: str, final_environment: str | None) -> str:
+def _driver_name_for_environment(
+    driver: str, final_environment: str | None, rp_pio_index: int = 1
+) -> str:
     if driver == "SPI" and _is_teensy4_environment(final_environment):
         return "SPI_UNIFIED"
     if (
         driver == "FLEX_IO"
         and final_environment is not None
-        and final_environment.lower() in ("rp2040", "rpipico")
+        and final_environment.lower()
+        in ("rp2040", "rpipico", "rp2350", "rpipico2")
     ):
-        # RP exposes concrete PIO engines, which are the names accepted by
-        # the RPC driver registry. PIO1 leaves PIO0 available to the RX oracle.
-        return "PIO1"
+        # RP exposes two independent PIO engines as PIO0 and PIO1.  Their
+        # concrete names must remain distinct so a runtime-exclusive test can
+        # select one physical PIO block without replacing the other.
+        return f"PIO{rp_pio_index}"
     return driver
 
 
@@ -436,7 +440,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             sys.exit(2)
 
     is_teensy4 = _is_teensy4_environment(final_environment)
-    is_teensy_specific_driver = args.object_fled or args.flex_io
+    is_teensy_specific_driver = (args.object_fled or args.flex_io) and (
+        is_teensy4 or final_environment is None
+    )
 
     if args.use_root_platformio_ini and (is_teensy4 or is_teensy_specific_driver):
         print(
@@ -481,9 +487,27 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.object_fled:
             drivers.append("OBJECT_FLED")
         if args.flex_io:
-            drivers.append("FLEX_IO")
+            is_rp = final_environment is not None and final_environment.lower() in (
+                "rp2040",
+                "rpipico",
+                "rp2350",
+                "rpipico2",
+            )
+            if args.rp_pio_both and is_rp:
+                drivers.extend(("PIO0", "PIO1"))
+            else:
+                drivers.append(
+                    _driver_name_for_environment(
+                        "FLEX_IO", final_environment, args.rp_pio_index
+                    )
+                )
 
     parallel_mode = args.parallel
+    if args.rp_pio_both and (not args.flex_io or not parallel_mode):
+        print(
+            f"{Fore.RED}❌ --rp-pio-both requires --flex-io --parallel{Style.RESET_ALL}"
+        )
+        return 1
     if parallel_mode:
         if len(drivers) < 2:
             print(
@@ -3506,11 +3530,35 @@ def _validate_test_rpc_response(
     expected_tx_pin, expected_rx_pin = _expected_test_pins(
         method, cmd, expected_tx_pin, expected_rx_pin
     )
+    is_concurrent_resource_test = (
+        method == "runParallelTest"
+        and data.get("concurrent_resource_test") is True
+        and set(expected_drivers) == {"PIO0", "PIO1"}
+    )
+    if is_concurrent_resource_test and data.get("show_success") is not True:
+        errors.append("concurrent resource test requires show_success=true")
+    if is_concurrent_resource_test:
+        response_drivers = data.get("drivers")
+        if not isinstance(response_drivers, list):
+            errors.append("concurrent resource test requires driver entries")
+        else:
+            pins_by_driver: dict[str, int] = {}
+            for entry in response_drivers:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("driver")
+                pin_tx = entry.get("pinTx")
+                if isinstance(name, str) and _is_plain_int(pin_tx):
+                    pins_by_driver[name] = pin_tx
+            if set(pins_by_driver) != {"PIO0", "PIO1"}:
+                errors.append("concurrent resource test requires PIO0 and PIO1 TX pins")
+            elif pins_by_driver["PIO0"] == pins_by_driver["PIO1"]:
+                errors.append("concurrent resource test requires distinct PIO TX pins")
     if expected_tx_pin is not None or expected_rx_pin is not None:
         capture_backend = data.get("captureBackend")
         if not isinstance(capture_backend, str) or not capture_backend:
             errors.append("missing string captureBackend")
-        if data.get("passed") is True:
+        if data.get("passed") is True and not is_concurrent_resource_test:
             capture_evidence_bytes = data.get("captureEvidenceBytes")
             capture_evidence_raw_edges = data.get("captureEvidenceRawEdges")
             has_capture_bytes = (
@@ -3793,6 +3841,26 @@ async def _run_rpc_tests(ctx: RunContext, qctx: QuietContext) -> int:
                         print(f"   Lane: {failure.get('lane', 'unknown')}")
                         print(f"   Expected: {failure.get('expected', 'unknown')}")
                         print(f"   Actual: {failure.get('actual', 'unknown')}")
+
+                    if "rpPioActive" in test_data:
+                        print(
+                            "   RP PIO: "
+                            f"active={test_data['rpPioActive']} "
+                            f"lastError={test_data.get('rpPioLastError', '')!r} "
+                            f"started={test_data.get('rpPioStartSucceeded')} "
+                            f"words={test_data.get('rpPioWordCount')}"
+                        )
+                        patterns = test_data.get("patterns")
+                        if isinstance(patterns, list) and patterns:
+                            first_pattern = patterns[0]
+                            if (
+                                isinstance(first_pattern, dict)
+                                and "rpPioGpioTransitions" in first_pattern
+                            ):
+                                print(
+                                    "   RP PIO GPIO transitions: "
+                                    f"{first_pattern['rpPioGpioTransitions']}"
+                                )
 
                     display_tight_timing(test_data)
                     display_objectfled_diagnostics(test_data)

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -26,6 +26,7 @@ from ci.autoresearch.phases import (
     _run_build_deploy,
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
+    _validate_test_rpc_response,
 )
 from ci.rpc_client import RpcError
 from ci.util.port_utils import ChipDetectionResult, auto_detect_upload_port
@@ -105,6 +106,10 @@ def _make_args(**overrides) -> Args:
         dma_uart=False,
         rp_spi_loopback=False,
         rp_spi_index=0,
+        rp_spi_public_api=False,
+        rp_spi_chipset="apa102",
+        rp_pio_index=1,
+        rp_pio_both=False,
         fault_emit_test=False,
         # Default existing-test behavior: use the legacy root-platformio.ini
         # path so the ``fake_project_dir`` fixture's hand-written ini is the
@@ -578,6 +583,78 @@ class TestParseArgsAndBuildCommands:
         assert isinstance(result, RunContext)
         assert result.drivers == ["PIO1"]
         assert result.json_rpc_commands[0]["params"]["driver"] == "PIO1"
+
+    def test_flex_io_selects_pio0_on_rp2040(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            flex_io=True,
+            rp_pio_index=0,
+            environment_positional="rp2040",
+            project_dir=fake_project_dir,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["PIO0"]
+        assert result.json_rpc_commands[0]["params"]["driver"] == "PIO0"
+
+    def test_rp_pio_both_generates_one_parallel_command(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            flex_io=True,
+            rp_pio_both=True,
+            parallel=True,
+            environment_positional="rp2040",
+            project_dir=fake_project_dir,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["PIO0", "PIO1"]
+        assert result.json_rpc_commands[0]["method"] == "runParallelTest"
+
+    def test_rp_pio_parallel_response_uses_resource_evidence(self) -> None:
+        command = {
+            "method": "runParallelTest",
+            "params": {
+                "drivers": [
+                    {"driver": "PIO0", "laneSizes": [100]},
+                    {"driver": "PIO1", "laneSizes": [100]},
+                ]
+            },
+        }
+        response = {
+            "success": True,
+            "passed": True,
+            "totalTests": 1,
+            "passedTests": 1,
+            "drivers": [
+                {"driver": "PIO0", "pinTx": 11},
+                {"driver": "PIO1", "pinTx": 12},
+            ],
+            "captureBackend": "PIO_RX",
+            "captureEvidenceBytes": 0,
+            "captureEvidenceRawEdges": 0,
+            "requestedTxPin": 11,
+            "requestedRxPin": 8,
+            "actualTxPin": 11,
+            "actualRxPin": 8,
+            "concurrent_resource_test": True,
+            "show_success": True,
+        }
+        assert _validate_test_rpc_response(
+            "runParallelTest", command, response, 11, 8
+        ) == []
 
     def test_lpuart_is_deprecated_alias_for_uart(
         self, fake_project_dir: Path, capsys: pytest.CaptureFixture[str]

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -302,7 +302,8 @@ constexpr int DEFAULT_PIN_RX = autoresearch::defaultRxPin();
 // RX buffer sized for maximum expected strip size
 // Each LED = 24 bits = 24 symbols, plus headroom for RESET pulses
 // Maximum: 3000 LEDs (hardcoded for ESP32/S3 with PSRAM support)
-#if defined(FL_IS_TEENSY_4X) || defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) || defined(FL_IS_ESP_32C5)
+#if defined(FL_IS_TEENSY_4X) || defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) || \
+    defined(FL_IS_ESP_32C5) || defined(FL_IS_RP)
 constexpr int RX_BUFFER_SIZE = 100 * 32 + 100;  // Memory-constrained: 100 LEDs max for autoresearch
 #elif defined(FL_IS_ESP_32DEV)
 // FastLED#3569 — classic ESP32-WROOM (~320 KB DRAM, no PSRAM) ran out

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -234,6 +234,8 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                 else if (n == "LCD_CLOCKLESS") opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "UART")          opts.mBus = fl::Bus::UART;
                 else if (n == "FLEX_IO")       { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }
+                else if (n == "PIO0")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 0; }
+                else if (n == "PIO1")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }
                 else if (n == "OBJECT_FLED")   opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "LPUART")        opts.mBus = fl::Bus::UART;
                 else if (n == "BIT_BANG")      opts.mBus = fl::Bus::BIT_BANG;
@@ -291,7 +293,7 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     uint32_t show_start = micros();
     for (int iter = 0; iter < iterations; iter++) {
         FastLED.show();
-        FastLED.wait(5000);  // 5 second timeout for DMA completion
+        show_success = FastLED.wait(5000) && show_success;  // 5 second timeout for DMA completion
     }
     uint32_t show_duration_us = micros() - show_start;
 
@@ -300,8 +302,15 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
     bool rx_validation_passed = true;
     bool rx_validation_attempted = false;
     fl::vector<fl::RunResult> run_results;
+    const bool is_rp_pio_pair = driver_entries.size() == 2 &&
+        ((driver_entries[0].name == "PIO0" && driver_entries[1].name == "PIO1") ||
+         (driver_entries[0].name == "PIO1" && driver_entries[1].name == "PIO0"));
 
-    if (mState->rx_channel && driver_entries.size() > 0) {
+    // PIO0+PIO1 is a resource-concurrency test. Its two transmitters have
+    // already been exact-byte loopback-validated independently; re-entering
+    // capture after their shared show() creates another channel while both
+    // engines remain configured and tests a different resource topology.
+    if (mState->rx_channel && driver_entries.size() > 0 && !is_rp_pio_pair) {
         const auto& primary_driver = driver_entries[0];
 
         // Only attempt RX validation if the primary driver's pin matches our TX pin
@@ -392,6 +401,8 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                  static_cast<int64_t>(capture_evidence_raw_edges));
     response.set("duration_ms", static_cast<int64_t>(duration_ms));
     response.set("show_duration_us", static_cast<int64_t>(show_duration_us));
+    response.set("show_success", show_success);
+    response.set("concurrent_resource_test", is_rp_pio_pair);
     response.set("iterations", static_cast<int64_t>(iterations));
     response.set("rx_validation_attempted", rx_validation_attempted);
     response.set("rx_validation_passed", rx_validation_passed);

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -38,12 +38,16 @@
 #include "AutoResearchTimingDrift.h"
 #include "AutoResearchParlioStream.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
+#include "platforms/arm/rp/is_rp.h"
 #if defined(FL_IS_TEENSY_4X)
 #include "platforms/arm/teensy/teensy4_common/rx_flexpwm_channel.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/flexio/flexio_driver.h"
 #endif
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+#include "platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h"
+#endif
 #include <Arduino.h>
 
 #include "fl/net/ble.h"
@@ -1012,6 +1016,18 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
                                      : fl::string("none");
     response.set("captureBackend", capture_backend.c_str());
     response.set("laneCount", static_cast<int64_t>(lane_sizes.size()));
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+    if (driver_name == "PIO0" || driver_name == "PIO1") {
+        auto& pio = driver_name == "PIO0"
+                        ? fl::BusTraits<fl::Bus::FLEX_IO, 0>::instance()
+                        : fl::BusTraits<fl::Bus::FLEX_IO, 1>::instance();
+        response.set("rpPioActive", pio.isActive());
+        response.set("rpPioLastError", pio.lastError().c_str());
+        response.set("rpPioStartAttempted", pio.lastStartAttempted());
+        response.set("rpPioStartSucceeded", pio.lastStartSucceeded());
+        response.set("rpPioWordCount", static_cast<int64_t>(pio.lastWordCount()));
+    }
+#endif
 
     fl::json sizes_response = fl::json::array();
     for (int size : lane_sizes) {
@@ -1109,6 +1125,13 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             pat.set("decodeBytes", static_cast<int64_t>(rr.decodeBytes));
             pat.set("decodeOutputCapacity",
                     static_cast<int64_t>(rr.decodeOutputCapacity));
+            if (rr.rpPioGpioTransitions >= 0) {
+                pat.set("rpPioGpioTransitions",
+                        static_cast<int64_t>(rr.rpPioGpioTransitions));
+            }
+            if (!rr.rxBeginError.empty()) {
+                pat.set("rxBeginError", rr.rxBeginError.c_str());
+            }
             if (!rr.rawEdgeSample.empty()) {
                 pat.set("rawEdgeSample", rr.rawEdgeSample.c_str());
             }

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -13,6 +13,10 @@
 #if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
 
 #include "AutoResearchTest.h"
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+#include "fl/stl/atomic.h"
+#include "fl/stl/isr.h"
+#endif
 #include "LegacyClocklessProxy.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 #include <FastLED.h>
@@ -48,6 +52,15 @@
 #include "color.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/iterator.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+void countRpPioRxRisingEdges(void* user_data) {
+    auto* edges = static_cast<fl::atomic_int*>(user_data);
+    if (edges != nullptr) {
+        edges->fetch_add(1);
+    }
+}
+#endif
 
 // Phase 0: Include PARLIO debug instrumentation
 #if defined(ESP32) && FASTLED_ESP32_HAS_PARLIO
@@ -356,12 +369,15 @@ static size_t decodeSpiEdges(fl::shared_ptr<fl::RxChannel> rx_channel,
 // Returns number of bytes captured, or 0 on error
 size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
                fl::span<uint8_t> rx_buffer,
+               size_t expected_data_bytes,
                const fl::ChipsetTimingConfig& timing,
                const char* driver_name,
                fl::RunResult* diagnostics) {
     if (diagnostics) {
         diagnostics->captureWaitResult = -1;
         diagnostics->rawEdgesAfterWait = 0;
+        diagnostics->rpPioGpioTransitions = -1;
+        diagnostics->rxBeginError.clear();
     }
 
     if (!rx_channel) {
@@ -382,6 +398,27 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
                        || (fl::strcmp(driver_name, "LPUART") == 0);
     bool is_object_fled_driver = (fl::strcmp(driver_name, "OBJECT_FLED") == 0);
     rx_config.edge_capacity = rx_buffer.size() * 8;
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+    // RP's platform-default RX resolves to PIO, while RxChannel retains the
+    // requested PLATFORM_DEFAULT enum. Recognize both that public default and
+    // an explicit PIO backend so the DMA capture is sized per frame.
+    const bool is_rp_pio_capture =
+        rx_channel->backend() == fl::RxBackend::PIO ||
+        fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0;
+    if (is_rp_pio_capture) {
+        // The shared result buffer is intentionally sized for the largest
+        // AutoResearch run, not this frame. PIO DMA stores one word for each
+        // high and low phase, so using that whole buffer here would request
+        // several MiB on a Pico and leave DMA with an invalid destination.
+        constexpr size_t kPioPhasesPerDataByte = 16;
+        if (expected_data_bytes >
+            (static_cast<size_t>(-1) - 1u) / kPioPhasesPerDataByte) {
+            FL_ERROR("[CAPTURE] PIO edge-capacity overflow");
+            return 0;
+        }
+        rx_config.edge_capacity = expected_data_bytes * kPioPhasesPerDataByte + 1u;
+    }
+#endif
 
     // Internal loopback configuration: Enable ONLY for RMT TX -> RMT RX scenarios
     // When driver_name == "RMT", enable io_loop_back to route RMT TX output to RMT RX internally
@@ -434,6 +471,7 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
 
         // Arm RX for capture
         if (!rx_channel->begin(rx_config)) {
+            if (diagnostics) diagnostics->rxBeginError = rx_channel->lastBeginError();
             FL_ERROR("Failed to arm RX receiver");
             return 0;
         }
@@ -446,13 +484,46 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     } else {
         // Non-RMT (PARLIO, SPI, etc.): Single-TX approach
         if (!rx_channel->begin(rx_config)) {
+            if (diagnostics) diagnostics->rxBeginError = rx_channel->lastBeginError();
             AR_FL_WARN("[CAPTURE] RX begin() failed for pin " << rx_channel->getPin());
             return 0;
         }
         AR_FL_WARN("[CAPTURE] RX armed, calling FastLED.show()...");
 
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+        fl::atomic_int rising_edges(0);
+        fl::isr::handle edge_counter;
+        bool edge_counter_attached = false;
+        const bool measure_rp_pio =
+            (fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0) &&
+            diagnostics != nullptr;
+        if (measure_rp_pio) {
+            // FastLED.show() drives the channel engine until it reaches its
+            // terminal state, so polling GPIO after show() is too late to
+            // observe a short clockless frame. Count rising edges through the
+            // shared FastLED ISR dispatcher while show() is running instead.
+            // This is deliberately a binary physical oracle: an IRQ count
+            // above zero proves the jumper carries TX activity, while the PIO
+            // RX backend remains responsible for exact-byte verification.
+            fl::isr::config edge_config;
+            edge_config.handler = countRpPioRxRisingEdges;
+            edge_config.user_data = &rising_edges;
+            edge_config.flags = fl::isr::ISR_FLAG_EDGE_RISING;
+            edge_counter_attached = fl::isr::attach_external_handler(
+                static_cast<fl::u8>(rx_channel->getPin()), edge_config, &edge_counter) == 0;
+        }
+#endif
         FastLED.show();
         AR_FL_WARN("[CAPTURE] FastLED.show() returned, calling wait...");
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+        if (edge_counter_attached && edge_counter.is_valid()) {
+            fl::isr::detach_handler(edge_counter);
+        }
+        if ((fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0) &&
+            diagnostics != nullptr) {
+            diagnostics->rpPioGpioTransitions = edge_counter_attached ? rising_edges.load() : -1;
+        }
+#endif
         if (!FastLED.wait(TX_WAIT_TIMEOUT_MS)) {
             if (is_object_fled_driver) {
                 fl::objectFledDiagnosticsRecord("afterFastLedWaitTimeout");
@@ -747,7 +818,8 @@ void runTest(const char* test_name,
             continue;
         }
 
-        size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, config.timing, config.driver_name);
+        size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, num_leds * 3u,
+                                        config.timing, config.driver_name);
 
         if (bytes_captured == 0) {
             FL_ERROR("[" << ctx.driver_name << "/" << ctx.timing_name << "/" << ctx.pattern_name
@@ -904,7 +976,8 @@ void runMultiTest(const char* test_name,
             result.totalBytes = num_leds * 3;
 
             // Capture RX data
-            size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, config.timing, config.driver_name, &result);
+            size_t bytes_captured = capture(config.rx_channel, config.rx_buffer, num_leds * 3u,
+                                            config.timing, config.driver_name, &result);
             result.capturedBytes = static_cast<int>(bytes_captured);
 
             if (bytes_captured == 0) {

--- a/examples/AutoResearch/AutoResearchTest.h
+++ b/examples/AutoResearch/AutoResearchTest.h
@@ -92,6 +92,8 @@ struct RunResult {
     int decodeError;                ///< DecodeError value, or -1 when decode succeeded/not run
     int decodeBytes;                ///< Bytes reported directly by decode()
     int decodeOutputCapacity;       ///< Output span size passed to decode()
+    int rpPioGpioTransitions;       ///< CPU-observed RX-pin transitions during RP PIO TX
+    fl::string rxBeginError;         ///< Machine-readable reason when RX begin() fails
     fl::string rawEdgeSample;       ///< Compact first-edge sample for failures
     int mismatchedBytes;            ///< Number of individual bytes that differ
     int lsbOnlyErrors;              ///< Bytes where (expected ^ actual) == 0x01
@@ -102,8 +104,8 @@ struct RunResult {
     RunResult() : run_number(0), total_leds(0), mismatches(0),
                   totalBytes(0), capturedBytes(0), captureWaitResult(-1),
                   rawEdgesAfterWait(0), decodeOk(-1), decodeError(-1),
-                  decodeBytes(0), decodeOutputCapacity(0), mismatchedBytes(0),
-                  lsbOnlyErrors(0), captureFailed(false), passed(false) {}
+                  decodeBytes(0), decodeOutputCapacity(0), rpPioGpioTransitions(-1),
+                  mismatchedBytes(0), lsbOnlyErrors(0), captureFailed(false), passed(false) {}
 };
 
 /// @brief Multi-run test configuration
@@ -127,11 +129,13 @@ struct MultiRunConfig {
 // Capture transmitted LED data via RX loopback
 // - rx_channel: Shared pointer to RX device (persistent across calls)
 // - rx_buffer: Buffer to store received bytes
+// - expected_data_bytes: bytes in the current frame (bounds RP PIO DMA storage)
 // - timing: Chipset timing configuration for RX decoder
 // - driver_name: Name of the TX driver being tested (e.g., "RMT", "PARLIO") - enables io_loop_back only for RMT
 // Returns number of bytes captured, or 0 on error
 size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
                fl::span<uint8_t> rx_buffer,
+               size_t expected_data_bytes,
                const fl::ChipsetTimingConfig& timing,
                const char* driver_name,
                fl::RunResult* diagnostics = nullptr);

--- a/src/fl/channels/rx.h
+++ b/src/fl/channels/rx.h
@@ -311,6 +311,10 @@ public:
      */
     virtual bool begin(const RxConfig& config) FL_NO_EXCEPT = 0;
 
+    /// @brief Machine-readable reason from the most recent failed begin().
+    /// @return Empty string when the device has no additional diagnostic.
+    virtual const char* lastBeginError() const FL_NO_EXCEPT { return ""; }
+
     /**
      * @brief Check if receive operation is complete
      * @return true if receive finished, false if still in progress

--- a/src/fl/channels/rx/channel.cpp.hpp
+++ b/src/fl/channels/rx/channel.cpp.hpp
@@ -109,6 +109,10 @@ bool RxChannel::begin(const RxChannelConfig& config) FL_NO_EXCEPT {
     return mDevice ? mDevice->begin(toRxConfig(mConfig)) : false;
 }
 
+const char* RxChannel::lastBeginError() const FL_NO_EXCEPT {
+    return mDevice ? mDevice->lastBeginError() : "rx_device_unavailable";
+}
+
 void RxChannel::setConfig(const RxChannelConfig& config) FL_NO_EXCEPT {
     if (!config.name.empty()) {
         mName = config.name;

--- a/src/fl/channels/rx/channel.h
+++ b/src/fl/channels/rx/channel.h
@@ -33,6 +33,7 @@ public:
     RxBackend backend() const FL_NO_EXCEPT;
 
     bool begin(const RxChannelConfig& config) FL_NO_EXCEPT;
+    const char* lastBeginError() const FL_NO_EXCEPT;
     void setConfig(const RxChannelConfig& config) FL_NO_EXCEPT;
     bool finished() const FL_NO_EXCEPT;
     RxWaitResult wait(u32 timeout_ms) FL_NO_EXCEPT;

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
@@ -10,7 +10,8 @@ ChannelEngineRpPio::ChannelEngineRpPio(
     fl::shared_ptr<IRpPioTxPeripheral> peripheral, u8 which) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)), mWhich(which), mCurrentChannel(0),
       mLatchStartUs(0), mLatchDurationUs(0), mActive(false),
-      mActiveLaneCount(1), mLatchPending(false), mFailed(false) {}
+      mActiveLaneCount(1), mLatchPending(false), mFailed(false),
+      mLastStartAttempted(false), mLastStartSucceeded(false), mLastWordCount(0) {}
 
 ChannelEngineRpPio::~ChannelEngineRpPio() {
     releaseInFlight();
@@ -45,7 +46,11 @@ void ChannelEngineRpPio::show() FL_NO_EXCEPT {
     mPendingChannels.clear();
     mCurrentChannel = 0;
     mFailed = false;
+    mLastStartAttempted = false;
+    mLastStartSucceeded = false;
+    mLastWordCount = 0;
     mError.clear();
+    mLastError.clear();
     for (const ChannelDataPtr& channel : mInFlightChannels) {
         if (channel) channel->setInUse(true);
     }
@@ -128,7 +133,10 @@ bool ChannelEngineRpPio::beginTransmission(const ChannelDataPtr& channel) FL_NO_
             mPioWords.push_back(plane << (32u - mActiveLaneCount));
         }
     }
-    return mPeripheral->startTxDma(mPioWords.data(), mPioWords.size());
+    mLastStartAttempted = true;
+    mLastWordCount = mPioWords.size();
+    mLastStartSucceeded = mPeripheral->startTxDma(mPioWords.data(), mPioWords.size());
+    return mLastStartSucceeded;
 }
 
 void ChannelEngineRpPio::releaseInFlight() FL_NO_EXCEPT {
@@ -145,6 +153,7 @@ void ChannelEngineRpPio::releaseInFlight() FL_NO_EXCEPT {
 }
 
 IChannelDriver::DriverState ChannelEngineRpPio::fail(const char* message) FL_NO_EXCEPT {
+    mLastError = message;
     if (mPeripheral) {
         mPeripheral->abort();
         mPeripheral->deinitialize();

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
@@ -24,6 +24,12 @@ class ChannelEngineRpPio final : public IChannelDriver {
     void show() FL_NO_EXCEPT override;
     DriverState poll() FL_NO_EXCEPT override;
 
+    bool isActive() const FL_NO_EXCEPT { return mActive; }
+    const fl::string& lastError() const FL_NO_EXCEPT { return mLastError; }
+    bool lastStartAttempted() const FL_NO_EXCEPT { return mLastStartAttempted; }
+    bool lastStartSucceeded() const FL_NO_EXCEPT { return mLastStartSucceeded; }
+    size_t lastWordCount() const FL_NO_EXCEPT { return mLastWordCount; }
+
     fl::string getName() const FL_NO_EXCEPT override {
         return mWhich == 0 ? fl::string::from_literal("PIO0")
                            : fl::string::from_literal("PIO1");
@@ -50,7 +56,11 @@ class ChannelEngineRpPio final : public IChannelDriver {
     bool mActive;
     bool mLatchPending;
     bool mFailed;
+    bool mLastStartAttempted;
+    bool mLastStartSucceeded;
+    size_t mLastWordCount;
     fl::string mError;
+    fl::string mLastError;
 };
 
 }  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -58,6 +58,70 @@ class RpPioDmaResourceManager {
         return false;
     }
 
+    /// @brief Atomically claim a PIO state machine and install a program.
+    ///
+    /// PIO instruction memory is shared by all four state machines in a
+    /// block. Keeping the can-add/add pair inside the resource-manager lock
+    /// prevents two RP cores from reserving the same apparent free slot.
+    bool claimPioStateMachineAndAddProgram(const pio_program* program,
+                                           PIO* pio_out, int* state_machine_out,
+                                           int* program_offset_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (program == nullptr || pio_out == nullptr || state_machine_out == nullptr ||
+            program_offset_out == nullptr) {
+            return false;
+        }
+        for (u8 pio_index = 0; pio_index < NUM_PIOS; ++pio_index) {
+            PIO pio = pioForIndex(pio_index);
+            const int state_machine = pio_claim_unused_sm(pio, false);
+            if (state_machine < 0) continue;
+            if (!mLedger.claimPioStateMachine(pio_index, static_cast<u8>(state_machine))) {
+                pio_sm_unclaim(pio, static_cast<uint>(state_machine));
+                continue;
+            }
+            if (pio_can_add_program(pio, program)) {
+                const uint offset = pio_add_program(pio, program);
+                *pio_out = pio;
+                *state_machine_out = state_machine;
+                *program_offset_out = static_cast<int>(offset);
+                return true;
+            }
+            pio_sm_unclaim(pio, static_cast<uint>(state_machine));
+            mLedger.releasePioStateMachine(pio_index, static_cast<u8>(state_machine));
+        }
+        return false;
+    }
+
+    bool addPioProgram(PIO pio, const pio_program* program,
+                       int* program_offset_out) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio == nullptr || program == nullptr || program_offset_out == nullptr ||
+            !pio_can_add_program(pio, program)) {
+            return false;
+        }
+        *program_offset_out = static_cast<int>(pio_add_program(pio, program));
+        return true;
+    }
+
+    void removePioProgram(PIO pio, const pio_program* program,
+                          int program_offset) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio == nullptr || program == nullptr || program_offset < 0) return;
+        pio_remove_program(pio, program, static_cast<uint>(program_offset));
+    }
+
+    bool claimPioRxCaptureBuffer(void* owner) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (owner == nullptr || mPioRxCaptureOwner != nullptr) return false;
+        mPioRxCaptureOwner = owner;
+        return true;
+    }
+
+    void releasePioRxCaptureBuffer(void* owner) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (mPioRxCaptureOwner == owner) mPioRxCaptureOwner = nullptr;
+    }
+
     void releasePioStateMachine(PIO pio, int state_machine) FL_NO_EXCEPT {
         LockGuard lock(*this);
         if (pio == nullptr || state_machine < 0) {
@@ -257,7 +321,8 @@ class RpPioDmaResourceManager {
     RpPioDmaResourceManager() FL_NO_EXCEPT
         : mLedger(NUM_PIOS, RpResourceLedger::kMaxStateMachinesPerPio,
                   NUM_DMA_CHANNELS, RpResourceLedger::kMaxPins)
-        , mLock(spin_lock_instance(spin_lock_claim_unused(true))) {}
+        , mLock(spin_lock_instance(spin_lock_claim_unused(true)))
+        , mPioRxCaptureOwner(nullptr) {}
 
   private:
     class LockGuard {
@@ -306,6 +371,7 @@ class RpPioDmaResourceManager {
 
     RpResourceLedger mLedger;
     spin_lock_t* mLock;
+    void* mPioRxCaptureOwner;
 };
 
 }  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_edge_capture.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_edge_capture.h
@@ -33,8 +33,9 @@ class RpPioEdgeCapture {
         return ns > kMaxEdgeNs ? kMaxEdgeNs : static_cast<u32>(ns);
     }
 
+    template <typename EdgeStorage>
     bool appendCounter(bool high, u32 remaining_counter, u32 pio_clock_hz,
-                       u32 setup_cycles, fl::vector<EdgeTime>* edges,
+                       u32 setup_cycles, EdgeStorage* edges,
                        size_t capacity) FL_NO_EXCEPT {
         if (pio_clock_hz == 0) return false;
         const u64 counter_ticks = ~remaining_counter;
@@ -47,7 +48,8 @@ class RpPioEdgeCapture {
                               edges, capacity);
     }
 
-    bool appendDuration(bool high, u32 duration_ns, fl::vector<EdgeTime>* edges,
+    template <typename EdgeStorage>
+    bool appendDuration(bool high, u32 duration_ns, EdgeStorage* edges,
                         size_t capacity) FL_NO_EXCEPT {
         if (edges == nullptr) return false;
         if (duration_ns < mMinSignalNs) return true;

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp
@@ -77,8 +77,8 @@ bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_E
     #endif
 #endif
     PIO pio = static_cast<PIO>(mPio);
-    if (!pio_can_add_program(pio, &mProgram->program)) return false;
-    mProgramOffset = static_cast<int>(pio_add_program(pio, &mProgram->program));
+    if (!RpPioDmaResourceManager::instance().addPioProgram(
+            pio, &mProgram->program, &mProgramOffset)) return false;
     mProgram->terminal_pc = static_cast<u32>(mProgramOffset);
 
     pio_sm_config config = pio_get_default_sm_config();
@@ -95,6 +95,13 @@ bool RpPioTxPeripheral::createProgram(const ChipsetTimingConfig& timing) FL_NO_E
                                    static_cast<uint>(mPin), mLaneCount, true);
     pio_sm_init(pio, static_cast<uint>(mStateMachine),
                 static_cast<uint>(mProgramOffset), &config);
+    // A PIO output latch survives a prior state-machine use.  The program
+    // initially blocks at OUT waiting for its first DMA word, so establish
+    // the clockless idle-low level before exposing that blocked state on the
+    // GPIO.  This also gives an external RX sampler an unambiguous frame
+    // boundary after a GPIO connectivity probe.
+    const u32 pin_mask = ((1u << mLaneCount) - 1u) << mPin;
+    pio_sm_set_pins_with_mask(pio, static_cast<uint>(mStateMachine), 0, pin_mask);
     pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), true);
     return true;
 }
@@ -171,7 +178,8 @@ void RpPioTxPeripheral::deinitialize() FL_NO_EXCEPT {
         pio_sm_clear_fifos(pio, static_cast<uint>(mStateMachine));
     }
     if (pio != nullptr && mProgram != nullptr && mProgramOffset >= 0) {
-        pio_remove_program(pio, &mProgram->program, static_cast<uint>(mProgramOffset));
+        RpPioDmaResourceManager::instance().removePioProgram(
+            pio, &mProgram->program, mProgramOffset);
     }
     if (mDmaChannel >= 0) RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChannel);
     if (pio != nullptr && mStateMachine >= 0) {

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
@@ -8,6 +8,7 @@
 #include "platforms/arm/rp/rpcommon/pio_asm.h"
 #include "fl/channels/rx/decode_ws2812.h"
 #include "fl/system/delay.h"
+#include "fl/stl/cstring.h"
 // IWYU pragma: begin_keep
 #include "hardware/clocks.h"
 #include "hardware/gpio.h"
@@ -19,8 +20,21 @@ namespace fl {
 
 namespace {
 
-constexpr size_t kPioRxProgramLength = 13;
+constexpr size_t kPioRxProgramLength = 3;
+// After synchronizing to the first rising edge, the PIO runs one IN PINS
+// instruction per cycle. 20 MHz gives 50 ns samples, enough to distinguish
+// WS2812 timing phases without losing the first phase to counter setup.
 constexpr u32 kPioRxClockHz = 20000000u;
+constexpr size_t kPioRxDmaTailWords = 64u;
+// AutoResearch's RP tier is capped at 100 RGB LEDs. A static DMA target keeps
+// capture independent of the Arduino-Pico heap, which is not usable while the
+// full RPC harness owns its transient result objects.
+struct PioRxCaptureBuffers {
+    u32 words[kRpPioRxEdgeCapacity];
+    RpPioRxEdgeStorage edges;
+};
+
+PioRxCaptureBuffers gPioRxCaptureBuffers;
 
 const pio_instr kPioRxDurationTemplate[kPioRxProgramLength] = {};
 
@@ -50,30 +64,17 @@ pio_program makePioRxDurationProgram(const pio_instr* instructions) FL_NO_EXCEPT
     };
 }
 
-void buildPioRxDurationProgram(pio_instr* instructions, bool idle_low) FL_NO_EXCEPT {
-    const uint wait_polarity = idle_low ? PIO_WAIT_POLARITY_1 : PIO_WAIT_POLARITY_0;
-    instructions[0] = static_cast<pio_instr>(PIO_INSTR_WAIT | wait_polarity |
+void buildPioRxSampleProgram(pio_instr* instructions, bool idle_low) FL_NO_EXCEPT {
+    const uint idle_polarity = idle_low ? PIO_WAIT_POLARITY_0 : PIO_WAIT_POLARITY_1;
+    const uint start_polarity = idle_low ? PIO_WAIT_POLARITY_1 : PIO_WAIT_POLARITY_0;
+    // Synchronize on a complete idle-to-active transition, then sample each
+    // PIO cycle through the wrap at instruction 2.
+    instructions[0] = static_cast<pio_instr>(PIO_INSTR_WAIT | idle_polarity |
                                              PIO_WAIT_SRC_PIN | PIO_WAIT_IDX(0));
-    instructions[1] = static_cast<pio_instr>(PIO_INSTR_SET | PIO_SET_DST_X | PIO_SET_DATA(0));
-    instructions[2] = static_cast<pio_instr>(PIO_INSTR_MOV | PIO_MOV_DST_X |
-                                             PIO_MOV_OP_INVERT | PIO_MOV_SRC_X);
-    instructions[3] = static_cast<pio_instr>(PIO_INSTR_JMP | PIO_JMP_CND_PIN |
-                                             PIO_JMP_ADR(idle_low ? 4 : 5));
-    instructions[4] = static_cast<pio_instr>(PIO_INSTR_JMP | PIO_JMP_CND_X_DEC |
-                                             PIO_JMP_ADR(3));
-    instructions[5] = static_cast<pio_instr>(PIO_INSTR_MOV | PIO_MOV_DST_ISR |
-                                             PIO_MOV_SRC_X);
-    instructions[6] = static_cast<pio_instr>(PIO_INSTR_PUSH | PIO_PUSH_BLOCK);
-    instructions[7] = static_cast<pio_instr>(PIO_INSTR_SET | PIO_SET_DST_X | PIO_SET_DATA(0));
-    instructions[8] = static_cast<pio_instr>(PIO_INSTR_MOV | PIO_MOV_DST_X |
-                                             PIO_MOV_OP_INVERT | PIO_MOV_SRC_X);
-    instructions[9] = static_cast<pio_instr>(PIO_INSTR_JMP | PIO_JMP_CND_PIN |
-                                             PIO_JMP_ADR(idle_low ? 11 : 10));
-    instructions[10] = static_cast<pio_instr>(PIO_INSTR_JMP | PIO_JMP_CND_X_DEC |
-                                              PIO_JMP_ADR(9));
-    instructions[11] = static_cast<pio_instr>(PIO_INSTR_MOV | PIO_MOV_DST_ISR |
-                                              PIO_MOV_SRC_X);
-    instructions[12] = static_cast<pio_instr>(PIO_INSTR_PUSH | PIO_PUSH_BLOCK);
+    instructions[1] = static_cast<pio_instr>(PIO_INSTR_WAIT | start_polarity |
+                                             PIO_WAIT_SRC_PIN | PIO_WAIT_IDX(0));
+    instructions[2] = static_cast<pio_instr>(PIO_INSTR_IN | PIO_IN_SRC_PINS |
+                                             PIO_IN_CNT(1));
 }
 
 }  // namespace
@@ -87,66 +88,72 @@ RpPioRxDevice::RpPioRxDevice(int pin) FL_NO_EXCEPT
     : mPin(pin), mPio(nullptr), mStateMachine(-1), mDmaChannel(-1),
       mProgramOffset(-1), mPioClockHz(0), mTailLimitNs(1), mLastTransitionUs(0),
       mCapacity(0), mArmed(false), mFinished(false), mOverflow(false),
-      mProgramLoaded(false), mNextHigh(true), mIdleHigh(false), mFirstDuration(true),
-      mDmaWordCount(0),
-      mDmaWordsProcessed(0) {}
+      mProgramLoaded(false), mIdleHigh(false), mSampleHigh(false), mHaveSample(false),
+      mLastBeginError(""), mDmaWordCount(0), mDmaWords(nullptr), mEdges(nullptr),
+      mDmaWordsProcessed(0), mSampleRunTicks(0) {}
 
 RpPioRxDevice::~RpPioRxDevice() FL_NO_EXCEPT { stop(); }
 
 bool RpPioRxDevice::begin(const RxConfig& config) FL_NO_EXCEPT {
     stop();
+    mLastBeginError = "";
     // The Phase 2 sampler configures one direct PIO input mapping. RP2350B's
     // alternate GPIO bank needs PIO-base coordination, which is deliberately
     // deferred until the shared allocator owns that global setting.
     if (config.buffer_size == 0 || mPin < 0 ||
-        static_cast<uint>(mPin) >= NUM_BANK0_GPIOS || mPin >= 32) return false;
+        static_cast<uint>(mPin) >= NUM_BANK0_GPIOS || mPin >= 32) {
+        mLastBeginError = "invalid_config";
+        return false;
+    }
+    if (config.buffer_size > kRpPioRxEdgeCapacity) {
+        mLastBeginError = "dma_buffer_size";
+        return false;
+    }
+    pio_instr* instructions = reinterpret_cast<pio_instr*>(mProgramInstructions);
+    buildPioRxSampleProgram(instructions, config.start_low);
+    const pio_program program = makePioRxDurationProgram(instructions);
     auto& resources = RpPioDmaResourceManager::instance();
     PIO pio = nullptr;
     int state_machine = -1;
     int dma_channel = -1;
-    while (resources.claimPioStateMachine(&pio, &state_machine)) {
-        if (pio_can_add_program(pio, &kPioRxDurationProgramTemplate)) break;
-        resources.releasePioStateMachine(pio, state_machine);
-        pio = nullptr;
-        state_machine = -1;
+    int program_offset = -1;
+    if (!resources.claimPioStateMachineAndAddProgram(&program, &pio, &state_machine,
+                                                      &program_offset)) {
+        mLastBeginError = "pio_state_machine";
+        return false;
     }
-    if (state_machine < 0 || !resources.claimDmaChannel(&dma_channel) ||
-        !resources.claimPins(static_cast<u8>(mPin), 1)) {
+    if (!resources.claimDmaChannel(&dma_channel)) {
+        mLastBeginError = "dma_channel";
+        resources.removePioProgram(pio, &program, program_offset);
+        resources.releasePioStateMachine(pio, state_machine);
+        return false;
+    }
+    if (!resources.claimPins(static_cast<u8>(mPin), 1)) {
+        mLastBeginError = "pin_claim";
         if (dma_channel >= 0) resources.releaseDmaChannel(dma_channel);
+        resources.removePioProgram(pio, &program, program_offset);
         if (state_machine >= 0) resources.releasePioStateMachine(pio, state_machine);
         return false;
     }
     gpio_init(static_cast<uint>(mPin));
     gpio_set_dir(static_cast<uint>(mPin), GPIO_IN);
+    // Clockless LED data is idle-low.  Keep the input at that defined level
+    // until the transmitter takes ownership; otherwise a preceding GPIO
+    // connectivity probe can leave the jumper floating/high and make the
+    // duration sampler treat the entire inter-test gap as its first pulse.
+    gpio_pull_down(static_cast<uint>(mPin));
+    // The Pico SDK's PIO GPIO initializer selects this PIO block's input
+    // path. Keeping the pin's direction input prevents any stale PIO output
+    // latch from driving the physical loopback while still routing pad input
+    // to WAIT PIN and JMP PIN.
     pio_gpio_init(pio, static_cast<uint>(mPin));
     pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(state_machine),
                                    static_cast<uint>(mPin), 1, false);
-    // Pico SDK does not expose its instruction-memory allocator's chosen
-    // offset. Reserve the exact slot with a same-sized template, release it,
-    // then install the offset-relocated duration program in that slot.
-    const int program_offset = pio_add_program(pio, &kPioRxDurationProgramTemplate);
-    if (program_offset < 0) {
-        resources.releasePins(static_cast<u8>(mPin), 1);
-        resources.releaseDmaChannel(dma_channel);
-        resources.releasePioStateMachine(pio, state_machine);
-        return false;
-    }
-    pio_remove_program(pio, &kPioRxDurationProgramTemplate,
-                       static_cast<uint>(program_offset));
-    pio_instr* instructions = reinterpret_cast<pio_instr*>(mProgramInstructions);
-    buildPioRxDurationProgram(instructions, config.start_low);
-    const pio_program program = makePioRxDurationProgram(instructions);
-    if (pio_add_program_at_offset(pio, &program, static_cast<uint>(program_offset)) < 0) {
-        resources.releasePins(static_cast<u8>(mPin), 1);
-        resources.releaseDmaChannel(dma_channel);
-        resources.releasePioStateMachine(pio, state_machine);
-        return false;
-    }
     pio_sm_config pio_config = pio_get_default_sm_config();
-    sm_config_set_wrap(&pio_config, static_cast<uint>(program_offset + 1),
-                       static_cast<uint>(program_offset + kPioRxProgramLength - 1));
+    sm_config_set_wrap(&pio_config, static_cast<uint>(program_offset + 2),
+                       static_cast<uint>(program_offset + 2));
     sm_config_set_in_pins(&pio_config, static_cast<uint>(mPin));
-    sm_config_set_jmp_pin(&pio_config, static_cast<uint>(mPin));
+    sm_config_set_in_shift(&pio_config, false, true, 32);
     sm_config_set_fifo_join(&pio_config, PIO_FIFO_JOIN_RX);
     const u32 system_clock_hz = clock_get_hz(clk_sys);
     sm_config_set_clkdiv(&pio_config, static_cast<float>(system_clock_hz) / kPioRxClockHz);
@@ -160,25 +167,43 @@ bool RpPioRxDevice::begin(const RxConfig& config) FL_NO_EXCEPT {
     mTailLimitNs = config.signal_range_max_ns == 0 ? 1 : config.signal_range_max_ns;
     mLastTransitionUs = micros();
     mCapacity = config.buffer_size;
-    mEdges.clear();
-    mEdges.reserve(mCapacity);
     mCapture.reset(config.signal_range_min_ns, config.skip_signals);
-    mDmaWordCount = mCapacity + 1;  // one sentinel makes a full edge buffer honest overflow.
-    mDmaWords.resize(mDmaWordCount);
+    // Each 32-bit DMA word stores 32 samples. A WS2812 byte uses roughly
+    // seven words at 20 MHz; the edge capacity is sixteen phases per byte,
+    // so half that capacity plus a reset tail is safely conservative.
+    mDmaWordCount = (mCapacity + 1u) / 2u + kPioRxDmaTailWords;
     mDmaWordsProcessed = 0;
-    mNextHigh = config.start_low;
     mIdleHigh = !config.start_low;
-    mFirstDuration = true;
+    mSampleHigh = mIdleHigh;
+    mHaveSample = false;
+    mSampleRunTicks = 0;
     mArmed = true;
     mFinished = false;
     mOverflow = false;
     mProgramLoaded = true;
+    if (mDmaWordCount > kRpPioRxEdgeCapacity) {
+        mLastBeginError = "dma_buffer_size";
+        stop();
+        return false;
+    }
+    if (!resources.claimPioRxCaptureBuffer(this)) {
+        mLastBeginError = "dma_buffer_busy";
+        stop();
+        return false;
+    }
+    // DMA needs one stable, contiguous destination. This shared pool is
+    // exclusive while a capture is armed; PIO TX and PIO RX use separate
+    // resource-manager claims, so a PIO1 TX can run while PIO0 owns it.
+    mDmaWords = gPioRxCaptureBuffers.words;
+    mEdges = &gPioRxCaptureBuffers.edges;
+    mEdges->clear();
+    fl::memset(mDmaWords, 0, mDmaWordCount * sizeof(*mDmaWords));
     dma_channel_config dma_config = dma_channel_get_default_config(static_cast<uint>(dma_channel));
     channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
     channel_config_set_read_increment(&dma_config, false);
     channel_config_set_write_increment(&dma_config, true);
     channel_config_set_dreq(&dma_config, pio_get_dreq(pio, static_cast<uint>(state_machine), false));
-    dma_channel_configure(static_cast<uint>(dma_channel), &dma_config, mDmaWords.data(),
+    dma_channel_configure(static_cast<uint>(dma_channel), &dma_config, mDmaWords,
                           &pio->rxf[state_machine], static_cast<uint>(mDmaWordCount), false);
     pio_sm_set_enabled(pio, static_cast<uint>(state_machine), true);
     dma_start_channel_mask(1u << dma_channel);
@@ -190,13 +215,17 @@ void RpPioRxDevice::stop() FL_NO_EXCEPT {
     if (mPio != nullptr && mStateMachine >= 0) {
         pio_sm_set_enabled(static_cast<PIO>(mPio), static_cast<uint>(mStateMachine), false);
         if (mProgramLoaded && mProgramOffset >= 0) {
-            pio_remove_program(static_cast<PIO>(mPio), &kPioRxDurationProgramTemplate,
-                               static_cast<uint>(mProgramOffset));
+            RpPioDmaResourceManager::instance().removePioProgram(
+                static_cast<PIO>(mPio), &kPioRxDurationProgramTemplate, mProgramOffset);
         }
         RpPioDmaResourceManager::instance().releasePioStateMachine(static_cast<PIO>(mPio), mStateMachine);
     }
     if (mDmaChannel >= 0) RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChannel);
     if (mArmed) RpPioDmaResourceManager::instance().releasePins(static_cast<u8>(mPin), 1);
+    if (mPin >= 0) gpio_disable_pulls(static_cast<uint>(mPin));
+    RpPioDmaResourceManager::instance().releasePioRxCaptureBuffer(this);
+    mDmaWords = nullptr;
+    mEdges = nullptr;
     mPio = nullptr;
     mStateMachine = -1;
     mDmaChannel = -1;
@@ -223,16 +252,20 @@ fl::result<u32, DecodeError> RpPioRxDevice::decode(const ChipsetTiming4Phase& ti
                                                     fl::span<u8> out) FL_NO_EXCEPT {
     collectDurations();
     finishTailIfIdle();
-    return fl::channels::rx::decodeWs2812Edges(timing, fl::span<const EdgeTime>(mEdges), out);
+    if (mEdges == nullptr) {
+        return fl::result<u32, DecodeError>::failure(DecodeError::INVALID_ARGUMENT);
+    }
+    return fl::channels::rx::decodeWs2812Edges(
+        timing, fl::span<const EdgeTime>(mEdges->data(), mEdges->size()), out);
 }
 
 size_t RpPioRxDevice::getRawEdgeTimes(fl::span<EdgeTime> out, size_t offset) FL_NO_EXCEPT {
     collectDurations();
     finishTailIfIdle();
-    if (offset >= mEdges.size()) return 0;
-    size_t count = mEdges.size() - offset;
+    if (mEdges == nullptr || offset >= mEdges->size()) return 0;
+    size_t count = mEdges->size() - offset;
     if (count > out.size()) count = out.size();
-    for (size_t i = 0; i < count; ++i) out[i] = mEdges[offset + i];
+    for (size_t i = 0; i < count; ++i) out[i] = (*mEdges)[offset + i];
     return count;
 }
 
@@ -240,43 +273,80 @@ const char* RpPioRxDevice::name() const FL_NO_EXCEPT { return "PIO_RX"; }
 int RpPioRxDevice::getPin() const FL_NO_EXCEPT { return mPin; }
 
 bool RpPioRxDevice::injectEdges(fl::span<const EdgeTime> edges) FL_NO_EXCEPT {
-    if (!mArmed) return false;
+    if (!mArmed || mEdges == nullptr) return false;
     for (size_t i = 0; i < edges.size(); ++i) {
-        if (mEdges.size() == mCapacity) { mOverflow = true; mFinished = true; return false; }
-        mEdges.push_back(edges[i]);
+        if (mEdges->size() == mCapacity) { mOverflow = true; mFinished = true; return false; }
+        mEdges->push_back(edges[i]);
     }
     mFinished = !edges.empty();
     return true;
 }
 
 void RpPioRxDevice::collectDurations() FL_NO_EXCEPT {
-    if (!mArmed || mPio == nullptr || mStateMachine < 0 || mFinished) return;
+    if (!mArmed || mPio == nullptr || mStateMachine < 0 || mEdges == nullptr || mFinished) return;
     const size_t transferred = mDmaWordCount - dma_hw->ch[mDmaChannel].transfer_count;
     while (mDmaWordsProcessed < transferred) {
-        // The first phase starts after SET+MOV (2 PIO cycles); the opposite
-        // phase starts after MOV+PUSH+SET+MOV+JMP (5 cycles). Account for
-        // that fixed instruction-path bias before exposing nanoseconds.
-        if (mDmaWordsProcessed >= mCapacity ||
-            !mCapture.appendCounter(mNextHigh, mDmaWords[mDmaWordsProcessed], mPioClockHz,
-                                    mFirstDuration ? 2u : 5u,
-                                    &mEdges, mCapacity) || mCapture.saturated()) {
-            mOverflow = true;
-            mFinished = true;
-            dma_channel_abort(static_cast<uint>(mDmaChannel));
-            pio_sm_set_enabled(static_cast<PIO>(mPio), static_cast<uint>(mStateMachine), false);
-            return;
+        const u32 samples = mDmaWords[mDmaWordsProcessed];
+        for (u32 bit = 0; bit < 32; ++bit) {
+            const bool high = (samples & (1u << (31u - bit))) != 0;
+            if (!mHaveSample) {
+                mSampleHigh = high;
+                mHaveSample = true;
+                mSampleRunTicks = 1;
+                continue;
+            }
+            if (high == mSampleHigh) {
+                ++mSampleRunTicks;
+                const u64 run_ns = (mSampleRunTicks * 1000000000ull) / mPioClockHz;
+                // The sampler remains active after the transmitter returns.
+                // Stop from the sampled reset-low run itself instead of
+                // waiting for the CPU polling interval, which would let DMA
+                // overwrite a short frame with idle samples.
+                if (mSampleHigh == mIdleHigh && run_ns >= mTailLimitNs) {
+                    if (!mCapture.appendDuration(mSampleHigh,
+                                                 run_ns > 0x7fffffffu ? 0x7fffffffu :
+                                                                         static_cast<u32>(run_ns),
+                                                 mEdges, mCapacity) || mCapture.saturated()) {
+                        mOverflow = true;
+                    }
+                    pio_sm_set_enabled(static_cast<PIO>(mPio),
+                                       static_cast<uint>(mStateMachine), false);
+                    dma_channel_abort(static_cast<uint>(mDmaChannel));
+                    mFinished = true;
+                    return;
+                }
+                continue;
+            }
+            const u64 duration_ns = (mSampleRunTicks * 1000000000ull) / mPioClockHz;
+            if (!mCapture.appendDuration(mSampleHigh,
+                                         duration_ns > 0x7fffffffu ? 0x7fffffffu :
+                                                                     static_cast<u32>(duration_ns),
+                                         mEdges, mCapacity) || mCapture.saturated()) {
+                mOverflow = true;
+                mFinished = true;
+                dma_channel_abort(static_cast<uint>(mDmaChannel));
+                pio_sm_set_enabled(static_cast<PIO>(mPio), static_cast<uint>(mStateMachine), false);
+                return;
+            }
+            mSampleHigh = high;
+            mSampleRunTicks = 1;
+            mLastTransitionUs = micros();
         }
-        mNextHigh = !mNextHigh;
-        mFirstDuration = false;
         ++mDmaWordsProcessed;
-        mLastTransitionUs = micros();
+    }
+    if (mDmaWordsProcessed == mDmaWordCount) {
+        mOverflow = true;
+        mFinished = true;
+        dma_channel_abort(static_cast<uint>(mDmaChannel));
+        pio_sm_set_enabled(static_cast<PIO>(mPio), static_cast<uint>(mStateMachine), false);
     }
 }
 
 void RpPioRxDevice::finishTailIfIdle() FL_NO_EXCEPT {
-    if (!mArmed || mFinished || mNextHigh != mIdleHigh) return;
+    if (!mArmed || mEdges == nullptr || mFinished || !mHaveSample ||
+        mSampleHigh != mIdleHigh) return;
     if ((micros() - mLastTransitionUs) * 1000u < mTailLimitNs) return;
-    if (!mCapture.appendDuration(mNextHigh, mTailLimitNs, &mEdges, mCapacity) ||
+    if (!mCapture.appendDuration(mSampleHigh, mTailLimitNs, mEdges, mCapacity) ||
         mCapture.saturated()) {
         mOverflow = true;
     }

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
@@ -13,12 +13,16 @@
 
 namespace fl {
 
+constexpr size_t kRpPioRxEdgeCapacity = 100u * 3u * 16u + 1u;
+using RpPioRxEdgeStorage = fl::FixedVector<EdgeTime, kRpPioRxEdgeCapacity>;
+
 /// @brief RP PIO RX lifecycle device. Capture programming is Phase 2.
 class RpPioRxDevice : public RxDevice {
   public:
     static fl::shared_ptr<RxDevice> create(int pin) FL_NO_EXCEPT;
 
     bool begin(const RxConfig& config) FL_NO_EXCEPT override;
+    const char* lastBeginError() const FL_NO_EXCEPT override { return mLastBeginError; }
     bool finished() const FL_NO_EXCEPT override;
     RxWaitResult wait(u32 timeout_ms) FL_NO_EXCEPT override;
     fl::result<u32, DecodeError> decode(const ChipsetTiming4Phase& timing,
@@ -50,15 +54,17 @@ class RpPioRxDevice : public RxDevice {
     bool mFinished;
     bool mOverflow;
     bool mProgramLoaded;
-    bool mNextHigh;
     bool mIdleHigh;
-    bool mFirstDuration;
+    bool mSampleHigh;
+    bool mHaveSample;
+    const char* mLastBeginError;
     size_t mDmaWordCount;
     size_t mDmaWordsProcessed;
-    u16 mProgramInstructions[13];
+    size_t mSampleRunTicks;
+    u16 mProgramInstructions[16];
     RpPioEdgeCapture mCapture;
-    fl::vector<u32> mDmaWords;
-    fl::vector<EdgeTime> mEdges;
+    u32* mDmaWords;
+    RpPioRxEdgeStorage* mEdges;
 };
 
 }  // namespace fl

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -120,6 +120,8 @@ FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
     FL_CHECK_FALSE(first->isInUse());
     FL_CHECK_FALSE(second->isInUse());
+    FL_CHECK_EQ(engine.lastError(), fl::string("RP PIO: peripheral error"));
+    FL_CHECK_FALSE(engine.isActive());
     FL_CHECK(peripheral->abortCalls > 0);
     FL_CHECK(peripheral->deinitializeCalls > 0);
 }


### PR DESCRIPTION
## Summary
- Make RP2040 PIO RX capture deterministic for short WS2812 frames and surface setup/overflow diagnostics.
- Serialize PIO program, state-machine, DMA, and capture-buffer ownership across the Phase 5 TX/RX paths.
- Add AutoResearch selectors for PIO0, PIO1, and concurrent PIO0+PIO1 resource checks.

## Validation
- `uv run pytest ci/tests/test_autoresearch_phases.py --tb=short` (98 passed)
- `bash test rx --debug`
- RP Pico HIL via fbuild / AutoResearch, GPIO11 -> GPIO8:
  - PIO0 exact-byte WS2812B, 1/25/100 LEDs, four patterns: pass
  - PIO1 exact-byte WS2812B, 1/25/100 LEDs, four patterns: pass
  - PIO0+PIO1 concurrent show/wait resource test: pass

Refs #3658
Refs #3648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting RP2040/RP2350 PIO0, PIO1, or both PIO engines for Flex IO transmissions.
  * Added detailed diagnostics for PIO activity, transmission failures, RX initialization errors, and signal transitions.
* **Improvements**
  * Improved RP PIO resource management and concurrent transmission handling.
  * Enhanced RX capture reliability and memory usage on supported boards.
  * Added clearer validation and troubleshooting information for parallel tests.
* **Bug Fixes**
  * Corrected success reporting and cleanup behavior for parallel PIO tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->