### PR TITLE
feat(ci): add ESP-IDF component-build smoke test (esp32dev_idf5_component)

### DIFF
--- a/.github/workflows/build_esp32dev_idf5_component.yml
+++ b/.github/workflows/build_esp32dev_idf5_component.yml
@@ -1,0 +1,59 @@
+name: esp32dev_idf5_component
+
+# Compile-smoke via ESP-IDF's genuine CMake/idf.py component build system
+# (framework="arduino, espidf" — CONFIG_AUTOSTART_ARDUINO=y runs the .ino
+# sketch from inside an IDF app_main), instead of PlatformIO's Arduino-only
+# source-discovery build. Exercises the real idf_component_register() /
+# CMakeLists.txt path — the distribution mechanism #2121 (idf component
+# registry) depends on — and, combined with FastLED#3715's other changes
+# (which made the IDF-native code path the default rather than something
+# gated behind "Arduino absent"), the same native code a true bare-IDF
+# build would use.
+#
+# NOT a substitute for a genuine app_main()-only (no Arduino.h at all)
+# bare-IDF build — ARDUINO is still defined here. See FastLED#3724 for the
+# follow-up plan to add that.
+#
+# Only single-file .ino examples are safe on this board (see the
+# ESP32_C2_DEVKITM_1 comment in ci/boards.py): the dual "arduino, espidf"
+# component build does not auto-discover example .cpp files in
+# subdirectories (examples/Codec/, examples/Downscale/, etc.).
+#
+# Part of FastLED#3715 / #3724.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - '!src/platforms/arm/**'
+      - '!src/platforms/wasm/**'
+      - '!src/platforms/avr/**'
+      - 'src/platforms/esp/**'
+      - 'examples/Blink/**'
+      - 'ci/**'
+      - '.github/workflows/build_esp32dev_idf5_component.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    paths:
+      - 'src/platforms/esp/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/build_esp32dev_idf5_component.yml'
+      - 'ci/boards.py'
+
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: esp32dev_idf5_component --examples Blink

--- a/.github/workflows/build_esp32dev_idf5_component.yml
+++ b/.github/workflows/build_esp32dev_idf5_component.yml
@@ -47,10 +47,21 @@ on:
       - 'uv.lock'
   pull_request:
     paths:
+      - 'src/**'
+      - '!src/platforms/arm/**'
+      - '!src/platforms/wasm/**'
+      - '!src/platforms/avr/**'
       - 'src/platforms/esp/**'
-      - 'CMakeLists.txt'
+      - 'examples/Blink/**'
+      - 'ci/**'
       - '.github/workflows/build_esp32dev_idf5_component.yml'
-      - 'ci/boards.py'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -849,6 +849,38 @@ ESP32DEV_IDF6 = Board(
     platform_needs_install=True,
 )
 
+# ESP-IDF component-build smoke test (FastLED#3724, part of #3715).
+#
+# framework="arduino, espidf" makes PlatformIO build via ESP-IDF's
+# CMake/idf.py component system (CONFIG_AUTOSTART_ARDUINO=y runs the .ino
+# sketch's setup()/loop() from within an IDF app_main — see
+# ci/compiler/pio.py's sdkconfig.defaults handling). This is NOT the same
+# as a pure bare-IDF app_main() project, but it does exercise the real
+# idf_component_register()/CMakeLists.txt path (see root CMakeLists.txt)
+# instead of PlatformIO's Arduino-only source-discovery build — the actual
+# distribution mechanism #2121 (idf component registry) depends on.
+#
+# Combined with #3715's other changes (which made the IDF-native code path
+# the *default*, not something gated behind "Arduino absent"), this leg
+# already exercises nearly all of the same code as a true bare-IDF build:
+# ARDUINO is still defined here (Arduino runs as an IDF component), so this
+# does NOT prove behavior with <Arduino.h> completely unavailable — that
+# residual gap needs a genuine app_main()-only harness project, which is
+# out of scope for this pass; see FastLED#3724 for the follow-up plan.
+#
+# Scope note (#3724 / see the ESP32_C2_DEVKITM_1 comment above): the dual
+# "arduino, espidf" component build does not auto-discover example .cpp
+# files in subdirectories (examples/Codec/, examples/Downscale/, etc.) —
+# only single-file .ino examples like Blink are safe to compile with this
+# board until that LDF gap is fixed.
+ESP32DEV_IDF5_COMPONENT = Board(
+    board_name="esp32dev_idf5_component",
+    real_board_name="esp32dev",
+    platform=ESP32_IDF_5_3_PIOARDUINO,
+    framework="arduino, espidf",
+    board_partitions="huge_app.csv",
+)
+
 # Heap-poisoning debug variant (FastLED#3588): same pioarduino platform
 # as esp32dev but with custom_sdkconfig, which makes pioarduino rebuild
 # the IDF libs from source with comprehensive heap poisoning + end-of-


### PR DESCRIPTION
Closes #3724 (partial — see scope note below). Part of meta #3715 (ESP Arduino-decoupling).

## What this adds
A new CI leg, `esp32dev_idf5_component`, that builds via PlatformIO's `framework = "arduino, espidf"` — ESP-IDF's genuine CMake/idf.py component system, with `CONFIG_AUTOSTART_ARDUINO=y` running the `.ino` sketch's `setup()`/`loop()` from inside an IDF `app_main`. This is meaningfully different from every other ESP32 CI leg in this repo, all of which use PlatformIO's Arduino-only source-discovery build.

**Why this matters:** it exercises the real `idf_component_register()` / root `CMakeLists.txt` path — the distribution mechanism #2121 (idf component registry) depends on — which no other CI leg touches. Combined with #3715's other merged changes (#3726/#3727/#3728/#3730/#3732/#3733, which made the IDF-native code path the *default* rather than something gated behind "Arduino absent"), this build exercises nearly all the same native code a true bare-IDF build would use.

## What this does NOT prove (scope note, matches #3724's own acceptance criteria)
This is **not** a substitute for a genuine `app_main()`-only build with `<Arduino.h>` completely unavailable — `ARDUINO` is still defined here (Arduino runs as an IDF component via `CONFIG_AUTOSTART_ARDUINO`). A true bare-IDF harness needs a dedicated `main/` component project (no `.ino`, no Arduino core at all), which is a larger follow-up:
- IDF 4.4 and 6.x legs (this PR only adds one — the 5.x pin, the acceptance criteria's highest-priority ask)
- A genuine `app_main()`-only harness (no Arduino anywhere in the build)
- The negative-test proof ("a deliberately introduced `#include <Arduino.h>` fails the bare leg")

Filing/tracking the remainder as explicit follow-up rather than rushing an unvalidated multi-leg matrix in this pass.

**Scope guard (from the ESP32-C2 precedent in `ci/boards.py`):** the dual `"arduino, espidf"` component build does not auto-discover example `.cpp` files in subdirectories (`examples/Codec/`, `examples/Downscale/`, etc.) — only single-file `.ino` examples are safe. This board is scoped to `Blink` only.

## Local validation
- [x] `bash lint` (full — python/cpp/js) — clean
- [x] `bash compile esp32dev_idf5_component --examples Blink` — **build succeeds**, produces a valid `firmware.bin` via the real ESP-IDF CMake build (flash 645471 bytes / 15.4%)
- ⚠️ **Caveat found during validation:** PlatformIO's memory-usage report shows `RAM: 345.54KB / 320.00KB (108.0%)` for this build — over the reported static RAM budget. The build still succeeds and links (a genuine overflow would be a linker error, not a successful build with valid artifacts), so this looks like a memory-report metric quirk for this specific dual-runtime (Arduino-as-IDF-component) framework combination rather than an actual overflow, but I want to flag it explicitly rather than bury it — worth a maintainer's eyes before relying on this leg's green checkmark as proof of runtime correctness. Flash usage (15.4%) is unremarkable.
- [ ] Not flashed to real hardware / not runtime-verified on-device.

## Test plan
- [x] `bash lint` — clean
- [x] `bash compile esp32dev_idf5_component --examples Blink` — compiles and links (with the RAM-report caveat above)
- [ ] GitHub Actions CI run on this PR — will confirm whether the RAM figure is a report artifact or a real constraint on the CI runner's toolchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI coverage for ESP32 development-board builds using an ESP-IDF component build workflow.
  * Added a smoke-test target for the Blink example to validate both Arduino and ESP-IDF 5.3 build paths.
* **CI Improvements**
  * Configured the workflow to run on relevant pushes and pull requests via path filtering, with concurrency controls to cancel in-progress runs for the same ref.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->