### PR TITLE
fix(wasm): serve local apps with cross-origin isolation

### DIFF
--- a/ci/wasm_server.py
+++ b/ci/wasm_server.py
@@ -1,0 +1,60 @@
+"""Serve a WASM example with the headers required by pthreads/SAB builds."""
+
+import argparse
+import http.server
+import socketserver
+import webbrowser
+from pathlib import Path
+
+
+class IsolatedRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Static-file handler that enables cross-origin isolation."""
+
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".js": "application/javascript",
+        ".mjs": "application/javascript",
+        ".wasm": "application/wasm",
+        ".json": "application/json",
+        ".css": "text/css",
+    }
+
+    def end_headers(self) -> None:
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        super().end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--no-browser", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    directory = args.directory.resolve()
+    if not directory.is_dir():
+        raise FileNotFoundError(f"WASM output directory not found: {directory}")
+
+    handler = lambda *handler_args, **handler_kwargs: IsolatedRequestHandler(  # noqa: E731
+        *handler_args, directory=str(directory), **handler_kwargs
+    )
+    with socketserver.ThreadingTCPServer(("", args.port), handler) as server:
+        url = f"http://127.0.0.1:{args.port}/"
+        print(f"Serving cross-origin-isolated WASM app at {url}", flush=True)
+        if not args.no_browser:
+            webbrowser.open(url)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping WASM server", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/run
+++ b/run
@@ -3,7 +3,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-# bash run wasm <example_name> - Compile WASM example and serve with live-server
+# bash run wasm <example_name> - Compile WASM example and serve with isolation
 # Example: bash run wasm AnimartrixRing
 
 if [ $# -eq 0 ]; then
@@ -49,15 +49,7 @@ if [ $COMPILE_EXIT -ne 0 ]; then
     exit $COMPILE_EXIT
 fi
 
-# Step 2: Check if live-server is installed
-if ! command -v live-server &> /dev/null; then
-    echo ""
-    echo "Error: live-server not found"
-    echo "Install it with: npm install -g live-server"
-    exit 1
-fi
-
-# Step 3: Serve with live-server
+# Step 3: Serve with the COOP/COEP headers required by WASM pthreads.
 OUTPUT_DIR="examples/${EXAMPLE_NAME}/fastled_js"
 
 if [ ! -d "$OUTPUT_DIR" ]; then
@@ -71,8 +63,8 @@ echo "=========================================="
 echo "Step 2: Serving ${OUTPUT_DIR}"
 echo "=========================================="
 echo ""
-echo "Starting live-server..."
+echo "Starting cross-origin-isolated WASM server..."
 echo "Press Ctrl+C to stop"
 echo ""
 
-live-server "$OUTPUT_DIR"
+uv run python ci/wasm_server.py "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- replace plain `live-server` in `bash run wasm <example>` with the repository-owned static server
- add COOP/COEP headers required for SharedArrayBuffer and WASM pthread workers
- preserve automatic browser opening and local development workflow

## Verification
- `bash compile wasm --examples HydroPack` — pass
- response headers verified: `same-origin` / `require-corp`
- browser probe verified `crossOriginIsolated: true` and worker initialization
- `uv run python ci/wasm_test.py HydroPack` — pass
- Python/JS/TypeScript checks passed; full lint is otherwise blocked only by the missing Windows Rust target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated server for WASM demos with cross-origin isolation support.
  * Added automatic handling for common WASM and JavaScript file types.
  * Added configurable output directory, port, and optional browser launch settings.

* **Bug Fixes**
  * Improved support for WASM builds that use threads and shared memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->