### PR TITLE
fix(teensy): expose Audio dependency to LDF scanners

### DIFF
--- a/src/platforms/arm/teensy/ldf_headers.h
+++ b/src/platforms/arm/teensy/ldf_headers.h
@@ -4,11 +4,19 @@
 
 // ok no namespace fl
 
+#include "platforms/arm/teensy/audio_input_teensy_config.h"
+
 /// @file platforms/arm/teensy/ldf_headers.h
 /// Teensy PlatformIO Library Dependency Finder (LDF) hints
 ///
-/// This file contains #if 0 blocks with library includes to hint dependencies
-/// to PlatformIO's LDF scanner without actually compiling the code.
+/// This file exposes Teensy framework dependencies through the FastLED include
+/// chain so PlatformIO's LDF and fbuild's header scanner can select them.
 
-// Teensy platform - no additional LDF hints needed currently
-// Add library includes here if LDF issues are discovered
+// Keep the Teensy Audio dependency in the normal FastLED include chain. This
+// is intentional: PlatformIO LDF and fbuild both need to see Audio.h in a
+// reachable header in order to select the bundled Audio implementation.
+#if FASTLED_USES_TEENSY_AUDIO_INPUT && TEENSY_AUDIO_LIBRARY_AVAILABLE
+// IWYU pragma: begin_keep
+#include <Audio.h>
+// IWYU pragma: end_keep
+#endif


### PR DESCRIPTION
## Summary

- expose `<Audio.h>` through FastLED’s Teensy platform include chain
- let PlatformIO LDF and fbuild observe/select the Teensy Audio implementation
- preserve the existing `TEENSY_AUDIO_LIBRARY_AVAILABLE` guard and low-RAM board exclusions

## Intended result

The intended result is that a sketch including only `FastLED.h` places Teensy Audio in the dependency chain for both PlatformIO LDF and fbuild. This is a small dependency-discovery shim; it does not manually compile Audio sources or broadly enable unrelated Teensy framework libraries. LTO and section garbage collection remain responsible for removing unused Audio code.

## Validation

- `bash compile teensy41 --examples Blink` — passed; fbuild compile database contains `libraries/Audio/input_i2s.cpp` and `input_i2s2.cpp`; flash remained 100,352 bytes and RAM was 72,544 bytes.
- `bash compile teensy41 --examples AudioInput` — passed; Teensy Audio consumer links successfully.
- `bash compile wasm --examples Blink` — passed.
- `bash lint --cpp` — passed; existing 42 PlatformIO-internal findings remain warn-only.

Coordinated with FastLED/fbuild#1088.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Teensy Audio library detection and integration for PlatformIO projects.
  * Ensured the Audio library is included when Teensy audio input support is enabled and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->