### PR TITLE
fix(rp2040): keep multi-lane SPI out of channel adapter

### DIFF
--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -8,7 +8,7 @@
 /// to ChannelManager::instance().
 ///
 /// Priority Order:
-/// - SPI_UNIFIED (6-8): True SPI hardware (octal/quad/dual-lane via PIO)
+/// - SPI_UNIFIED: True single-lane SPI channel hardware
 ///
 /// Architecture Pattern:
 /// This follows the ESP32 pattern:
@@ -26,9 +26,6 @@
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/stl/shared_ptr.h"
-#include "platforms/shared/spi_hw_2.h"
-#include "platforms/shared/spi_hw_4.h"
-#include "platforms/shared/spi_hw_8.h"
 #include "platforms/arm/rp/rpcommon/init_channel_driver.h"
 #include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
 #include "platforms/arm/rp/rpcommon/rp_spi_bus_traits.h"
@@ -46,47 +43,11 @@ static void addSpiHardwareIfPossible(ChannelManager& manager) {
     fl::vector<int> priorities;
     fl::vector<const char*> names;
 
-    // ========================================================================
-    // Collect SpiHw8 controllers (highest priority: 8)
-    // ========================================================================
-    const auto& hw8Controllers = SpiHw8::getAll();
-    FL_DBG_F("RP2040/RP2350: Found %s SpiHw8 controllers", hw8Controllers.size());
-
-    for (const auto& ctrl : hw8Controllers) {
-        if (ctrl) {
-            controllers.push_back(ctrl);
-            priorities.push_back(8);
-            names.push_back(ctrl->getName());  // "SPI0" or "SPI1"
-        }
-    }
-
-    // ========================================================================
-    // Collect SpiHw4 controllers (medium priority: 7)
-    // ========================================================================
-    const auto& hw4Controllers = SpiHw4::getAll();
-    FL_DBG_F("RP2040/RP2350: Found %s SpiHw4 controllers", hw4Controllers.size());
-
-    for (const auto& ctrl : hw4Controllers) {
-        if (ctrl) {
-            controllers.push_back(ctrl);
-            priorities.push_back(7);
-            names.push_back(ctrl->getName());  // "SPI0" or "SPI1"
-        }
-    }
-
-    // ========================================================================
-    // Collect SpiHw2 controllers (lower priority: 6)
-    // ========================================================================
-    const auto& hw2Controllers = SpiHw2::getAll();
-    FL_DBG_F("RP2040/RP2350: Found %s SpiHw2 controllers", hw2Controllers.size());
-
-    for (const auto& ctrl : hw2Controllers) {
-        if (ctrl) {
-            controllers.push_back(ctrl);
-            priorities.push_back(6);
-            names.push_back(ctrl->getName());  // "SPI0" or "SPI1"
-        }
-    }
+    // RP2040's PIO-based SpiHw2/4/8 controllers are intentionally not added
+    // here. They are multi-lane backends for MultiLaneDevice, which owns the
+    // lane buffers and performs the required bit transposition before DMA.
+    // SpiChannelEngineAdapter receives independent ChannelData buffers and
+    // cannot safely reinterpret them as a parallel transfer.
 
     // ========================================================================
     // Create unified adapter with all controllers


### PR DESCRIPTION
Closes #3699\n\n## Summary\n- keep RP2040 PIO multi-lane SPI controllers on their dedicated MultiLaneDevice path\n- stop registering independent SpiHw2/4/8 controllers with the single-channel adapter\n- preserve the concrete dual/quad/octal implementations and transposition path\n\n## Validation\n- bash test tests/fl/channels/spi (pass)\n- bash test tests/fl/channels/adapters/spi_channel_adapter (pass)\n- bash compile rp2040 --examples Blink (fbuild daemon/zccache timeout; no source diagnostic)\n- bash lint (blocked by missing x86_64-pc-windows-msvc Rust target in the local environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SPI channel prioritization to accurately identify true single-lane SPI hardware.
  * Removed multi-lane PIO SPI backends from unified SPI adapter registration, preventing unsupported controllers from being exposed.
  * Improved handling when no compatible SPI hardware controllers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->