### PR TITLE
fix(hydropack): use FL_STATIC_ASSERT instead of raw static_assert

### DIFF
--- a/examples/hydropack/hydropack.ino
+++ b/examples/hydropack/hydropack.ino
@@ -23,6 +23,7 @@
 #include <FastLED.h>
 
 #include "fl/math/math.h"
+#include "fl/stl/static_assert.h"
 #include "fl/ui/ui.h"
 
 // ---------------------------------------------------------------------------
@@ -77,7 +78,7 @@ const fl::vec2f kHydroPackLedLayout[] = {
     {68.0f, 34.0f}, {68.0f, 50.0f}, {68.0f, 66.0f},
 };
 
-static_assert(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
+FL_STATIC_ASSERT(sizeof(kHydroPackLedLayout) / sizeof(kHydroPackLedLayout[0]) ==
                   kPreviewLedCount,
               "HydroPack screenmap must contain every preview LED");
 


### PR DESCRIPTION
## Summary
- `examples/hydropack/hydropack.ino:80` used a raw `static_assert`, which `BannedMacrosChecker` flags — `FL_STATIC_ASSERT` keeps compile-time assertions portable on old embedded toolchains.
- This was blocking `bash lint --cpp` for every unrelated PR (discovered while starting work on FastLED#3715's ESP-Arduino-decoupling sub-issues).

## Test plan
- [x] `bash lint --cpp` — passes (was `cpp_linting FAILED` before this fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Hydropack example’s compile-time LED layout validation for improved compatibility while preserving the existing error message and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->