### PR TITLE
refactor(stl): move malloc/free hook pointer into a Singleton (#3484)

### DIFF
--- a/src/fl/stl/allocator.cpp.hpp
+++ b/src/fl/stl/allocator.cpp.hpp
@@ -60,8 +60,20 @@ void *(*Alloc)(fl::size) = DefaultAlloc;
 void (*Dealloc)(void *) = DefaultFree;
 
 #if defined(FASTLED_TESTING)
-// Test hook interface pointer
-MallocFreeHook* gMallocFreeHook = nullptr;
+// Test hook interface pointer. Storage lives inside a Singleton so
+// `--gc-sections` can drop it together with Singleton<T>::instance() when no
+// test installs a hook (FastLED#3484 / #3481).
+// Already inside this file's anonymous namespace.
+//
+// Safe to call from inside Malloc()/Free(): Singleton<T>::instance()
+// placement-news into a static char buffer and never touches the heap, so
+// routing the hook lookup through it cannot recurse back into the allocator.
+struct MallocFreeHookState {
+    MallocFreeHook* hook = nullptr;
+};
+inline MallocFreeHook*& malloc_free_hook() FL_NO_EXCEPT {
+    return fl::Singleton<MallocFreeHookState>::instance().hook;
+}
 
 int& tls_reintrancy_count() {
     return SingletonThreadLocal<int>::instance();
@@ -103,11 +115,11 @@ void SetMallocFreeHook(MallocFreeHook* hook) {
     // triggering recursive Malloc() that would corrupt the reentrancy counter.
     (void)tls_reintrancy_count();
 
-    gMallocFreeHook = hook;
+    malloc_free_hook() = hook;
 }
 
 void ClearMallocFreeHook() {
-    gMallocFreeHook = nullptr;
+    malloc_free_hook() = nullptr;
 }
 #endif
 
@@ -124,10 +136,10 @@ void *PSRamAllocate(fl::size size, bool zero) {
     }
     
 #if defined(FASTLED_TESTING)
-    if (gMallocFreeHook && ptr) {
+    if (malloc_free_hook() && ptr) {
         MemoryGuard allows_hook;
         if (allows_hook.enabled()) {
-            gMallocFreeHook->onMalloc(ptr, size);
+            malloc_free_hook()->onMalloc(ptr, size);
         }
     }
 #endif
@@ -137,11 +149,11 @@ void *PSRamAllocate(fl::size size, bool zero) {
 
 void PSRamDeallocate(void *ptr) {
 #if defined(FASTLED_TESTING)
-    if (gMallocFreeHook && ptr) {
-        // gMallocFreeHook->onFree(ptr);
+    if (malloc_free_hook() && ptr) {
+        // malloc_free_hook()->onFree(ptr);
         MemoryGuard allows_hook;
         if (allows_hook.enabled()) {
-            gMallocFreeHook->onFree(ptr);
+            malloc_free_hook()->onFree(ptr);
         }
     }
 #endif
@@ -153,10 +165,10 @@ void* Malloc(fl::size size) {
     void* ptr = Alloc(size); 
     
 #if defined(FASTLED_TESTING)
-    if (gMallocFreeHook && ptr) {
+    if (malloc_free_hook() && ptr) {
         MemoryGuard allows_hook;    
         if (allows_hook.enabled()) {
-            gMallocFreeHook->onMalloc(ptr, size);
+            malloc_free_hook()->onMalloc(ptr, size);
         }
     }
 #endif
@@ -166,10 +178,10 @@ void* Malloc(fl::size size) {
 
 void Free(void *ptr) {
 #if defined(FASTLED_TESTING)
-    if (gMallocFreeHook && ptr) {
+    if (malloc_free_hook() && ptr) {
         MemoryGuard allows_hook;
         if (allows_hook.enabled()) {
-            gMallocFreeHook->onFree(ptr);
+            malloc_free_hook()->onFree(ptr);
         }
     }
 #endif


### PR DESCRIPTION
## Summary

Closes #3484.

Most of that issue was already done. Of the three statics it lists, the slab registry pair (`slab_registry[64]` + `slab_registry_count` — the ~1.5 KB `.bss` table the issue was mainly about) moved into `fl::Singleton<SlabRegistryState>` as part of #3495. This PR finishes the file by migrating the one remaining item, `gMallocFreeHook`.

## Why a Singleton specifically

`malloc_free_hook()` is called from inside `Malloc()` and `Free()` themselves, so the holder must not allocate. `Singleton<T>::instance()` placement-news into a static aligned char buffer and never touches the heap:

```cpp
static AlignedStorage storage;
static T* ptr = nullptr;
if (!ptr) { ptr = new (&storage.data) T(); }
```

A lazily heap-allocated holder here would recurse back into the allocator on first use. Verified before making the change; called out in a comment so it isn't "simplified" later.

## Scope note — no bloat delta to report

The issue's acceptance criteria ask for `bash bloat esp32dev` before/after confirmation. That is **not applicable to this particular static**: `gMallocFreeHook` is inside `#if defined(FASTLED_TESTING)`, so it never existed in firmware builds in the first place. The measurable elision win was the slab table, and that already landed in #3495. Flagging this rather than presenting a no-op diff as a saving.

## Testing

- `bash test --cpp --clean` — **355/355 pass**
- `bash test allocator` — passes; `tests/fl/stl/allocator.cpp` exercises `SetMallocFreeHook` across several cases, which is the path this PR changes
- `fastled-lint --checker singleton_elision src/fl/stl/allocator.cpp.hpp` — clean
- `bash lint` — fully green

## Related finding (not addressed here)

While verifying, I found `singleton_elision` passes on files that still carry mutable namespace-scope statics — e.g. `flexio_driver.cpp.hpp` still has `sDmaChannel`, `sDmaComplete`, `sInitialized`, `sFlexIOPin` and reports clean. So a green checker run does **not** imply the remaining Tier issues (#3485–#3491) are complete; they need to be verified by reading, not by the linter. Worth knowing before #3492 promotes the checker to hard-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation testing behavior by making allocation and deallocation hooks more reliable.
  * Preserved existing memory safety protections and reentrancy handling while updating hook management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->