### PR TITLE
feat(esp32): make ESP-IDF spi_master the only ESP32 SPI backend

### DIFF
--- a/src/platforms/esp/32/core/fastspi_esp32.h
+++ b/src/platforms/esp/32/core/fastspi_esp32.h
@@ -17,12 +17,12 @@
 // by default via GPIO matrix routing. The define is accepted for backwards compatibility
 // but no longer required. Use FASTLED_FORCE_SOFTWARE_SPI to disable hardware SPI if needed.
 //
-// The ESP-IDF native backend (driver/spi_master.h) is the only ESP32 SPI
-// implementation. It is present in every Arduino-ESP32 install (Arduino-ESP32
-// bundles ESP-IDF), so there is no behavioral difference under Arduino vs.
-// bare ESP-IDF builds. FASTLED_ESP32_SPI_ARDUINO=1 is a temporary escape
-// hatch back to the retired Arduino SPIClass backend if a regression is
-// found; file a bug at github.com/FastLED/FastLED/issues if you need it.
+// The ESP-IDF native backend (driver/spi_master.h) is the default ESP32 SPI
+// implementation, used for both Arduino-ESP32 (which bundles ESP-IDF) and
+// bare ESP-IDF builds — there is no behavioral difference between the two.
+// FL_ESP32_SPI_ARDUINO=1 is a temporary escape hatch back to the retired
+// Arduino SPIClass backend if a regression is found; file a bug at
+// github.com/FastLED/FastLED/issues if you need it.
 
 // ok no namespace fl
 
@@ -38,7 +38,7 @@
 
 // Dispatch to platform-specific implementation
 
-#if defined(FASTLED_ESP32_SPI_ARDUINO) && FASTLED_ESP32_SPI_ARDUINO && defined(ARDUINO)
+#if defined(FL_ESP32_SPI_ARDUINO) && FL_ESP32_SPI_ARDUINO && defined(ARDUINO)
     // Opt-in escape hatch back to the Arduino SPIClass backend.
     // IWYU pragma: begin_keep
     #include "platforms/esp/32/core/fastspi_esp32_arduino.h"

--- a/src/platforms/esp/32/core/fastspi_esp32.h
+++ b/src/platforms/esp/32/core/fastspi_esp32.h
@@ -18,10 +18,12 @@
 // but no longer required. Use FASTLED_FORCE_SOFTWARE_SPI to disable hardware SPI if needed.
 //
 // The ESP-IDF native backend (driver/spi_master.h) is the default ESP32 SPI
-// implementation, used for both Arduino-ESP32 (which bundles ESP-IDF) and
-// bare ESP-IDF builds — there is no behavioral difference between the two.
-// FL_ESP32_SPI_ARDUINO=1 is a temporary escape hatch back to the retired
-// Arduino SPIClass backend if a regression is found; file a bug at
+// implementation, used identically for both Arduino-ESP32 (which bundles
+// ESP-IDF) and bare ESP-IDF builds. It is a separate implementation from
+// the retired Arduino SPIClass backend, not a thin wrapper around it — the
+// two have not been hardware-validated against each other bit-for-bit.
+// FL_ESP32_SPI_ARDUINO=1 is a temporary escape hatch back to the Arduino
+// SPIClass backend if a regression is found; file a bug at
 // github.com/FastLED/FastLED/issues if you need it.
 
 // ok no namespace fl

--- a/src/platforms/esp/32/core/fastspi_esp32.h
+++ b/src/platforms/esp/32/core/fastspi_esp32.h
@@ -16,6 +16,13 @@
 // FASTLED_ALL_PINS_HARDWARE_SPI is now deprecated on ESP32. Hardware SPI is enabled
 // by default via GPIO matrix routing. The define is accepted for backwards compatibility
 // but no longer required. Use FASTLED_FORCE_SOFTWARE_SPI to disable hardware SPI if needed.
+//
+// The ESP-IDF native backend (driver/spi_master.h) is the only ESP32 SPI
+// implementation. It is present in every Arduino-ESP32 install (Arduino-ESP32
+// bundles ESP-IDF), so there is no behavioral difference under Arduino vs.
+// bare ESP-IDF builds. FASTLED_ESP32_SPI_ARDUINO=1 is a temporary escape
+// hatch back to the retired Arduino SPIClass backend if a regression is
+// found; file a bug at github.com/FastLED/FastLED/issues if you need it.
 
 // ok no namespace fl
 
@@ -31,13 +38,14 @@
 
 // Dispatch to platform-specific implementation
 
-#if defined(ARDUINO) && !defined(FL_NO_ARDUINO)
-    // Arduino framework build - use Arduino SPI implementation
+#if defined(FASTLED_ESP32_SPI_ARDUINO) && FASTLED_ESP32_SPI_ARDUINO && defined(ARDUINO)
+    // Opt-in escape hatch back to the Arduino SPIClass backend.
     // IWYU pragma: begin_keep
     #include "platforms/esp/32/core/fastspi_esp32_arduino.h"
     // IWYU pragma: end_keep
 #else
-    // Pure ESP-IDF build or NO_ARDUINO override - use native SPI
+    // Default: native ESP-IDF SPI (driver/spi_master.h). Used for both
+    // Arduino-ESP32 (which bundles ESP-IDF) and bare ESP-IDF builds.
     // IWYU pragma: begin_keep
     #include "platforms/esp/32/core/fastspi_esp32_idf.h"
     // IWYU pragma: end_keep

--- a/src/platforms/esp/32/ldf_headers.h
+++ b/src/platforms/esp/32/ldf_headers.h
@@ -14,9 +14,10 @@
 /// that PlatformIO's LDF may not automatically detect when using chain mode.
 
 // SPI: No Arduino SPI.h dependency — the default backend is ESP-IDF's
-// driver/spi_master.h (see core/fastspi_esp32_idf.h). The Arduino SPIClass
-// backend is a FASTLED_ESP32_SPI_ARDUINO=1 opt-in escape hatch only; users
-// who set that flag are expected to also declare their own <SPI.h> LDF need.
+// driver/spi_master.h (see core/fastspi_esp32_idf.h), used for both
+// Arduino-ESP32 and bare ESP-IDF builds. The Arduino SPIClass backend is a
+// FL_ESP32_SPI_ARDUINO=1 opt-in escape hatch only; users who set that flag
+// are expected to also declare their own <SPI.h> LDF need.
 
 // WARNING: Do NOT add WiFi.h, Wire.h, FS.h, or other large framework libraries here.
 // PlatformIO's LDF scans #include directives even inside #if 0 blocks, which causes

--- a/src/platforms/esp/32/ldf_headers.h
+++ b/src/platforms/esp/32/ldf_headers.h
@@ -13,13 +13,10 @@
 /// ESP32 uses the Arduino ESP32 framework which provides several built-in libraries
 /// that PlatformIO's LDF may not automatically detect when using chain mode.
 
-// Force LDF to detect SPI library dependency
-// FastLED's ESP32 FastSPI implementation uses <SPI.h> from the Arduino ESP32 framework
-#if 0
-// IWYU pragma: begin_keep
-#include <SPI.h>
-// IWYU pragma: end_keep
-#endif
+// SPI: No Arduino SPI.h dependency — the default backend is ESP-IDF's
+// driver/spi_master.h (see core/fastspi_esp32_idf.h). The Arduino SPIClass
+// backend is a FASTLED_ESP32_SPI_ARDUINO=1 opt-in escape hatch only; users
+// who set that flag are expected to also declare their own <SPI.h> LDF need.
 
 // WARNING: Do NOT add WiFi.h, Wire.h, FS.h, or other large framework libraries here.
 // PlatformIO's LDF scans #include directives even inside #if 0 blocks, which causes


### PR DESCRIPTION
Closes #3718. Part of meta #3715 (ESP Arduino-decoupling).

## Problem
`fastspi_esp32.h` dispatched to the Arduino `SPIClass` backend (`fastspi_esp32_arduino.h`, `<SPI.h>`) whenever `ARDUINO` was defined, and only used the already-complete native IDF backend (`fastspi_esp32_idf.h`, `driver/spi_master.h`) otherwise (`FL_NO_ARDUINO` builds). Since Arduino-ESP32 bundles the same IDF SPI driver, there was no reason for these to diverge.

## Fix
- Flip the default in `fastspi_esp32.h` to always use `fastspi_esp32_idf.h`.
- Keep `fastspi_esp32_arduino.h` as an opt-in escape hatch behind `FL_ESP32_SPI_ARDUINO=1`, in case a regression is found (rather than deleting it outright).
- Drop the `<SPI.h>` LDF hint in `ldf_headers.h`, which existed only to pre-install the Arduino SPI library for the now-non-default backend.

## Risk / hardware note
This is the highest hardware-behavior-risk sub-issue in the #3715 series — it changes what actually drives the SPI clock/data pins for clocked chipsets (APA102, SK9822, LPD8806, DotStar). `fastspi_esp32_idf.h` is not new code — it's a pre-existing, complete backend already reachable via `FL_NO_ARDUINO`.

**What I validated:** `bash compile esp32dev --examples Apa102` against real Arduino-ESP32 3.3.7 (IDF 5.x) — compiles and links successfully with the native backend now active by default (flash 433.64KB, ram 149.91KB).

**What I did not validate:** wire-level SPI protocol correctness (scope/logic-analyzer capture, or an LED strip lighting up correctly) — no LED strip or logic analyzer was available in this session. Recommend a bench smoke-test (an APA102 strip, or a SPI loopback capture per the original issue's acceptance criteria) before merging, or as a fast follow-up validation.

## Test plan
- [x] `bash lint --cpp` — clean
- [x] `bash test --cpp` — unaffected (ESP32 platform code isn't compiled on host)
- [x] `bash compile esp32dev --examples Apa102` — compiles and links
- [x] CodeRabbit review addressed: renamed `FASTLED_ESP32_SPI_ARDUINO` → `FL_ESP32_SPI_ARDUINO` (frozen `FASTLED_*` vocabulary rule), clarified "default" vs "only" wording
- [ ] Hardware smoke test (APA102 strip / SPI loopback capture) — **not performed, see note above**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ESP32 builds now use the native ESP-IDF SPI implementation by default (same behavior for Arduino-ESP32 and bare ESP-IDF builds).
  * Added an opt-in configuration to switch back to the legacy Arduino SPI backend.

* **Documentation**
  * Clarified how SPI support is provided by default and how to enable the legacy backend.
  * Updated build dependency guidance so enabling the legacy backend also includes the required `<SPI.h>` dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->