### PR TITLE
fix(spi): legacy addLeds SK9822/APA102 controllers use all-ones end clocks

### DIFF
--- a/src/fl/chipsets/apa102.h
+++ b/src/fl/chipsets/apa102.h
@@ -33,7 +33,11 @@ template <
 	fl::u32 SPI_SPEED = DATA_RATE_MHZ(6),
 	fl::FiveBitGammaCorrectionMode GAMMA_CORRECTION_MODE = fl::FiveBitGammaCorrectionMode::kFiveBitGammaCorrectionMode_Null,
 	fl::u32 START_FRAME = 0x00000000,
-	fl::u32 END_FRAME = 0xFF000000
+	// The vendor datasheet requires all ones for the end clocks. These clocks
+	// shift the final LED frame through a long cascade; a zero (or partial)
+	// end frame is not a substitute because it can be misread as a start
+	// frame. Matches encodeAPA102()/encodeSK9822() in fl/chipsets/encoders/.
+	fl::u32 END_FRAME = 0xFFFFFFFF
 >
 class APA102Controller : public CPixelLEDController<RGB_ORDER> {
 	typedef fl::SPIOutput<DATA_PIN, CLOCK_PIN, SPI_SPEED> SPI;
@@ -265,6 +269,14 @@ public:
 		// - End frame: (num_leds / 32) + 1 DWords = 4 * ((num_leds / 32) + 1) bytes
 		return 4 + (num_leds * 4) + (4 * ((num_leds / 32) + 1));
 	}
+
+	/// Get the configured start frame DWord.
+	/// @returns the raw START_FRAME template value
+	static constexpr fl::u32 getStartFrame() { return START_FRAME; }
+
+	/// Get the configured end frame DWord.
+	/// @returns the raw END_FRAME template value
+	static constexpr fl::u32 getEndFrame() { return END_FRAME; }
 };
 
 /// APA102 high definition controller class.
@@ -290,13 +302,13 @@ class APA102ControllerHD : public APA102Controller<
 	SPI_SPEED,
 	fl::FiveBitGammaCorrectionMode::kFiveBitGammaCorrectionMode_BitShift,
 	fl::u32(0x00000000),
-	fl::u32(0x00000000)> {
+	fl::u32(0xFFFFFFFF)> {
 public:
   APA102ControllerHD() FL_NO_EXCEPT = default;
   APA102ControllerHD(const APA102ControllerHD&) FL_NO_EXCEPT = delete;
 };
 
-/// SK9822 controller class. It's exactly the same as the APA102Controller protocol but with a different END_FRAME and default SPI_SPEED.
+/// SK9822 controller class. It's exactly the same as the APA102Controller protocol but with a different default SPI_SPEED.
 /// @tparam DATA_PIN the data pin for these LEDs
 /// @tparam CLOCK_PIN the clock pin for these LEDs
 /// @tparam RGB_ORDER the RGB ordering for these LEDs
@@ -314,11 +326,11 @@ class SK9822Controller : public APA102Controller<
 	SPI_SPEED,
 	fl::FiveBitGammaCorrectionMode::kFiveBitGammaCorrectionMode_Null,
 	0x00000000,
-	0x00000000
+	0xFFFFFFFF
 > {
 };
 
-/// SK9822 controller class. It's exactly the same as the APA102Controller protocol but with a different END_FRAME and default SPI_SPEED.
+/// SK9822 controller class. It's exactly the same as the APA102Controller protocol but with a different default SPI_SPEED.
 /// @tparam DATA_PIN the data pin for these LEDs
 /// @tparam CLOCK_PIN the clock pin for these LEDs
 /// @tparam RGB_ORDER the RGB ordering for these LEDs
@@ -336,7 +348,7 @@ class SK9822ControllerHD : public APA102Controller<
 	SPI_SPEED,
 	fl::FiveBitGammaCorrectionMode::kFiveBitGammaCorrectionMode_BitShift,
 	0x00000000,
-	0x00000000
+	0xFFFFFFFF
 > {
 };
 
@@ -354,7 +366,7 @@ class HD107Controller : public APA102Controller<
 	SPI_SPEED,
 	fl::FiveBitGammaCorrectionMode::kFiveBitGammaCorrectionMode_Null,
 	0x00000000,
-	0x00000000
+	0xFFFFFFFF
 > {};
 
 /// HD107HD is just the APA102HD with a default 40Mhz clock rate.

--- a/tests/fl/chipsets/spi_frame_protocol.cpp
+++ b/tests/fl/chipsets/spi_frame_protocol.cpp
@@ -3,6 +3,7 @@
 
 #include "test.h"
 
+#include "fl/chipsets/apa102.h"
 #include "fl/chipsets/encoders/apa102.h"
 #include "fl/chipsets/encoders/sk9822.h"
 #include "fl/stl/array.h"
@@ -98,6 +99,37 @@ FL_TEST_CASE("Auto-brightness encoders keep an empty public frame complete") {
     encodeSK9822_AutoBrightness(empty.begin(), empty.end(), fl::back_inserter(sk));
     checkFrame(apa, 0, 31);
     checkFrame(sk, 0, 31);
+}
+
+FL_TEST_CASE("Legacy addLeds controllers use all-ones end clocks matching the encoder contract") {
+    // The channel-engine encoders above emit an all-ones (0xFFFFFFFF) end
+    // clock DWord per #3669. The legacy addLeds<> controller templates must
+    // agree, or a long SK9822/APA102 cascade driven through the classic path
+    // gets an end frame that can be misread as a new start frame (#3682).
+    using Apa102 = APA102Controller<2, 3>;
+    using Apa102HD = APA102ControllerHD<2, 3>;
+    using Sk9822 = SK9822Controller<2, 3>;
+    using Sk9822HD = SK9822ControllerHD<2, 3>;
+    using Hd107 = HD107Controller<2, 3>;
+    using Hd107HD = HD107HDController<2, 3>;
+
+    FL_CHECK_EQ(Apa102::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Apa102::getEndFrame(), 0xFFFFFFFFu);
+
+    FL_CHECK_EQ(Apa102HD::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Apa102HD::getEndFrame(), 0xFFFFFFFFu);
+
+    FL_CHECK_EQ(Sk9822::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Sk9822::getEndFrame(), 0xFFFFFFFFu);
+
+    FL_CHECK_EQ(Sk9822HD::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Sk9822HD::getEndFrame(), 0xFFFFFFFFu);
+
+    FL_CHECK_EQ(Hd107::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Hd107::getEndFrame(), 0xFFFFFFFFu);
+
+    FL_CHECK_EQ(Hd107HD::getStartFrame(), 0x00000000u);
+    FL_CHECK_EQ(Hd107HD::getEndFrame(), 0xFFFFFFFFu);
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Closes #3682

## Summary

Commit 34a86a7295 (#3669) fixed the channel-engine encoders (`fl/chipsets/encoders/{apa102,sk9822}.h`) to emit all-ones (`0xFFFFFFFF` per DWord) end-clock frames, matching the vendor datasheet requirement — these clocks shift the final LED frame through a long cascade, and a zero/partial end frame is not a substitute because it can be misread as a new start frame.

The legacy `addLeds<>` controller templates in `src/fl/chipsets/apa102.h` were never updated and still emitted mostly-zero end clocks:

- `APA102Controller` base default: `END_FRAME = 0xFF000000`
- `APA102ControllerHD`, `SK9822Controller`, `SK9822ControllerHD`, `HD107Controller`: `END_FRAME = 0x00000000`

On a long cascade (>32 LEDs) driven through the classic `FastLED.addLeds<SK9822, ...>` path, this meant the final LED frame wasn't fully shifted through, and the wrong end frame could be misread as a new start frame — the same failure #3669 already fixed on the newer channel-engine path.

## Changes

- `src/fl/chipsets/apa102.h`: align all five `END_FRAME` defaults with the encoder contract (`0xFFFFFFFF`). `HD107HDController` inherits the fix transitively through `APA102ControllerHD` (no explicit override needed).
- Dropped the now-stale "different END_FRAME" doc-comment claim on `SK9822Controller`/`SK9822ControllerHD` — after this fix, `END_FRAME` is identical between APA102 and SK9822; only the default `SPI_SPEED` differs.
- Added `getStartFrame()`/`getEndFrame()` public static accessors to `APA102Controller` so the wire-protocol contract is directly unit-testable without needing hardware or SPI byte capture.
- `tests/fl/chipsets/spi_frame_protocol.cpp`: new test case asserting `getEndFrame() == 0xFFFFFFFF` / `getStartFrame() == 0x00000000` for every affected legacy controller template.

This is a maintainer-authorized wire-protocol default change per the issue's own note ("changing shipped wire output needed your sign-off rather than a drive-by fix") — filed and directed by the repo admin.

## Testing

- `bash test spi_frame_protocol --cpp` — RED before the header fix (6 assertions failing with the old END_FRAME values), GREEN after.
- `bash test spi_frame_protocol --debug` — sanitizer pass, clean.
- `bash test fastled_core --cpp` — sanity check for existing `APA102` addLeds usage, still passing.
- `bash lint --cpp <changed files>` — clean (both changed files pass all C++ lint checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected APA102-family LED frame termination to use the required all-ones end frame.
  * Updated APA102, SK9822, and HD107 variants for consistent protocol behavior.

* **New Features**
  * Added compile-time accessors for retrieving controller start and end frame values.

* **Tests**
  * Added coverage validating framing behavior across supported legacy controller variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->