### PR TITLE
fix(examples): restrict HydroPack to ESP32 builds

### DIFF
--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -5,7 +5,7 @@
 ///          INMP441 mic -> normalized bass detection -> 50 Hz PWM gates.
 /// @example hydropack.ino
 
-// @filter: (mem is large)
+// @filter: (mem is large) and (platform is esp32*)
 
 // This sketch targets the ESP32-C3 and is also a valid FastLED WASM sketch:
 //   pip install fastled


### PR DESCRIPTION
Closes #3685

## Summary
- Restrict the HydroPack example to ESP32-family board builds.
- Prevent Teensy CI from linking unavailable Teensy Audio classes.
- Preserve the documented WASM preview and ESP32-C3 target.

## Validation
- bash compile teensy41 --examples hydropack (skips by filter)
- bash compile wasm --examples hydropack
- bash compile esp32c3 --examples hydropack
- bash lint --cpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hydropack example’s platform selection guidance to include ESP32 targets while retaining the existing memory requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->