### PR TITLE
chore(wasm): update gfx release pin

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -1,3 +1,6 @@
 # Lessons Learned
 
 <!-- Add lessons from corrections and discoveries here -->
+
+- Inspect the actual WASM compiler manifest before assuming an npm dependency: it
+  currently pins the `@fastled/gfx` GitHub Release tarball by exact URL.

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -1,3 +1,10 @@
 # Task Tracker
 
 <!-- Add tasks here as checkable items -->
+
+## WASM gfx electrical-group update
+
+- [x] Verify the `gfx-v0.1.1` release tarball is available.
+- [x] Update the compiler's strict gfx tarball pin and lockfile.
+- [x] Run compiler typecheck and production build.
+- [x] Review and push the FastLED PR.

--- a/src/platforms/wasm/compiler/package-lock.json
+++ b/src/platforms/wasm/compiler/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "fastled-wasm-frontend",
       "dependencies": {
-        "@fastled/gfx": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.0/fastled-gfx-0.1.0.tgz",
+        "@fastled/gfx": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.1/fastled-gfx-0.1.1.tgz",
         "three": "0.183.2"
       },
       "devDependencies": {
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/@fastled/gfx": {
-      "version": "0.1.0",
-      "resolved": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.0/fastled-gfx-0.1.0.tgz",
-      "integrity": "sha512-l2Zu5/5Wtma0pIRkGAkjiK/4QfK+kiAUjKbtxWINskw9ymwqMzluryrBbxH267P9elIBI9Rn8EUJi0CT4BrDBg==",
+      "version": "0.1.1",
+      "resolved": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.1/fastled-gfx-0.1.1.tgz",
+      "integrity": "sha512-7HTbUC9NO0NPlRrN0pS5j6yreT85DeAnnku/ZuScdxEuQypdBEWfsKx3sONui+cwC9j6JgIW1PrVIRjepiRz2A==",
       "license": "ISC",
       "peerDependencies": {
         "three": ">=0.170 <0.190"

--- a/src/platforms/wasm/compiler/package.json
+++ b/src/platforms/wasm/compiler/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@fastled/gfx": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.0/fastled-gfx-0.1.0.tgz",
+    "@fastled/gfx": "https://github.com/zackees/ledmapper/releases/download/gfx-v0.1.1/fastled-gfx-0.1.1.tgz",
     "three": "0.183.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pin the WASM compiler to the released `@fastled/gfx` 0.1.1 tarball
- refresh the npm lock integrity from that exact release asset
- record the dependency-source correction: this compiler currently consumes the GitHub Release tarball, not the npm registry package

## Validation
- `npm ci` (compiler)
- `npm run typecheck` (compiler)
- `npm run build` (compiler)
- direct imported-package contract: `electrical_group` is preserved as `ScreenmapShape.electricalGroup`

Coordinated with zackees/ledmapper#461. The npm bootstrap workflow correction is zackees/ledmapper#463; npm publication is tracked separately in zackees/ledmapper#462.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the WebAssembly graphics package to version 0.1.1, improving compatibility with the latest graphics release.

* **Documentation**
  * Added guidance for verifying the compiler manifest before assuming package sources.
  * Updated task tracking for the graphics package release and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->