### PR TITLE
test(spi): cover public SK9822 channel API

### DIFF
--- a/tests/fl/channels/bus_traits.cpp
+++ b/tests/fl/channels/bus_traits.cpp
@@ -100,11 +100,14 @@ FL_TEST_CASE("FastLED.addLeds<APA102, ..., fl::Bus::BIT_BANG> SPI variant compil
 
 FL_TEST_CASE("FastLED.addLeds default-AUTO call sites compile") {
     static CRGB clockless[8];
-    static CRGB spi[8];
+    static CRGB apa102[8];
+    static CRGB sk9822[8];
     auto& a = FastLED.addLeds<WS2812, 3, GRB>(clockless, 8);
-    auto& b = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12)>(spi, 8);
+    auto& b = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12)>(apa102, 8);
+    auto& c = FastLED.addLeds<SK9822, 24, 19, RGB, DATA_RATE_MHZ(12)>(sk9822, 8);
     (void)a;
     (void)b;
+    (void)c;
 }
 
 FL_TEST_CASE("enableDrivers<Bus::BIT_BANG>() is idempotent") {


### PR DESCRIPTION
Closes #3700\n\n## Summary\n- compile the default public SK9822 addLeds call alongside APA102\n- preserve explicit channel/bus routing coverage\n- pair public API coverage with the existing APA102/SK9822 framing tests\n\n## Validation\n- bash test tests/fl/channels/bus_traits (pass)\n- bash test tests/fl/chipsets/spi_frame_protocol (pass on #3704)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded compile-time coverage for automatic bus selection across WS2812, APA102, and SK9822 LED types.
  * Added validation for separate LED buffers and wiring configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->