### PR TITLE
fix(lint): pin Rust toolchain so soldr builds fastled-lint via rustup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Pins the Rust toolchain used to build ci/lint_cpp_rs (fastled-lint).
+#
+# Without a pin, soldr resolves rustc from PATH. On hosts where a non-rustup
+# Rust shadows rustup (e.g. chocolatey ships an x86_64-pc-windows-gnu build
+# with no msvc std), soldr still canonicalizes the build target to
+# x86_64-pc-windows-msvc and every crate fails with:
+#   error[E0463]: can't find crate for `std`
+# With this file present, soldr (and rustup-proxied cargo) resolve the
+# toolchain through rustup instead of PATH, which always carries the host
+# target's std.
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Summary

`bash lint` was hard-failing on hosts where a non-rustup Rust shadows rustup on PATH: the `fastled-lint` build (via soldr) died on every crate with `error[E0463]: can't find crate for `std``.

**Root cause:** with no `rust-toolchain.toml` in the repo, soldr resolves `rustc` from PATH. On this bench host that's chocolatey's `rustc.exe` — an `x86_64-pc-windows-gnu`-host build whose sysroot contains *only* the gnu std. soldr canonicalizes the build target to `x86_64-pc-windows-msvc`, so every compile requests an msvc std that doesn't exist.

**Fix:** pin the toolchain at the repo root. With the pin present, soldr (and rustup-proxied cargo) resolve through rustup — verified with `cargo build -v`: rustc switches from `C:\ProgramData\chocolatey\bin\rustc.exe` to soldr's managed `rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe` and the build succeeds. Only `ci/lint_cpp_rs` is affected (sole crate in the repo).

Second commit: repairing the linter surfaced a previously-invisible `BannedMacrosChecker` violation in `examples/hydropack/hydropack.ino` (raw `static_assert` from #3712, which merged while the Rust linter couldn't build). Swapped to `FL_STATIC_ASSERT` + its include.

## Testing

- `soldr --no-cache cargo build --bin fastled-lint` — was E0463 on all crates, now succeeds
- `bash lint --cpp` — fully green (previously `❌ cpp_linting FAILED`)
- `bash compile wasm --examples hydropack` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust toolchain consistency for linting and build checks.
  * Prevented host-environment configuration issues that could cause standard library resolution failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->