### PR TITLE
feat(esp32): bare-IDF fl::platforms time implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,6 @@ idf_component_register(SRCS ${FastLED_SRCS}
                        INCLUDE_DIRS "src"
                        REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
                                 esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif
-                                app_update)
+                                app_update esp_timer esp_rom)
 
 project(FastLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,21 @@ cmake_minimum_required(VERSION 3.5)
 # Collect all source files
 file(GLOB_RECURSE FastLED_SRCS "src/*.cpp")
 
+set(FASTLED_REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
+                      esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif
+                      app_update esp_timer)
 
+# esp_rom is a standalone component only from IDF 4.x onward (esp_rom_sys.h /
+# esp_rom_delay_us). On IDF 3.x, platform_time_esp32.cpp.hpp instead uses
+# rom/ets_sys.h (ets_delay_us), which ships as part of the legacy target
+# component and has no separate REQUIRES entry.
+if(NOT DEFINED IDF_VERSION_MAJOR OR IDF_VERSION_MAJOR GREATER_EQUAL 4)
+    list(APPEND FASTLED_REQUIRES esp_rom)
+endif()
 
 # Register the component with ESP-IDF
 idf_component_register(SRCS ${FastLED_SRCS}
                        INCLUDE_DIRS "src"
-                       REQUIRES arduino-esp32 esp_driver_i2s esp_driver_mcpwm esp_driver_rmt
-                                esp_http_server esp_lcd driver esp_mm esp_wifi esp_netif
-                                app_update esp_timer esp_rom)
+                       REQUIRES ${FASTLED_REQUIRES})
 
 project(FastLED)

--- a/src/platforms/esp/32/clockless_block_esp32.h
+++ b/src/platforms/esp/32/clockless_block_esp32.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/static_assert.h"
+#include "fl/system/delay.h"
 #include "platforms/esp/32/core/clock_cycles.h"
 #include "esp_intr_alloc.h"
 #include "eorder.h"
@@ -87,7 +88,7 @@ public:
 #ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
 	    ++_retry_cnt;
 #endif
-	    delayMicroseconds(WAIT_TIME * 10);
+	    fl::delayMicroseconds(WAIT_TIME * 10);
 	    // ets_intr_lock();
 		interrupt_lock();
 	}

--- a/src/platforms/esp/32/platform_time_esp32.cpp.hpp
+++ b/src/platforms/esp/32/platform_time_esp32.cpp.hpp
@@ -5,17 +5,27 @@
 // ESP32-specific platform time implementation
 // Uses vTaskDelay for millisecond-scale delays to yield to FreeRTOS scheduler,
 // enabling coroutines and background tasks to run during delays.
+//
+// Pure ESP-IDF implementation (esp_timer + FreeRTOS + ROM delay) — no Arduino
+// core dependency. Identical under Arduino-ESP32 (which bundles ESP-IDF) and
+// bare ESP-IDF builds.
 
 #include "platforms/esp/is_esp.h"
 
-#if defined(FL_IS_ESP32) && defined(ARDUINO) && !defined(FASTLED_STUB_IMPL)
+#if defined(FL_IS_ESP32) && !defined(FASTLED_STUB_IMPL)
 
 #include "platforms/time_platform.h"
-#include "fl/system/arduino.h"
+#include "platforms/esp/esp_version.h"
 
 // IWYU pragma: begin_keep
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_timer.h"
+#if ESP_IDF_VERSION_4_OR_HIGHER
+#include "esp_rom_sys.h"  // esp_rom_delay_us (ESP-IDF v4.0+)
+#else
+#include "rom/ets_sys.h"  // ets_delay_us (ESP-IDF v3.x)
+#endif
 // IWYU pragma: end_keep
 
 namespace fl {
@@ -36,19 +46,23 @@ void delayMicroseconds(fl::u32 us) {
         vTaskDelay(pdMS_TO_TICKS(ms));
     }
     if (remainder_us > 0) {
-        ::delayMicroseconds(remainder_us);
+#if ESP_IDF_VERSION_4_OR_HIGHER
+        esp_rom_delay_us(remainder_us);
+#else
+        ets_delay_us(remainder_us);
+#endif
     }
 }
 
 fl::u32 millis() {
-    return static_cast<fl::u32>(::millis());
+    return static_cast<fl::u32>(esp_timer_get_time() / 1000);
 }
 
 fl::u32 micros() {
-    return static_cast<fl::u32>(::micros());
+    return static_cast<fl::u32>(esp_timer_get_time());
 }
 
 }  // namespace platforms
 }  // namespace fl
 
-#endif  // FL_IS_ESP32 && ARDUINO && !FASTLED_STUB_IMPL
+#endif  // FL_IS_ESP32 && !FASTLED_STUB_IMPL


### PR DESCRIPTION
Closes #3716. Part of meta #3715 (ESP Arduino-decoupling).

## Problem
`platform_time_esp32.cpp.hpp` implements `fl::platforms::{delay,delayMicroseconds,millis,micros}` for ESP32, but the whole file was gated on `defined(ARDUINO)`, and internally called Arduino globals (`::millis()`, `::micros()`, `::delayMicroseconds()`). A bare ESP-IDF build (`framework=espidf`, no Arduino core) has **no time implementation at all** for these symbols — a link failure. This is the hard blocker for any bare-IDF FastLED build.

## Fix
- Replace `::millis()`/`::micros()` with `esp_timer_get_time()`.
- Replace `::delayMicroseconds()`'s remainder busy-wait with `esp_rom_delay_us()` (IDF 4.0+) / `ets_delay_us()` (IDF 3.x), gated on the existing `ESP_IDF_VERSION_4_OR_HIGHER` predicate from `esp_version.h` — same pattern already used in `watchdog_esp32_idf4.hpp`.
- Drop the `defined(ARDUINO)` condition entirely; the file now compiles identically under Arduino-ESP32 (which bundles ESP-IDF) and bare ESP-IDF.
- `clockless_block_esp32.h:90`'s unqualified `delayMicroseconds(...)` call is now explicitly qualified as `fl::delayMicroseconds(...)` for clarity (it already resolved to the `fl::` facade via unqualified lookup inside `namespace fl`, since `fl::delayMicroseconds` forwards to `fl::platforms::delayMicroseconds` — this makes that intent unambiguous).

## Test plan
- [x] `bash test --cpp` — 355/355 host tests pass
- [x] `bash lint --cpp` — clean
- [x] `bash compile esp32dev --examples Blink` — real Arduino-ESP32 3.3.7 (IDF 5.x) build succeeds and links, exercising the new `esp_timer_get_time()`/`esp_rom_delay_us()` code path (flash 382KB, ram 143KB — matches prior baseline)
- [ ] True `framework=espidf` (no Arduino) compile-test — no CI leg exists yet; tracked by #3724. This PR is a prerequisite for that leg to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timing and pixel output reliability on ESP32 platforms.
  - Enhanced ESP-IDF native compatibility by using ESP-IDF timing primitives instead of Arduino core time calls.
  - Refined `millis()`/`micros()` and delay behavior for more accurate timing, including interrupt-safe microsecond waits.

- **Chores**
  - Updated the ESP-IDF component requirements in the build configuration to include additional time-related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->