### PR TITLE
fix(wasm): enforce canonical Meson path joins

### DIFF
--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -42,8 +42,11 @@ def _wasm_fast_path() -> int | None:
     Returns exit code if handled, None to fall through to full argument parser.
     Saves ~130ms by skipping CompilationArgumentParser and its 62 transitive imports.
     """
-    # argv: ci-compile.py wasm ExampleName [--run] [--just-compile] [-v]
+    # argv: ci-compile.py wasm ExampleName [--clean] [--run] [--just-compile] [-v]
     args = sys.argv[1:]
+    has_clean = "--clean" in args
+    if has_clean:
+        args = [arg for arg in args if arg != "--clean"]
     if not args or args[0].lower() != "wasm":
         return None
     rest = args[1:]
@@ -78,6 +81,8 @@ def _wasm_fast_path() -> int | None:
         # --run needs wasm_compile for Playwright test orchestration
         saved_argv = sys.argv
         sys.argv = ["ci.wasm_compile", f"examples/{example}"]
+        if has_clean:
+            sys.argv.append("--force")
         sys.argv.append("--run")
         try:
             from ci.wasm_compile import main as wasm_compile_main
@@ -96,7 +101,12 @@ def _wasm_fast_path() -> int | None:
 
     from ci.wasm_build import build as wasm_build
 
-    rc = wasm_build(example=example, output=str(output_js), verbose=has_verbose)
+    rc = wasm_build(
+        example=example,
+        output=output_js.as_posix(),
+        verbose=has_verbose,
+        force=has_clean,
+    )
     if rc == 0:
         print("WASM compilation successful")
     else:

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -333,9 +333,9 @@ def main() -> int:
         # Create duration tracker
         tracker = DurationTracker()
 
-        # Determine if we should run in parallel
-        # Parallel mode: 2+ stages and not in single-mode (--cpp/--js)
-        parallel = len(stages) > 1 and not args.js_only and not args.cpp_only
+        # Run every multi-stage invocation concurrently.  `--cpp` includes the
+        # C++, Meson, and repository-policy checks, all of which are independent.
+        parallel = len(stages) > 1
 
         # Create orchestrator
         orchestrator = LintOrchestrator(stages, tracker, parallel)

--- a/ci/lint/stage_impls.py
+++ b/ci/lint/stage_impls.py
@@ -225,6 +225,8 @@ def run_cpp_lint(
         cmd = ["uv", "run", "python", "ci/lint_cpp/run_all_checkers.py"]
         if use_rust_cpp_lint:
             cmd.append("--rust")
+        else:
+            cmd.append("--no-rust")
 
         # 900s (15 min) covers cold CI runners that must `cargo install`
         # the zccache binary from source — happens on macOS when soldr's

--- a/ci/lint_meson/path_norm_join_checker.py
+++ b/ci/lint_meson/path_norm_join_checker.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reject Meson ``/`` joins on canonical forward-slash path variables.
+
+``path_norm_*`` values are deliberately composed with ``+ '/' +``. Meson's
+``/`` operator uses the host-native separator, so applying it to one of those
+values on Windows creates a mixed-separator path and defeats compiler/PCH
+caches. A small lexer removes comments and quoted strings before a regex
+checks the unambiguous unsafe token sequence; a full Meson parser would add
+substantial complexity without improving this focused rule.
+"""
+
+import re
+
+from ci.util.check_files import FileContent, FileContentChecker
+
+
+_PATH_NORM_JOIN_PATTERN = re.compile(r"\b(path_norm_[A-Za-z0-9_]*)\s*/")
+
+
+def _code_without_strings_and_comments(line: str) -> str:
+    """Replace quoted strings and comments so only executable Meson remains."""
+    code: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for char in line:
+        if quote is not None:
+            code.append(" ")
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+        elif char in {"'", '"'}:
+            quote = char
+            code.append(" ")
+        elif char == "#":
+            break
+        else:
+            code.append(char)
+    return "".join(code)
+
+
+class PathNormJoinChecker(FileContentChecker):
+    """Forbid host-native Meson path joins on ``path_norm_*`` values."""
+
+    def __init__(self) -> None:
+        self.violations: dict[str, list[tuple[int, str]]] = {}
+
+    def should_process_file(self, file_path: str) -> bool:
+        return file_path.replace("\\", "/").endswith("meson.build")
+
+    def check_file_content(self, file_content: FileContent) -> list[str]:
+        for line_number, line in enumerate(file_content.lines, 1):
+            code = _code_without_strings_and_comments(line)
+            match = _PATH_NORM_JOIN_PATTERN.search(code)
+            if match:
+                variable = match.group(1)
+                self.violations.setdefault(file_content.path, []).append(
+                    (
+                        line_number,
+                        f"Meson's '/' operator injects native separators when "
+                        f"joining {variable}. Use string concatenation with a "
+                        f"literal forward slash instead: {variable} + '/' + "
+                        "'relative/path'.",
+                    )
+                )
+        return []

--- a/ci/lint_meson/run_all_checkers.py
+++ b/ci/lint_meson/run_all_checkers.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 from ci.lint_meson.backslash_path_checker import BackslashPathChecker
+from ci.lint_meson.path_norm_join_checker import PathNormJoinChecker
 from ci.util.check_files import FileContentChecker, MultiCheckerFileProcessor
 
 
@@ -21,8 +22,13 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 def _collect_meson_files(root: Path) -> list[str]:
-    """Find all meson.build files under root."""
-    return sorted(str(p) for p in root.rglob("meson.build") if ".build" not in p.parts)
+    """Find repository Meson files, excluding generated and nested worktrees."""
+    excluded_directories = {".build", ".claude", ".git"}
+    return sorted(
+        str(path)
+        for path in root.rglob("meson.build")
+        if not excluded_directories.intersection(path.relative_to(root).parts)
+    )
 
 
 def _collect_violations(
@@ -68,6 +74,7 @@ def run_meson_lint() -> bool:
     # All checkers — add new checkers here
     checkers: list[FileContentChecker] = [
         BackslashPathChecker(),
+        PathNormJoinChecker(),
     ]
 
     processor = MultiCheckerFileProcessor()

--- a/ci/lint_meson/test_path_norm_join_checker.py
+++ b/ci/lint_meson/test_path_norm_join_checker.py
@@ -1,0 +1,54 @@
+"""Tests for the Meson canonical-path join lint rule."""
+
+from pathlib import Path
+
+from ci.lint_meson.path_norm_join_checker import PathNormJoinChecker
+from ci.lint_meson.run_all_checkers import _collect_meson_files
+from ci.util.check_files import FileContent
+
+
+def _check(source: str) -> dict[str, list[tuple[int, str]]]:
+    checker = PathNormJoinChecker()
+    checker.check_file_content(
+        FileContent(path="fixture/meson.build", content=source, lines=[])
+    )
+    return checker.violations
+
+
+def test_rejects_path_norm_variables_joined_with_meson_operator() -> None:
+    violations = _check(
+        "wasm_include = '-I' + path_norm_root / 'src/platforms/wasm'\n"
+        "nested = path_norm_custom / 'generated'\n"
+    )
+
+    issues = violations["fixture/meson.build"]
+    assert [line for line, _ in issues] == [1, 2]
+    assert "path_norm_root" in issues[0][1]
+    assert "path_norm_custom" in issues[1][1]
+
+
+def test_allows_literal_forward_slash_concatenation_and_comments() -> None:
+    violations = _check(
+        "src = path_norm_root + '/src'\n"
+        "include = '-I' + path_norm_I_src\n"
+        "# example = path_norm_root / 'src'\n"
+        "message('example = path_norm_root / \\'src\\'')\n"
+    )
+
+    assert violations == {}
+
+
+def test_ignores_non_meson_files() -> None:
+    assert not PathNormJoinChecker().should_process_file("fixture/meson_options.txt")
+
+
+def test_collects_only_repository_meson_files(tmp_path: Path) -> None:
+    (tmp_path / "meson.build").touch()
+    generated = tmp_path / ".build" / "generated"
+    generated.mkdir(parents=True)
+    (generated / "meson.build").touch()
+    worktree = tmp_path / ".claude" / "worktrees" / "other"
+    worktree.mkdir(parents=True)
+    (worktree / "meson.build").touch()
+
+    assert _collect_meson_files(tmp_path) == [str(tmp_path / "meson.build")]

--- a/ci/meson/wasm/meson.build
+++ b/ci/meson/wasm/meson.build
@@ -43,7 +43,7 @@ wasm_all_sources = fastled_sources + platforms_shared_files
 # ci/meson/shared/meson.build.
 wasm_abs_include_args = [
   path_norm_I_src,
-  '-I' + path_norm_root / 'src/platforms/wasm/compiler',
+  '-I' + path_norm_root + '/src/platforms/wasm/compiler',
 ]
 
 fastled_wasm_lib = static_library('fastled',

--- a/ci/tests/test_ci_compile_wasm.py
+++ b/ci/tests/test_ci_compile_wasm.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+
+PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def _load_ci_compile_module():
+    spec = importlib.util.spec_from_file_location(
+        "ci_compile_under_test", PROJECT_ROOT / "ci" / "ci-compile.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_wasm_fast_path_consumes_clean_and_forces_reconfigure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    import ci.wasm_build
+
+    ci_compile = _load_ci_compile_module()
+    build_calls: list[dict[str, object]] = []
+
+    def fake_build(**kwargs: object) -> int:
+        build_calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(ci.wasm_build, "build", fake_build)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ci-compile.py", "--clean", "wasm", "--examples", "Blink"],
+    )
+
+    assert ci_compile._wasm_fast_path() == 0
+    assert build_calls == [
+        {
+            "example": "Blink",
+            "output": "examples/Blink/fastled_js/fastled.js",
+            "verbose": False,
+            "force": True,
+        }
+    ]

--- a/ci/tests/test_meson_private_include_normalization.py
+++ b/ci/tests/test_meson_private_include_normalization.py
@@ -14,6 +14,22 @@ from ci.meson.build_config import (
 
 
 class TestMesonPrivateIncludeNormalization(unittest.TestCase):
+    def test_wasm_include_roots_use_literal_forward_slash_composition(self) -> None:
+        """Meson's path join reintroduces backslashes on Windows (issue #2328)."""
+        project_root = Path(__file__).parents[2]
+        wasm_meson = (project_root / "ci" / "meson" / "wasm" / "meson.build").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "'-I' + path_norm_root + '/src/platforms/wasm/compiler'",
+            wasm_meson,
+        )
+        self.assertNotIn(
+            "path_norm_root / 'src/platforms/wasm/compiler'",
+            wasm_meson,
+        )
+
     def test_normalizes_quoted_and_unquoted_private_includes(self) -> None:
         with TemporaryDirectory() as temp_dir:
             build_dir = Path(temp_dir)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -203,12 +203,12 @@ foreach example_name : example_paths.keys()
     # (issue #2328). DO NOT use include_directories() — Meson emits these as
     # backslash + relative paths on Windows, which defeats #pragma once dedup.
     # inc_dir is project-relative (e.g. "examples/Blink" or "examples\\Blink");
-    # normalize to path_norm_root / <rest> via forward-slash '/' operator.
+    # normalize to path_norm_root + '/' + <rest> with literal separators.
     per_example_I_args = []
     foreach inc_dir : example_include_dirs
         # Canonicalize any backslashes the discovery script may have emitted
         inc_dir_fwd = inc_dir.replace('\\', '/')
-        per_example_I_args += ['-I' + path_norm_root / inc_dir_fwd]
+        per_example_I_args += ['-I' + path_norm_root + '/' + inc_dir_fwd]
     endforeach
 
     # Construct proper path: <example_root>/<example_name>.ino


### PR DESCRIPTION
## Summary
- fix Windows-unsafe Meson path joins and enforce them with a Meson lint rule
- run independent lint stages in parallel, including --cpp
- make documented WASM clean builds and the C++ lint fallback honor their flags

## Validation
- ash compile --clean wasm --examples Blink
- ash lint --no-rust --skip-platformio-check
- focused pytest: 12 passed

The default Rust C++ lint path is blocked locally because the installed Rust toolchain lacks the Windows MSVC target; the supported Python fallback passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM clean builds to reliably force reconfiguration.
  * Corrected path construction for WASM and example include directories.
  * Expanded lint parallelization for multi-stage checks.
  * Added detection of unsafe Meson path joins and clearer handling of C++ lint modes.

* **Tests**
  * Added regression coverage for WASM clean builds, include paths, and Meson path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->