### PR TITLE
docs(rp2040): document public hardware SPI routing

### DIFF
--- a/src/platforms/arm/compile_test.hpp
+++ b/src/platforms/arm/compile_test.hpp
@@ -101,7 +101,11 @@ static void arm_compile_tests() {
     #error "RP2040 platforms should have FASTLED_ALLOW_INTERRUPTS set to 1"
     #endif
     #ifdef FASTLED_FORCE_SOFTWARE_SPI
-    // RP2040 forces software SPI - this is expected
+    // The legacy SPI manager remains software-only; public SPI chipsets use
+    // the channel API instead.
+    #endif
+    #if FASTLED_SPI_USES_CHANNEL_API != 1
+    #error "RP2040 public SPI chipsets must use the Channel API"
     #endif
 #endif
 

--- a/src/platforms/arm/rp/rpcommon/README.md
+++ b/src/platforms/arm/rp/rpcommon/README.md
@@ -169,6 +169,19 @@ Data:  GPIO 3, 5, 7, 9, 11, 13, 15, 17
 
 ### System Definitions
 
+#### Public SPI API routing
+
+RP2040's legacy `SPIOutput` template is intentionally software-only. The
+public `FastLED.addLeds<APA102...>()` and `FastLED.addLeds<SK9822...>()` paths
+are routed through the Channel API by `FASTLED_SPI_USES_CHANNEL_API` and use
+`ChannelEngineRpSpi` with the fixed-function PL022 SPI0/SPI1 drivers. This is
+the supported public hardware-SPI path for one LED stream.
+
+The PIO+DMA `SpiHw2`, `SpiHw4`, and `SpiHw8` implementations are reserved for
+`MultiLaneDevice`, which owns the per-lane buffers and performs bit
+transposition before transmission. They are not interchangeable with the
+single-channel `SpiChannelEngineAdapter`.
+
 #### `led_sysdefs_rp_common.h`
 **Purpose**: Common system definitions shared across all RP2xxx platforms
 

--- a/src/platforms/arm/rp/rpcommon/led_sysdefs_rp_common.h
+++ b/src/platforms/arm/rp/rpcommon/led_sysdefs_rp_common.h
@@ -33,7 +33,11 @@
 // - RP2040: Cortex-M0+ → defined in led_sysdefs_arm_rp2040.h
 // - RP2350: Cortex-M33 → NOT defined (uses compiler's __ARM_ARCH_8M_MAIN__)
 
-// TODO: PORT SPI TO HW
+// The legacy SPIOutput template remains software-only on RP2xxx. Public
+// APA102/SK9822 addLeds() calls are routed through the RP channel API by
+// FASTLED_SPI_USES_CHANNEL_API and use ChannelEngineRpSpi with PL022 SPI0/1.
+// Keep this define for callers that explicitly use the legacy SPI manager;
+// removing it would silently select an unimplemented legacy hardware backend.
 //#define FASTLED_SPI_BYTE_ONLY
 #define FASTLED_FORCE_SOFTWARE_SPI
 // Force FAST_SPI_INTERRUPTS_WRITE_PINS on becuase two cores running


### PR DESCRIPTION
Closes #3698\n\n## Summary\n- document that public APA102/SK9822 addLeds routes through the RP Channel API\n- distinguish the supported fixed SPI0/SPI1 path from legacy SPIOutput and multi-lane PIO backends\n- add a compile-time RP2040 guard requiring the public SPI Channel API\n\n## Validation\n- bash test tests/fl/chipsets/spi_frame_protocol (pass)\n- bash compile rp2040 --examples Blink (blocked by fbuild daemon disconnect before compilation)\n- bash lint (blocked by missing x86_64-pc-windows-msvc Rust target in the local environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compile-time validation to ensure RP2040 and Pico targets use the supported public SPI channel API.

* **Documentation**
  * Clarified SPI routing for APA102 and SK9822 LED strips.
  * Documented the distinction between public channel-based SPI and legacy or multi-lane SPI implementations.
  * Added guidance for maintaining compatibility with legacy SPI users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->