### PR TITLE
docs(agents): publish driver bring-up postmortems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
 | Test-Driven Development (TDD) | Use `/tdd` or `/tdd-implement` skills |
 | Editing `.fled` container docs or `src/fl/fled/` | `agents/docs/fled-format.md` |
 | Hardware autoresearch / `bash autoresearch` | `agents/docs/hardware-autoresearch.md` |
+| Hardware driver bring-up evidence or postmortems | `agents/docs/driver-bringup-postmortems.md` |
 | Debugging a C++ crash | `agents/docs/debugging.md` |
 | Investigating binary size / flash bloat | `agents/docs/binary-size-analysis.md` |
 | Creating a new C++ linter | `agents/docs/linter-architecture.md` |

--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -55,6 +55,7 @@ Reference links for agents:
 
 - [CLAUDE.md](../../CLAUDE.md)
 - [hardware-autoresearch.md](hardware-autoresearch.md)
+- [driver bring-up postmortems](driver-bringup-postmortems.md)
 - [autoresearch wrapper](../../autoresearch)
 - [ci/autoresearch/args.py](../../ci/autoresearch/args.py)
 - [ci/autoresearch/phases.py](../../ci/autoresearch/phases.py)


### PR DESCRIPTION
Implements #3652.

Links the citation-backed driver bring-up postmortem guide from CLAUDE.md and the hardware AutoResearch runbook. The guide includes current fbuild/AutoResearch-only workflow, evidence limits, incident checklists, quiet-control audit, resource-pressure soak, and both RP2040/ESP32 narratives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added references to driver bring-up postmortems in relevant guidance documents.
  * Improved discoverability of hardware driver evidence and troubleshooting documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->