### PR TITLE
Add support for STM32G0-based boards.

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1425,6 +1425,12 @@ NUCLEO_F439ZI = Board(
     platform="ststm32",
 )
 
+# Nucleo board for STM32G070
+NUCLEO_G070RB = Board(
+    board_name="nucleo_g070rb",
+    platform="ststm32",
+)
+
 # Arduino UNO Q board support.
 # PlatformIO does not yet ship an ArduinoCore-zephyr UNO Q platform, so CI uses
 # the STM32duino STM32U585ZITxQ toolchain as a compile target while preserving

--- a/ci/lint_cpp_rs/src/lint_core/prelude_constants.rs
+++ b/ci/lint_cpp_rs/src/lint_core/prelude_constants.rs
@@ -707,6 +707,8 @@ const NATIVE_TO_MODERN_DEFINES: &[(&str, &str)] = &[
     ("STM32L4xx", "FL_IS_STM32_L4"),
     ("STM32H7", "FL_IS_STM32_H7"),
     ("STM32H7xx", "FL_IS_STM32_H7"),
+    ("STM32G0", "FL_IS_STM32_G0"),
+    ("STM32G0xx", "FL_IS_STM32_G0"),
     ("STM32G4", "FL_IS_STM32_G4"),
     ("STM32G4xx", "FL_IS_STM32_G4"),
     ("STM32U5", "FL_IS_STM32_U5"),

--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -43,7 +43,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/led_sysdefs_arm_sam.h"  // ok platform headers
-#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX) || defined(STM32G0) || defined(STM32G0xx)
 #include "platforms/arm/stm32/led_sysdefs_arm_stm32.h"  // ok platform headers
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/led_sysdefs_arm_d21.h"  // ok platform headers

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -32,7 +32,7 @@
 #elif defined(__SAM3X8E__)
 // Include sam/due headers
 #include "platforms/arm/sam/fastled_arm_sam.h"  // ok platform headers
-#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX) || defined(STM32G0) || defined(STM32G0xx)
 #include "platforms/arm/stm32/fastled_arm_stm32.h"  // ok platform headers
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)
 #include "platforms/arm/d21/fastled_arm_d21.h"  // ok platform headers

--- a/src/platforms/arm/common/m0clockless_asm.h
+++ b/src/platforms/arm/common/m0clockless_asm.h
@@ -37,6 +37,7 @@
 
 #include "fl/chipsets/timing_traits.h"
 #include "platforms/arm/is_arm.h"
+#include "platforms/cpu_frequency.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
@@ -107,9 +108,14 @@ showLedData(volatile fl::u32 *_port, fl::u32 _bitmask, const fl::u8 *_leds, fl::
   //   T2 (800ns) = (800 * 48 + 500) / 1000 = 38 cycles
   //   T3 (450ns) = (450 * 48 + 500) / 1000 = 22 cycles
   /////////////////////////////////////////////////////////////////////////////
-  static constexpr fl::u32 T1 = (TIMING::T1 * (F_CPU / 1000000UL) + 500) / 1000;
-  static constexpr fl::u32 T2 = (TIMING::T2 * (F_CPU / 1000000UL) + 500) / 1000;
-  static constexpr fl::u32 T3 = (TIMING::T3 * (F_CPU / 1000000UL) + 500) / 1000;
+#if defined(GET_CPU_FREQUENCY)
+  static constexpr fl::u32 clock_hz = GET_CPU_FREQUENCY();
+#else
+  static constexpr fl::u32 clock_hz = F_CPU;
+#endif
+  static constexpr fl::u32 T1 = (TIMING::T1 * (clock_hz / 1000000UL) + 500) / 1000;
+  static constexpr fl::u32 T2 = (TIMING::T2 * (clock_hz / 1000000UL) + 500) / 1000;
+  static constexpr fl::u32 T3 = (TIMING::T3 * (clock_hz / 1000000UL) + 500) / 1000;
 
   /////////////////////////////////////////////////////////////////////////////
   // REGISTER ALLOCATION

--- a/src/platforms/arm/common/m0clockless_c.h
+++ b/src/platforms/arm/common/m0clockless_c.h
@@ -34,6 +34,7 @@
 #include "fl/chipsets/timing_traits.h"
 #include "fl/stl/noexcept.h"
 #include "platforms/arm/is_arm.h"  // FL_IS_ARM_M0_PLUS (loop-delay period selection)
+#include "platforms/cpu_frequency.h"
 
 // CMSIS interrupt-control intrinsics used by `showLedData`. These live as
 // `__STATIC_INLINE` functions in `cmsis_gcc.h` per Cortex-M CMSIS bundle.
@@ -48,7 +49,7 @@
 // Skip entirely when a CMSIS device header is on the include path (it declares
 // these as functions, which the #ifndef guards below cannot detect, so defining
 // them here would clash). LPC builds set FASTLED_HAS_CMSIS in led_sysdefs.
-#if !defined(FASTLED_HAS_CMSIS)
+#if !defined(FASTLED_HAS_CMSIS) && !defined(__CMSIS_GCC_H) && !defined(__CMSIS_GCC_M_H)
 #ifndef __get_PRIMASK
 static inline fl::u32 __get_PRIMASK(void) FL_NO_EXCEPT {
     fl::u32 primask;
@@ -388,7 +389,11 @@ static constexpr fl::u32 ns_to_cycles(fl::u32 ns) FL_NO_EXCEPT {
   // gnu++11. Keep the constants in plain digits so the header stays portable
   // across both C++11 and C++14+ builds. Enforced by BareDigitSeparatorChecker
   // in ci/lint_cpp_rs/src/checkers/.
+#if defined(GET_CPU_FREQUENCY)
+  return (fl::u32)(((u64)ns * (u64)GET_CPU_FREQUENCY() + 999999999ULL) / 1000000000ULL);
+#else
   return (fl::u32)(((u64)ns * (u64)F_CPU + 999999999ULL) / 1000000000ULL);
+#endif
 }
 
 template<int HI_OFFSET, int LO_OFFSET, typename TIMING, EOrder RGB_ORDER, int WAIT_TIME>

--- a/src/platforms/arm/fastpin_arm.h
+++ b/src/platforms/arm/fastpin_arm.h
@@ -28,7 +28,7 @@
 #elif defined(__SAM3X8E__)
     // Arduino Due (SAM3X8E)
     #include "platforms/arm/sam/fastpin_arm_sam.h"
-#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX)
+#elif defined(STM32F10X_MD) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F2XX) || defined(STM32F4) || defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX) || defined(STM32G0) || defined(STM32G0xx)
     // STM32 microcontrollers
     #include "platforms/arm/stm32/fastpin_arm_stm32.h"
 #elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || defined(__SAMD21E18A__)

--- a/src/platforms/arm/stm32/README.md
+++ b/src/platforms/arm/stm32/README.md
@@ -1,6 +1,6 @@
 # FastLED Platform: STM32
 
-STM32 family support (e.g., F1, F2, F4 series).
+STM32 family support (e.g., F1, F2, F4, G0, H7, U5 series).
 
 ## Supported Cores
 

--- a/src/platforms/arm/stm32/clockless_arm_stm32.h
+++ b/src/platforms/arm/stm32/clockless_arm_stm32.h
@@ -25,11 +25,71 @@ FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
 #endif
 
+#include "platforms/arm/is_arm.h"
+#include "platforms/arm/common/m0clockless.h"
+
 namespace fl {
 // Definition for a single channel clockless controller for the stm32 family of chips, like that used in the spark core
 // See clockless.h for detailed info on how the template parameters are used.
 
 #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
+#if defined(FL_IS_ARM_M0_PLUS) || defined(FL_IS_ARM_M0) || defined(__ARM_ARCH_6M__)
+
+template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 280>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+    typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
+    typedef typename FastPin<DATA_PIN>::port_t data_t;
+
+    data_t mPinMask;
+    data_ptr_t mPort;
+    CMinWait<WAIT_TIME> mWait;
+
+public:
+    virtual void init() FL_NO_EXCEPT {
+        FastPin<DATA_PIN>::setOutput();
+        mPinMask = FastPin<DATA_PIN>::mask();
+        mPort = FastPin<DATA_PIN>::port();
+    }
+
+    virtual u16 getMaxRefreshRate() const { return 400; }
+
+protected:
+    virtual void showPixels(PixelController<RGB_ORDER> & pixels) FL_NO_EXCEPT {
+        mWait.wait();
+        fl::interruptsDisable();
+        if(!showRGBInternal(pixels)) {
+            fl::interruptsEnable();
+            delayMicroseconds(WAIT_TIME);
+            fl::interruptsDisable();
+            showRGBInternal(pixels);
+        }
+        fl::interruptsEnable();
+        mWait.mark();
+    }
+
+    static u32 showRGBInternal(PixelController<RGB_ORDER> pixels) FL_NO_EXCEPT {
+        if (pixels.size() == 0) {
+            return 1;   // nonzero means success
+        }
+        struct M0ClocklessData data;
+        data.d[0] = pixels.d[0];
+        data.d[1] = pixels.d[1];
+        data.d[2] = pixels.d[2];
+        data.s[0] = pixels.mColorAdjustment.premixed[0];
+        data.s[1] = pixels.mColorAdjustment.premixed[1];
+        data.s[2] = pixels.mColorAdjustment.premixed[2];
+        data.e[0] = pixels.e[0];
+        data.e[1] = pixels.e[1];
+        data.e[2] = pixels.e[2];
+        data.adj = pixels.mAdvance;
+
+        typename FastPin<DATA_PIN>::port_ptr_t portBase = FastPin<DATA_PIN>::port();
+        return showLedData<4, 20, TIMING, RGB_ORDER, WAIT_TIME>(portBase, FastPin<DATA_PIN>::mask(), pixels.mData, pixels.mLen, &data);
+    }
+};
+
+#else
 
 #if defined(FL_IS_STM32_F2)
 // The photon runs faster than the others
@@ -124,10 +184,12 @@ protected:
         const u32 t1t2_clocks = t1_clocks + t2_clocks;
         const u32 t1t2t3_clocks = t1t2_clocks + t3_clocks;
 
-        // Get access to the clock
+        // Get access to the clock if available (Cortex-M3/M4/M7/M33)
+#if defined(CoreDebug) && defined(DWT)
         CoreDebug->DEMCR  |= CoreDebug_DEMCR_TRCENA_Msk;
         DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
         DWT->CYCCNT = 0;
+#endif
 
         FASTLED_REGISTER data_ptr_t port = FastPin<DATA_PIN>::port();
         FASTLED_REGISTER data_t hi = *port | FastPin<DATA_PIN>::mask();;
@@ -138,7 +200,9 @@ protected:
 
         u32 next_mark = t1t2t3_clocks;
 
+#if defined(DWT)
         DWT->CYCCNT = 0;
+#endif
 
         // Detect RGBW mode using pattern from RP2040 drivers
         const bool is_rgbw = rgbw.active();
@@ -158,11 +222,13 @@ protected:
             }
             first_pixel = false;
             // if interrupts took longer than 45µs, punt on the current frame
+#if defined(DWT)
             if(DWT->CYCCNT > next_mark) {
                 if((DWT->CYCCNT-next_mark) > ((WAIT_TIME-INTERRUPT_THRESHOLD)*clks_per_us)) {
                     fl::interruptsEnable(); return 0;\
                 }
             }
+#endif
 
             hi = *port | FastPin<DATA_PIN>::mask();
             lo = *port & ~FastPin<DATA_PIN>::mask();
@@ -198,9 +264,15 @@ protected:
         // Only need final enable if interrupts weren't re-enabled in the loop
         fl::interruptsEnable();
         #endif
+#if defined(DWT)
         return DWT->CYCCNT;
+#else
+        return 1;  // nonzero means success
+#endif
     }
 };
+
+#endif
 
 }  // namespace fl
 

--- a/src/platforms/arm/stm32/delay.h
+++ b/src/platforms/arm/stm32/delay.h
@@ -29,7 +29,11 @@ constexpr u32 cycles_from_ns_stm32(u32 ns, u32 hz) FL_NO_EXCEPT {
 FASTLED_FORCE_INLINE void delayNanoseconds_impl(u32 ns, u32 hz) FL_NO_EXCEPT {
   u32 cycles = cycles_from_ns_stm32(ns, hz);
   if (cycles == 0) return;
+#if defined(DWT) || (defined(__CORTEX_M) && (__CORTEX_M >= 3))
   delay_cycles_dwt_arm(cycles);
+#else
+  delayMicroseconds((ns + 999) / 1000);
+#endif
 }
 
 /// Platform-specific implementation of nanosecond delay with auto-detected frequency (STM32)

--- a/src/platforms/arm/stm32/fastpin_arm_stm32.h
+++ b/src/platforms/arm/stm32/fastpin_arm_stm32.h
@@ -14,7 +14,7 @@
 // The legacy definitions use incorrect Arduino pin numbers instead of STM32 pin names
 // STM32F1: Blue Pill, Maple Mini, etc.
 // STM32F4: Black Pill, Nucleo, Discovery, etc.
-#if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_MAPLE_MINI) || defined(ARDUINO_GENERIC_STM32F103T) || defined(STM32F103TBU6) || defined(STM32F103TB) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F103C8) || defined(ARDUINO_GENERIC_STM32F103C8) || defined(ARDUINO_GENERIC_F103C8TX) || defined(STM32F4) || defined(STM32F4xx) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q)
+#if defined(ARDUINO_BLUEPILL_F103C8) || defined(ARDUINO_MAPLE_MINI) || defined(ARDUINO_GENERIC_STM32F103T) || defined(STM32F103TBU6) || defined(STM32F103TB) || defined(__STM32F1__) || defined(STM32F1) || defined(STM32F103C8) || defined(ARDUINO_GENERIC_STM32F103C8) || defined(ARDUINO_GENERIC_F103C8TX) || defined(STM32F4) || defined(STM32F4xx) || defined(ARDUINO_UNO_Q) || defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(STM32G0) || defined(STM32G0xx)
 #if !defined(ARDUINO_HY_TINYSTM103TB)
 #define USE_NEW_STM32_PIN_DEFINITIONS
 #endif

--- a/src/platforms/arm/stm32/is_stm32.h
+++ b/src/platforms/arm/stm32/is_stm32.h
@@ -54,6 +54,8 @@
     defined(STM32H723xx) || defined(STM32H725xx) || defined(STM32H730xx) || \
     defined(STM32H735xx) || defined(STM32H755xx) || defined(STM32H757xx) || \
     defined(STM32H7A3xx) || defined(STM32H7B3xx) || \
+    /* STM32G0 Family */ \
+    defined(STM32G0) || defined(STM32G0xx) || \
     /* STM32G4 Family (170 MHz, Motor Control) */ \
     defined(STM32G4) || defined(STM32G4xx) || \
     /* STM32U5 Family (160 MHz, Ultra Low Power) */ \
@@ -102,6 +104,12 @@
     defined(STM32H735xx) || defined(STM32H755xx) || defined(STM32H757xx) || \
     defined(STM32H7A3xx) || defined(STM32H7B3xx)
 #define FL_IS_STM32_H7
+#endif
+
+// FL_IS_STM32_G0 - STM32G0 Family
+#if defined(STM32G0) || defined(STM32G0xx)
+#define FL_IS_STM32_G0
+#define FL_IS_ARM_M0_PLUS
 #endif
 
 // FL_IS_STM32_G4 - STM32G4 Family (170 MHz, 32-128 KB RAM, 128-512 KB Flash, Mainstream)

--- a/src/platforms/arm/stm32/pins/boards/g0/generic_g0.h
+++ b/src/platforms/arm/stm32/pins/boards/g0/generic_g0.h
@@ -1,0 +1,109 @@
+#pragma once
+// ok no namespace fl
+
+// Generic STM32G0 Family Pin Definitions (all STM32G0 devices: G030, G031, G050, G070, G071, G081, G0B0, G0B1, G0C1, etc.)
+// Included by families/stm32g0.h - do not include directly
+// Defines pin mappings inside fl:: namespace
+// Maps pin numbers directly according to standard STM32duino PinName definitions:
+// PA0-PA15 = 0-15  (PA4 = pin 4)
+// PB0-PB15 = 16-31 (PB5 = pin 21)
+// PC0-PC15 = 32-47
+// PD0-PD15 = 48-63
+// PF0-PF15 = 64-79
+
+// IWYU pragma: private, include "platforms/arm/stm32/pins/families/stm32g0.h"
+
+#include "platforms/arm/stm32/pins/core/armpin_template.h"
+#include "platforms/arm/stm32/pins/core/gpio_port_init.h"
+#include "platforms/arm/stm32/pins/core/pin_macros.h"
+#include "platforms/arm/stm32/pins/families/stm32g0.h"
+
+// PA0-PA15 (pins 0-15)
+_DEFPIN_ARM_G0(0, 0, A);
+_DEFPIN_ARM_G0(1, 1, A);
+_DEFPIN_ARM_G0(2, 2, A);
+_DEFPIN_ARM_G0(3, 3, A);
+_DEFPIN_ARM_G0(4, 4, A);
+_DEFPIN_ARM_G0(5, 5, A);
+_DEFPIN_ARM_G0(6, 6, A);
+_DEFPIN_ARM_G0(7, 7, A);
+_DEFPIN_ARM_G0(8, 8, A);
+_DEFPIN_ARM_G0(9, 9, A);
+_DEFPIN_ARM_G0(10, 10, A);
+_DEFPIN_ARM_G0(11, 11, A);
+_DEFPIN_ARM_G0(12, 12, A);
+_DEFPIN_ARM_G0(13, 13, A);
+_DEFPIN_ARM_G0(14, 14, A);
+_DEFPIN_ARM_G0(15, 15, A);
+
+// PB0-PB15 (pins 16-31)
+_DEFPIN_ARM_G0(16, 0, B);
+_DEFPIN_ARM_G0(17, 1, B);
+_DEFPIN_ARM_G0(18, 2, B);
+_DEFPIN_ARM_G0(19, 3, B);
+_DEFPIN_ARM_G0(20, 4, B);
+_DEFPIN_ARM_G0(21, 5, B);
+_DEFPIN_ARM_G0(22, 6, B);
+_DEFPIN_ARM_G0(23, 7, B);
+_DEFPIN_ARM_G0(24, 8, B);
+_DEFPIN_ARM_G0(25, 9, B);
+_DEFPIN_ARM_G0(26, 10, B);
+_DEFPIN_ARM_G0(27, 11, B);
+_DEFPIN_ARM_G0(28, 12, B);
+_DEFPIN_ARM_G0(29, 13, B);
+_DEFPIN_ARM_G0(30, 14, B);
+_DEFPIN_ARM_G0(31, 15, B);
+
+// PC0-PC15 (pins 32-47)
+_DEFPIN_ARM_G0(32, 0, C);
+_DEFPIN_ARM_G0(33, 1, C);
+_DEFPIN_ARM_G0(34, 2, C);
+_DEFPIN_ARM_G0(35, 3, C);
+_DEFPIN_ARM_G0(36, 4, C);
+_DEFPIN_ARM_G0(37, 5, C);
+_DEFPIN_ARM_G0(38, 6, C);
+_DEFPIN_ARM_G0(39, 7, C);
+_DEFPIN_ARM_G0(40, 8, C);
+_DEFPIN_ARM_G0(41, 9, C);
+_DEFPIN_ARM_G0(42, 10, C);
+_DEFPIN_ARM_G0(43, 11, C);
+_DEFPIN_ARM_G0(44, 12, C);
+_DEFPIN_ARM_G0(45, 13, C);
+_DEFPIN_ARM_G0(46, 14, C);
+_DEFPIN_ARM_G0(47, 15, C);
+
+// PD0-PD15 (pins 48-63)
+_DEFPIN_ARM_G0(48, 0, D);
+_DEFPIN_ARM_G0(49, 1, D);
+_DEFPIN_ARM_G0(50, 2, D);
+_DEFPIN_ARM_G0(51, 3, D);
+_DEFPIN_ARM_G0(52, 4, D);
+_DEFPIN_ARM_G0(53, 5, D);
+_DEFPIN_ARM_G0(54, 6, D);
+_DEFPIN_ARM_G0(55, 7, D);
+_DEFPIN_ARM_G0(56, 8, D);
+_DEFPIN_ARM_G0(57, 9, D);
+_DEFPIN_ARM_G0(58, 10, D);
+_DEFPIN_ARM_G0(59, 11, D);
+_DEFPIN_ARM_G0(60, 12, D);
+_DEFPIN_ARM_G0(61, 13, D);
+_DEFPIN_ARM_G0(62, 14, D);
+_DEFPIN_ARM_G0(63, 15, D);
+
+// PF0-PF15 (pins 64-79)
+_DEFPIN_ARM_G0(64, 0, F);
+_DEFPIN_ARM_G0(65, 1, F);
+_DEFPIN_ARM_G0(66, 2, F);
+_DEFPIN_ARM_G0(67, 3, F);
+_DEFPIN_ARM_G0(68, 4, F);
+_DEFPIN_ARM_G0(69, 5, F);
+_DEFPIN_ARM_G0(70, 6, F);
+_DEFPIN_ARM_G0(71, 7, F);
+_DEFPIN_ARM_G0(72, 8, F);
+_DEFPIN_ARM_G0(73, 9, F);
+_DEFPIN_ARM_G0(74, 10, F);
+_DEFPIN_ARM_G0(75, 11, F);
+_DEFPIN_ARM_G0(76, 12, F);
+_DEFPIN_ARM_G0(77, 13, F);
+_DEFPIN_ARM_G0(78, 14, F);
+_DEFPIN_ARM_G0(79, 15, F);

--- a/src/platforms/arm/stm32/pins/boards/g0/nucleo_g070rb.h
+++ b/src/platforms/arm/stm32/pins/boards/g0/nucleo_g070rb.h
@@ -1,0 +1,78 @@
+#pragma once
+// ok no namespace fl
+
+// Nucleo G070RB Pin Definitions
+// Matches STMicroelectronics variant_NUCLEO_G070RB.cpp pin map
+// Included by families/stm32g0.h - do not include directly
+
+// IWYU pragma: private, include "platforms/arm/stm32/pins/families/stm32g0.h"
+
+#include "platforms/arm/stm32/pins/core/armpin_template.h"
+#include "platforms/arm/stm32/pins/core/gpio_port_init.h"
+#include "platforms/arm/stm32/pins/core/pin_macros.h"
+#include "platforms/arm/stm32/pins/families/stm32g0.h"
+
+// Arduino Digital Pins D0-D15
+_DEFPIN_ARM_G0(0, 5, C);   // PC_5  (D0)
+_DEFPIN_ARM_G0(1, 4, C);   // PC_4  (D1)
+_DEFPIN_ARM_G0(2, 10, A);  // PA_10 (D2)
+_DEFPIN_ARM_G0(3, 3, B);   // PB_3  (D3)
+_DEFPIN_ARM_G0(4, 5, B);   // PB_5  (D4)
+_DEFPIN_ARM_G0(5, 4, B);   // PB_4  (D5)
+_DEFPIN_ARM_G0(6, 14, B);  // PB_14 (D6)
+_DEFPIN_ARM_G0(7, 8, A);   // PA_8  (D7)
+_DEFPIN_ARM_G0(8, 9, A);   // PA_9  (D8)
+_DEFPIN_ARM_G0(9, 7, C);   // PC_7  (D9)
+_DEFPIN_ARM_G0(10, 0, B);  // PB_0  (D10)
+_DEFPIN_ARM_G0(11, 7, A);  // PA_7  (D11)
+_DEFPIN_ARM_G0(12, 6, A);  // PA_6  (D12)
+_DEFPIN_ARM_G0(13, 5, A);  // PA_5  (D13 / LED_BUILTIN)
+_DEFPIN_ARM_G0(14, 9, B);  // PB_9  (D14)
+_DEFPIN_ARM_G0(15, 8, B);  // PB_8  (D15)
+
+// Morpho Headers & Onboard Peripheral Pins (16..52)
+_DEFPIN_ARM_G0(16, 10, C); // PC_10
+_DEFPIN_ARM_G0(17, 12, C); // PC_12
+_DEFPIN_ARM_G0(18, 14, A); // PA_14 (SWD)
+_DEFPIN_ARM_G0(19, 0, D);  // PD_0
+_DEFPIN_ARM_G0(20, 3, D);  // PD_3
+_DEFPIN_ARM_G0(21, 13, A); // PA_13 (SWD)
+_DEFPIN_ARM_G0(22, 4, D);  // PD_4
+_DEFPIN_ARM_G0(23, 15, A); // PA_15
+_DEFPIN_ARM_G0(24, 7, B);  // PB_7
+_DEFPIN_ARM_G0(25, 13, C); // PC_13 (USER_BTN)
+_DEFPIN_ARM_G0(26, 14, C); // PC_14
+_DEFPIN_ARM_G0(27, 15, C); // PC_15
+_DEFPIN_ARM_G0(28, 0, F);  // PF_0
+_DEFPIN_ARM_G0(29, 1, F);  // PF_1
+_DEFPIN_ARM_G0(30, 2, C);  // PC_2
+_DEFPIN_ARM_G0(31, 3, C);  // PC_3
+_DEFPIN_ARM_G0(32, 11, C); // PC_11
+_DEFPIN_ARM_G0(33, 2, D);  // PD_2
+_DEFPIN_ARM_G0(34, 1, D);  // PD_1
+_DEFPIN_ARM_G0(35, 5, D);  // PD_5
+_DEFPIN_ARM_G0(36, 9, C);  // PC_9
+_DEFPIN_ARM_G0(37, 8, C);  // PC_8
+_DEFPIN_ARM_G0(38, 6, C);  // PC_6
+_DEFPIN_ARM_G0(39, 3, A);  // PA_3 (ST-LINK RX)
+_DEFPIN_ARM_G0(40, 6, D);  // PD_6
+_DEFPIN_ARM_G0(41, 11, A); // PA_11
+_DEFPIN_ARM_G0(42, 12, A); // PA_12
+_DEFPIN_ARM_G0(43, 1, C);  // PC_1
+_DEFPIN_ARM_G0(44, 0, C);  // PC_0
+_DEFPIN_ARM_G0(45, 2, B);  // PB_2
+_DEFPIN_ARM_G0(46, 6, B);  // PB_6
+_DEFPIN_ARM_G0(47, 15, B); // PB_15
+_DEFPIN_ARM_G0(48, 10, B); // PB_10
+_DEFPIN_ARM_G0(49, 13, B); // PB_13
+_DEFPIN_ARM_G0(50, 2, A);  // PA_2 (ST-LINK TX)
+_DEFPIN_ARM_G0(51, 8, D);  // PD_8
+_DEFPIN_ARM_G0(52, 9, D);  // PD_9
+
+// Arduino Analog Pins A0-A5 (pins 53..58)
+_DEFPIN_ARM_G0(53, 0, A);  // A0 / PA_0
+_DEFPIN_ARM_G0(54, 1, A);  // A1 / PA_1
+_DEFPIN_ARM_G0(55, 4, A);  // A2 / PA_4
+_DEFPIN_ARM_G0(56, 1, B);  // A3 / PB_1
+_DEFPIN_ARM_G0(57, 11, B); // A4 / PB_11
+_DEFPIN_ARM_G0(58, 12, B); // A5 / PB_12

--- a/src/platforms/arm/stm32/pins/core/armpin_template.h
+++ b/src/platforms/arm/stm32/pins/core/armpin_template.h
@@ -40,8 +40,21 @@ public:
   typedef volatile u32 * port_ptr_t;
   typedef u32 port_t;
 
-  inline static void setOutput() { pinMode(PIN, PinMode::Output); }
-  inline static void setInput() { pinMode(PIN, PinMode::Input); }
+  inline static void setOutput() {
+    // Configure physical MCU hardware GPIO registers via Arduino BSP
+    ::pinMode(PIN, OUTPUT);
+
+    // Update FastLED's internal pin state tracking
+    fl::pinMode(PIN, PinMode::Output);
+  }
+
+  inline static void setInput() {
+    // Configure physical MCU hardware GPIO registers via Arduino BSP
+    ::pinMode(PIN, INPUT);
+
+    // Update FastLED's internal pin state tracking
+    fl::pinMode(PIN, PinMode::Input);
+  }
 
   // Set pin HIGH - use BSRR lower 16 bits (same for ALL families)
   inline static void hi() FL_NO_EXCEPT __attribute__ ((always_inline)) {

--- a/src/platforms/arm/stm32/pins/families/stm32g0.h
+++ b/src/platforms/arm/stm32/pins/families/stm32g0.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// IWYU pragma: private
+
+// STM32G0 family variant using unified template.
+// STM32G0 GPIO has a BRR register, so reset can use BRR directly.
+
+#include "platforms/arm/stm32/pins/core/armpin_template.h"
+#include "platforms/arm/stm32/pins/core/gpio_port_init.h"
+#include "platforms/arm/stm32/pins/core/pin_macros.h"
+
+namespace fl {
+
+#define _DEFPIN_ARM_G0(PIN, BIT, PORT) _DEFPIN_STM32(PIN, BIT, PORT, true)
+
+_STM32_INIT_PORT(A);
+_STM32_INIT_PORT(B);
+_STM32_INIT_PORT(C);
+_STM32_INIT_PORT(D);
+
+#if defined(GPIOE)
+  _STM32_INIT_PORT(E);
+#endif
+#if defined(GPIOF)
+  _STM32_INIT_PORT(F);
+#endif
+
+#ifdef FASTLED_STM32_BOARD_FILE
+  #include FASTLED_STM32_BOARD_FILE  // nolint
+#else
+  #error "FASTLED_STM32_BOARD_FILE not defined - include this file via fastpin_dispatcher.h"
+#endif
+
+#define HAS_HARDWARE_PIN_SUPPORT
+
+}  // namespace fl

--- a/src/platforms/arm/stm32/pins/fastpin_dispatcher.h
+++ b/src/platforms/arm/stm32/pins/fastpin_dispatcher.h
@@ -117,6 +117,22 @@
   #include "families/stm32u5.h"  // nolint
 
 // ========================================
+// STM32G0 Family (HAS_BRR = true)
+// ========================================
+
+  // IWYU pragma: end_keep
+#elif defined(ARDUINO_NUCLEO_G070RB)
+  #define FASTLED_STM32_BOARD_FILE "platforms/arm/stm32/pins/boards/g0/nucleo_g070rb.h"
+  // IWYU pragma: begin_keep
+  #include "families/stm32g0.h"  // nolint
+
+  // IWYU pragma: end_keep
+#elif defined(ARDUINO_GENERIC_G070KBTX) || defined(ARDUINO_GENERIC_G070RBTX) || defined(ARDUINO_GENERIC_G070CBTX) || defined(STM32G0) || defined(STM32G0xx) || defined(STM32G070xx)
+  #define FASTLED_STM32_BOARD_FILE "platforms/arm/stm32/pins/boards/g0/generic_g0.h"
+  // IWYU pragma: begin_keep
+  #include "families/stm32g0.h"  // nolint
+
+// ========================================
 // Unknown Board - Error with Guidance
 // ========================================
 

--- a/src/platforms/arm/stm32/stm32_capabilities.h
+++ b/src/platforms/arm/stm32/stm32_capabilities.h
@@ -50,6 +50,8 @@
     #define FASTLED_STM32_FAMILY_NAME "STM32L4"
 #elif defined(FL_IS_STM32_H7)
     #define FASTLED_STM32_FAMILY_NAME "STM32H7"
+#elif defined(FL_IS_STM32_G0)
+    #define FASTLED_STM32_FAMILY_NAME "STM32G0"
 #elif defined(FL_IS_STM32_G4)
     #define FASTLED_STM32_FAMILY_NAME "STM32G4"
 #elif defined(FL_IS_STM32_U5)
@@ -91,6 +93,15 @@
     #define FASTLED_STM32_HAS_DMAMUX  // H7 has DMAMUX for flexible routing
     #define FASTLED_STM32_HAS_BDMA    // H7 has BDMA for low-power domain
     #define FASTLED_STM32_HAS_MDMA    // H7 has MDMA for memory-to-memory
+#endif
+
+// STM32G0 uses channel-based DMA with DMAMUX
+#if defined(FL_IS_STM32_G0)
+    #define FASTLED_STM32_DMA_CHANNEL_BASED
+    #define FASTLED_STM32_DMA_CONTROLLERS 1
+    #define FASTLED_STM32_DMA_CHANNELS_PER_CONTROLLER 7
+    #define FASTLED_STM32_DMA_TOTAL_CHANNELS 7
+    #define FASTLED_STM32_HAS_DMAMUX  // G0 has DMAMUX for flexible channel routing
 #endif
 
 // STM32G4 uses DMA with DMAMUX
@@ -305,6 +316,24 @@
             #endif
         #endif
 
+    #elif defined(FL_IS_STM32_G0)
+        // G0 LL driver headers
+        #if FL_HAS_INCLUDE("stm32g0xx_ll_tim.h")
+            #include "stm32g0xx_ll_tim.h"
+        #endif
+        #if FL_HAS_INCLUDE("stm32g0xx_ll_dma.h")
+            #include "stm32g0xx_ll_dma.h"
+        #endif
+        #if FL_HAS_INCLUDE("stm32g0xx_ll_gpio.h")
+            #include "stm32g0xx_ll_gpio.h"
+        #endif
+        #if FL_HAS_INCLUDE("stm32g0xx_ll_bus.h")
+            #include "stm32g0xx_ll_bus.h"
+        #endif
+        #if FL_HAS_INCLUDE("stm32g0xx_ll_dmamux.h")
+            #include "stm32g0xx_ll_dmamux.h"
+        #endif
+
     #elif defined(FL_IS_STM32_G4)
         // G4 LL driver headers
         #if FL_HAS_INCLUDE("stm32g4xx_ll_tim.h")
@@ -415,7 +444,8 @@
 #if !defined(FL_IS_STM32_F1) && !defined(FL_IS_STM32_F2) && \
     !defined(FL_IS_STM32_F4) && !defined(FL_IS_STM32_F7) && \
     !defined(FL_IS_STM32_L4) && !defined(FL_IS_STM32_H7) && \
-    !defined(FL_IS_STM32_G4) && !defined(FL_IS_STM32_U5)
+    !defined(FL_IS_STM32_G0) && !defined(FL_IS_STM32_G4) && \
+    !defined(FL_IS_STM32_U5)
     #warning "No specific STM32 family detected - using conservative defaults"
 #endif
 

--- a/src/platforms/cpu_frequency.h
+++ b/src/platforms/cpu_frequency.h
@@ -25,6 +25,9 @@
 #elif defined(STM32F1) || defined(__STM32F1__) || defined(STM32F10X_MD)
   // STM32F1: 72 MHz
   #define GET_CPU_FREQUENCY() 72000000UL
+#elif defined(STM32G0xx)
+  // STM32G0: 64 MHz
+  #define GET_CPU_FREQUENCY() 64000000UL
 #elif defined(STM32U5) || defined(STM32U5xx) || defined(STM32U585xx) || \
       defined(STM32U585XX) || defined(ARDUINO_UNO_Q) || \
       defined(CONFIG_BOARD_ARDUINO_UNO_Q) || defined(CONFIG_SOC_STM32U585XX)

--- a/src/platforms/is_platform.h
+++ b/src/platforms/is_platform.h
@@ -21,6 +21,7 @@
 /// - FL_IS_STM32_F7: STM32F7 family
 /// - FL_IS_STM32_L4: STM32L4 family (low-power)
 /// - FL_IS_STM32_H7: STM32H7 family (Giga R1, high-performance)
+/// - FL_IS_STM32_G0: STM32G0 family
 /// - FL_IS_STM32_G4: STM32G4 family (motor control)
 /// - FL_IS_STM32_U5: STM32U5 family (ultra-low-power)
 ///


### PR DESCRIPTION
This adds pin mappings for all STM32G0-based 'generic' boards, which use the default Arduino pin mappings, as well as for the *Nucleo G070RB* board.

I tested this on a generic STM32G070KBT board (custom design).

I generated this with Google's Antigravity. I reviewed it manually, and I'm moderately confident in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added STM32G0 support, including the NUCLEO-G070RB.
  * Added STM32G0 pin mappings (generic and board-specific) with hardware pin support.
  * Extended STM32 detection and STM32G0 capability handling (DMA/DMAMUX) and routing for STM32G0 targets.
* **Bug Fixes**
  * Improved clockless LED timing and delay behavior on targets without DWT cycle counters.
* **Documentation**
  * Expanded the documented STM32 family support statement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->