### PR TITLE
fix(ci): stop test caches absorbing files added during a run

### DIFF
--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -508,8 +508,45 @@ def check_full_run_cache(
         return None
 
 
+def capture_source_watermarks(cwd: Optional[Path] = None) -> "dict[str, float]":
+    """Snapshot source-tree mtimes to gate a test run that is about to start.
+
+    Must be called BEFORE the run whose result it will describe. Scanning at
+    save time instead is wrong: a file added while the suite was running gets
+    folded into the watermark, so the cache claims that file's state was tested
+    when it never was, and every later run skips on a stale pass. Capturing up
+    front leaves such a file strictly newer than the watermark, so the next run
+    correctly rebuilds. See the test-discovery counterpart in
+    meson_setup_phases._write_test_list_watermark.
+    """
+    root = cwd if cwd is not None else Path.cwd()
+    _meson_files = [
+        root / "meson.build",
+        root / "tests" / "meson.build",
+        root / "ci" / "meson" / "native" / "meson.build",
+        root / "ci" / "meson" / "wasm" / "meson.build",
+        root / "examples" / "meson.build",
+    ]
+    _meson_max = 0.0
+    for mf in _meson_files:
+        try:
+            _meson_max = max(_meson_max, mf.stat().st_mtime)
+        except OSError:
+            pass
+    return {
+        "src_max_file_mtime": _get_max_source_file_mtime(root / "src"),
+        "tests_max_file_mtime": _get_max_source_file_mtime(root / "tests"),
+        "examples_max_file_mtime": _get_max_source_file_mtime(root / "examples"),
+        "meson_max_file_mtime": _meson_max,
+    }
+
+
 def save_full_run_result(
-    build_dir: Path, num_passed: int, num_tests: int, duration: float
+    build_dir: Path,
+    num_passed: int,
+    num_tests: int,
+    duration: float,
+    watermarks: "Optional[dict[str, float]]" = None,
 ) -> None:
     """Save full test suite result for future fast-path.
 
@@ -517,6 +554,12 @@ def save_full_run_result(
     Stores build-state gates so future runs can skip fingerprint + imports
     when nothing has changed. Also captures examples/ mtime so the
     'bash test --cpp' ultra-early exit can correctly detect example changes.
+
+    Args:
+        watermarks: Source mtimes from capture_source_watermarks(), taken
+            BEFORE the run. Omitting them falls back to scanning now, which
+            cannot distinguish "unchanged" from "changed while we were
+            running" and so can cache a pass over untested files.
     """
     cache_file = get_full_run_cache_file(build_dir)
     try:
@@ -538,6 +581,17 @@ def save_full_run_result(
             except OSError:
                 pass
 
+        marks = (
+            watermarks
+            if watermarks is not None
+            else {
+                "src_max_file_mtime": _get_max_source_file_mtime(cwd / "src"),
+                "tests_max_file_mtime": _get_max_source_file_mtime(cwd / "tests"),
+                "examples_max_file_mtime": _get_max_source_file_mtime(cwd / "examples"),
+                "meson_max_file_mtime": _meson_max,
+            }
+        )
+
         data = {
             "result": "pass",
             "num_passed": num_passed,
@@ -546,10 +600,7 @@ def save_full_run_result(
             "build_ninja_mtime": (
                 build_ninja.stat().st_mtime if build_ninja.exists() else 0.0
             ),
-            "src_max_file_mtime": _get_max_source_file_mtime(cwd / "src"),
-            "tests_max_file_mtime": _get_max_source_file_mtime(cwd / "tests"),
-            "examples_max_file_mtime": _get_max_source_file_mtime(cwd / "examples"),
-            "meson_max_file_mtime": _meson_max,
+            **marks,
         }
 
         with open(cache_file, "w", encoding="utf-8") as f:

--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -508,6 +508,19 @@ def check_full_run_cache(
         return None
 
 
+# The full set of source-tree watermarks a full-run cache entry is gated on.
+# Persisting a partial set would leave an ungated directory, so writes require
+# all four.
+_WATERMARK_KEYS = frozenset(
+    {
+        "src_max_file_mtime",
+        "tests_max_file_mtime",
+        "examples_max_file_mtime",
+        "meson_max_file_mtime",
+    }
+)
+
+
 def capture_source_watermarks(cwd: Optional[Path] = None) -> "dict[str, float]":
     """Snapshot source-tree mtimes to gate a test run that is about to start.
 
@@ -581,16 +594,15 @@ def save_full_run_result(
             except OSError:
                 pass
 
-        marks = (
-            watermarks
-            if watermarks is not None
-            else {
-                "src_max_file_mtime": _get_max_source_file_mtime(cwd / "src"),
-                "tests_max_file_mtime": _get_max_source_file_mtime(cwd / "tests"),
-                "examples_max_file_mtime": _get_max_source_file_mtime(cwd / "examples"),
-                "meson_max_file_mtime": _meson_max,
-            }
-        )
+        # A complete pre-run watermark is mandatory. There is deliberately no
+        # scan-now fallback: scanning here (after the run) is the original bug
+        # -- it folds files added during the run into the watermark and marks
+        # them as covered by a pass they never took part in. If the caller
+        # cannot supply a full set, skip persisting entirely. The cost is one
+        # extra full run next time; the alternative is a silent stale green.
+        if watermarks is None or not _WATERMARK_KEYS <= watermarks.keys():
+            return
+        marks = {k: watermarks[k] for k in _WATERMARK_KEYS}
 
         data = {
             "result": "pass",

--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -460,21 +460,13 @@ def check_full_run_cache(
         ):
             return None
 
-        # 2a. Check meson.build files (detects build config changes)
+        # 2a. Check meson.build files (detects build config changes).
+        # _max_meson_build_mtime raises on an unreadable (as opposed to
+        # absent) build file rather than under-reporting the max, which here
+        # would read as "unchanged" and serve a stale entry. The enclosing
+        # except turns that into a cache miss -- fail closed.
         cwd = Path.cwd()
-        _meson_files = [
-            cwd / "meson.build",
-            cwd / "tests" / "meson.build",
-            cwd / "ci" / "meson" / "native" / "meson.build",
-            cwd / "ci" / "meson" / "wasm" / "meson.build",
-            cwd / "examples" / "meson.build",
-        ]
-        _meson_max = 0.0
-        for mf in _meson_files:
-            try:
-                _meson_max = max(_meson_max, mf.stat().st_mtime)
-            except OSError:
-                pass
+        _meson_max = _max_meson_build_mtime(cwd)
         if _meson_max > saved.get("meson_max_file_mtime", -1.0) + 0.001:
             return None
 
@@ -521,6 +513,43 @@ _WATERMARK_KEYS = frozenset(
 )
 
 
+def _meson_build_files(root: Path) -> "list[Path]":
+    """The build-definition files whose mtimes gate every cache entry."""
+    return [
+        root / "meson.build",
+        root / "tests" / "meson.build",
+        root / "ci" / "meson" / "native" / "meson.build",
+        root / "ci" / "meson" / "wasm" / "meson.build",
+        root / "examples" / "meson.build",
+    ]
+
+
+def _max_meson_build_mtime(root: Path) -> float:
+    """Max mtime across the build-definition files. Fails closed.
+
+    A missing file is expected and skipped -- not every checkout has, say,
+    examples/meson.build. Any OTHER stat error (permissions, I/O) is raised
+    rather than swallowed.
+
+    Swallowing those would silently produce a LOW maximum, and low is the
+    dangerous direction: on the check side the comparison is
+    `now > saved -> invalidate`, so an under-reported "now" reads as
+    "unchanged" and serves a stale cache entry for a build definition that
+    actually changed. That is the same silent-staleness failure this module's
+    watermarks exist to prevent, so it must not be reintroduced by an
+    over-broad except.
+    """
+    max_mtime = 0.0
+    for mf in _meson_build_files(root):
+        try:
+            max_mtime = max(max_mtime, mf.stat().st_mtime)
+        except FileNotFoundError:
+            continue  # optional build file, genuinely absent
+        except OSError as e:
+            raise OSError(f"cannot stat build definition {mf}: {e}") from e
+    return max_mtime
+
+
 def capture_source_watermarks(cwd: Optional[Path] = None) -> "dict[str, float]":
     """Snapshot source-tree mtimes to gate a test run that is about to start.
 
@@ -531,26 +560,18 @@ def capture_source_watermarks(cwd: Optional[Path] = None) -> "dict[str, float]":
     front leaves such a file strictly newer than the watermark, so the next run
     correctly rebuilds. See the test-discovery counterpart in
     meson_setup_phases._write_test_list_watermark.
+
+    Raises:
+        OSError: if a build-definition file exists but cannot be stat'd. The
+            caller must not fall back to a partial value -- see
+            _max_meson_build_mtime.
     """
     root = cwd if cwd is not None else Path.cwd()
-    _meson_files = [
-        root / "meson.build",
-        root / "tests" / "meson.build",
-        root / "ci" / "meson" / "native" / "meson.build",
-        root / "ci" / "meson" / "wasm" / "meson.build",
-        root / "examples" / "meson.build",
-    ]
-    _meson_max = 0.0
-    for mf in _meson_files:
-        try:
-            _meson_max = max(_meson_max, mf.stat().st_mtime)
-        except OSError:
-            pass
     return {
         "src_max_file_mtime": _get_max_source_file_mtime(root / "src"),
         "tests_max_file_mtime": _get_max_source_file_mtime(root / "tests"),
         "examples_max_file_mtime": _get_max_source_file_mtime(root / "examples"),
-        "meson_max_file_mtime": _meson_max,
+        "meson_max_file_mtime": _max_meson_build_mtime(root),
     }
 
 
@@ -570,29 +591,17 @@ def save_full_run_result(
 
     Args:
         watermarks: Source mtimes from capture_source_watermarks(), taken
-            BEFORE the run. Omitting them falls back to scanning now, which
-            cannot distinguish "unchanged" from "changed while we were
-            running" and so can cache a pass over untested files.
+            BEFORE the run. REQUIRED and must be complete -- if omitted or
+            partial this fails closed and returns WITHOUT persisting a cache
+            entry. There is deliberately no scan-now fallback: scanning at save
+            time cannot distinguish "unchanged" from "changed while we were
+            running", so it would cache a pass over files that were never
+            tested. Callers that cannot supply a full set simply forgo the
+            fast path for one run.
     """
     cache_file = get_full_run_cache_file(build_dir)
     try:
         build_ninja = build_dir / "build.ninja"
-        cwd = Path.cwd()
-
-        # Compute meson.build max mtime
-        _meson_files = [
-            cwd / "meson.build",
-            cwd / "tests" / "meson.build",
-            cwd / "ci" / "meson" / "native" / "meson.build",
-            cwd / "ci" / "meson" / "wasm" / "meson.build",
-            cwd / "examples" / "meson.build",
-        ]
-        _meson_max = 0.0
-        for mf in _meson_files:
-            try:
-                _meson_max = max(_meson_max, mf.stat().st_mtime)
-            except OSError:
-                pass
 
         # A complete pre-run watermark is mandatory. There is deliberately no
         # scan-now fallback: scanning here (after the run) is the original bug

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -625,6 +625,14 @@ def build_meson_setup_cmd(
             wrapped.extend(["--input-file", str(sidecar)])
         # `--` separates wrapper flags from the trailing meson args.
         wrapped.append("--")
+        # `--reconfigure` must survive the wrapper. Without it the wrapper runs
+        # a plain `meson setup` against an already-configured dir, meson prints
+        # "Directory already configured" and regenerates nothing -- so a
+        # source-triggered reconfigure (e.g. a newly added test file) is
+        # detected, reported, and then silently dropped. Only `--clean` picked
+        # the file up.
+        if reconfigure:
+            wrapped.append("--reconfigure")
         wrapped.extend(meson_args)
         return wrapped
 

--- a/ci/meson/meson_setup_phases.py
+++ b/ci/meson/meson_setup_phases.py
@@ -385,22 +385,46 @@ def check_meson_build_modified(source_dir: Path, build_dir: Path) -> bool:
     return False
 
 
+def _write_test_list_watermark(build_dir: Path, max_tests_dir_mtime: float) -> None:
+    """Persist the tests/ dir mtime that the current cached list corresponds to.
+
+    Written atomically: a torn watermark would be parsed as corrupt and force a
+    full rescan, which is safe but silently costs ~400ms on every build.
+    """
+    watermark_path = build_dir / "test_list_watermark.txt"
+    temp_path = watermark_path.with_suffix(".tmp")
+    try:
+        temp_path.write_text(f"{max_tests_dir_mtime!r}\n")
+        temp_path.replace(watermark_path)
+    except OSError:
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+
+
 def detect_test_file_changes(
     source_dir: Path, build_dir: Path, max_tests_dir_mtime: float
 ) -> bool:
     """Return True when discovered test files differ from the cached list."""
     test_list_cache_path = build_dir / "test_list_cache.txt"
-    skip_test_discovery = False
+    # Watermark = the max tests/ dir mtime observed by the scan that produced
+    # the cached list. It must NOT be the cache file's own mtime: the cache is
+    # written *after* discovery, so a test file created in between would carry
+    # an older parent-dir mtime than the cache and be masked forever -- the
+    # fast path would report "no changes" on every subsequent run and the new
+    # test would silently never build, while the suite still reported green.
+    # Comparing against a watermark captured *before* the scan makes anything
+    # added during or after that scan strictly newer, so it is always caught.
+    watermark_path = build_dir / "test_list_watermark.txt"
     if test_list_cache_path.exists():
         try:
-            tlc_mtime = test_list_cache_path.stat().st_mtime
-            if max_tests_dir_mtime <= tlc_mtime:
-                skip_test_discovery = True
-        except OSError:
+            watermark = float(watermark_path.read_text().strip())
+            if max_tests_dir_mtime <= watermark:
+                return False
+        except (OSError, ValueError):
+            # No/corrupt watermark -- fall through to the authoritative compare.
             pass
-
-    if skip_test_discovery:
-        return False
 
     try:
         import importlib.util
@@ -489,12 +513,10 @@ def detect_test_file_changes(
                     temp_cache.unlink()
                 except (OSError, IOError):
                     pass
+            _write_test_list_watermark(build_dir, max_tests_dir_mtime)
             return True
-        # No changes — touch cache so directory-mtime fast-path activates next run.
-        try:
-            test_list_cache.touch()
-        except OSError:
-            pass
+        # No changes — record the watermark so the fast path activates next run.
+        _write_test_list_watermark(build_dir, max_tests_dir_mtime)
         return False
 
     except KeyboardInterrupt as ki:

--- a/ci/util/fingerprint.py
+++ b/ci/util/fingerprint.py
@@ -76,6 +76,8 @@ class FingerprintManager:
         self.fingerprint_dir.mkdir(exist_ok=True)
         self._fingerprints: dict[str, FingerprintResult] = {}
         self._prev_fingerprints: dict[str, Optional[FingerprintResult]] = {}
+        # name -> max source mtime seen at the START of this invocation's check
+        self._observed_max_mtime: dict[str, float] = {}
 
     def _get_fingerprint_file(self, name: str) -> Path:
         # For cpp_test and examples, include build mode in filename to separate caches per build mode
@@ -97,6 +99,7 @@ class FingerprintManager:
                         num_tests_passed=data.get("num_tests_passed"),
                         duration_seconds=data.get("duration_seconds"),
                         test_name=data.get("test_name"),
+                        source_max_mtime=data.get("source_max_mtime"),
                     )
                 except json.JSONDecodeError:
                     ts_print(f"Invalid {name} fingerprint file. Recalculating...")
@@ -118,6 +121,8 @@ class FingerprintManager:
             fingerprint_dict["duration_seconds"] = fingerprint.duration_seconds
         if fingerprint.test_name is not None:
             fingerprint_dict["test_name"] = fingerprint.test_name
+        if fingerprint.source_max_mtime is not None:
+            fingerprint_dict["source_max_mtime"] = fingerprint.source_max_mtime
         with open(fingerprint_file, "w") as f:
             json.dump(fingerprint_dict, f, indent=2)
 
@@ -144,6 +149,17 @@ class FingerprintManager:
                     fingerprint.num_tests_passed = prev_fp.num_tests_passed
                     fingerprint.duration_seconds = prev_fp.duration_seconds
                     fingerprint.test_name = prev_fp.test_name
+            # Persist the watermark from this invocation's opening scan. On a
+            # fast-path hit nothing was rebuilt, so carry the previous value
+            # forward rather than advancing it -- advancing would absorb any
+            # file added since that run into a pass it never took part in.
+            if fingerprint.source_max_mtime is None:
+                observed = self._observed_max_mtime.get(name)
+                prev_seen = self._prev_fingerprints.get(name)
+                if observed is not None:
+                    fingerprint.source_max_mtime = observed
+                elif prev_seen is not None:
+                    fingerprint.source_max_mtime = prev_seen.source_max_mtime
             self.write(name, fingerprint)
 
     def update_test_metadata(
@@ -203,18 +219,31 @@ class FingerprintManager:
         if not fp_file.exists():
             return False
         try:
-            fp_mtime = fp_file.stat().st_mtime
             max_file_mtime = max(
                 (_get_max_source_file_mtime(d, exts=exts) for d in dirs), default=0.0
             )
-            if max_file_mtime > fp_mtime:
-                return False  # a source file was modified after fingerprint write
+            # Remember what this scan saw. If a run follows, save_all() persists
+            # it as the new watermark, describing the tree at that run's START.
+            self._observed_max_mtime[name] = max_file_mtime
             prev = self.read(name)
             if prev is None or prev.status != "success":
                 return False  # no previous result or previous run failed
-            # Fast-path fires: record the cached result without running the calculator
+            # Gate on the watermark recorded when the cached run BEGAN. There is
+            # deliberately no fall back to fp_file.stat().st_mtime: that file is
+            # written at run END, so a source file created mid-run compares as
+            # older and is skipped forever. A cache without a watermark (written
+            # before this field existed) simply takes the slow path once.
+            if prev.source_max_mtime is None:
+                return False
+            if max_file_mtime > prev.source_max_mtime:
+                return False  # a source file changed after the cached run began
+            # Fast-path fires: nothing will be rebuilt, so do NOT advance the
+            # watermark -- keep the one the cached run was actually gated on.
+            self._observed_max_mtime.pop(name, None)
             self._prev_fingerprints[name] = prev
-            self._fingerprints[name] = FingerprintResult(hash=prev.hash)
+            self._fingerprints[name] = FingerprintResult(
+                hash=prev.hash, source_max_mtime=prev.source_max_mtime
+            )
             return True
         except OSError:
             return False

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1531,8 +1531,14 @@ def runner(
     # Skip if fingerprint cache indicates no changes
     if test_categories.unit_only:
         if cpp_test_change:
+            from ci.meson.cache_utils import capture_source_watermarks
             from ci.meson.runner import run_meson_build_and_test
             from ci.util.paths import PROJECT_ROOT
+
+            # Snapshot the tree BEFORE building/running. Capturing after the run
+            # would absorb any file added meanwhile into the watermark, caching
+            # a pass over code that was never compiled or executed.
+            _watermarks = capture_source_watermarks(PROJECT_ROOT)
 
             build_dir = PROJECT_ROOT / ".build" / "meson"
             test_name = args.test if args.test else None
@@ -1700,6 +1706,7 @@ def runner(
                         result.num_tests_passed,
                         result.num_tests_run,
                         result.duration,
+                        watermarks=_watermarks,
                     )
                 except KeyboardInterrupt as ki:
                     handle_keyboard_interrupt(ki)
@@ -1891,11 +1898,28 @@ def runner(
                         if _cache_file_tr.exists():
                             _saved_tr = _json.loads(_cache_file_tr.read_text())
                             if _saved_tr.get("result") == "pass":
+                                # Refresh ONLY build_ninja_mtime. Carry the
+                                # original watermarks forward untouched -- this
+                                # path runs when tests were SKIPPED, so
+                                # rescanning here would fold any file added
+                                # since that run into the watermark and mark it
+                                # as covered by a pass it never took part in.
+                                _carry = {
+                                    _k: _saved_tr[_k]
+                                    for _k in (
+                                        "src_max_file_mtime",
+                                        "tests_max_file_mtime",
+                                        "examples_max_file_mtime",
+                                        "meson_max_file_mtime",
+                                    )
+                                    if _k in _saved_tr
+                                }
                                 save_full_run_result(
                                     _build_dir_tr,
                                     _saved_tr.get("num_passed", 0),
                                     _saved_tr.get("num_tests", 0),
                                     _saved_tr.get("duration", 0.0),
+                                    watermarks=_carry or None,
                                 )
                     except KeyboardInterrupt as ki:
                         handle_keyboard_interrupt(ki)

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1904,23 +1904,25 @@ def runner(
                                 # rescanning here would fold any file added
                                 # since that run into the watermark and mark it
                                 # as covered by a pass it never took part in.
-                                _carry = {
-                                    _k: _saved_tr[_k]
-                                    for _k in (
-                                        "src_max_file_mtime",
-                                        "tests_max_file_mtime",
-                                        "examples_max_file_mtime",
-                                        "meson_max_file_mtime",
-                                    )
-                                    if _k in _saved_tr
-                                }
-                                save_full_run_result(
-                                    _build_dir_tr,
-                                    _saved_tr.get("num_passed", 0),
-                                    _saved_tr.get("num_tests", 0),
-                                    _saved_tr.get("duration", 0.0),
-                                    watermarks=_carry or None,
+                                _keys = (
+                                    "src_max_file_mtime",
+                                    "tests_max_file_mtime",
+                                    "examples_max_file_mtime",
+                                    "meson_max_file_mtime",
                                 )
+                                # Only refresh when the whole watermark set
+                                # survives. A partial carry (e.g. a cache file
+                                # written before watermarks existed) would
+                                # leave a directory ungated, so drop the
+                                # refresh instead -- the next run just re-runs.
+                                if all(_k in _saved_tr for _k in _keys):
+                                    save_full_run_result(
+                                        _build_dir_tr,
+                                        _saved_tr.get("num_passed", 0),
+                                        _saved_tr.get("num_tests", 0),
+                                        _saved_tr.get("duration", 0.0),
+                                        watermarks={_k: _saved_tr[_k] for _k in _keys},
+                                    )
                     except KeyboardInterrupt as ki:
                         handle_keyboard_interrupt(ki)
                     except Exception:

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1538,7 +1538,13 @@ def runner(
             # Snapshot the tree BEFORE building/running. Capturing after the run
             # would absorb any file added meanwhile into the watermark, caching
             # a pass over code that was never compiled or executed.
-            _watermarks = capture_source_watermarks(PROJECT_ROOT)
+            # An unreadable build file must not take down the test run: fall
+            # back to None, which makes save_full_run_result skip persisting.
+            # Worst case is one lost fast path, never a stale green.
+            try:
+                _watermarks = capture_source_watermarks(PROJECT_ROOT)
+            except OSError:
+                _watermarks = None
 
             build_dir = PROJECT_ROOT / ".build" / "meson"
             test_name = args.test if args.test else None

--- a/ci/util/test_types.py
+++ b/ci/util/test_types.py
@@ -158,6 +158,12 @@ class FingerprintResult:
     num_tests_passed: Optional[int] = None
     duration_seconds: Optional[float] = None
     test_name: Optional[str] = None  # Human-readable test category name
+    # Max source-file mtime observed when this fingerprint's run STARTED.
+    # The mtime fast-path gates on this, never on the fingerprint file's own
+    # mtime: that file is written when the run ENDS, so a source file created
+    # while the run was in flight looks older than the cache and gets skipped
+    # on every later run while the suite still reports green.
+    source_max_mtime: Optional[float] = None
 
     def get_cache_summary(self) -> str:
         """Get a human-readable summary of cached test results"""


### PR DESCRIPTION
## The bug

Two test caches record their invalidation watermark at cache-**write** time, which happens *after* the run finishes. Any file created while a run is in flight therefore ends up **older** than the watermark, so every subsequent run concludes "no changes" and skips it — permanently, and while still reporting the suite all-green.

Concretely: **a newly added test can silently never build, and `bash test --cpp` prints "All tests passed".**

## Reproduction

Added `tests/fl/zz_cache_probe.cpp`, then ran `bash test --cpp`:

```
✅ All tests passed (356/356 in 25.62s)     <- ran for real, but count should be 357
```

The new test was absent. It only appeared under `--clean` (357). Instrumenting `detect_test_file_changes()` showed why:

```
max_tests_dir_mtime = 1785179284.83   (tests/fl bumped when the file was added)
test_list_cache.txt = 1785179287.04   (written 2.2s LATER)
shortcut_skips      = True            -> returns "unchanged", file lists never compared
```

Because the shortcut compares against the cache file's own mtime, and the cache is written at the end of a run that began before the file existed, the file is masked on every future run.

## Fix

- **`meson_setup_phases`** — compare against a watermark captured *before* discovery (`test_list_watermark.txt`) instead of the cache file's mtime, and drop the `touch()` that created the masking window. The authoritative file-list comparison still runs whenever the watermark is missing or stale.
- **`cache_utils` / `test_runner`** — add `capture_source_watermarks()`, taken before the build starts, threaded into `save_full_run_result()`. The cache-hit path now carries the previous watermarks **forward** instead of rescanning: that path runs when tests were *skipped*, so rescanning was marking untested files as covered by a pass they never took part in.

The fast paths are preserved — only the reference point changes — so there's no added scan cost on the hot path.

## Testing

- `bash test --cpp --clean` — 356/356 pass
- `bash lint` — fully green

## Follow-ups found while investigating (not in this PR)

1. **zccache daemon serves hits for deleted caches.** With no cache file on disk, the daemon-backed path returns `rc=1 skip (no changes)` while the standalone binary correctly returns `rc=0 run (no cache file)`. After `zccache stop` the identical call flips to `rc=0`. The daemon keys state by cache-file path and never revalidates the backing file exists. This affects every daemon-backed consumer today (`cpp_lint`, `js_lint`, `python_lint`) and belongs in the zccache repo.
2. **`cpp_test` doesn't use zccache at all** — it hand-rolls the mtime fast-path plus a Python SHA-256 calculator. Delegating to `zccache-fp` would be correct by construction (it hashes at check time and only promotes on success) and measured *faster* than the Python miss path: ~170ms vs 200-400ms over ~2800 files. Worth doing once (1) is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-result caching by tracking source/test “watermarks” and only reusing cached outputs when inputs truly match.
  * Fixed cache invalidation when the test list changes by using a dedicated watermark file instead of touching cache timestamps.
  * Improved fingerprint fast-path correctness by persisting and carrying forward source max mtimes across runs.
  * Ensured Meson reconfiguration propagates correctly when using the zccache `meson configure` wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->