### PR TITLE
feat(hydropack): add adaptive LED audio preview

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -12,5 +12,6 @@
   dots: use the sensitive analyzer for the center and the loud analyzer for
   the triangles so strong bass appears to launch outward.
 
-- For HydroPack's audience-safe behavior, prefer FastLED's INMP441-calibrated
-  SPL meter and tempo stability gate over a custom sound-floor histogram.
+- For HydroPack's audience-safe behavior, use FastLED's INMP441-calibrated
+  SPL meter with its adaptive bass-beat detector rather than a custom
+  sound-floor histogram or a separate tempo lock.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -7,3 +7,7 @@
 
 - For the current HydroPack prototype, prioritize a readable ordinary-LED
   approximation of the < | > layout over further EL-shape fidelity.
+
+- HydroPack's two sensitivity levels are visual layers, not separate status
+  dots: use the sensitive analyzer for the center and the loud analyzer for
+  the triangles so strong bass appears to launch outward.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -4,3 +4,6 @@
 
 - Inspect the actual WASM compiler manifest before assuming an npm dependency: it
   currently pins the `@fastled/gfx` GitHub Release tarball by exact URL.
+
+- For the current HydroPack prototype, prioritize a readable ordinary-LED
+  approximation of the < | > layout over further EL-shape fidelity.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -20,10 +20,10 @@
   qualifying beat evidence plus a low-ZCF check to arm a temporary
   music-present state. Never use a fixed tempo-consistency or animation lock.
 
-- FastLED's `getBeatConfidence()` is a normalized 0-1 spectral-flux score;
-  use it only to arm music mode. Keep Vibe as the immediate rhythmic response
-  after arming. FFT operates on short PCM frames, while the detector compares
-  the resulting spectrum across frames.
+- For browser media, derive the 0-1 music confidence from Vibe's normalized
+  bass rise above its short-term average. The generic raw spectral-flux beat
+  detector can remain below its fixed threshold despite healthy decoded audio.
 
-- A WASM-only debug LED can expose the latest beat-confidence pulse without
-  adding a physical output pixel to the HydroPack fixture.
+- A WASM-only per-frame telemetry toggle can expose raw Beat and Tempo
+  confidence alongside Vibe levels without adding a physical output pixel to
+  the HydroPack fixture.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -16,12 +16,14 @@
   SPL meter with its adaptive bass-beat detector rather than a custom
   sound-floor histogram or a separate tempo lock.
 
-- For a responsive music-only visual, use two qualifying bass beats in a
-  broad 30-240 BPM-equivalent range plus a low-ZCF check to arm a temporary
-  music-present state. Treat that range as music evidence, never a fixed
-  tempo-consistency or animation-lock requirement.
+- For a responsive music-only visual, require five seconds of recurring
+  qualifying beat evidence plus a low-ZCF check to arm a temporary
+  music-present state. Never use a fixed tempo-consistency or animation lock.
 
 - FastLED's `getBeatConfidence()` is a normalized 0-1 spectral-flux score;
   use it only to arm music mode. Keep Vibe as the immediate rhythmic response
   after arming. FFT operates on short PCM frames, while the detector compares
   the resulting spectrum across frames.
+
+- A WASM-only debug LED can expose the latest beat-confidence pulse without
+  adding a physical output pixel to the HydroPack fixture.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -15,3 +15,7 @@
 - For HydroPack's audience-safe behavior, use FastLED's INMP441-calibrated
   SPL meter with its adaptive bass-beat detector rather than a custom
   sound-floor histogram or a separate tempo lock.
+
+- For a responsive music-only visual, use two qualifying bass beats in a
+  short window plus a low-ZCF check to arm a temporary music-present state;
+  this rejects one-off speech/noise without requiring a rigid BPM lock.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -11,3 +11,6 @@
 - HydroPack's two sensitivity levels are visual layers, not separate status
   dots: use the sensitive analyzer for the center and the loud analyzer for
   the triangles so strong bass appears to launch outward.
+
+- For HydroPack's audience-safe behavior, prefer FastLED's INMP441-calibrated
+  SPL meter and tempo stability gate over a custom sound-floor histogram.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -17,5 +17,11 @@
   sound-floor histogram or a separate tempo lock.
 
 - For a responsive music-only visual, use two qualifying bass beats in a
-  short window plus a low-ZCF check to arm a temporary music-present state;
-  this rejects one-off speech/noise without requiring a rigid BPM lock.
+  broad 30-240 BPM-equivalent range plus a low-ZCF check to arm a temporary
+  music-present state. Treat that range as music evidence, never a fixed
+  tempo-consistency or animation-lock requirement.
+
+- FastLED's `getBeatConfidence()` is a normalized 0-1 spectral-flux score;
+  use it only to arm music mode. Keep Vibe as the immediate rhythmic response
+  after arming. FFT operates on short PCM frames, while the detector compares
+  the resulting spectrum across frames.

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -8,3 +8,10 @@
 - [x] Update the compiler's strict gfx tarball pin and lockfile.
 - [x] Run compiler typecheck and production build.
 - [x] Review and push the FastLED PR.
+
+## HydroPack LED audio prototype
+
+- [x] Replace the EL geometry preview with a normal LED < | > screenmap.
+- [x] Add independent sensitive and loud adaptive-audio indicators.
+- [x] Compile the WASM example and launch its local preview.
+- [x] Review and push the FastLED PR.

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -15,3 +15,4 @@
 - [x] Add independent sensitive and loud adaptive-audio indicators.
 - [x] Compile the WASM example and launch its local preview.
 - [x] Review and push the FastLED PR.
+- [x] Gate HydroPack launches on calibrated SPL and stable musical tempo.

--- a/examples/hydropack/data/leds-triangles-bar-indicators.json
+++ b/examples/hydropack/data/leds-triangles-bar-indicators.json
@@ -1,0 +1,39 @@
+{
+  "version": 2,
+  "groups": {
+    "left-triangle": { "color": "#0088ff" },
+    "center-bar": { "color": "#0088ff" },
+    "right-triangle": { "color": "#0088ff" },
+    "audio-indicators": { "color": "#00ffff" }
+  },
+  "segments": [
+    {
+      "id": "left-triangle",
+      "pin": "pin1",
+      "group": "left-triangle",
+      "x": [12, 22, 22, 32, 32, 32],
+      "y": [50, 42, 58, 34, 50, 66]
+    },
+    {
+      "id": "center-bar",
+      "pin": "pin1",
+      "group": "center-bar",
+      "x": [50, 50, 50, 50, 50, 50],
+      "y": [30, 38, 46, 54, 62, 70]
+    },
+    {
+      "id": "right-triangle",
+      "pin": "pin1",
+      "group": "right-triangle",
+      "x": [88, 78, 78, 68, 68, 68],
+      "y": [50, 42, 58, 34, 50, 66]
+    },
+    {
+      "id": "audio-indicators",
+      "pin": "pin1",
+      "group": "audio-indicators",
+      "x": [44, 56],
+      "y": [88, 88]
+    }
+  ]
+}

--- a/examples/hydropack/data/leds-triangles-bar.json
+++ b/examples/hydropack/data/leds-triangles-bar.json
@@ -3,8 +3,7 @@
   "groups": {
     "left-triangle": { "color": "#0088ff" },
     "center-bar": { "color": "#0088ff" },
-    "right-triangle": { "color": "#0088ff" },
-    "audio-indicators": { "color": "#00ffff" }
+    "right-triangle": { "color": "#0088ff" }
   },
   "segments": [
     {
@@ -27,13 +26,6 @@
       "group": "right-triangle",
       "x": [88, 78, 78, 68, 68, 68],
       "y": [50, 42, 58, 34, 50, 66]
-    },
-    {
-      "id": "audio-indicators",
-      "pin": "pin1",
-      "group": "audio-indicators",
-      "x": [44, 56],
-      "y": [88, 88]
     }
   ]
 }

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -11,8 +11,9 @@
 //   - center: sensitive - fires on a transient just above the song average
 //   - triangles: loud - fire only on a substantially stronger transient
 //
-// The output is gated by calibrated sound pressure, a stable musical tempo,
-// and a bass beat. This keeps ordinary conversation and random noise dark.
+// The output is gated by calibrated sound pressure and an adaptive bass beat.
+// This keeps ordinary conversation and random noise dark without waiting for
+// a tempo lock before the first visible musical hit.
 // Once music is established, FastLED's Vibe detector tracks its running bass
 // average; relative bass energy is about 1.0 at the current average. A loud
 // hit lights the center, then launches into the triangles.
@@ -42,7 +43,6 @@ constexpr uint8_t kRightTriangleStart = 12;
 constexpr uint8_t kPreviewLedCount = 18;
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
 constexpr float kDefaultStageThresholdDbSpl = 80.0f;
-constexpr float kMinimumTempoConfidence = 0.50f;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -76,8 +76,8 @@ fl::UIAudio audioUi("Audio Input", audioConfig);
 
 fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "The INMP441 sound-pressure gate and stable beat detector keep "
-    "conversation dark. On confident musical bass beats, the center fires "
+    "The INMP441 sound-pressure gate and adaptive bass beat detector keep "
+    "conversation dark. On musical bass beats, the center fires "
     "at the sensitive level and stronger hits launch to both triangles.");
 
 fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
@@ -99,8 +99,6 @@ uint32_t gTriangleFireAtMs = 0;
 fl::audio::SoundLevelMeter gSoundLevelMeter;
 fl::shared_ptr<fl::audio::Processor> gAudio;
 float gSoundPressureDbSpl = 33.0f;
-float gTempoConfidence = 0.0f;
-bool gTempoStable = false;
 
 void updateSoundLevel() {
     if (!gAudio) {
@@ -165,27 +163,19 @@ void setup() {
     }
 
     gAudio->setNoiseFloorTrackingEnabled(true);
-    gAudio->onVibeLevels([](const fl::audio::detector::VibeLevels &) {
+    gAudio->onVibeLevels([](const fl::audio::detector::VibeLevels &levels) {
         // Feed every block so the calibrated meter observes the actual quiet
         // floor, rather than only the relatively loud blocks that trigger a
         // beat callback.
         updateSoundLevel();
-    });
-    gAudio->onTempoWithConfidence([](float, float confidence) {
-        gTempoConfidence = confidence;
-    });
-    gAudio->onTempoStable([]() { gTempoStable = true; });
-    gAudio->onTempoUnstable([]() { gTempoStable = false; });
-    gAudio->onBeat([]() {
-        const float bass = gAudio->getVibeBass();
-        if (!gTempoStable || gTempoConfidence < kMinimumTempoConfidence ||
-            gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
-            !gAudio->isVibeBassSpike()) {
+        if (!levels.bassSpike ||
+            gSoundPressureDbSpl < stageThresholdDbSpl.value()) {
             return;
         }
-        fireAnalyzer(bass, centerThreshold.value(), 0.35f, gCenterLevel);
-        if (bass > triangleThreshold.value()) {
-            fireAnalyzer(bass, triangleThreshold.value(), 0.50f,
+        fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,
+                     gCenterLevel);
+        if (levels.bass > triangleThreshold.value()) {
+            fireAnalyzer(levels.bass, triangleThreshold.value(), 0.50f,
                          gPendingTriangleLevel);
             gTriangleFireAtMs = millis() + kTriangleLaunchDelayMs;
         }

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -1,6 +1,6 @@
 // FL_AGENT_ALLOW_NEW_EXAMPLE
 /// @file hydropack.ino
-/// @brief HydroPack: two adaptive bass analyzers animate an LED < | > layout.
+/// @brief HydroPack: stage-level musical bass animates an LED < | > layout.
 /// @example hydropack.ino
 
 // @filter: (mem is large) and (platform is esp32*)
@@ -11,11 +11,11 @@
 //   - center: sensitive - fires on a transient just above the song average
 //   - triangles: loud - fire only on a substantially stronger transient
 //
-// The detector is FastLED's built-in Vibe detector. Like Songstone's adaptive
-// window, it tracks a slow running song average; relative bass energy is about
-// 1.0 at the current average. FastLED's adaptive noise-floor tracker gates
-// microphone hiss before Vibe sees it. A loud hit lights the center, then
-// launches into the triangles; a moderate hit lights the center only.
+// The output is gated by calibrated sound pressure, a stable musical tempo,
+// and a bass beat. This keeps ordinary conversation and random noise dark.
+// Once music is established, FastLED's Vibe detector tracks its running bass
+// average; relative bass energy is about 1.0 at the current average. A loud
+// hit lights the center, then launches into the triangles.
 
 #include <Arduino.h>
 #include <FastLED.h>
@@ -41,6 +41,8 @@ constexpr uint8_t kCenterStart = 6;
 constexpr uint8_t kRightTriangleStart = 12;
 constexpr uint8_t kPreviewLedCount = 18;
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
+constexpr float kDefaultStageThresholdDbSpl = 80.0f;
+constexpr float kMinimumTempoConfidence = 0.50f;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -72,12 +74,15 @@ fl::audio::Config audioConfig = fl::audio::Config::CreateInmp441(
     I2S_WS, I2S_SD, I2S_CLK, fl::audio::AudioChannel::Right);
 fl::UIAudio audioUi("Audio Input", audioConfig);
 
-fl::UITitle title("HydroPack Two-Level Bass Launch");
+fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "Two analyzers read the same adaptive bass signal. The center bar fires "
-    "at the sensitive level. Stronger hits launch out to both triangles. "
-    "Quiet input is fully dark.");
+    "The INMP441 sound-pressure gate and stable beat detector keep "
+    "conversation dark. On confident musical bass beats, the center fires "
+    "at the sensitive level and stronger hits launch to both triangles.");
 
+fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
+                                 kDefaultStageThresholdDbSpl, 60.0f, 105.0f,
+                                 1.0f);
 fl::UISlider centerThreshold("Center (Sensitive) Threshold", 1.05f, 1.0f,
                              3.0f, 0.05f);
 fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
@@ -91,6 +96,23 @@ float gCenterLevel = 0.0f;
 float gTriangleLevel = 0.0f;
 float gPendingTriangleLevel = 0.0f;
 uint32_t gTriangleFireAtMs = 0;
+fl::audio::SoundLevelMeter gSoundLevelMeter;
+fl::shared_ptr<fl::audio::Processor> gAudio;
+float gSoundPressureDbSpl = 33.0f;
+float gTempoConfidence = 0.0f;
+bool gTempoStable = false;
+
+void updateSoundLevel() {
+    if (!gAudio) {
+        return;
+    }
+    const fl::audio::Sample &sample = gAudio->getSample();
+    if (!sample.isValid() || sample.pcm().empty()) {
+        return;
+    }
+    gSoundLevelMeter.processBlock(sample.pcm());
+    gSoundPressureDbSpl = static_cast<float>(gSoundLevelMeter.getSPL());
+}
 
 void fireAnalyzer(float bass, float threshold, float minIntensity,
                   float &level) {
@@ -133,23 +155,37 @@ void setup() {
     centerThreshold.setGroup("Two-Level Bass Analyzers");
     triangleThreshold.setGroup("Two-Level Bass Analyzers");
     fadeSeconds.setGroup("Two-Level Bass Analyzers");
+    stageThresholdDbSpl.setGroup("Stage Music Gate");
 
     // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
-    auto audio = FastLED.add(audioUi);
-    if (!audio) {
+    gAudio = FastLED.add(audioUi);
+    if (!gAudio) {
         FL_WARN("HydroPack: no audio processor available");
         return;
     }
 
-    audio->setNoiseFloorTrackingEnabled(true);
-    audio->onVibeLevels([](const fl::audio::detector::VibeLevels &levels) {
-        if (!levels.bassSpike) {
+    gAudio->setNoiseFloorTrackingEnabled(true);
+    gAudio->onVibeLevels([](const fl::audio::detector::VibeLevels &) {
+        // Feed every block so the calibrated meter observes the actual quiet
+        // floor, rather than only the relatively loud blocks that trigger a
+        // beat callback.
+        updateSoundLevel();
+    });
+    gAudio->onTempoWithConfidence([](float, float confidence) {
+        gTempoConfidence = confidence;
+    });
+    gAudio->onTempoStable([]() { gTempoStable = true; });
+    gAudio->onTempoUnstable([]() { gTempoStable = false; });
+    gAudio->onBeat([]() {
+        const float bass = gAudio->getVibeBass();
+        if (!gTempoStable || gTempoConfidence < kMinimumTempoConfidence ||
+            gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
+            !gAudio->isVibeBassSpike()) {
             return;
         }
-        fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,
-                     gCenterLevel);
-        if (levels.bass > triangleThreshold.value()) {
-            fireAnalyzer(levels.bass, triangleThreshold.value(), 0.50f,
+        fireAnalyzer(bass, centerThreshold.value(), 0.35f, gCenterLevel);
+        if (bass > triangleThreshold.value()) {
+            fireAnalyzer(bass, triangleThreshold.value(), 0.50f,
                          gPendingTriangleLevel);
             gTriangleFireAtMs = millis() + kTriangleLaunchDelayMs;
         }

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -12,8 +12,9 @@
 //   - triangles: loud - fire only on a substantially stronger transient
 //
 // The output is gated by calibrated sound pressure and an adaptive bass beat.
-// This keeps ordinary conversation and random noise dark without waiting for
-// a tempo lock before the first visible musical hit.
+// A short music-presence latch needs two bass beats and rejects high-ZCF hiss,
+// keeping ordinary conversation and isolated noise dark without a rigid BPM
+// lock before every visible musical hit.
 // Once music is established, FastLED's Vibe detector tracks its running bass
 // average; relative bass energy is about 1.0 at the current average. A loud
 // hit lights the center, then launches into the triangles.
@@ -43,6 +44,10 @@ constexpr uint8_t kRightTriangleStart = 12;
 constexpr uint8_t kPreviewLedCount = 18;
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
 constexpr float kDefaultStageThresholdDbSpl = 80.0f;
+constexpr uint8_t kMusicBeatsToActivate = 2;
+constexpr uint32_t kMusicBeatWindowMs = 1600;
+constexpr uint32_t kMusicHoldMs = 2000;
+constexpr float kMaximumMusicZcf = 0.40f;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -76,9 +81,9 @@ fl::UIAudio audioUi("Audio Input", audioConfig);
 
 fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "The INMP441 sound-pressure gate and adaptive bass beat detector keep "
-    "conversation dark. On musical bass beats, the center fires "
-    "at the sensitive level and stronger hits launch to both triangles.");
+    "The INMP441 sound-pressure gate needs two low-hiss bass beats to arm "
+    "music mode. Conversation and one-off noise stay dark; musical bass "
+    "fires the center, with stronger hits launching to both triangles.");
 
 fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
                                  kDefaultStageThresholdDbSpl, 60.0f, 105.0f,
@@ -99,6 +104,9 @@ uint32_t gTriangleFireAtMs = 0;
 fl::audio::SoundLevelMeter gSoundLevelMeter;
 fl::shared_ptr<fl::audio::Processor> gAudio;
 float gSoundPressureDbSpl = 33.0f;
+uint8_t gMusicBeatCount = 0;
+uint32_t gFirstMusicBeatMs = 0;
+uint32_t gMusicActiveUntilMs = 0;
 
 void updateSoundLevel() {
     if (!gAudio) {
@@ -110,6 +118,35 @@ void updateSoundLevel() {
     }
     gSoundLevelMeter.processBlock(sample.pcm());
     gSoundPressureDbSpl = static_cast<float>(gSoundLevelMeter.getSPL());
+}
+
+bool isMusicPresent() {
+    const fl::audio::Sample &sample = gAudio->getSample();
+    if (!sample.isValid() || sample.zcf() >= kMaximumMusicZcf) {
+        return false;
+    }
+
+    const uint32_t now = millis();
+    if (now < gMusicActiveUntilMs) {
+        // Each qualifying bass beat extends the short music-present hold.
+        gMusicActiveUntilMs = now + kMusicHoldMs;
+        return true;
+    }
+
+    if (gMusicBeatCount == 0 || now - gFirstMusicBeatMs > kMusicBeatWindowMs) {
+        gMusicBeatCount = 1;
+        gFirstMusicBeatMs = now;
+        return false;
+    }
+
+    ++gMusicBeatCount;
+    if (gMusicBeatCount < kMusicBeatsToActivate) {
+        return false;
+    }
+
+    gMusicBeatCount = 0;
+    gMusicActiveUntilMs = now + kMusicHoldMs;
+    return true;
 }
 
 void fireAnalyzer(float bass, float threshold, float minIntensity,
@@ -169,7 +206,8 @@ void setup() {
         // beat callback.
         updateSoundLevel();
         if (!levels.bassSpike ||
-            gSoundPressureDbSpl < stageThresholdDbSpl.value()) {
+            gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
+            !isMusicPresent()) {
             return;
         }
         fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -1,44 +1,31 @@
 // FL_AGENT_ALLOW_NEW_EXAMPLE
-/// @file    hydropack.ino
-/// @brief   HydroPack: dual EL-panel beat visualizer. The inner panel fires
-///          on sensitive (quiet) beats, the outer panel only on loud beats.
-///          INMP441 mic -> normalized bass detection -> 50 Hz PWM gates.
+/// @file hydropack.ino
+/// @brief HydroPack: an LED approximation of the < | > EL layout with two
+///          adaptive microphone indicators: Sensitive and Loud.
 /// @example hydropack.ino
 
 // @filter: (mem is large) and (platform is esp32*)
 
-// This sketch targets the ESP32-C3 and is also a valid FastLED WASM sketch:
-//   pip install fastled
-//   fastled examples/hydropack
-// On WASM the audio comes from the browser (microphone or audio file) and the
-// two EL panels are rendered as an inner disc + outer ring preview. On the
-// ESP32-C3 the audio comes from a real INMP441 and the panels are driven by
-// low-frequency 50 Hz PWM suitable for gating an EL inverter.
+// This is deliberately an LED prototype, not an EL renderer. It draws two
+// triangular clusters and a center bar using ordinary addressable LEDs, then
+// adds two status LEDs below them:
+//   - cyan: Sensitive - fires on a bass transient just above the song average
+//   - magenta: Loud - fires only on a substantially stronger transient
 //
-// For a continuous-envelope EL panel example (browser audio only), see
-// examples/ElPanelReactive. HydroPack differs in that it is spike-gated:
-// panels flash on discrete beats instead of tracking the audio level, and it
-// wires a real INMP441 for standalone wearable use.
-//
-// Audio pipeline ("normalize, then select-filter"):
-//   1. Signal conditioning (DC removal, spike filter, noise gate) plus the
-//      INMP441 frequency-response profile normalize the raw mic signal.
-//   2. The vibe detector tracks the bass band of the FFT and self-normalizes
-//      it against the running song average (~1.0 = average loudness), so the
-//      same thresholds work at whisper and club volume.
-//   3. Rising bass energy (a spike) is split by loudness: beats just above
-//      the average fire the sensitive inner panel; only strong hits fire the
-//      loud outer panel.
+// The detector is FastLED's built-in Vibe detector. Like Songstone's adaptive
+// window, it tracks a slow running song average; relative bass energy is about
+// 1.0 at the current average. FastLED's adaptive noise-floor tracker gates
+// microphone hiss before Vibe sees it. A loud hit therefore fires both LEDs,
+// while a moderate hit fires Sensitive only.
 
 #include <Arduino.h>
 #include <FastLED.h>
 
 #include "fl/math/math.h"
-#include "fl/system/pin.h"
 #include "fl/ui/ui.h"
 
 // ---------------------------------------------------------------------------
-// Configuration (ESP32-C3 pin map)
+// Configuration
 // ---------------------------------------------------------------------------
 
 // INMP441 wiring (matches examples/AudioInput):
@@ -48,169 +35,124 @@
 #define I2S_SD 8
 #define I2S_CLK 4
 
-// EL panel gate pins. Each drives the enable line / transistor gate of an EL
-// inverter, active high.
-#define PIN_EL_INNER 5
-#define PIN_EL_OUTER 6
-#define PIN_EL_WIRE 10
-
-// EL inverters must be gated slowly - low-frequency PWM at 50 Hz.
-#define EL_PWM_FREQ_HZ 50
-
-// On-screen preview (WASM) and optional debug strip (hardware): one channel
-// per geometry-native EL output.
 #define PIN_PREVIEW 3
-#define NUM_PREVIEW_LEDS 3
 
-// ---------------------------------------------------------------------------
-// EL panel drive: 50 Hz low-frequency PWM through the fl pin API
-// ---------------------------------------------------------------------------
-// fl::setPwmFrequency() + fl::analogWrite() pick the right PWM backend per
-// platform (LEDC on ESP32, including the Arduino core 2.x/3.x differences).
-// The browser preview has no PWM hardware, so the calls are skipped there;
-// the preview LEDs are the panels on WASM.
+constexpr uint8_t kGeometryLedCount = 18;
+constexpr uint8_t kSensitiveIndicator = 18;
+constexpr uint8_t kLoudIndicator = 19;
+constexpr uint8_t kPreviewLedCount = 20;
 
-void initPanels() {
-#ifndef __EMSCRIPTEN__
-    fl::pinMode(PIN_EL_INNER, fl::PinMode::Output);
-    fl::pinMode(PIN_EL_OUTER, fl::PinMode::Output);
-    fl::pinMode(PIN_EL_WIRE, fl::PinMode::Output);
-    fl::setPwmFrequency(PIN_EL_INNER, EL_PWM_FREQ_HZ);
-    fl::setPwmFrequency(PIN_EL_OUTER, EL_PWM_FREQ_HZ);
-    fl::setPwmFrequency(PIN_EL_WIRE, EL_PWM_FREQ_HZ);
-    fl::analogWrite(PIN_EL_INNER, 0);
-    fl::analogWrite(PIN_EL_OUTER, 0);
-    fl::analogWrite(PIN_EL_WIRE, 0);
-#endif
+CRGB previewLeds[kPreviewLedCount];
+
+// Six LEDs form each triangle, six form the center bar, and the last two are
+// the explicitly labeled audio indicators. The layout reads < | > in the
+// WASM screenmap renderer without relying on EL panel/wire primitives.
+const fl::vec2f kHydroPackLedLayout[] = {
+    // Left triangle (<)
+    {12.0f, 50.0f}, {22.0f, 42.0f}, {22.0f, 58.0f},
+    {32.0f, 34.0f}, {32.0f, 50.0f}, {32.0f, 66.0f},
+    // Center bar (|)
+    {50.0f, 30.0f}, {50.0f, 38.0f}, {50.0f, 46.0f},
+    {50.0f, 54.0f}, {50.0f, 62.0f}, {50.0f, 70.0f},
+    // Right triangle (>)
+    {88.0f, 50.0f}, {78.0f, 42.0f}, {78.0f, 58.0f},
+    {68.0f, 34.0f}, {68.0f, 50.0f}, {68.0f, 66.0f},
+    // Sensitive, Loud
+    {44.0f, 88.0f}, {56.0f, 88.0f},
+};
+
+static_assert(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
+                  kPreviewLedCount,
+              "HydroPack screenmap must contain every preview LED");
+
+fl::ScreenMap makePreviewMap() {
+    return fl::ScreenMap(kHydroPackLedLayout, 1.4f);
 }
 
-void writePanels(uint8_t innerDuty, uint8_t wireDuty, uint8_t outerDuty) {
-#ifndef __EMSCRIPTEN__
-    // Skip rewrites of an unchanged duty: the 50 Hz PWM only latches a new
-    // value once per 20 ms period anyway.
-    static int lastInner = -1;
-    static int lastOuter = -1;
-    static int lastWire = -1;
-    if (innerDuty != lastInner) {
-        fl::analogWrite(PIN_EL_INNER, innerDuty);
-        lastInner = innerDuty;
-    }
-    if (outerDuty != lastOuter) {
-        fl::analogWrite(PIN_EL_OUTER, outerDuty);
-        lastOuter = outerDuty;
-    }
-    if (wireDuty != lastWire) {
-        fl::analogWrite(PIN_EL_WIRE, wireDuty);
-        lastWire = wireDuty;
-    }
-#else
-    FASTLED_UNUSED(innerDuty);
-    FASTLED_UNUSED(wireDuty);
-    FASTLED_UNUSED(outerDuty);
-#endif
-}
-
-// ---------------------------------------------------------------------------
-// Globals
-// ---------------------------------------------------------------------------
-
-CRGB previewLeds[NUM_PREVIEW_LEDS];
+fl::ScreenMap previewMap = makePreviewMap();
 
 fl::audio::Config audioConfig = fl::audio::Config::CreateInmp441(
     I2S_WS, I2S_SD, I2S_CLK, fl::audio::AudioChannel::Right);
 fl::UIAudio audioUi("Audio Input", audioConfig);
 
-fl::UITitle title("HydroPack");
+fl::UITitle title("HydroPack LED Audio Prototype");
 fl::UIDescription description(
-    "Dual EL-panel beat visualizer. The INMP441 signal is normalized, then "
-    "bass beats are split by loudness: the inner panel fires on sensitive "
-    "beats, the outer panel only on loud ones. Panels are gated with 50 Hz "
-    "low-frequency PWM.");
+    "LED approximation of the < | > layout. Cyan is Sensitive: it fires on "
+    "moderate bass hits. Magenta is Loud: it fires only on strong hits. "
+    "Both thresholds adapt to the current song and microphone noise floor.");
 
-// Vibe bass is self-normalizing: ~1.0 = the song's running average, so the
-// thresholds read as "x times louder than average".
-fl::UISlider innerThreshold("Inner (Sensitive) Threshold", 1.05f, 1.0f, 3.0f, 0.05f);
-fl::UISlider outerThreshold("Outer (Loud) Threshold", 1.6f, 1.0f, 6.0f, 0.05f);
-fl::UISlider fadeSeconds("Panel Fade Seconds", 0.25f, 0.05f, 2.0f, 0.05f);
+fl::UISlider sensitiveThreshold("Sensitive Threshold", 1.05f, 1.0f, 3.0f,
+                                0.05f);
+fl::UISlider loudThreshold("Loud Threshold", 1.65f, 1.0f, 6.0f, 0.05f);
+fl::UISlider fadeSeconds("Indicator Fade Seconds", 0.25f, 0.05f, 2.0f,
+                          0.05f);
 
-// Beat envelopes, 0.0-1.0. Raised by the audio callback, decayed in loop().
-float gInnerLevel = 0.0f;
-float gOuterLevel = 0.0f;
+// 0.0-1.0 envelopes. The audio callback raises them and the render loop
+// decays them. Keeping two independent envelopes makes the behavior visible:
+// Sensitive can remain lit while Loud stays dark.
+float gSensitiveLevel = 0.0f;
+float gLoudLevel = 0.0f;
 
-// Preview layout: two filled triangular EL panels and one thick EL wire.
-fl::ScreenMap makePreviewMap() {
-    fl::ScreenMap map(NUM_PREVIEW_LEDS, 0.5f);
-    const fl::vec2f left[] = {{30.0f, 50.0f}, {10.0f, 25.0f}, {10.0f, 75.0f}};
-    const fl::vec2f wire[] = {{42.0f, 50.0f}, {58.0f, 50.0f}};
-    const fl::vec2f right[] = {{70.0f, 50.0f}, {90.0f, 25.0f}, {90.0f, 75.0f}};
-    map.setShape(0, fl::ScreenMap::Shape::EL_PANEL, left, 3);
-    map.setShape(1, fl::ScreenMap::Shape::EL_WIRE, wire, 2, 5.0f);
-    map.setShape(2, fl::ScreenMap::Shape::EL_PANEL, right, 3);
-    return map;
-}
-
-fl::ScreenMap previewMap = makePreviewMap();
-
-// Raise a panel envelope when a bass spike crosses its threshold. Intensity
-// scales with how far the beat lands above the threshold, with a floor so
-// barely-over beats still visibly flash.
-void firePanel(float bass, float threshold, float minIntensity, float &level) {
+void fireIndicator(float bass, float threshold, float minIntensity,
+                   float &level) {
     if (bass <= threshold) {
         return;
     }
-    const float intensity =
-        fl::clamp((bass - threshold) / threshold, minIntensity, 1.0f);
+    const float intensity = fl::clamp((bass - threshold) / threshold,
+                                      minIntensity, 1.0f);
     level = fl::max(level, intensity);
 }
 
-// ---------------------------------------------------------------------------
-// Arduino setup / loop
-// ---------------------------------------------------------------------------
+uint8_t toByte(float value) {
+    return static_cast<uint8_t>(fl::clamp(value, 0.0f, 255.0f));
+}
+
+void renderPreview() {
+    // The physical-layout LEDs are electric blue only while an indicator is
+    // active. Quiet input is fully dark.
+    const float combined = fl::max(gSensitiveLevel, gLoudLevel);
+    const uint8_t geometryBrightness = toByte(combined * 160.0f);
+    for (uint8_t i = 0; i < kGeometryLedCount; ++i) {
+        previewLeds[i] = CRGB(0, geometryBrightness / 3, geometryBrightness);
+    }
+
+    const uint8_t sensitive = toByte(gSensitiveLevel * 255.0f);
+    const uint8_t loud = toByte(gLoudLevel * 255.0f);
+    previewLeds[kSensitiveIndicator] = CRGB(0, sensitive, sensitive);
+    previewLeds[kLoudIndicator] = CRGB(loud, 0, loud);
+}
 
 void setup() {
     Serial.begin(115200);
 
-    FastLED.addLeds<WS2812B, PIN_PREVIEW, GRB>(previewLeds, NUM_PREVIEW_LEDS)
+    FastLED.addLeds<WS2812B, PIN_PREVIEW, GRB>(previewLeds, kPreviewLedCount)
         .setScreenMap(previewMap);
     FastLED.setBrightness(255);
 
-    initPanels();
+    sensitiveThreshold.setGroup("Adaptive Audio Indicators");
+    loudThreshold.setGroup("Adaptive Audio Indicators");
+    fadeSeconds.setGroup("Adaptive Audio Indicators");
 
-    innerThreshold.setGroup("Beat Detection");
-    outerThreshold.setGroup("Beat Detection");
-    fadeSeconds.setGroup("Beat Detection");
-
-    // Unified audio path: browser audio on WASM, INMP441 over I2S on the
-    // ESP32-C3. Samples are auto-pumped into the processor during show().
+    // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
     auto audio = FastLED.add(audioUi);
     if (!audio) {
         FL_WARN("HydroPack: no audio processor available");
         return;
     }
 
-    // Normalization: the conditioning pipeline (DC removal, spike filter,
-    // noise gate) is on by default; adaptive noise floor tracking keeps
-    // quiet-room hiss from triggering the panels.
     audio->setNoiseFloorTrackingEnabled(true);
-
-    // Select-filter: only rising bass energy counts as a beat, then the
-    // self-normalized level picks which panel(s) fire.
     audio->onVibeLevels([](const fl::audio::detector::VibeLevels &levels) {
         if (!levels.bassSpike) {
             return;
         }
-        // Inner panel: sensitive - beats just above the running average.
-        firePanel(levels.bass, innerThreshold.value(), 0.35f, gInnerLevel);
-        // Outer panel: loud beats only.
-        firePanel(levels.bass, outerThreshold.value(), 0.5f, gOuterLevel);
+        fireIndicator(levels.bass, sensitiveThreshold.value(), 0.35f,
+                      gSensitiveLevel);
+        fireIndicator(levels.bass, loudThreshold.value(), 0.50f, gLoudLevel);
     });
 }
 
 void loop() {
-    // 100 fps is plenty for a 50 Hz output device; pacing the frame keeps a
-    // battery-powered wearable from busy-looping at full speed.
     EVERY_N_MILLIS(10) {
-        // Frame-time based decay so the fade speed is FPS independent.
         static uint32_t lastMs = 0;
         static bool firstFrame = true;
         const uint32_t now = millis();
@@ -221,22 +163,12 @@ void loop() {
         const float fade = fadeSeconds.value();
         if (fade > 0.0f && deltaMs > 0) {
             const float decay = float(deltaMs) / (1000.0f * fade);
-            gInnerLevel = fl::clamp(gInnerLevel - decay, 0.0f, 1.0f);
-            gOuterLevel = fl::clamp(gOuterLevel - decay, 0.0f, 1.0f);
+            gSensitiveLevel = fl::clamp(gSensitiveLevel - decay, 0.0f, 1.0f);
+            gLoudLevel = fl::clamp(gLoudLevel - decay, 0.0f, 1.0f);
         }
 
-        // Drive the EL panels: envelope -> 50 Hz PWM duty.
-        const uint8_t innerDuty = uint8_t(gInnerLevel * 255.0f);
-        const uint8_t outerDuty = uint8_t(gOuterLevel * 255.0f);
-        const uint8_t wireDuty = uint8_t(((gInnerLevel + gOuterLevel) * 0.5f) * 255.0f);
-        writePanels(innerDuty, wireDuty, outerDuty);
-
-        // Preview: inner disc = aqua (sensitive), outer ring = ice blue (loud).
-        previewLeds[0] = CRGB(innerDuty, 0, 0);
-        previewLeds[1] = CRGB(0, wireDuty, 0);
-        previewLeds[2] = CRGB(0, 0, outerDuty);
-
-        FastLED.show(); // audio is auto-pumped here
+        renderPreview();
+        FastLED.show();  // Auto-pumps browser or I2S microphone audio.
     }
     delay(1);
 }

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -199,11 +199,18 @@ void renderPreview() {
         previewLeds[kCenterStart + i] = centerColor;
     }
 #if defined(FL_IS_WASM)
-    const uint8_t debugBrightness =
-        showBeatConfidenceDebug.value() ? toByte(gBeatConfidence * 255.0f)
-                                         : 0;
-    previewLeds[kDebugLedIndex] =
-        CRGB(debugBrightness, debugBrightness, debugBrightness);
+    // Keep the widget visibly red at zero, then turn it bright green as the
+    // 0-1 confidence rises. A black zero was indistinguishable from a missing
+    // debug LED in the preview.
+    const uint8_t debugRed =
+        showBeatConfidenceDebug.value()
+            ? toByte(24.0f * (1.0f - gBeatConfidence))
+            : 0;
+    const uint8_t debugGreen =
+        showBeatConfidenceDebug.value()
+            ? toByte(16.0f + gBeatConfidence * 239.0f)
+            : 0;
+    previewLeds[kDebugLedIndex] = CRGB(debugRed, debugGreen, 0);
 #endif
 }
 
@@ -234,6 +241,7 @@ void setup() {
         // floor, rather than only the relatively loud blocks that trigger a
         // beat callback.
         updateSoundLevel();
+        gBeatConfidence = gAudio->getBeatConfidence();
         if (!levels.bassSpike ||
             gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
             !isMusicModeActive()) {
@@ -278,10 +286,6 @@ void loop() {
             gCenterLevel = fl::clamp(gCenterLevel - decay, 0.0f, 1.0f);
             gTriangleLevel = fl::clamp(gTriangleLevel - decay, 0.0f, 1.0f);
         }
-        const float confidenceDecay = float(deltaMs) / 750.0f;
-        gBeatConfidence =
-            fl::clamp(gBeatConfidence - confidenceDecay, 0.0f, 1.0f);
-
         renderPreview();
         FastLED.show();  // Auto-pumps browser or I2S microphone audio.
     }

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -13,9 +13,8 @@
 //
 // FastLED's normalized spectral-flux beat confidence arms music mode. Vibe
 // remains the actual real-time bass response: its spikes drive the animation
-// only while music mode is armed. The arming latch needs two bass beats in a
-// broad musical tempo range and rejects high-ZCF hiss. The beat spacing may
-// speed up or slow down; it is evidence of music, not an animation BPM lock.
+// only while music mode is armed. Music mode warms up over five seconds of
+// recurring confident beats, with no fixed BPM or tempo-consistency lock.
 // Once music is established, FastLED's Vibe detector tracks its running bass
 // average; relative bass energy is about 1.0 at the current average. A loud
 // hit lights the center, then launches into the triangles.
@@ -42,12 +41,17 @@
 constexpr uint8_t kTriangleLedCount = 6;
 constexpr uint8_t kCenterStart = 6;
 constexpr uint8_t kRightTriangleStart = 12;
-constexpr uint8_t kPreviewLedCount = 18;
+constexpr uint8_t kHydroPackLedCount = 18;
+#if defined(FL_IS_WASM)
+constexpr uint8_t kDebugLedIndex = kHydroPackLedCount;
+constexpr uint8_t kPreviewLedCount = kHydroPackLedCount + 1;
+#else
+constexpr uint8_t kPreviewLedCount = kHydroPackLedCount;
+#endif
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
 constexpr float kDefaultStageThresholdDbSpl = 80.0f;
-constexpr uint8_t kMusicBeatsToActivate = 2;
-constexpr uint32_t kMinimumMusicBeatIntervalMs = 250;
-constexpr uint32_t kMaximumMusicBeatIntervalMs = 2000;
+constexpr uint32_t kMusicWarmupMs = 5000;
+constexpr uint32_t kMaximumMusicBeatGapMs = 2000;
 constexpr uint32_t kMusicHoldMs = 2000;
 constexpr float kMaximumMusicZcf = 0.40f;
 constexpr float kDefaultMinimumBeatConfidence = 0.25f;
@@ -66,6 +70,10 @@ const fl::vec2f kHydroPackLedLayout[] = {
     // Right triangle (>)
     {88.0f, 50.0f}, {78.0f, 42.0f}, {78.0f, 58.0f},
     {68.0f, 34.0f}, {68.0f, 50.0f}, {68.0f, 66.0f},
+#if defined(FL_IS_WASM)
+    // Preview-only widget LED: beat confidence, not part of the fixture.
+    {96.0f, 10.0f},
+#endif
 };
 
 static_assert(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
@@ -84,9 +92,9 @@ fl::UIAudio audioUi("Audio Input", audioConfig);
 
 fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "The INMP441 sound-pressure gate needs two confident low-hiss bass beats "
-    "to arm music mode, at any reasonable tempo. Conversation and one-off "
-    "noise stay dark; musical bass "
+    "The INMP441 sound-pressure gate warms up for five seconds of confident "
+    "beats before arming music mode. Conversation and one-off noise stay "
+    "dark; musical bass "
     "fires the center, with stronger hits launching to both triangles.");
 
 fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
@@ -95,6 +103,8 @@ fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
 fl::UISlider minimumBeatConfidence("Minimum Beat Confidence",
                                    kDefaultMinimumBeatConfidence, 0.0f, 1.0f,
                                    0.05f);
+fl::UICheckbox showBeatConfidenceDebug("Show Beat Confidence Debug LED",
+                                       true);
 fl::UISlider centerThreshold("Center (Sensitive) Threshold", 1.05f, 1.0f,
                              3.0f, 0.05f);
 fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
@@ -111,8 +121,9 @@ uint32_t gTriangleFireAtMs = 0;
 fl::audio::SoundLevelMeter gSoundLevelMeter;
 fl::shared_ptr<fl::audio::Processor> gAudio;
 float gSoundPressureDbSpl = 33.0f;
-uint8_t gMusicBeatCount = 0;
-uint32_t gFirstMusicBeatMs = 0;
+float gBeatConfidence = 0.0f;
+uint32_t gMusicWarmupStartedMs = 0;
+uint32_t gLastQualifyingBeatMs = 0;
 uint32_t gMusicActiveUntilMs = 0;
 
 void updateSoundLevel() {
@@ -134,26 +145,22 @@ bool isMusicPresent() {
     }
 
     const uint32_t now = millis();
-    if (now < gMusicActiveUntilMs) {
+    if (static_cast<int32_t>(now - gMusicActiveUntilMs) < 0) {
         // Each qualifying bass beat extends the short music-present hold.
         gMusicActiveUntilMs = now + kMusicHoldMs;
         return true;
     }
 
-    const uint32_t intervalMs = now - gFirstMusicBeatMs;
-    if (gMusicBeatCount == 0 || intervalMs > kMaximumMusicBeatIntervalMs ||
-        intervalMs < kMinimumMusicBeatIntervalMs) {
-        gMusicBeatCount = 1;
-        gFirstMusicBeatMs = now;
+    if (gMusicWarmupStartedMs == 0 ||
+        now - gLastQualifyingBeatMs > kMaximumMusicBeatGapMs) {
+        gMusicWarmupStartedMs = now;
+    }
+    gLastQualifyingBeatMs = now;
+
+    if (now - gMusicWarmupStartedMs < kMusicWarmupMs) {
         return false;
     }
 
-    ++gMusicBeatCount;
-    if (gMusicBeatCount < kMusicBeatsToActivate) {
-        return false;
-    }
-
-    gMusicBeatCount = 0;
     gMusicActiveUntilMs = now + kMusicHoldMs;
     return true;
 }
@@ -191,6 +198,13 @@ void renderPreview() {
     for (uint8_t i = 0; i < kTriangleLedCount; ++i) {
         previewLeds[kCenterStart + i] = centerColor;
     }
+#if defined(FL_IS_WASM)
+    const uint8_t debugBrightness =
+        showBeatConfidenceDebug.value() ? toByte(gBeatConfidence * 255.0f)
+                                         : 0;
+    previewLeds[kDebugLedIndex] =
+        CRGB(debugBrightness, debugBrightness, debugBrightness);
+#endif
 }
 
 void setup() {
@@ -205,6 +219,7 @@ void setup() {
     fadeSeconds.setGroup("Two-Level Bass Analyzers");
     stageThresholdDbSpl.setGroup("Stage Music Gate");
     minimumBeatConfidence.setGroup("Stage Music Gate");
+    showBeatConfidenceDebug.setGroup("Debug");
 
     // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
     gAudio = FastLED.add(audioUi);
@@ -233,7 +248,8 @@ void setup() {
         }
     });
     gAudio->onBeat([]() {
-        if (gAudio->getBeatConfidence() < minimumBeatConfidence.value() ||
+        gBeatConfidence = gAudio->getBeatConfidence();
+        if (gBeatConfidence < minimumBeatConfidence.value() ||
             gSoundPressureDbSpl < stageThresholdDbSpl.value()) {
             return;
         }
@@ -262,6 +278,9 @@ void loop() {
             gCenterLevel = fl::clamp(gCenterLevel - decay, 0.0f, 1.0f);
             gTriangleLevel = fl::clamp(gTriangleLevel - decay, 0.0f, 1.0f);
         }
+        const float confidenceDecay = float(deltaMs) / 750.0f;
+        gBeatConfidence =
+            fl::clamp(gBeatConfidence - confidenceDecay, 0.0f, 1.0f);
 
         renderPreview();
         FastLED.show();  // Auto-pumps browser or I2S microphone audio.

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -11,10 +11,11 @@
 //   - center: sensitive - fires on a transient just above the song average
 //   - triangles: loud - fire only on a substantially stronger transient
 //
-// The output is gated by calibrated sound pressure and an adaptive bass beat.
-// A short music-presence latch needs two bass beats and rejects high-ZCF hiss,
-// keeping ordinary conversation and isolated noise dark without a rigid BPM
-// lock before every visible musical hit.
+// FastLED's normalized spectral-flux beat confidence arms music mode. Vibe
+// remains the actual real-time bass response: its spikes drive the animation
+// only while music mode is armed. The arming latch needs two bass beats in a
+// broad musical tempo range and rejects high-ZCF hiss. The beat spacing may
+// speed up or slow down; it is evidence of music, not an animation BPM lock.
 // Once music is established, FastLED's Vibe detector tracks its running bass
 // average; relative bass energy is about 1.0 at the current average. A loud
 // hit lights the center, then launches into the triangles.
@@ -45,9 +46,11 @@ constexpr uint8_t kPreviewLedCount = 18;
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
 constexpr float kDefaultStageThresholdDbSpl = 80.0f;
 constexpr uint8_t kMusicBeatsToActivate = 2;
-constexpr uint32_t kMusicBeatWindowMs = 1600;
+constexpr uint32_t kMinimumMusicBeatIntervalMs = 250;
+constexpr uint32_t kMaximumMusicBeatIntervalMs = 2000;
 constexpr uint32_t kMusicHoldMs = 2000;
 constexpr float kMaximumMusicZcf = 0.40f;
+constexpr float kDefaultMinimumBeatConfidence = 0.25f;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -81,13 +84,17 @@ fl::UIAudio audioUi("Audio Input", audioConfig);
 
 fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "The INMP441 sound-pressure gate needs two low-hiss bass beats to arm "
-    "music mode. Conversation and one-off noise stay dark; musical bass "
+    "The INMP441 sound-pressure gate needs two confident low-hiss bass beats "
+    "to arm music mode, at any reasonable tempo. Conversation and one-off "
+    "noise stay dark; musical bass "
     "fires the center, with stronger hits launching to both triangles.");
 
 fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
                                  kDefaultStageThresholdDbSpl, 60.0f, 105.0f,
                                  1.0f);
+fl::UISlider minimumBeatConfidence("Minimum Beat Confidence",
+                                   kDefaultMinimumBeatConfidence, 0.0f, 1.0f,
+                                   0.05f);
 fl::UISlider centerThreshold("Center (Sensitive) Threshold", 1.05f, 1.0f,
                              3.0f, 0.05f);
 fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
@@ -133,7 +140,9 @@ bool isMusicPresent() {
         return true;
     }
 
-    if (gMusicBeatCount == 0 || now - gFirstMusicBeatMs > kMusicBeatWindowMs) {
+    const uint32_t intervalMs = now - gFirstMusicBeatMs;
+    if (gMusicBeatCount == 0 || intervalMs > kMaximumMusicBeatIntervalMs ||
+        intervalMs < kMinimumMusicBeatIntervalMs) {
         gMusicBeatCount = 1;
         gFirstMusicBeatMs = now;
         return false;
@@ -147,6 +156,10 @@ bool isMusicPresent() {
     gMusicBeatCount = 0;
     gMusicActiveUntilMs = now + kMusicHoldMs;
     return true;
+}
+
+bool isMusicModeActive() {
+    return static_cast<int32_t>(millis() - gMusicActiveUntilMs) < 0;
 }
 
 void fireAnalyzer(float bass, float threshold, float minIntensity,
@@ -191,6 +204,7 @@ void setup() {
     triangleThreshold.setGroup("Two-Level Bass Analyzers");
     fadeSeconds.setGroup("Two-Level Bass Analyzers");
     stageThresholdDbSpl.setGroup("Stage Music Gate");
+    minimumBeatConfidence.setGroup("Stage Music Gate");
 
     // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
     gAudio = FastLED.add(audioUi);
@@ -207,7 +221,7 @@ void setup() {
         updateSoundLevel();
         if (!levels.bassSpike ||
             gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
-            !isMusicPresent()) {
+            !isMusicModeActive()) {
             return;
         }
         fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,
@@ -217,6 +231,13 @@ void setup() {
                          gPendingTriangleLevel);
             gTriangleFireAtMs = millis() + kTriangleLaunchDelayMs;
         }
+    });
+    gAudio->onBeat([]() {
+        if (gAudio->getBeatConfidence() < minimumBeatConfidence.value() ||
+            gSoundPressureDbSpl < stageThresholdDbSpl.value()) {
+            return;
+        }
+        isMusicPresent();
     });
 }
 

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -40,7 +40,7 @@ constexpr uint8_t kTriangleLedCount = 6;
 constexpr uint8_t kCenterStart = 6;
 constexpr uint8_t kRightTriangleStart = 12;
 constexpr uint8_t kPreviewLedCount = 18;
-constexpr uint32_t kTriangleLaunchDelayMs = 35;
+constexpr uint32_t kTriangleLaunchDelayMs = 5;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -85,8 +85,8 @@ fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
 fl::UISlider fadeSeconds("Launch Fade Seconds", 0.25f, 0.05f, 2.0f, 0.05f);
 
 // The two analyzers have independent envelopes but share one bass input.
-// The loud analyzer is released after a brief delay to make the center-to-
-// triangles animation read as an outward launch.
+// The loud analyzer is released 5 ms after the center, preserving an outward
+// launch without adding a perceptible artificial delay.
 float gCenterLevel = 0.0f;
 float gTriangleLevel = 0.0f;
 float gPendingTriangleLevel = 0.0f;

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -1,22 +1,21 @@
 // FL_AGENT_ALLOW_NEW_EXAMPLE
 /// @file hydropack.ino
-/// @brief HydroPack: an LED approximation of the < | > EL layout with two
-///          adaptive microphone indicators: Sensitive and Loud.
+/// @brief HydroPack: two adaptive bass analyzers animate an LED < | > layout.
 /// @example hydropack.ino
 
 // @filter: (mem is large) and (platform is esp32*)
 
 // This is deliberately an LED prototype, not an EL renderer. It draws two
-// triangular clusters and a center bar using ordinary addressable LEDs, then
-// adds two status LEDs below them:
-//   - cyan: Sensitive - fires on a bass transient just above the song average
-//   - magenta: Loud - fires only on a substantially stronger transient
+// triangular clusters and a center bar using ordinary addressable LEDs. Two
+// independent threshold analyzers consume the same self-normalized bass input:
+//   - center: sensitive - fires on a transient just above the song average
+//   - triangles: loud - fire only on a substantially stronger transient
 //
 // The detector is FastLED's built-in Vibe detector. Like Songstone's adaptive
 // window, it tracks a slow running song average; relative bass energy is about
 // 1.0 at the current average. FastLED's adaptive noise-floor tracker gates
-// microphone hiss before Vibe sees it. A loud hit therefore fires both LEDs,
-// while a moderate hit fires Sensitive only.
+// microphone hiss before Vibe sees it. A loud hit lights the center, then
+// launches into the triangles; a moderate hit lights the center only.
 
 #include <Arduino.h>
 #include <FastLED.h>
@@ -37,16 +36,16 @@
 
 #define PIN_PREVIEW 3
 
-constexpr uint8_t kGeometryLedCount = 18;
-constexpr uint8_t kSensitiveIndicator = 18;
-constexpr uint8_t kLoudIndicator = 19;
-constexpr uint8_t kPreviewLedCount = 20;
+constexpr uint8_t kTriangleLedCount = 6;
+constexpr uint8_t kCenterStart = 6;
+constexpr uint8_t kRightTriangleStart = 12;
+constexpr uint8_t kPreviewLedCount = 18;
+constexpr uint32_t kTriangleLaunchDelayMs = 35;
 
 CRGB previewLeds[kPreviewLedCount];
 
-// Six LEDs form each triangle, six form the center bar, and the last two are
-// the explicitly labeled audio indicators. The layout reads < | > in the
-// WASM screenmap renderer without relying on EL panel/wire primitives.
+// Six LEDs form each triangle and six form the center bar. The layout reads
+// < | > in the WASM screenmap renderer without EL panel/wire primitives.
 const fl::vec2f kHydroPackLedLayout[] = {
     // Left triangle (<)
     {12.0f, 50.0f}, {22.0f, 42.0f}, {22.0f, 58.0f},
@@ -57,8 +56,6 @@ const fl::vec2f kHydroPackLedLayout[] = {
     // Right triangle (>)
     {88.0f, 50.0f}, {78.0f, 42.0f}, {78.0f, 58.0f},
     {68.0f, 34.0f}, {68.0f, 50.0f}, {68.0f, 66.0f},
-    // Sensitive, Loud
-    {44.0f, 88.0f}, {56.0f, 88.0f},
 };
 
 static_assert(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
@@ -75,26 +72,28 @@ fl::audio::Config audioConfig = fl::audio::Config::CreateInmp441(
     I2S_WS, I2S_SD, I2S_CLK, fl::audio::AudioChannel::Right);
 fl::UIAudio audioUi("Audio Input", audioConfig);
 
-fl::UITitle title("HydroPack LED Audio Prototype");
+fl::UITitle title("HydroPack Two-Level Bass Launch");
 fl::UIDescription description(
-    "LED approximation of the < | > layout. Cyan is Sensitive: it fires on "
-    "moderate bass hits. Magenta is Loud: it fires only on strong hits. "
-    "Both thresholds adapt to the current song and microphone noise floor.");
+    "Two analyzers read the same adaptive bass signal. The center bar fires "
+    "at the sensitive level. Stronger hits launch out to both triangles. "
+    "Quiet input is fully dark.");
 
-fl::UISlider sensitiveThreshold("Sensitive Threshold", 1.05f, 1.0f, 3.0f,
-                                0.05f);
-fl::UISlider loudThreshold("Loud Threshold", 1.65f, 1.0f, 6.0f, 0.05f);
-fl::UISlider fadeSeconds("Indicator Fade Seconds", 0.25f, 0.05f, 2.0f,
-                          0.05f);
+fl::UISlider centerThreshold("Center (Sensitive) Threshold", 1.05f, 1.0f,
+                             3.0f, 0.05f);
+fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
+                               6.0f, 0.05f);
+fl::UISlider fadeSeconds("Launch Fade Seconds", 0.25f, 0.05f, 2.0f, 0.05f);
 
-// 0.0-1.0 envelopes. The audio callback raises them and the render loop
-// decays them. Keeping two independent envelopes makes the behavior visible:
-// Sensitive can remain lit while Loud stays dark.
-float gSensitiveLevel = 0.0f;
-float gLoudLevel = 0.0f;
+// The two analyzers have independent envelopes but share one bass input.
+// The loud analyzer is released after a brief delay to make the center-to-
+// triangles animation read as an outward launch.
+float gCenterLevel = 0.0f;
+float gTriangleLevel = 0.0f;
+float gPendingTriangleLevel = 0.0f;
+uint32_t gTriangleFireAtMs = 0;
 
-void fireIndicator(float bass, float threshold, float minIntensity,
-                   float &level) {
+void fireAnalyzer(float bass, float threshold, float minIntensity,
+                  float &level) {
     if (bass <= threshold) {
         return;
     }
@@ -108,18 +107,20 @@ uint8_t toByte(float value) {
 }
 
 void renderPreview() {
-    // The physical-layout LEDs are electric blue only while an indicator is
-    // active. Quiet input is fully dark.
-    const float combined = fl::max(gSensitiveLevel, gLoudLevel);
-    const uint8_t geometryBrightness = toByte(combined * 160.0f);
-    for (uint8_t i = 0; i < kGeometryLedCount; ++i) {
-        previewLeds[i] = CRGB(0, geometryBrightness / 3, geometryBrightness);
-    }
+    // Quiet is fully dark. The sensitive center appears first; a loud hit
+    // subsequently drives the two triangle clusters outward from it.
+    const uint8_t centerBrightness = toByte(gCenterLevel * 200.0f);
+    const uint8_t triangleBrightness = toByte(gTriangleLevel * 180.0f);
+    const CRGB centerColor(0, centerBrightness / 3, centerBrightness);
+    const CRGB triangleColor(0, triangleBrightness / 3, triangleBrightness);
 
-    const uint8_t sensitive = toByte(gSensitiveLevel * 255.0f);
-    const uint8_t loud = toByte(gLoudLevel * 255.0f);
-    previewLeds[kSensitiveIndicator] = CRGB(0, sensitive, sensitive);
-    previewLeds[kLoudIndicator] = CRGB(loud, 0, loud);
+    for (uint8_t i = 0; i < kTriangleLedCount; ++i) {
+        previewLeds[i] = triangleColor;
+        previewLeds[kRightTriangleStart + i] = triangleColor;
+    }
+    for (uint8_t i = 0; i < kTriangleLedCount; ++i) {
+        previewLeds[kCenterStart + i] = centerColor;
+    }
 }
 
 void setup() {
@@ -129,9 +130,9 @@ void setup() {
         .setScreenMap(previewMap);
     FastLED.setBrightness(255);
 
-    sensitiveThreshold.setGroup("Adaptive Audio Indicators");
-    loudThreshold.setGroup("Adaptive Audio Indicators");
-    fadeSeconds.setGroup("Adaptive Audio Indicators");
+    centerThreshold.setGroup("Two-Level Bass Analyzers");
+    triangleThreshold.setGroup("Two-Level Bass Analyzers");
+    fadeSeconds.setGroup("Two-Level Bass Analyzers");
 
     // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
     auto audio = FastLED.add(audioUi);
@@ -145,9 +146,13 @@ void setup() {
         if (!levels.bassSpike) {
             return;
         }
-        fireIndicator(levels.bass, sensitiveThreshold.value(), 0.35f,
-                      gSensitiveLevel);
-        fireIndicator(levels.bass, loudThreshold.value(), 0.50f, gLoudLevel);
+        fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,
+                     gCenterLevel);
+        if (levels.bass > triangleThreshold.value()) {
+            fireAnalyzer(levels.bass, triangleThreshold.value(), 0.50f,
+                         gPendingTriangleLevel);
+            gTriangleFireAtMs = millis() + kTriangleLaunchDelayMs;
+        }
     });
 }
 
@@ -160,11 +165,17 @@ void loop() {
         firstFrame = false;
         lastMs = now;
 
+        if (gPendingTriangleLevel > 0.0f &&
+            static_cast<int32_t>(now - gTriangleFireAtMs) >= 0) {
+            gTriangleLevel = fl::max(gTriangleLevel, gPendingTriangleLevel);
+            gPendingTriangleLevel = 0.0f;
+        }
+
         const float fade = fadeSeconds.value();
         if (fade > 0.0f && deltaMs > 0) {
             const float decay = float(deltaMs) / (1000.0f * fade);
-            gSensitiveLevel = fl::clamp(gSensitiveLevel - decay, 0.0f, 1.0f);
-            gLoudLevel = fl::clamp(gLoudLevel - decay, 0.0f, 1.0f);
+            gCenterLevel = fl::clamp(gCenterLevel - decay, 0.0f, 1.0f);
+            gTriangleLevel = fl::clamp(gTriangleLevel - decay, 0.0f, 1.0f);
         }
 
         renderPreview();

--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -11,9 +11,9 @@
 //   - center: sensitive - fires on a transient just above the song average
 //   - triangles: loud - fire only on a substantially stronger transient
 //
-// FastLED's normalized spectral-flux beat confidence arms music mode. Vibe
-// remains the actual real-time bass response: its spikes drive the animation
-// only while music mode is armed. Music mode warms up over five seconds of
+// Vibe's normalized bass-rise confidence arms music mode and drives the
+// actual real-time response. It is codec-level independent, unlike a fixed
+// raw spectral-flux threshold. Music mode warms up over two seconds of
 // recurring confident beats, with no fixed BPM or tempo-consistency lock.
 // Once music is established, FastLED's Vibe detector tracks its running bass
 // average; relative bass energy is about 1.0 at the current average. A loud
@@ -42,19 +42,24 @@ constexpr uint8_t kTriangleLedCount = 6;
 constexpr uint8_t kCenterStart = 6;
 constexpr uint8_t kRightTriangleStart = 12;
 constexpr uint8_t kHydroPackLedCount = 18;
-#if defined(FL_IS_WASM)
-constexpr uint8_t kDebugLedIndex = kHydroPackLedCount;
-constexpr uint8_t kPreviewLedCount = kHydroPackLedCount + 1;
-#else
 constexpr uint8_t kPreviewLedCount = kHydroPackLedCount;
-#endif
 constexpr uint32_t kTriangleLaunchDelayMs = 5;
-constexpr float kDefaultStageThresholdDbSpl = 80.0f;
-constexpr uint32_t kMusicWarmupMs = 5000;
+constexpr float kDefaultStageThresholdDbSpl = 72.0f;
+constexpr uint32_t kMusicWarmupMs = 2000;
 constexpr uint32_t kMaximumMusicBeatGapMs = 2000;
 constexpr uint32_t kMusicHoldMs = 2000;
+constexpr float kMusicModeFadeSeconds = 0.5f;
 constexpr float kMaximumMusicZcf = 0.40f;
-constexpr float kDefaultMinimumBeatConfidence = 0.25f;
+constexpr float kDefaultMinimumBeatConfidence = 0.05f;
+// Locked HydroPack response: the center detects ordinary bass hits; the
+// triangles require a substantially louder hit. Two cascaded envelopes keep
+// the attack sharp while giving the center a slightly longer tail.
+constexpr float kCenterBassThreshold = 1.05f;
+constexpr float kTriangleBassThreshold = 1.65f;
+constexpr float kCenterEnvelopeAttackSeconds = 0.015f;
+constexpr float kCenterEnvelopeFadeSeconds = 0.060f;
+constexpr float kTriangleEnvelopeAttackSeconds = 0.015f;
+constexpr float kTriangleEnvelopeFadeSeconds = 0.040f;
 
 CRGB previewLeds[kPreviewLedCount];
 
@@ -70,10 +75,6 @@ const fl::vec2f kHydroPackLedLayout[] = {
     // Right triangle (>)
     {88.0f, 50.0f}, {78.0f, 42.0f}, {78.0f, 58.0f},
     {68.0f, 34.0f}, {68.0f, 50.0f}, {68.0f, 66.0f},
-#if defined(FL_IS_WASM)
-    // Preview-only widget LED: beat confidence, not part of the fixture.
-    {96.0f, 10.0f},
-#endif
 };
 
 static_assert(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
@@ -92,7 +93,7 @@ fl::UIAudio audioUi("Audio Input", audioConfig);
 
 fl::UITitle title("HydroPack Stage Music Launch");
 fl::UIDescription description(
-    "The INMP441 sound-pressure gate warms up for five seconds of confident "
+    "The INMP441 sound-pressure gate warms up for two seconds of confident "
     "beats before arming music mode. Conversation and one-off noise stay "
     "dark; musical bass "
     "fires the center, with stronger hits launching to both triangles.");
@@ -100,23 +101,23 @@ fl::UIDescription description(
 fl::UISlider stageThresholdDbSpl("Minimum Music Level (dB SPL)",
                                  kDefaultStageThresholdDbSpl, 60.0f, 105.0f,
                                  1.0f);
-fl::UISlider minimumBeatConfidence("Minimum Beat Confidence",
+fl::UISlider minimumBeatConfidence("Minimum Vibe Beat Confidence",
                                    kDefaultMinimumBeatConfidence, 0.0f, 1.0f,
                                    0.05f);
-fl::UICheckbox showBeatConfidenceDebug("Show Beat Confidence Debug LED",
-                                       true);
-fl::UISlider centerThreshold("Center (Sensitive) Threshold", 1.05f, 1.0f,
-                             3.0f, 0.05f);
-fl::UISlider triangleThreshold("Triangles (Loud) Threshold", 1.65f, 1.0f,
-                               6.0f, 0.05f);
-fl::UISlider fadeSeconds("Launch Fade Seconds", 0.25f, 0.05f, 2.0f, 0.05f);
+#if defined(FL_IS_WASM)
+fl::UICheckbox streamDetectorFrames("Stream Detector Frames", true);
+#endif
 
 // The two analyzers have independent envelopes but share one bass input.
 // The loud analyzer is released 5 ms after the center, preserving an outward
 // launch without adding a perceptible artificial delay.
 float gCenterLevel = 0.0f;
 float gTriangleLevel = 0.0f;
+float gCenterEnvelopeStage = 0.0f;
+float gTriangleEnvelopeStage = 0.0f;
+float gCenterTrigger = 0.0f;
 float gPendingTriangleLevel = 0.0f;
+float gTriangleTrigger = 0.0f;
 uint32_t gTriangleFireAtMs = 0;
 fl::audio::SoundLevelMeter gSoundLevelMeter;
 fl::shared_ptr<fl::audio::Processor> gAudio;
@@ -125,6 +126,7 @@ float gBeatConfidence = 0.0f;
 uint32_t gMusicWarmupStartedMs = 0;
 uint32_t gLastQualifyingBeatMs = 0;
 uint32_t gMusicActiveUntilMs = 0;
+float gMusicModeLevel = 0.0f;
 
 void updateSoundLevel() {
     if (!gAudio) {
@@ -169,14 +171,58 @@ bool isMusicModeActive() {
     return static_cast<int32_t>(millis() - gMusicActiveUntilMs) < 0;
 }
 
+float getVibeBeatConfidence(
+    const fl::audio::detector::VibeLevels &levels) {
+    const float bassAverage = gAudio->getVibeBassAtt();
+    if (!levels.bassSpike || bassAverage <= 0.0f) {
+        return 0.0f;
+    }
+    return fl::clamp((levels.bass - bassAverage) / bassAverage, 0.0f, 1.0f);
+}
+
 void fireAnalyzer(float bass, float threshold, float minIntensity,
-                  float &level) {
+                  float &trigger) {
     if (bass <= threshold) {
         return;
     }
     const float intensity = fl::clamp((bass - threshold) / threshold,
                                       minIntensity, 1.0f);
-    level = fl::max(level, intensity);
+    trigger = fl::max(trigger, intensity);
+}
+
+float applyAttackDecay(float value, float target, float attackSeconds,
+                       float decaySeconds, float deltaSeconds) {
+    const float seconds = target > value ? attackSeconds : decaySeconds;
+    if (seconds <= 0.0f) {
+        return target;
+    }
+    const float amount = fl::clamp(deltaSeconds / seconds, 0.0f, 1.0f);
+    return value + (target - value) * amount;
+}
+
+void advanceDoubleEnvelope(float &trigger, float &stage, float &level,
+                           float attackSeconds, float decaySeconds,
+                           float deltaSeconds) {
+    // Two cascaded attack/decay filters soften the event into a natural
+    // envelope. Both stages share an intentionally short attack; their decay
+    // is independently adjustable for the center and triangle elements.
+    stage = applyAttackDecay(stage, trigger, attackSeconds, decaySeconds,
+                             deltaSeconds);
+    level = applyAttackDecay(level, stage, attackSeconds, decaySeconds,
+                              deltaSeconds);
+    trigger = 0.0f;
+}
+
+float advanceLinearFade(float value, float target, float durationSeconds,
+                        float deltaSeconds) {
+    if (durationSeconds <= 0.0f) {
+        return target;
+    }
+    const float step = deltaSeconds / durationSeconds;
+    if (target > value) {
+        return fl::min(target, value + step);
+    }
+    return fl::max(target, value - step);
 }
 
 uint8_t toByte(float value) {
@@ -186,8 +232,10 @@ uint8_t toByte(float value) {
 void renderPreview() {
     // Quiet is fully dark. The sensitive center appears first; a loud hit
     // subsequently drives the two triangle clusters outward from it.
-    const uint8_t centerBrightness = toByte(gCenterLevel * 200.0f);
-    const uint8_t triangleBrightness = toByte(gTriangleLevel * 180.0f);
+    const uint8_t centerBrightness =
+        toByte(gCenterLevel * gMusicModeLevel * 200.0f);
+    const uint8_t triangleBrightness =
+        toByte(gTriangleLevel * gMusicModeLevel * 180.0f);
     const CRGB centerColor(0, centerBrightness / 3, centerBrightness);
     const CRGB triangleColor(0, triangleBrightness / 3, triangleBrightness);
 
@@ -198,20 +246,6 @@ void renderPreview() {
     for (uint8_t i = 0; i < kTriangleLedCount; ++i) {
         previewLeds[kCenterStart + i] = centerColor;
     }
-#if defined(FL_IS_WASM)
-    // Keep the widget visibly red at zero, then turn it bright green as the
-    // 0-1 confidence rises. A black zero was indistinguishable from a missing
-    // debug LED in the preview.
-    const uint8_t debugRed =
-        showBeatConfidenceDebug.value()
-            ? toByte(24.0f * (1.0f - gBeatConfidence))
-            : 0;
-    const uint8_t debugGreen =
-        showBeatConfidenceDebug.value()
-            ? toByte(16.0f + gBeatConfidence * 239.0f)
-            : 0;
-    previewLeds[kDebugLedIndex] = CRGB(debugRed, debugGreen, 0);
-#endif
 }
 
 void setup() {
@@ -221,12 +255,11 @@ void setup() {
         .setScreenMap(previewMap);
     FastLED.setBrightness(255);
 
-    centerThreshold.setGroup("Two-Level Bass Analyzers");
-    triangleThreshold.setGroup("Two-Level Bass Analyzers");
-    fadeSeconds.setGroup("Two-Level Bass Analyzers");
     stageThresholdDbSpl.setGroup("Stage Music Gate");
     minimumBeatConfidence.setGroup("Stage Music Gate");
-    showBeatConfidenceDebug.setGroup("Debug");
+#if defined(FL_IS_WASM)
+    streamDetectorFrames.setGroup("Debug");
+#endif
 
     // The unified input is browser audio on WASM and INMP441 I2S on ESP32.
     gAudio = FastLED.add(audioUi);
@@ -241,27 +274,45 @@ void setup() {
         // floor, rather than only the relatively loud blocks that trigger a
         // beat callback.
         updateSoundLevel();
-        gBeatConfidence = gAudio->getBeatConfidence();
+        gBeatConfidence = getVibeBeatConfidence(levels);
+#if defined(FL_IS_WASM)
+        // Keep this as one compact line per analysis frame. It deliberately
+        // polls both independent rhythm detectors: raw Beat is an onset
+        // detector; Tempo is the recurring-rhythm estimator. Calling these
+        // getters also enables their lazy detector instances for the next
+        // audio frame, so the trace diagnoses the real WASM signal path.
+        if (streamDetectorFrames.value()) {
+            const fl::audio::Sample &sample = gAudio->getSample();
+            fl::printf(
+                "HYDRO frame=%lu spl=%.1f zcf=%.3f silent=%u "
+                "beat=%.3f bpm=%.1f tempo=%.3f tempo_bpm=%.1f "
+                "vibe_bass=%.3f vibe_att=%.3f vibe_conf=%.3f spike=%u "
+                "bass_raw=%.3f gate=%u\\n",
+                static_cast<unsigned long>(millis()), gSoundPressureDbSpl,
+                sample.zcf(), gAudio->isSilent() ? 1U : 0U,
+                gAudio->getBeatConfidence(), gAudio->getBPM(),
+                gAudio->getTempoConfidence(), gAudio->getTempoBPM(),
+                levels.bass, gAudio->getVibeBassAtt(), gBeatConfidence,
+                levels.bassSpike ? 1U : 0U, levels.bassRaw,
+                isMusicModeActive() ? 1U : 0U);
+        }
+#endif
+        if (gBeatConfidence >= minimumBeatConfidence.value() &&
+            gSoundPressureDbSpl >= stageThresholdDbSpl.value()) {
+            isMusicPresent();
+        }
         if (!levels.bassSpike ||
             gSoundPressureDbSpl < stageThresholdDbSpl.value() ||
             !isMusicModeActive()) {
             return;
         }
-        fireAnalyzer(levels.bass, centerThreshold.value(), 0.35f,
-                     gCenterLevel);
-        if (levels.bass > triangleThreshold.value()) {
-            fireAnalyzer(levels.bass, triangleThreshold.value(), 0.50f,
+        fireAnalyzer(levels.bass, kCenterBassThreshold, 0.35f,
+                     gCenterTrigger);
+        if (levels.bass > kTriangleBassThreshold) {
+            fireAnalyzer(levels.bass, kTriangleBassThreshold, 0.50f,
                          gPendingTriangleLevel);
             gTriangleFireAtMs = millis() + kTriangleLaunchDelayMs;
         }
-    });
-    gAudio->onBeat([]() {
-        gBeatConfidence = gAudio->getBeatConfidence();
-        if (gBeatConfidence < minimumBeatConfidence.value() ||
-            gSoundPressureDbSpl < stageThresholdDbSpl.value()) {
-            return;
-        }
-        isMusicPresent();
     });
 }
 
@@ -276,15 +327,25 @@ void loop() {
 
         if (gPendingTriangleLevel > 0.0f &&
             static_cast<int32_t>(now - gTriangleFireAtMs) >= 0) {
-            gTriangleLevel = fl::max(gTriangleLevel, gPendingTriangleLevel);
+            gTriangleTrigger = fl::max(gTriangleTrigger,
+                                       gPendingTriangleLevel);
             gPendingTriangleLevel = 0.0f;
         }
 
-        const float fade = fadeSeconds.value();
-        if (fade > 0.0f && deltaMs > 0) {
-            const float decay = float(deltaMs) / (1000.0f * fade);
-            gCenterLevel = fl::clamp(gCenterLevel - decay, 0.0f, 1.0f);
-            gTriangleLevel = fl::clamp(gTriangleLevel - decay, 0.0f, 1.0f);
+        if (deltaMs > 0) {
+            const float deltaSeconds = float(deltaMs) * 0.001f;
+            gMusicModeLevel = advanceLinearFade(
+                gMusicModeLevel, isMusicModeActive() ? 1.0f : 0.0f,
+                kMusicModeFadeSeconds, deltaSeconds);
+            advanceDoubleEnvelope(gCenterTrigger, gCenterEnvelopeStage,
+                                  gCenterLevel,
+                                  kCenterEnvelopeAttackSeconds,
+                                  kCenterEnvelopeFadeSeconds, deltaSeconds);
+            advanceDoubleEnvelope(gTriangleTrigger, gTriangleEnvelopeStage,
+                                  gTriangleLevel,
+                                  kTriangleEnvelopeAttackSeconds,
+                                  kTriangleEnvelopeFadeSeconds,
+                                  deltaSeconds);
         }
         renderPreview();
         FastLED.show();  // Auto-pumps browser or I2S microphone audio.


### PR DESCRIPTION
## Summary\n- replace HydroPack's EL preview primitives with an 18-pixel ordinary-LED \< | >\ screenmap\n- use two independent thresholds over the same adaptive Vibe bass input: the sensitive center bar fires first, then a loud hit reaches both triangles after 5 ms\n- quiet input is fully dark; FastLED noise-floor tracking suppresses microphone hiss\n\n## Validation\n- \ash compile wasm --examples hydropack\\n- JSON screenmap contract: 18 mapped LEDs\n- ASCII source check and \git diff --check\\n\nThe local WASM preview is running at http://127.0.0.1:59610/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a HydroPack addressable-LED audio prototype that renders a fixed screen-map with a center-sensitive stage and outward-launching triangle visuals (including a timed launch delay).
  - Improved audio triggering using calibrated SPL thresholds combined with music-only responsiveness for more consistent, audience-safe behavior.
  - Added a new “triangles-bar” LED layout configuration.
- **Documentation**
  - Updated HydroPack lesson guidance with clearer visual-layers interpretation and revised SPL/musical detection recommendations.
  - Added a HydroPack LED audio prototype checklist for validation and launch readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->