### PR TITLE
fix(wasm): repair default gfx renderer, kill manifest 404s, fail browser test on console errors

### DIFF
--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -1651,6 +1651,9 @@ def generate_manifest(example_name: str, output_dir: Path) -> None:
     )
     data_files: list[dict[str, str | int]] = []
     _SKIP = frozenset(("fastled_js", ".build"))
+    # clangd/editor integration artifacts (`fastled --write-clangd`, IDE
+    # setups) that match data extensions but must never ship as sketch data.
+    _SKIP_FILES = frozenset(("compile_commands.json",))
 
     # Use os.scandir with directory pruning — avoids walking fastled_js/ and .build/
     # On Windows, DirEntry.stat() reuses FindFirstFile data (no extra syscall)
@@ -1666,9 +1669,18 @@ def generate_manifest(example_name: str, output_dir: Path) -> None:
                 for entry in it:
                     try:
                         if entry.is_dir(follow_symlinks=False):
-                            if entry.name not in _SKIP:
+                            # Prune hidden dirs (.vscode, .build variants) in
+                            # addition to the explicit skip list.
+                            if entry.name not in _SKIP and not entry.name.startswith(
+                                "."
+                            ):
                                 stack.append(entry.path)
                         elif entry.is_file(follow_symlinks=False):
+                            # IDE/tooling artifacts live next to the .ino but
+                            # are not sketch data: listing them makes the
+                            # frontend fetch (and 404) them at runtime.
+                            if entry.name.startswith(".") or entry.name in _SKIP_FILES:
+                                continue
                             _, ext = os.path.splitext(entry.name)
                             if ext.lower() in data_extensions:
                                 rel_path = entry.path[example_len:]

--- a/ci/wasm_test.py
+++ b/ci/wasm_test.py
@@ -36,8 +36,15 @@ def parse_args():
     )
     parser.add_argument(
         "--gfx",
-        default="0",
-        help="Graphics mode parameter (default: 0)",
+        default=None,
+        help="Graphics mode override (0=legacy 2D, 1=shared gfx renderer). "
+        "Default: no parameter, exercising the renderer users actually get.",
+    )
+    parser.add_argument(
+        "--allow-console-errors",
+        action="store_true",
+        help="Report browser console errors without failing the test "
+        "(default: any console error or uncaught page exception fails).",
     )
     return parser.parse_args()
 
@@ -206,7 +213,9 @@ async def main() -> None:
 
                 page.on("pageerror", page_error_handler)
 
-                test_url = f"http://localhost:{port}/?gfx={args.gfx}"
+                test_url = f"http://localhost:{port}/"
+                if args.gfx is not None:
+                    test_url += f"?gfx={args.gfx}"
                 console.print(f"[dim]Navigating to: {test_url}[/dim]")
                 await page.goto(
                     test_url,
@@ -293,6 +302,20 @@ async def main() -> None:
                         f"[bold red]✗ Error:[/bold red] FastLED.js failed to initialize within {max_wait_ms // 1000} seconds",
                     )
                     raise Exception("FastLED.js failed to initialize")
+
+                # Rendering alone is not success: any console error or uncaught
+                # page exception fails the run so runtime regressions (bad
+                # screenmaps, 404'd resources, worker crashes) can't ship
+                # silently. Opt out with --allow-console-errors.
+                fatal_errors = [e for e in browser_errors if e.startswith("[error]")]
+                if fatal_errors and not args.allow_console_errors:
+                    console.print(
+                        f"[bold red]✗ Error:[/bold red] {len(fatal_errors)} browser console "
+                        "error(s) detected (pass --allow-console-errors to downgrade)"
+                    )
+                    raise Exception(
+                        f"Browser console errors detected: {fatal_errors[:5]}"
+                    )
 
             except KeyboardInterrupt as ki:
                 handle_keyboard_interrupt(ki)

--- a/src/platforms/wasm/compiler/modules/graphics/graphics_manager_gfx.ts
+++ b/src/platforms/wasm/compiler/modules/graphics/graphics_manager_gfx.ts
@@ -10,17 +10,32 @@ function asBytes(value) {
   return null;
 }
 
-/** Convert FastLED's `{group: {strips: {id: {x, y}}}}` shape to package JSON. */
+/** Extract `{x, y, diameter?}` from a strip entry. The engine's wire shape
+ * nests coordinates as `{map: {x, y}, diameter}` (see js_bindings.cpp.hpp and
+ * graphics_manager.ts); bare `{x, y}` is accepted for pre-normalized data. */
+function stripCoords(strip) {
+  if (Array.isArray(strip?.x) && Array.isArray(strip?.y)) return strip;
+  if (Array.isArray(strip?.map?.x) && Array.isArray(strip?.map?.y)) {
+    const entry = { x: strip.map.x, y: strip.map.y };
+    if (typeof strip.diameter === 'number') entry.diameter = strip.diameter;
+    return entry;
+  }
+  return null;
+}
+
+/** Convert FastLED's `{group: {strips: {id: {map: {x, y}, diameter}}}}` shape to package JSON. */
 export function toGfxScreenmap(screenMaps) {
   if (screenMaps?.map) return screenMaps;
   const map = {};
   for (const [groupId, group] of Object.entries(screenMaps ?? {})) {
     if (group?.strips && typeof group.strips === 'object') {
       for (const [stripId, strip] of Object.entries(group.strips)) {
-        if (Array.isArray(strip?.x) && Array.isArray(strip?.y)) map[`${groupId}:${stripId}`] = strip;
+        const coords = stripCoords(strip);
+        if (coords) map[`${groupId}:${stripId}`] = coords;
       }
-    } else if (Array.isArray(group?.x) && Array.isArray(group?.y)) {
-      map[groupId] = group;
+    } else {
+      const coords = stripCoords(group);
+      if (coords) map[groupId] = coords;
     }
   }
   if (Object.keys(map).length === 0) throw new Error('screenmap: no coordinate strips found');
@@ -61,7 +76,10 @@ export class GraphicsManagerGfx {
   }
 
   updateScreenMap(screenMapsData) {
-    this.screenMaps = screenMapsData ?? {};
+    // Keep the previous screenmap when an empty update arrives; strips can
+    // register a moment after the first frames at startup.
+    if (!screenMapsData || Object.keys(screenMapsData).length === 0) return;
+    this.screenMaps = screenMapsData;
     if (this.core) this.core.setScreenmap(toGfxScreenmap(this.screenMaps));
   }
 
@@ -69,7 +87,9 @@ export class GraphicsManagerGfx {
     if (!frameData) return;
     if (frameData.screenMap) this.updateScreenMap(frameData.screenMap);
     if (!this.core) {
-      if (Object.keys(this.screenMaps).length === 0) throw new Error('screenmap: frame arrived before initialization');
+      // Frames can legitimately arrive before the screenmap during startup;
+      // skip them until coordinates exist instead of erroring every frame.
+      if (Object.keys(this.screenMaps).length === 0) return;
       this.core = createGfxCore({
         canvas: this.canvas,
         screenmap: toGfxScreenmap(this.screenMaps),
@@ -78,7 +98,11 @@ export class GraphicsManagerGfx {
         bloom: this._autoBloom ? { mode: 'auto' } : { mode: 'off' },
       });
     }
-    this.core.pushFrame(combineFrame(frameData));
+    const frame = combineFrame(frameData);
+    // Startup ticks can deliver zero strip bytes before the first show();
+    // the core treats a short frame as an error, so skip until data exists.
+    if (frame.byteLength === 0) return;
+    this.core.pushFrame(frame);
   }
 
   reset() { this.core?.dispose(); this.core = null; }

--- a/src/platforms/wasm/compiler/modules/ui/ui_manager.ts
+++ b/src/platforms/wasm/compiler/modules/ui/ui_manager.ts
@@ -1409,7 +1409,7 @@ export class JsonUiManager {
 
     // First pass: organize elements by group and analyze layout requirements
     jsonData.forEach((data) => {
-      console.log('data:', data);
+      if (this.debugMode) console.log('data:', data);
       const { group } = data;
       const hasGroup = group !== '' && group !== undefined && group !== null;
 
@@ -1417,7 +1417,7 @@ export class JsonUiManager {
       this.addElementLayoutHints(data);
 
       if (hasGroup) {
-        console.log(`Group ${group} found, for item ${data.name}`);
+        if (this.debugMode) console.log(`Group ${group} found, for item ${data.name}`);
         if (!groupedElements.has(group)) {
           groupedElements.set(group, []);
         }


### PR DESCRIPTION
## What

Follow-up to #3683: the WASM app had runtime console errors that no gate caught, and the **default** browser renderer was broken outright by the gfx-core refactor.

### Bugs fixed

1. **Default renderer never drew** (`graphics_manager_gfx.ts`): the shared `@fastled/gfx` adapter — the default whenever no `gfx=` URL override is present — expected strips shaped `{x, y}`, but the engine wire format nests coordinates as `{map: {x, y}, diameter}` (see `js_bindings.cpp.hpp` and the legacy `graphics_manager.ts`). Every strip was dropped, the worker threw `screenmap: no coordinate strips found` **per frame**, and rendering fell through to a fallback. Also hardened the startup races the fix exposed: empty screenmap updates no longer clobber a good one, frames arriving before the screenmap are skipped instead of throwing per frame, and zero-byte startup frames are dropped instead of tripping the core's frame-size check.
2. **Manifest 404s** (`ci/wasm_build.py`): `generate_manifest()` swept every `.json` in the sketch dir into `files.json`, so clangd artifacts (`.vscode/settings.json`, `compile_commands.json`) written by `fastled --write-clangd` got listed as sketch data — the frontend fetched them and logged two 404 console errors on every load. Hidden dirs/files and `compile_commands.json` are now pruned.
3. **Console log spam** (`ui_manager.ts`): the unconditional per-element `data:` / `Group … found, for item …` logs (one of which, garbled, was mistaken for an error during triage) are now debug-gated.

### Why no test caught this

`ci/wasm_test.py` (Playwright) had two blind spots:
- It **captured console errors but only printed them** — success was judged solely on "frames rendered".
- It forced `?gfx=0`, so CI only ever exercised the **legacy** renderer, never the default one users get.

### The gate (friction-free error catching)

`ci/wasm_test.py` now **fails on any browser console error or uncaught page exception** (opt out with `--allow-console-errors`) and defaults to **no `gfx` override**, exercising the real default renderer. Either change alone would have caught everything above.

## Validation

- `uv run ci/wasm_test.py hydropack` / `wasm` / `Blink` — all pass strict mode on the default renderer, zero console errors.
- Live `fastled` CLI server (`fastled examples/hydropack --no-https`): 3 consecutive Playwright sweeps, zero console errors / page errors / 4xx-5xx.
- End-to-end visual: injected a synthesized beat WAV over CDP — the default renderer now draws the dual rings (with bloom) correctly; accent beats light both rings, regular beats only the sensitive inner ring.
- `bash lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graphics startup handling to prevent errors when screen maps or frame data are temporarily unavailable.
  * Added support for additional screen map coordinate formats and strip diameter information.
  * Improved browser test failure detection for fatal console errors.
  * Prevented build manifests from including hidden files, directories, and tooling artifacts.
  * Suppressed diagnostic UI logging unless debug mode is enabled.

* **Improvements**
  * Graphics tests no longer add an unnecessary graphics parameter when it is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->