### PR TITLE
feat(esp8266): qualify delayMicroseconds; document scope decision on the rest

### DIFF
--- a/src/platforms/esp/8266/clockless_block_esp8266.h
+++ b/src/platforms/esp/8266/clockless_block_esp8266.h
@@ -13,6 +13,7 @@
 #include "fastled_delay.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fl/system/delay.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
@@ -56,7 +57,7 @@ public:
 			#ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
 			++_retry_cnt;
 			#endif
-			delayMicroseconds(WAIT_TIME * 10);
+			fl::delayMicroseconds(WAIT_TIME * 10);
 			os_intr_lock();
 		}
 		// #if FASTLED_ALLOW_INTTERUPTS == 0

--- a/src/platforms/esp/8266/clockless_esp8266.h
+++ b/src/platforms/esp/8266/clockless_esp8266.h
@@ -9,6 +9,7 @@
 #include "fastled_delay.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fl/system/delay.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
@@ -64,7 +65,7 @@ protected:
       #ifdef FASTLED_DEBUG_COUNT_FRAME_RETRIES
       ++_retry_cnt;
       #endif
-      delayMicroseconds(WAIT_TIME);
+      fl::delayMicroseconds(WAIT_TIME);
     }
     mWait.mark();
   }


### PR DESCRIPTION
Closes #3723. Part of meta #3715 (ESP Arduino-decoupling).

## Change
Small, safe cleanup: `clockless_esp8266.h` and `clockless_block_esp8266.h` call unqualified `delayMicroseconds(...)` inside `namespace fl { ... }` — this already resolves to the `fl::` facade via unqualified lookup (same situation as `clockless_block_esp32.h` before #3716), but is now explicit: `fl::delayMicroseconds(...)`.

## Scope decision (documented per the issue's own guidance)
#3723's acceptance criteria explicitly called for "a decision recorded... for UART1 + hardware-SPI: native registers or documented Arduino-only" rather than a rushed half-migration. After looking at each remaining item, here's the call:

- **`fl::delayMicroseconds()` still resolves to Arduino's `::delayMicroseconds()`** on ESP8266 (no ESP8266-specific `platform_time` file exists; it falls through to the generic `platforms/arduino/platform_time.cpp.hpp`). A native `ets_delay_us()`-based microsecond delay is plausible and safe, but ESP8266's millisecond-scale `delay()` needs software-watchdog-aware chunking to avoid resets — I can't validate that across delay durations without extensive on-device testing. **Documented follow-up, not migrated.**
- **`pgmspace.h`**: NOT migrated. ESP8266 flash reads are memory-mapped and alignment-sensitive (see this file's own `FL_ALIGN_PROGMEM` comment) — exactly the kind of change that risks silent data corruption if gotten subtly wrong, and the existing Arduino implementation is the only one in this codebase that's actually hardware-validated. **Kept Arduino-only.**
- **`fastspi_esp8266.h` (`<SPI.h>`) and `fastled_esp8266_uart.h` (`HardwareSerial Serial1`)**: NOT migrated. Both are real protocol implementations with no existing native-SDK counterpart in this codebase to promote (unlike ESP32, which already had a complete `fastspi_esp32_idf.h`). A register-level rewrite is a real, separate effort deserving its own issue with dedicated hardware bring-up — not something to rush inside a low-priority sub-issue of a larger meta. **Kept Arduino-only.**

## Test plan
- [x] `bash lint --cpp` — clean
- [x] `bash test --cpp` — 355/355 pass
- [ ] `bash compile esp8266 --examples Blink` — real ESP8266 hardware attached (NodeMCU 0.9 / ESP-12) at COM11; validating separately due to fbuild daemon lock contention with other concurrent #3715 sub-issue builds, will follow up with results as a PR comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microsecond timing reliability for ESP8266 LED output and frame retry handling.
  * Preserved existing delay behavior while routing timing through the platform’s FastLED delay utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->