### PR TITLE
ci(teensy): add AudioInput parity coverage

### DIFF
--- a/.github/workflows/nightly_fbuild_pio_parity.yml
+++ b/.github/workflows/nightly_fbuild_pio_parity.yml
@@ -48,13 +48,16 @@ jobs:
       fail-fast: false
       matrix:
         # Representative cross-section: ESP32 (toolchain via pioarduino),
-        # Teensy 4.x (ARM EABI), and a tiny AVR (avr-gcc). One example
-        # per board to keep the run cost bounded.
+        # Teensy 4.x (ARM EABI), and a tiny AVR (avr-gcc). The Teensy pair
+        # keeps both the minimal-size baseline and the Audio LDF/link path
+        # covered on the same board.
         include:
           - board: esp32dev
             example: Blink
-          - board: teensy40
+          - board: teensy41
             example: Blink
+          - board: teensy41
+            example: AudioInput
           - board: uno
             example: Blink
     steps:


### PR DESCRIPTION
## Summary

- run the nightly fbuild/PlatformIO parity sweep on Teensy 4.1
- retain Blink as the minimal-size baseline
- add AudioInput so both backends exercise Teensy Audio LDF selection and link resolution

Refs FastLED/fbuild#1088.

## Validation

- `bash compile teensy41 --examples Blink`
- `bash compile teensy41 --backend platformio --examples Blink`
- `bash compile teensy41 --examples AudioInput`
- `bash compile teensy41 --backend platformio --examples AudioInput`
- `bash lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded nightly board coverage by switching the representative Teensy target to Teensy 4.1.
  * Added AudioInput validation alongside the Blink baseline to exercise audio linking paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->