### PR TITLE
fix(wasm): recover Hydropack microphone after cancellation

### DIFF
--- a/ci/wasm_audio_microphone_test.py
+++ b/ci/wasm_audio_microphone_test.py
@@ -1,0 +1,110 @@
+"""Playwright regression test for the Hydropack WASM microphone control.
+
+Regression coverage for issue #3688.
+
+The first permission request is cancelled in-page. Chromium's fake capture
+device then makes the second request deterministic, allowing this test to
+verify that cancellation leaves the control reusable without physical audio
+hardware.
+
+Usage:
+    uv run python ci/wasm_audio_microphone_test.py [example]
+"""
+
+import asyncio
+import socket
+import time
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+from ci.wasm_test import _find_free_port, start_http_server
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+async def main() -> None:
+    example = "HydroPack"
+    directory = PROJECT_ROOT / "examples" / example / "fastled_js"
+    if not directory.exists():
+        raise FileNotFoundError(
+            f"{directory} does not exist; run bash compile wasm --examples {example}"
+        )
+
+    port = _find_free_port(9133)
+    server = start_http_server(port, directory)
+    try:
+        for _ in range(20):
+            if not server.is_alive():
+                raise RuntimeError(f"WASM server failed to start on port {port}")
+            try:
+                with socket.create_connection(("localhost", port), timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError(f"WASM server did not start on port {port}")
+
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(
+                args=[
+                    "--autoplay-policy=no-user-gesture-required",
+                    "--use-fake-device-for-media-stream",
+                    "--use-fake-ui-for-media-stream",
+                ]
+            )
+            context = await browser.new_context()
+            await context.grant_permissions(
+                ["microphone"], origin=f"http://localhost:{port}"
+            )
+            page = await context.new_page()
+            await page.add_init_script(
+                """
+                (() => {
+                  const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(
+                    navigator.mediaDevices
+                  );
+                  let calls = 0;
+                  navigator.mediaDevices.getUserMedia = async (constraints) => {
+                    calls += 1;
+                    if (calls === 1) {
+                      throw new DOMException('Permission request dismissed', 'AbortError');
+                    }
+                    return originalGetUserMedia(constraints);
+                  };
+                })();
+                """
+            )
+            await page.goto(f"http://localhost:{port}/", wait_until="domcontentloaded")
+
+            microphone = page.locator("button.audio-mic-button")
+            await microphone.first.wait_for(state="visible", timeout=30000)
+            await microphone.first.click()
+
+            error = page.locator(".audio-error")
+            await error.wait_for(state="visible")
+            assert await error.text_content() == "Microphone Access Cancelled"
+            assert await microphone.first.is_enabled()
+            assert await microphone.first.text_content() == "🎤 Microphone"
+
+            await microphone.first.click()
+            await microphone.first.wait_for(state="visible")
+            await page.wait_for_function(
+                """() => document.querySelector('button.audio-mic-button')?.textContent ===
+                '🛑 Stop Recording'"""
+            )
+
+            await microphone.first.click()
+            await page.wait_for_function(
+                """() => document.querySelector('button.audio-mic-button')?.textContent ===
+                '🎤 Microphone'"""
+            )
+            await browser.close()
+    finally:
+        server.terminate()
+        server.join(timeout=5)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/platforms/wasm/compiler/modules/audio/audio_manager.ts
+++ b/src/platforms/wasm/compiler/modules/audio/audio_manager.ts
@@ -1164,24 +1164,70 @@ export class AudioManager {
    * @param {HTMLElement} controlDiv - The control container
    */
   setupMicrophoneHandler(micButton, controlDiv) {
-    let isCapturing = false;
+    let state = 'idle';
 
     micButton.addEventListener('click', async () => {
-      if (!isCapturing) {
-        // Start microphone capture
+      if (state === 'starting' || state === 'stopping') {
+        return;
+      }
+
+      if (state === 'capturing') {
+        state = 'stopping';
         try {
-          await this.startMicrophoneCapture(micButton, controlDiv);
-          isCapturing = true;
-        } catch (error) {
-          console.error('🎤 Failed to start microphone capture:', error);
+          await this.stopMicrophoneCapture(micButton, controlDiv);
+        } finally {
+          state = 'idle';
+        }
+        return;
+      }
+
+      state = 'starting';
+      micButton.disabled = true;
+      try {
+        await this.startMicrophoneCapture(micButton, controlDiv);
+        state = 'capturing';
+      } catch (error) {
+        console.error('🎤 Failed to start microphone capture:', error);
+        this.resetMicrophoneUi(micButton, controlDiv);
+        try {
+          const message = await this.getMicrophoneErrorMessage(error);
+          this.showAudioError(controlDiv, message);
+        } catch (messageError) {
+          console.error('🎤 Failed to determine microphone error:', messageError);
           this.showAudioError(controlDiv, 'Failed to access microphone. Please check permissions.');
         }
-      } else {
-        // Stop microphone capture
-        await this.stopMicrophoneCapture(micButton, controlDiv);
-        isCapturing = false;
+      } finally {
+        state = state === 'capturing' ? state : 'idle';
+        micButton.disabled = false;
       }
     });
+  }
+
+  /**
+   * Convert browser microphone errors into useful user-facing messages.
+   * Dismissing the permission prompt is reported as NotAllowedError by
+   * Chromium, so use the Permissions API state to distinguish it from a
+   * previously denied permission when the browser exposes that state.
+   */
+  async getMicrophoneErrorMessage(error) {
+    if (error?.name === 'AbortError') {
+      return 'Microphone Access Cancelled';
+    }
+
+    if (error?.name === 'NotAllowedError') {
+      try {
+        const permission = await navigator.permissions?.query({ name: 'microphone' });
+        if (!permission || permission.state === 'prompt') {
+          return 'Microphone Access Cancelled';
+        }
+      } catch (permissionError) {
+        if (AUDIO_DEBUG.enabled) {
+          console.warn('🎤 Could not query microphone permission state:', permissionError);
+        }
+      }
+    }
+
+    return 'Failed to access microphone. Please check permissions.';
   }
 
   /**
@@ -1190,9 +1236,13 @@ export class AudioManager {
    * @param {HTMLElement} controlDiv - The control container
    */
   async startMicrophoneCapture(micButton, controlDiv) {
+    let stream = null;
+    const audioInput = controlDiv.querySelector('input[type="file"]');
+    const audioId = audioInput ? audioInput.id : 'unknown';
+
     try {
       // Request microphone access
-      const stream = await navigator.mediaDevices.getUserMedia({
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           echoCancellation: true,
           noiseSuppression: true,
@@ -1201,20 +1251,14 @@ export class AudioManager {
         }
       });
 
-      // Update button state
-      micButton.textContent = '🛑 Stop Recording';
-      micButton.className = 'audio-mic-button recording';
-      micButton.title = 'Stop microphone recording';
-
-      // Get the audio input ID from the container
-      const audioInput = controlDiv.querySelector('input[type="file"]');
-      const audioId = audioInput ? audioInput.id : 'unknown';
-
       // Clean up any previous audio context
       await this.cleanupPreviousAudioContext(audioId);
 
       // Small delay to ensure cleanup is complete
       await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+      // Store before setup so a partial pipeline can be cleaned up on error.
+      this.storeMediaStream(audioId, stream);
 
       // Create audio element for the stream
       const audio = this.createStreamAudioElement(controlDiv, stream);
@@ -1225,12 +1269,23 @@ export class AudioManager {
       // Update UI to show recording state
       this.updateAudioProcessingIndicator(controlDiv);
 
-      // Store the stream for cleanup
-      this.storeMediaStream(audioId, stream);
+      // Update button state only after the complete pipeline is ready.
+      micButton.textContent = '🛑 Stop Recording';
+      micButton.className = 'audio-mic-button recording';
+      micButton.title = 'Stop microphone recording';
 
       console.log('🎤 Microphone capture started successfully');
     } catch (error) {
       console.error('🎤 Error starting microphone capture:', error);
+      if (stream) {
+        stream.getTracks().forEach(track => track.stop());
+      }
+      try {
+        await this.cleanupPreviousAudioContext(audioId);
+      } catch (cleanupError) {
+        console.error('🎤 Error cleaning up failed microphone startup:', cleanupError);
+      }
+      this.resetMicrophoneUi(micButton, controlDiv);
       throw error;
     }
   }
@@ -1264,20 +1319,33 @@ export class AudioManager {
         controlDiv.removeChild(existingAudio);
       }
 
-      // Reset button state
-      micButton.textContent = '🎤 Microphone';
-      micButton.className = 'audio-mic-button';
-      micButton.title = 'Capture audio from microphone';
-
-      // Remove processing indicator
-      const existingIndicator = controlDiv.querySelector('.audio-indicator');
-      if (existingIndicator) {
-        controlDiv.removeChild(existingIndicator);
-      }
-
       console.log('🎤 Microphone capture stopped');
     } catch (error) {
       console.error('🎤 Error stopping microphone capture:', error);
+    } finally {
+      this.resetMicrophoneUi(micButton, controlDiv);
+    }
+  }
+
+  /**
+   * Restore the microphone control to its reusable idle state.
+   */
+  resetMicrophoneUi(micButton, controlDiv) {
+    micButton.textContent = '🎤 Microphone';
+    micButton.className = 'audio-mic-button';
+    micButton.title = 'Capture audio from microphone';
+    micButton.disabled = false;
+
+    const existingIndicator = controlDiv.querySelector('.audio-indicator');
+    if (existingIndicator) {
+      controlDiv.removeChild(existingIndicator);
+    }
+
+    const existingAudio = controlDiv.querySelector('audio');
+    if (existingAudio) {
+      existingAudio.pause();
+      existingAudio.srcObject = null;
+      controlDiv.removeChild(existingAudio);
     }
   }
 


### PR DESCRIPTION
Closes #3688

## Summary
- distinguish cancelled microphone access from permission failures
- make microphone startup transactional and clean up partial streams/audio pipelines
- serialize microphone start/stop operations and always restore the reusable button state
- add a deterministic Playwright regression test using Chromium's fake microphone device

## Verification
- `bash lint --js` — pass (existing unrelated complexity warning only)
- `bash compile wasm --examples HydroPack` — pass
- `uv run python ci/wasm_test.py HydroPack` — pass
- `uv run python ci/wasm_audio_microphone_test.py` — pass
- full `bash lint` reached the existing Rust linter environment failure because `x86_64-pc-windows-msvc` is not installed; Python/TypeScript/JS/Meson/policy stages passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved microphone recording controls with clearer transitions between starting, recording, and stopping.
  * Added more informative messages for microphone cancellation, permission requests, and access denials.

* **Bug Fixes**
  * Microphone controls now reliably reset after recording errors or cleanup failures.
  * Fixed cancellation handling so recording can be started again without reloading.
  * Improved compatibility with environments without physical audio hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->