### PR TITLE
feat(esp32): remove unused fl/system/arduino.h leaks; unconditional heap_caps_*

### DIFF
--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -23,7 +23,6 @@
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/singleton.h"
 #include "fl/log/log.h"
-#include "fl/system/arduino.h"
 // IWYU pragma: end_keep
 
 FL_EXTERN_C_BEGIN

--- a/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/uart/uart_peripheral_esp.cpp.hpp
@@ -12,11 +12,7 @@
 
 #include "platforms/esp/32/drivers/uart/uart_peripheral_esp.h"
 #include "fl/log/log.h"
-#include "fl/log/log.h"
 #include "fl/stl/noexcept.h"
-// IWYU pragma: begin_keep
-#include "fl/system/arduino.h"
-// IWYU pragma: end_keep
 
 // Include ESP-IDF headers ONLY in .cpp file
 FL_EXTERN_C_BEGIN

--- a/src/platforms/esp/memory_esp32.hpp
+++ b/src/platforms/esp/memory_esp32.hpp
@@ -8,18 +8,12 @@
 
 // Platform-specific includes for ESP32
 #if defined(FL_IS_ESP32)
-    #if defined(ARDUINO)
-        // Arduino ESP32 - include esp_system.h for heap functions
-        FL_EXTERN_C_BEGIN
-        #include "esp_system.h"
-        FL_EXTERN_C_END
-    #else
-        // ESP-IDF native mode needs heap caps header
-        FL_EXTERN_C_BEGIN
-        #include "esp_heap_caps.h"
-#include "fl/stl/noexcept.h"
-        FL_EXTERN_C_END
-    #endif
+    // esp_heap_caps.h is a core ESP-IDF header, present identically under
+    // Arduino-ESP32 (which bundles ESP-IDF) and bare ESP-IDF builds.
+    FL_EXTERN_C_BEGIN
+    #include "esp_heap_caps.h"
+    #include "fl/stl/noexcept.h"
+    FL_EXTERN_C_END
 #endif
 
 namespace fl {
@@ -29,13 +23,7 @@ namespace platforms {
 /// @return Number of free bytes in heap
 inline size_t getFreeHeap() FL_NO_EXCEPT {
 #if defined(FL_IS_ESP32)
-    #if defined(ARDUINO)
-        // Arduino ESP32 - use esp_get_free_heap_size from SDK
-        return esp_get_free_heap_size();
-    #else
-        // ESP-IDF native
-        return heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
-    #endif
+    return heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
 #else
     return 0;
 #endif
@@ -58,12 +46,7 @@ inline size_t getHeapSize() FL_NO_EXCEPT {
 /// @return Minimum free heap ever recorded (low water mark)
 inline size_t getMinFreeHeap() FL_NO_EXCEPT {
 #if defined(FL_IS_ESP32)
-    #if defined(ARDUINO)
-        return esp_get_minimum_free_heap_size();
-    #else
-        // ESP-IDF native
-        return heap_caps_get_minimum_free_size(MALLOC_CAP_DEFAULT);
-    #endif
+    return heap_caps_get_minimum_free_size(MALLOC_CAP_DEFAULT);
 #else
     return 0;
 #endif


### PR DESCRIPTION
Closes #3721. Part of meta #3715 (ESP Arduino-decoupling).

## Problem
`fl/system/arduino.h` is a soft shim that pulls in the entire Arduino core (when present) at compile time. Two ESP32 TUs included it despite never referencing an Arduino symbol:
- `coroutine_esp32.impl.hpp` — FreeRTOS-only implementation.
- `drivers/uart/uart_peripheral_esp.cpp.hpp` — pure `driver/uart.h` implementation; its only "time" call is `fl::micros()`, the platform-agnostic `fl::` facade (declared in `platforms/time_platform.h`), not anything from `Arduino.h`.

Separately, `platforms/esp/memory_esp32.hpp` forked `getFreeHeap()`/`getMinFreeHeap()` on `defined(ARDUINO)` — but on inspection **both branches already call ESP-IDF SDK functions** (`esp_get_free_heap_size()` vs `heap_caps_get_free_size()`), just from two different IDF heap-API generations. Neither branch is actually Arduino-specific, so the fork is unnecessary.

## Fix
- Drop the `fl/system/arduino.h` include from the two pure-IDF TUs.
- `memory_esp32.hpp` now calls `heap_caps_get_free_size()`/`heap_caps_get_minimum_free_size()` unconditionally — `esp_heap_caps.h` is a core ESP-IDF header, present identically under Arduino-ESP32 (which bundles ESP-IDF) and bare ESP-IDF.

## Scope note
`drivers/i2s/i2s_lcd_cam_peripheral_mock.cpp.hpp`'s `#ifdef ARDUINO` fork was flagged by the original meta-issue audit but is **left untouched** here — it's host-stub-only test infrastructure (the whole file only compiles under `FASTLED_STUB_IMPL` or a non-Arduino host build) selecting between the stub Arduino shim and `platforms/stub/time_stub.h` for host testing. It has nothing to do with real ESP32 hardware builds.

## Test plan
- [x] `bash lint --cpp` — clean
- [x] `bash test --cpp` — 355/355 pass
- [x] `grep -rn "fl/system/arduino.h" src/platforms/esp/` — only remaining hits are the (out-of-scope) host-mock file above and the true fallback branch in `cled.cpp.hpp` (already scoped to #3719)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 compatibility by standardizing heap memory reporting across supported build environments.
  * Reduced platform-specific header requirements for ESP32 coroutine and UART components.
  * No user-facing API or runtime behavior changes beyond more consistent heap statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->