### PR TITLE
feat(esp32): remove <esp32-hal.h> Arduino fallbacks from clock_cycles.h

### DIFF
--- a/src/platforms/esp/32/core/clock_cycles.h
+++ b/src/platforms/esp/32/core/clock_cycles.h
@@ -6,6 +6,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/has_include.h"
+#include "fl/stl/noexcept.h"
 
 #include "fl/stl/stdint.h"
 #include "platforms/esp/esp_version.h"
@@ -14,13 +15,6 @@
 #include "hal/cpu_hal.h"
 // IWYU pragma: end_keep
 #define __cpu_hal_get_cycle_count esp_cpu_get_cycle_count
-#elif FL_HAS_INCLUDE(<esp32-hal.h>) && ESP_IDF_VERSION > ESP_IDF_VERSION_VAL(4, 1, 4)
-// IWYU pragma: begin_keep
-#include <esp32-hal.h>  // Relies on the Arduino core for ESP32
-// IWYU pragma: end_keep
-inline fl::u32 __cpu_hal_get_cycle_count() FL_NO_EXCEPT {
-  return static_cast<fl::u32>(cpu_hal_get_cycle_count());
-}
 #elif FL_HAS_INCLUDE(<hal/cpu_ll.h>)
   // esp-idf v4.3.0+
 // IWYU pragma: begin_keep
@@ -43,13 +37,20 @@ inline fl::u32 __cpu_hal_get_cycle_count() FL_NO_EXCEPT {
 inline fl::u32 __cpu_hal_get_cycle_count() FL_NO_EXCEPT {
   return static_cast<fl::u32>(xthal_get_ccount());
 }
-#else // Last fallback, if this fails then please file a bug at github.com/fastled/FastLED/issues and let us know what board you are using.
-// IWYU pragma: begin_keep
-#include <esp32-hal.h>  // Relies on the Arduino core for ESP32
-#include "fl/stl/noexcept.h"
-// IWYU pragma: end_keep
+#else
+// Last fallback: no IDF cycle-counter header was found. On Xtensa targets
+// read the CCOUNT special register directly (matches the __clock_cycles()
+// FASTLED_XTENSA path below). Non-Xtensa targets have no ROM/HAL fallback
+// left to try, so fail the build loudly instead of silently depending on
+// the Arduino core (<esp32-hal.h>) as earlier revisions of this file did.
 inline fl::u32 __cpu_hal_get_cycle_count() FL_NO_EXCEPT {
-  return static_cast<fl::u32>(cpu_hal_get_cycle_count());
+#if defined(FASTLED_XTENSA) || defined(__XTENSA__)
+  fl::u32 cyc;
+  __asm__ __volatile__ ("rsr %0,ccount" : "=a" (cyc));
+  return cyc;
+#else
+  #error "No ESP32 cycle-counter header found (hal/cpu_hal.h, hal/cpu_ll.h, esp_cpu.h, xtensa/hal.h). File a bug at github.com/FastLED/FastLED/issues with your board/toolchain."
+#endif
 }
 #endif  // ESP_IDF_VERSION
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
@@ -40,9 +40,6 @@
 #include "platforms/esp/32/drivers/rmt/rmt_4/irmt4_peripheral.h"
 
 FL_EXTERN_C_BEGIN
-// IWYU pragma: begin_keep
-#include <esp32-hal.h>
-// IWYU pragma: end_keep
 #if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR > 3
 #include "esp_intr_alloc.h"
 #else


### PR DESCRIPTION
Closes #3717. Part of meta #3715 (ESP Arduino-decoupling).

## Problem
`clock_cycles.h` had two fallback branches including the Arduino core's `<esp32-hal.h>` for the CPU cycle counter. Both were dead weight in practice:
- The branch they served (Xtensa targets) already reads `CCOUNT` directly via inline asm in `__clock_cycles()` — the ifdef chain in `clock_cycles.h` only matters for RISC-V targets.
- RISC-V ESP32 variants (C2/C3/C5/C6/H2) never shipped on an Arduino-ESP32 core old enough to need the removed `<hal/cpu_ll.h>`-predating branch, so that branch was effectively unreachable dead code.

Also `channel_driver_rmt4.h` had a redundant direct `<esp32-hal.h>` include — it already includes `clock_cycles.h` and uses its `__clock_cycles()` helper.

## Fix
- Remove both `<esp32-hal.h>` branches from `clock_cycles.h`. The IDF-native chain (`hal/cpu_hal.h` on IDF5+, `hal/cpu_ll.h` on IDF4.3+, `esp_cpu.h`, `xtensa/hal.h`) covers every real ESP32 toolchain. The final fallback now reads `CCOUNT` via inline asm on Xtensa or hard-errors with a clear message instead of silently depending on the Arduino core.
- Remove the redundant `<esp32-hal.h>` include from `channel_driver_rmt4.h`.

## Test plan
- [x] `bash lint --cpp` — clean
- [x] `bash test --cpp` — 355/355 pass
- [x] `bash compile esp32dev --examples Blink` — real Arduino-ESP32 3.3.7 (IDF 5.x) build succeeds and links (flash 391611 bytes, ram 146345 bytes — matches the #3716 baseline), exercising both the cycle-counter path and the RMT4 driver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESP32 timing support across supported processor targets.
  - Removed reliance on an obsolete platform header, improving compatibility with newer ESP32 environments.
  - Builds now provide a clearer error when the required cycle-counter support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->