### PR TITLE
feat(rp2040): add PIO FLEX_IO SPI fallback

### DIFF
--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -10,6 +10,7 @@
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
@@ -6,11 +6,30 @@
 
 namespace fl {
 
+namespace {
+
+// Keep native PL022 SPI preferred whenever the selected pair has a legal
+// hardware mux. FLEX_IO owns the remaining arbitrary PIO pin pairs.
+bool isNativeSpiPinPair(const SpiChipsetConfig& config) FL_NO_EXCEPT {
+    static constexpr u8 kMosi[] = {3, 7, 19, 23, 11, 15, 27};
+    static constexpr u8 kSck[] = {2, 6, 18, 22, 10, 14, 26};
+    for (size_t index = 0; index < sizeof(kMosi) / sizeof(kMosi[0]); ++index) {
+        if (config.dataPin == kMosi[index] && config.clockPin == kSck[index]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
 ChannelEngineRpPio::ChannelEngineRpPio(
-    fl::shared_ptr<IRpPioTxPeripheral> peripheral, u8 which) FL_NO_EXCEPT
-    : mPeripheral(fl::move(peripheral)), mWhich(which), mCurrentChannel(0),
-      mLatchStartUs(0), mLatchDurationUs(0), mActive(false),
-      mActiveLaneCount(1), mLatchPending(false), mFailed(false),
+    fl::shared_ptr<IRpPioTxPeripheral> peripheral,
+    fl::shared_ptr<IRpPioSpiPeripheral> spi_peripheral) FL_NO_EXCEPT
+    : mPeripheral(fl::move(peripheral)), mSpiPeripheral(fl::move(spi_peripheral)),
+      mCurrentChannel(0), mLatchStartUs(0), mLatchDurationUs(0),
+      mActiveLaneCount(1), mActiveMode(Mode::Clockless), mActive(false),
+      mLatchPending(false), mFailed(false),
       mLastStartAttempted(false), mLastStartSucceeded(false), mLastWordCount(0) {}
 
 ChannelEngineRpPio::~ChannelEngineRpPio() {
@@ -19,17 +38,26 @@ ChannelEngineRpPio::~ChannelEngineRpPio() {
         mPeripheral->abort();
         mPeripheral->deinitialize();
     }
+    if (mSpiPeripheral) {
+        mSpiPeripheral->abort();
+        mSpiPeripheral->deinitialize();
+    }
 }
 
 bool ChannelEngineRpPio::canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT {
-    if (!data || !data->isClockless() || data->getPin() < 0 || data->getPin() > 29) {
-        return false;
+    if (!data) return false;
+    if (data->isClockless()) {
+        if (!mPeripheral || data->getPin() < 0 || data->getPin() > 29) return false;
+        const ChipsetTimingConfig& timing = data->getTiming();
+        // pio_gen needs at least one cycle in each segment and subtracts two from
+        // the low tail instruction. Reject impossible runtime programs early.
+        return timing.t1_ns != 0 && timing.t2_ns != 0 && timing.t3_ns != 0 &&
+               timing.total_period_ns() >= 250;
     }
-    const ChipsetTimingConfig& timing = data->getTiming();
-    // pio_gen needs at least one cycle in each segment and subtracts two from
-    // the low tail instruction. Reject impossible runtime programs early.
-    return timing.t1_ns != 0 && timing.t2_ns != 0 && timing.t3_ns != 0 &&
-           timing.total_period_ns() >= 250;
+    const SpiChipsetConfig* spi = data->getChipset().ptr<SpiChipsetConfig>();
+    return mSpiPeripheral && spi != nullptr && spi->dataPin >= 0 && spi->dataPin <= 29 &&
+           spi->clockPin >= 0 && spi->clockPin <= 29 && spi->dataPin != spi->clockPin &&
+           spi->timing.clock_hz != 0 && !isNativeSpiPinPair(*spi);
 }
 
 void ChannelEngineRpPio::enqueue(ChannelDataPtr channelData) FL_NO_EXCEPT {
@@ -64,6 +92,21 @@ void ChannelEngineRpPio::show() FL_NO_EXCEPT {
 IChannelDriver::DriverState ChannelEngineRpPio::poll() FL_NO_EXCEPT {
     if (mFailed) return fail(mError.c_str());
     if (!mActive) return DriverState::READY;
+    if (mActiveMode == Mode::Spi) {
+        if (!mSpiPeripheral) return fail("RP PIO SPI: missing peripheral");
+        if (mSpiPeripheral->hasError()) return fail("RP PIO SPI: peripheral error");
+        if (mSpiPeripheral->isDmaBusy()) return DriverState::BUSY;
+        if (!mSpiPeripheral->isTerminalComplete()) return DriverState::DRAINING;
+        ++mCurrentChannel;
+        if (startNextTransmission()) return DriverState::BUSY;
+        if (mCurrentChannel < mInFlightChannels.size()) {
+            return fail("RP PIO SPI: unable to start queued channel");
+        }
+        mSpiPeripheral->deinitialize();
+        releaseInFlight();
+        mActive = false;
+        return DriverState::READY;
+    }
     if (!mPeripheral) return fail("RP PIO: missing peripheral");
     if (mPeripheral->hasError()) return fail("RP PIO: peripheral error");
     if (mPeripheral->isDmaBusy()) return DriverState::BUSY;
@@ -96,7 +139,29 @@ bool ChannelEngineRpPio::startNextTransmission() FL_NO_EXCEPT {
 }
 
 bool ChannelEngineRpPio::beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT {
-    if (!mPeripheral || !canHandle(channel)) return false;
+    if (!canHandle(channel)) return false;
+    if (channel->isSpi()) {
+        const fl::vector_psram<u8>& input = channel->getData();
+        const SpiChipsetConfig& chipset = channel->getChipset().get<SpiChipsetConfig>();
+        if (input.empty() || !mSpiPeripheral) return false;
+        RpPioSpiConfig config;
+        config.mosi_pin = static_cast<u8>(chipset.dataPin);
+        config.sck_pin = static_cast<u8>(chipset.clockPin);
+        config.clock_hz = chipset.timing.clock_hz;
+        if (!mSpiPeripheral->configure(config)) return false;
+        mPioWords.clear();
+        mPioWords.reserve(input.size());
+        for (u8 byte : input) {
+            mPioWords.push_back(static_cast<u32>(byte) << 24);
+        }
+        mActiveLaneCount = 1;
+        mActiveMode = Mode::Spi;
+        mLastStartAttempted = true;
+        mLastWordCount = mPioWords.size();
+        mLastStartSucceeded = mSpiPeripheral->startTxDma(mPioWords.data(), mPioWords.size());
+        return mLastStartSucceeded;
+    }
+    if (!mPeripheral) return false;
     const fl::vector_psram<u8>& input = channel->getData();
     if (input.empty()) return false;
     // Batch only an adjacent run that is provably safe: same wire timing,
@@ -111,6 +176,7 @@ bool ChannelEngineRpPio::beginTransmission(const ChannelDataPtr& channel) FL_NO_
         ++run;
     }
     mActiveLaneCount = run >= 8 ? 8 : run >= 4 ? 4 : run >= 2 ? 2 : 1;
+    mActiveMode = Mode::Clockless;
     RpPioTxConfig config;
     config.tx_pin = static_cast<u8>(channel->getPin());
     config.lane_count = mActiveLaneCount;
@@ -157,6 +223,10 @@ IChannelDriver::DriverState ChannelEngineRpPio::fail(const char* message) FL_NO_
     if (mPeripheral) {
         mPeripheral->abort();
         mPeripheral->deinitialize();
+    }
+    if (mSpiPeripheral) {
+        mSpiPeripheral->abort();
+        mSpiPeripheral->deinitialize();
     }
     releaseInFlight();
     mActive = false;

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
@@ -6,17 +6,20 @@
 #include "fl/channels/driver.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/vector.h"
+#include "platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h"
 #include "platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h"
 
 namespace fl {
 
-/// Single-lane PIO clockless engine. Consecutive multi-lane batching is only
-/// admitted once all lanes have exactly the same timing; this engine keeps the
-/// initial single-lane path explicit rather than silently batching mismatch.
+/// Unified RP PIO FLEX_IO engine. It serves clockless LED protocols and
+/// mode-0 SPI: the latter is the arbitrary-pin fallback when SPI0/SPI1 cannot
+/// route the requested pin pair. Consecutive clockless lanes are batched only
+/// when timing and length exactly match.
 class ChannelEngineRpPio final : public IChannelDriver {
   public:
     explicit ChannelEngineRpPio(fl::shared_ptr<IRpPioTxPeripheral> peripheral,
-                                u8 which) FL_NO_EXCEPT;
+                                fl::shared_ptr<IRpPioSpiPeripheral> spi_peripheral =
+                                    fl::shared_ptr<IRpPioSpiPeripheral>()) FL_NO_EXCEPT;
     ~ChannelEngineRpPio() override;
 
     bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
@@ -31,28 +34,30 @@ class ChannelEngineRpPio final : public IChannelDriver {
     size_t lastWordCount() const FL_NO_EXCEPT { return mLastWordCount; }
 
     fl::string getName() const FL_NO_EXCEPT override {
-        return mWhich == 0 ? fl::string::from_literal("PIO0")
-                           : fl::string::from_literal("PIO1");
+        return fl::string::from_literal("FLEX_IO");
     }
     Capabilities getCapabilities() const FL_NO_EXCEPT override {
-        return Capabilities(true, false);
+        return Capabilities(true, true);
     }
 
   private:
+    enum class Mode : u8 { Clockless, Spi };
+
     bool startNextTransmission() FL_NO_EXCEPT;
     bool beginTransmission(const ChannelDataPtr& channel) FL_NO_EXCEPT;
     void releaseInFlight() FL_NO_EXCEPT;
     DriverState fail(const char* message) FL_NO_EXCEPT;
 
     fl::shared_ptr<IRpPioTxPeripheral> mPeripheral;
+    fl::shared_ptr<IRpPioSpiPeripheral> mSpiPeripheral;
     fl::vector<ChannelDataPtr> mPendingChannels;
     fl::vector<ChannelDataPtr> mInFlightChannels;
     fl::vector<u32> mPioWords;
-    u8 mWhich;
     size_t mCurrentChannel;
     u32 mLatchStartUs;
     u32 mLatchDurationUs;
     u8 mActiveLaneCount;
+    Mode mActiveMode;
     bool mActive;
     bool mLatchPending;
     bool mFailed;

--- a/src/platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file irp_pio_spi_peripheral.h
+/// @brief Host-testable contract for PIO-backed SPI TX on RP2xxx.
+
+#include "fl/stl/cstddef.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+struct RpPioSpiConfig {
+    u8 mosi_pin = 0;
+    u8 sck_pin = 0;
+    u32 clock_hz = 0;
+};
+
+/// PIO SPI is the FLEX_IO fallback for SPI pin pairs which cannot use the
+/// RP2040's fixed SPI0/SPI1 muxes. DMA completion alone is insufficient: the
+/// final PIO bit must also return the clock to its idle-low state.
+class IRpPioSpiPeripheral {
+  public:
+    virtual ~IRpPioSpiPeripheral() FL_NO_EXCEPT = default;
+
+    virtual bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT = 0;
+    virtual bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT = 0;
+    virtual bool isDmaBusy() const FL_NO_EXCEPT = 0;
+    virtual bool isTerminalComplete() const FL_NO_EXCEPT = 0;
+    virtual bool hasError() const FL_NO_EXCEPT = 0;
+    virtual u32 nowMicros() const FL_NO_EXCEPT = 0;
+    virtual void abort() FL_NO_EXCEPT = 0;
+    virtual void deinitialize() FL_NO_EXCEPT = 0;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h
@@ -297,6 +297,51 @@ class RpPioDmaResourceManager {
         return true;
     }
 
+    /// @brief Atomically claim one PIO state machine, DMA channel, and two
+    /// arbitrary GPIO pins. PIO SPI uses a data pin plus a side-set clock pin,
+    /// which do not need to be consecutive.
+    bool claimPioDmaAndTwoPins(PIO* pio_out, int* state_machine_out,
+                               int* dma_channel_out, u8 first_pin,
+                               u8 second_pin, u8 pio_index) FL_NO_EXCEPT {
+        LockGuard lock(*this);
+        if (pio_out == nullptr || state_machine_out == nullptr ||
+            dma_channel_out == nullptr || first_pin == second_pin ||
+            pio_index >= NUM_PIOS) {
+            return false;
+        }
+        PIO claimed_pio = pioForIndex(pio_index);
+        const int claimed_sm = pio_claim_unused_sm(claimed_pio, false);
+        if (claimed_sm < 0 ||
+            !mLedger.claimPioStateMachine(pio_index, static_cast<u8>(claimed_sm))) {
+            if (claimed_sm >= 0) pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            return false;
+        }
+        if (!mLedger.claimPin(first_pin)) {
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            mLedger.releasePioStateMachine(pio_index, static_cast<u8>(claimed_sm));
+            return false;
+        }
+        if (!mLedger.claimPin(second_pin)) {
+            mLedger.releasePin(first_pin);
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            mLedger.releasePioStateMachine(pio_index, static_cast<u8>(claimed_sm));
+            return false;
+        }
+        const int dma = dma_claim_unused_channel(false);
+        if (dma < 0 || !mLedger.claimDmaChannel(static_cast<u8>(dma))) {
+            if (dma >= 0) dma_channel_unclaim(static_cast<uint>(dma));
+            mLedger.releasePin(first_pin);
+            mLedger.releasePin(second_pin);
+            pio_sm_unclaim(claimed_pio, static_cast<uint>(claimed_sm));
+            mLedger.releasePioStateMachine(pio_index, static_cast<u8>(claimed_sm));
+            return false;
+        }
+        *pio_out = claimed_pio;
+        *state_machine_out = claimed_sm;
+        *dma_channel_out = dma;
+        return true;
+    }
+
     bool claimPins(u8 first_pin, u8 count) FL_NO_EXCEPT {
         LockGuard lock(*this);
         for (u8 offset = 0; offset < count; ++offset) {

--- a/src/platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.cpp.hpp
@@ -1,0 +1,200 @@
+// IWYU pragma: private
+
+#include "platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.h"
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "fl/stl/chrono.h"
+#include "platforms/arm/rp/rpcommon/pio_asm.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+
+// IWYU pragma: begin_keep
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/pio.h"
+// IWYU pragma: end_keep
+
+namespace fl {
+
+struct RpPioSpiPeripheral::ProgramStorage {
+    pio_instr instructions[3];
+    pio_program program;
+    u32 terminal_pc;
+
+    ProgramStorage() FL_NO_EXCEPT : instructions{0, 0, 0}, program{}, terminal_pc(0) {}
+};
+
+RpPioSpiPeripheral::RpPioSpiPeripheral(u8 pio_index) FL_NO_EXCEPT
+    : mPio(nullptr), mStateMachine(-1), mDmaChannel(-1), mMosiPin(-1),
+      mSckPin(-1), mProgramOffset(-1), mPioIndex(pio_index),
+      mProgram(nullptr), mInitialized(false) {}
+
+RpPioSpiPeripheral::~RpPioSpiPeripheral() { deinitialize(); }
+
+bool RpPioSpiPeripheral::createProgram(u32 clock_hz) FL_NO_EXCEPT {
+    const u32 system_hz = clock_get_hz(clk_sys);
+    if (system_hz == 0 || clock_hz == 0) return false;
+
+    mProgram = new ProgramStorage(); // ok bare allocation
+    if (mProgram == nullptr) return false;
+    // Mode-0 SPI: set data while SCK is low, rise for one PIO cycle, then
+    // return low. Autopull after eight bits preserves byte boundaries.
+    mProgram->instructions[0] = static_cast<pio_instr>(
+        PIO_INSTR_OUT | PIO_OUT_DST_PINS | PIO_OUT_CNT(1) | PIO_SIDESET(0, 1));
+    mProgram->instructions[1] = static_cast<pio_instr>(PIO_NOP | PIO_SIDESET(1, 1));
+    mProgram->instructions[2] = static_cast<pio_instr>(PIO_NOP | PIO_SIDESET(0, 1));
+    mProgram->program.instructions = mProgram->instructions;
+    mProgram->program.length = 3;
+    mProgram->program.origin = -1;
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+    mProgram->program.pio_version = 0;
+    #if defined(PICO_PIO_VERSION) && PICO_PIO_VERSION > 0
+    mProgram->program.used_gpio_ranges = 0;
+    #endif
+#endif
+
+    PIO pio = static_cast<PIO>(mPio);
+    if (!RpPioDmaResourceManager::instance().addPioProgram(
+            pio, &mProgram->program, &mProgramOffset)) {
+        return false;
+    }
+    mProgram->terminal_pc = static_cast<u32>(mProgramOffset);
+
+    pio_sm_config config = pio_get_default_sm_config();
+    sm_config_set_wrap(&config, static_cast<uint>(mProgramOffset),
+                       static_cast<uint>(mProgramOffset + 2));
+    sm_config_set_sideset(&config, 1, false, false);
+    sm_config_set_out_pins(&config, static_cast<uint>(mMosiPin), 1);
+    sm_config_set_sideset_pins(&config, static_cast<uint>(mSckPin));
+    sm_config_set_out_shift(&config, false, true, 8);
+    const float divider = static_cast<float>(system_hz) /
+                          (static_cast<float>(clock_hz) * 3.0f);
+    if (divider < 1.0f) return false;
+    sm_config_set_clkdiv(&config, divider);
+
+    pio_gpio_init(pio, static_cast<uint>(mMosiPin));
+    pio_gpio_init(pio, static_cast<uint>(mSckPin));
+    pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(mStateMachine),
+                                   static_cast<uint>(mMosiPin), 1, true);
+    pio_sm_set_consecutive_pindirs(pio, static_cast<uint>(mStateMachine),
+                                   static_cast<uint>(mSckPin), 1, true);
+    pio_sm_init(pio, static_cast<uint>(mStateMachine),
+                static_cast<uint>(mProgramOffset), &config);
+    const u32 pins = (1u << mMosiPin) | (1u << mSckPin);
+    pio_sm_set_pins_with_mask(pio, static_cast<uint>(mStateMachine), 0, pins);
+    pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), true);
+    return true;
+}
+
+bool RpPioSpiPeripheral::configure(const RpPioSpiConfig& config) FL_NO_EXCEPT {
+    deinitialize();
+    if (config.mosi_pin > 29 || config.sck_pin > 29 ||
+        config.mosi_pin == config.sck_pin || config.clock_hz == 0) {
+        return false;
+    }
+    PIO pio = nullptr;
+    int state_machine = -1;
+    int dma_channel = -1;
+    if (!RpPioDmaResourceManager::instance().claimPioDmaAndTwoPins(
+            &pio, &state_machine, &dma_channel, config.mosi_pin, config.sck_pin,
+            mPioIndex)) {
+        return false;
+    }
+    mPio = pio;
+    mStateMachine = state_machine;
+    mDmaChannel = dma_channel;
+    mMosiPin = config.mosi_pin;
+    mSckPin = config.sck_pin;
+    if (!createProgram(config.clock_hz)) {
+        deinitialize();
+        return false;
+    }
+
+    dma_channel_config dma_config = dma_channel_get_default_config(
+        static_cast<uint>(mDmaChannel));
+    channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
+    channel_config_set_read_increment(&dma_config, true);
+    channel_config_set_write_increment(&dma_config, false);
+    channel_config_set_dreq(&dma_config, pio_get_dreq(static_cast<PIO>(mPio),
+                                                       static_cast<uint>(mStateMachine), true));
+    dma_channel_configure(static_cast<uint>(mDmaChannel), &dma_config,
+                          &static_cast<PIO>(mPio)->txf[mStateMachine], nullptr,
+                          0, false);
+    mInitialized = true;
+    return true;
+}
+
+bool RpPioSpiPeripheral::startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT {
+    if (!mInitialized || words == nullptr || word_count == 0 ||
+        dma_channel_is_busy(static_cast<uint>(mDmaChannel))) {
+        return false;
+    }
+    dma_channel_set_read_addr(static_cast<uint>(mDmaChannel), words, false);
+    dma_channel_set_trans_count(static_cast<uint>(mDmaChannel),
+                                static_cast<u32>(word_count), true);
+    return true;
+}
+
+bool RpPioSpiPeripheral::isDmaBusy() const FL_NO_EXCEPT {
+    return mDmaChannel >= 0 && dma_channel_is_busy(static_cast<uint>(mDmaChannel));
+}
+
+bool RpPioSpiPeripheral::isTerminalComplete() const FL_NO_EXCEPT {
+    if (!mInitialized || isDmaBusy()) return false;
+    const PIO pio = static_cast<PIO>(mPio);
+    return pio_sm_is_tx_fifo_empty(pio, static_cast<uint>(mStateMachine)) &&
+           pio_sm_get_pc(pio, static_cast<uint>(mStateMachine)) ==
+               static_cast<uint>(mProgram->terminal_pc);
+}
+
+bool RpPioSpiPeripheral::hasError() const FL_NO_EXCEPT { return false; }
+u32 RpPioSpiPeripheral::nowMicros() const FL_NO_EXCEPT { return fl::micros(); }
+
+void RpPioSpiPeripheral::abort() FL_NO_EXCEPT {
+    if (mDmaChannel >= 0) dma_channel_abort(static_cast<uint>(mDmaChannel));
+}
+
+void RpPioSpiPeripheral::deinitialize() FL_NO_EXCEPT {
+    abort();
+    PIO pio = static_cast<PIO>(mPio);
+    if (pio != nullptr && mStateMachine >= 0) {
+        pio_sm_set_enabled(pio, static_cast<uint>(mStateMachine), false);
+        pio_sm_clear_fifos(pio, static_cast<uint>(mStateMachine));
+    }
+    if (pio != nullptr && mProgram != nullptr && mProgramOffset >= 0) {
+        RpPioDmaResourceManager::instance().removePioProgram(
+            pio, &mProgram->program, mProgramOffset);
+    }
+    if (mDmaChannel >= 0) {
+        RpPioDmaResourceManager::instance().releaseDmaChannel(mDmaChannel);
+    }
+    if (pio != nullptr && mStateMachine >= 0) {
+        RpPioDmaResourceManager::instance().releasePioStateMachine(pio, mStateMachine);
+    }
+    if (mMosiPin >= 0) {
+        gpio_set_function(static_cast<uint>(mMosiPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mMosiPin), GPIO_IN);
+        RpPioDmaResourceManager::instance().releasePins(mMosiPin, 1);
+    }
+    if (mSckPin >= 0) {
+        gpio_set_function(static_cast<uint>(mSckPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mSckPin), GPIO_IN);
+        RpPioDmaResourceManager::instance().releasePins(mSckPin, 1);
+    }
+    delete mProgram; // ok bare allocation
+    mPio = nullptr;
+    mStateMachine = -1;
+    mDmaChannel = -1;
+    mMosiPin = -1;
+    mSckPin = -1;
+    mProgramOffset = -1;
+    mProgram = nullptr;
+    mInitialized = false;
+}
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/arm/rp/is_rp.h"
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+#include "platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h"
+
+namespace fl {
+
+class RpPioSpiPeripheral final : public IRpPioSpiPeripheral {
+  public:
+    explicit RpPioSpiPeripheral(u8 pio_index) FL_NO_EXCEPT;
+    ~RpPioSpiPeripheral() override;
+
+    bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override;
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override;
+    bool isDmaBusy() const FL_NO_EXCEPT override;
+    bool isTerminalComplete() const FL_NO_EXCEPT override;
+    bool hasError() const FL_NO_EXCEPT override;
+    u32 nowMicros() const FL_NO_EXCEPT override;
+    void abort() FL_NO_EXCEPT override;
+    void deinitialize() FL_NO_EXCEPT override;
+
+  private:
+    struct ProgramStorage;
+    bool createProgram(u32 clock_hz) FL_NO_EXCEPT;
+
+    void* mPio;
+    int mStateMachine;
+    int mDmaChannel;
+    int mMosiPin;
+    int mSckPin;
+    int mProgramOffset;
+    u8 mPioIndex;
+    ProgramStorage* mProgram;
+    bool mInitialized;
+};
+
+}  // namespace fl
+
+#endif  // defined(FL_IS_RP2040) || defined(FL_IS_RP2350)

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
@@ -13,6 +13,7 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/type_traits.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.h"
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.h"
 
 namespace fl {
@@ -21,10 +22,12 @@ namespace detail {
 template<u8 Which>
 struct RpPioTxBusHolder {
     fl::shared_ptr<RpPioTxPeripheral> peripheral;
+    fl::shared_ptr<RpPioSpiPeripheral> spiPeripheral;
     fl::shared_ptr<ChannelEngineRpPio> driver;
     RpPioTxBusHolder() FL_NO_EXCEPT
         : peripheral(fl::make_shared<RpPioTxPeripheral>(Which)),
-          driver(fl::make_shared<ChannelEngineRpPio>(peripheral, Which)) {}
+          spiPeripheral(fl::make_shared<RpPioSpiPeripheral>(Which)),
+          driver(fl::make_shared<ChannelEngineRpPio>(peripheral, spiPeripheral)) {}
 };
 
 template<u8 Which>
@@ -55,6 +58,8 @@ template<> struct BusTraits<Bus::FLEX_IO, 1> {
 
 template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 0> : fl::true_type {};
 template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 1> : fl::true_type {};
+template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 0> : fl::true_type {};
+template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 1> : fl::true_type {};
 
 }  // namespace fl
 

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -1,12 +1,14 @@
 /// @file channel_engine_rp_pio.cpp
-/// @brief Host lifecycle tests for RP PIO clockless TX.
+/// @brief Host lifecycle tests for RP PIO FLEX_IO TX.
 
 #include "test.h"
 
 #include "fl/channels/data.h"
+#include "fl/chipsets/spi.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/move.h"
 #include "fl/stl/shared_ptr.h"
+#include "fl/stl/singleton.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -56,9 +58,102 @@ class PioTxMock final : public IRpPioTxPeripheral {
     fl::vector<u32> capturedWords;
 };
 
+class PioSpiMock final {
+  public:
+    static PioSpiMock& instance() FL_NO_EXCEPT {
+        return Singleton<PioSpiMock>::instance();
+    }
+
+    void reset() FL_NO_EXCEPT {
+        lastConfig = RpPioSpiConfig();
+        configureOk = true;
+        startOk = true;
+        dmaBusy = false;
+        terminal = false;
+        error = false;
+        configureCalls = 0;
+        startCalls = 0;
+        abortCalls = 0;
+        deinitializeCalls = 0;
+        capturedWords.clear();
+    }
+
+    bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT {
+        lastConfig = config;
+        ++configureCalls;
+        return configureOk;
+    }
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT {
+        ++startCalls;
+        capturedWords.clear();
+        for (size_t index = 0; index < word_count; ++index) {
+            capturedWords.push_back(words[index]);
+        }
+        dmaBusy = startOk;
+        return startOk;
+    }
+    bool isDmaBusy() const FL_NO_EXCEPT { return dmaBusy; }
+    bool isTerminalComplete() const FL_NO_EXCEPT { return terminal; }
+    bool hasError() const FL_NO_EXCEPT { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT { return 0; }
+    void abort() FL_NO_EXCEPT { ++abortCalls; dmaBusy = false; }
+    void deinitialize() FL_NO_EXCEPT { ++deinitializeCalls; }
+
+    RpPioSpiConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool dmaBusy = false;
+    bool terminal = false;
+    bool error = false;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    fl::vector<u32> capturedWords;
+};
+
+fl::shared_ptr<IRpPioSpiPeripheral> createSpiMockPeripheral() {
+    class MockWrapper final : public IRpPioSpiPeripheral {
+      public:
+        bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override {
+            return PioSpiMock::instance().configure(config);
+        }
+        bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+            return PioSpiMock::instance().startTxDma(words, word_count);
+        }
+        bool isDmaBusy() const FL_NO_EXCEPT override {
+            return PioSpiMock::instance().isDmaBusy();
+        }
+        bool isTerminalComplete() const FL_NO_EXCEPT override {
+            return PioSpiMock::instance().isTerminalComplete();
+        }
+        bool hasError() const FL_NO_EXCEPT override {
+            return PioSpiMock::instance().hasError();
+        }
+        u32 nowMicros() const FL_NO_EXCEPT override {
+            return PioSpiMock::instance().nowMicros();
+        }
+        void abort() FL_NO_EXCEPT override { PioSpiMock::instance().abort(); }
+        void deinitialize() FL_NO_EXCEPT override {
+            PioSpiMock::instance().deinitialize();
+        }
+    };
+
+    PioSpiMock::instance().reset();
+    return fl::make_shared<MockWrapper>();
+}
+
 ChannelDataPtr makeChannel(int pin, const fl::vector_psram<u8>& bytes) {
     fl::vector_psram<u8> copy = bytes;
     return ChannelData::create(pin, makeTimingConfig<TIMING_WS2812_800KHZ>(),
+                               fl::move(copy));
+}
+
+ChannelDataPtr makeSpiChannel(int mosi_pin, int sck_pin, u32 clock_hz,
+                              const fl::vector_psram<u8>& bytes) {
+    fl::vector_psram<u8> copy = bytes;
+    return ChannelData::create(SpiChipsetConfig(
+                                   mosi_pin, sck_pin, SpiEncoder::apa102(clock_hz)),
                                fl::move(copy));
 }
 
@@ -66,7 +161,7 @@ ChannelDataPtr makeChannel(int pin, const fl::vector_psram<u8>& bytes) {
 
 FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
     auto peripheral = fl::make_shared<PioTxMock>();
-    ChannelEngineRpPio engine(peripheral, 0);
+    ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x00);
     bytes.push_back(0xFF);
@@ -104,7 +199,7 @@ FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
 
 FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
     auto peripheral = fl::make_shared<PioTxMock>();
-    ChannelEngineRpPio engine(peripheral, 1);
+    ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> firstBytes;
     firstBytes.push_back(0x12);
     fl::vector_psram<u8> secondBytes;
@@ -127,7 +222,7 @@ FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
 
 FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
     auto peripheral = fl::make_shared<PioTxMock>();
-    ChannelEngineRpPio engine(peripheral, 0);
+    ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x42);
     auto first = makeChannel(5, bytes);
@@ -147,7 +242,7 @@ FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
 
 FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes") {
     auto peripheral = fl::make_shared<PioTxMock>();
-    ChannelEngineRpPio engine(peripheral, 0);
+    ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> leftBytes;
     leftBytes.push_back(0x80);
     fl::vector_psram<u8> rightBytes;
@@ -177,7 +272,7 @@ FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes")
 FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs") {
     for (u8 lanes = 4; lanes <= 8; lanes = static_cast<u8>(lanes * 2)) {
         auto peripheral = fl::make_shared<PioTxMock>();
-        ChannelEngineRpPio engine(peripheral, 1);
+        ChannelEngineRpPio engine(peripheral);
         fl::vector_psram<u8> bytes;
         bytes.push_back(0xFF);
         for (u8 lane = 0; lane < lanes; ++lane) {
@@ -189,6 +284,47 @@ FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs")
         FL_CHECK_EQ(peripheral->capturedWords[0],
                     ((1u << lanes) - 1u) << (32u - lanes));
     }
+}
+
+FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
+    auto clockless = fl::make_shared<PioTxMock>();
+    auto spi = createSpiMockPeripheral();
+    PioSpiMock& spiMock = PioSpiMock::instance();
+    ChannelEngineRpPio engine(clockless, spi);
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(0xA5);
+    bytes.push_back(0x5A);
+    auto channel = makeSpiChannel(5, 9, 4000000, bytes);
+    FL_REQUIRE(engine.canHandle(channel));
+    FL_CHECK(engine.getCapabilities().supportsClockless);
+    FL_CHECK(engine.getCapabilities().supportsSpi);
+    FL_CHECK_EQ(engine.getName(), fl::string("FLEX_IO"));
+    engine.enqueue(channel);
+    engine.show();
+    FL_CHECK(channel->isInUse());
+    FL_CHECK_EQ(spiMock.lastConfig.mosi_pin, 5);
+    FL_CHECK_EQ(spiMock.lastConfig.sck_pin, 9);
+    FL_CHECK_EQ(spiMock.lastConfig.clock_hz, 4000000u);
+    FL_REQUIRE_EQ(spiMock.capturedWords.size(), static_cast<size_t>(2));
+    FL_CHECK_EQ(spiMock.capturedWords[0], 0xA5000000u);
+    FL_CHECK_EQ(spiMock.capturedWords[1], 0x5A000000u);
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
+    spiMock.dmaBusy = false;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
+    spiMock.terminal = true;
+    FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
+    FL_CHECK_FALSE(channel->isInUse());
+    FL_CHECK_EQ(spiMock.deinitializeCalls, 1);
+}
+
+FL_TEST_CASE("RP FLEX_IO defers native SPI pin pairs to the hardware driver") {
+    auto clockless = fl::make_shared<PioTxMock>();
+    auto spi = createSpiMockPeripheral();
+    ChannelEngineRpPio engine(clockless, spi);
+    fl::vector_psram<u8> bytes;
+    bytes.push_back(0x01);
+    FL_CHECK_FALSE(engine.canHandle(makeSpiChannel(3, 2, 4000000, bytes)));
+    FL_CHECK(engine.canHandle(makeSpiChannel(5, 9, 4000000, bytes)));
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
## Summary
- make the RP2040 PIO engine a unified FLEX_IO driver for clockless and mode-0 SPI output
- route arbitrary MOSI/SCK pairs through PIO + DMA while retaining native SPI0/SPI1 on canonical pin pairs
- add host lifecycle coverage for PIO SPI packing and native-SPI preference

## Validation
- ash test tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio
- build <generated rp2040 project> build -e rp2040 -v (Blink)

## Note
- targeted ash lint --cpp is blocked locally because the Rust C++ linter cannot build without the x86_64-pc-windows-msvc Rust target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SPI transmission support to FLEX_IO on RP2040 and RP2350 devices.
  * FLEX_IO can now use arbitrary valid MOSI and SCK pin pairs when native SPI routing is unavailable.
  * Added DMA-backed SPI transfers with improved transmission lifecycle handling.
* **Bug Fixes**
  * Improved resource allocation and rollback when PIO, DMA, or GPIO resources cannot be acquired.
* **Tests**
  * Added coverage for SPI transfers, DMA output, and pin-routing capability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->