### PR TITLE
chore(autoresearch): use --perf-XX / --test-XX flag prefixes (#3124)

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -180,7 +180,7 @@ bash autoresearch lpc845 --pin-toggle-rx --upload-port <port> --timeout 120s --s
 bash autoresearch lpc845 --ws2812-loopback --upload-port <port> --timeout 120s --skip-lint
 bash autoresearch lpc845 --uart --upload-port <port> --timeout 120s --skip-lint
 bash autoresearch lpc845 --dma-uart --upload-port <port> --timeout 120s --skip-lint
-bash autoresearch lpc845 --fault-emit-test --upload-port <port> --timeout 120s --skip-lint
+bash autoresearch lpc845 --test-fault-emit --upload-port <port> --timeout 120s --skip-lint
 
 # Teensy 4.x bring-up and driver validation.
 bash autoresearch teensy41 --upload-port <port> --timeout 120s
@@ -208,7 +208,7 @@ Pick the narrowest validation level that proves the claim:
   etc.). Raw peripheral benches such as `--dma-uart` are supporting evidence,
   not replacements for public API validation.
 - **Failure/safety behavior:** use dedicated modes such as
-  `--fault-emit-test`; capture decisive `FAULT:`, `REMOTE:`, or `RESULT:` lines.
+  `--test-fault-emit`; capture decisive `FAULT:`, `REMOTE:`, or `RESULT:` lines.
 
 Closeout evidence must include the command, board, port, wiring, decisive
 output, commit/PR URL, and issue URL. Stale chat comments, CI compile-only
@@ -345,7 +345,7 @@ that the device emits a `FAULT:` diagnostic before reset.
 
 ```bash
 fbuild port scan
-bash autoresearch lpc845 --fault-emit-test --upload-port COM10 --timeout 120s --skip-lint
+bash autoresearch lpc845 --test-fault-emit --upload-port COM10 --timeout 120s --skip-lint
 ```
 
 The test intentionally crashes the target twice. A pass means both triggers

--- a/autoresearch
+++ b/autoresearch
@@ -43,7 +43,7 @@ Driver Selection (optional - omit for GPIO-only mode):
   --pwm-dma-cl        LPC845-only: channels-API SCT+DMA clockless
                       self-loopback (FastLED #3468). Jumper P0_10↔P0_11.
   --dma-uart          LPC845-only: raw async UART TX DMA bench
-  --fault-emit-test   LPC845-only: trigger intentional OOM/stack faults and
+  --test-fault-emit   LPC845-only: trigger intentional OOM/stack faults and
                       assert FAULT diagnostics (FastLED #3302)
   --all               Test all drivers
   --simd              Test SIMD operations only (no LED drivers needed)

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -31,7 +31,7 @@ class Args:
     rpc_smoke: bool
     # Wave2D perf benchmark — accepts "<W>x<H>" (e.g. "32x32") or None.
     # Cf. issue #3124 for the future --perf-XX / --test-XX convention.
-    wave2d_perf: str | None
+    perf_wave2d: str | None
 
     # Standard options
     environment: str | None
@@ -129,7 +129,7 @@ class Args:
     rp_pio_both: bool
 
     # LPC845 fault emit validation (#3302).
-    fault_emit_test: bool
+    test_fault_emit: bool
 
     # Multi-frame capture — number of back-to-back show()/capture cycles per pattern.
     # None = driver-default (SPI → 2, others → 1). Explicit value overrides.
@@ -371,7 +371,7 @@ See Also:
             help="Exercise deliberateHang watchdog recovery and post-reset RPC smoke",
         )
         driver_group.add_argument(
-            "--wave2d-perf",
+            "--perf-wave2d",
             type=str,
             default=None,
             metavar="WxH",
@@ -502,7 +502,7 @@ See Also:
             "exclusive with --dma-spi / --pwm-dma-cl (flash budget).",
         )
         lpc_group.add_argument(
-            "--fault-emit-test",
+            "--test-fault-emit",
             action="store_true",
             help="LPC845-only fault-emission validation (#3302). Builds "
             "the gated low-memory fault RPCs, triggers intentional OOM "
@@ -846,7 +846,7 @@ See Also:
             ieee754=parsed.ieee754,
             rpc_smoke=parsed.rpc_smoke,
             watchdog_soak=parsed.watchdog_soak,
-            wave2d_perf=parsed.wave2d_perf,
+            perf_wave2d=parsed.perf_wave2d,
             environment=parsed.environment,
             verbose=parsed.verbose,
             skip_lint=parsed.skip_lint,
@@ -893,7 +893,7 @@ See Also:
             rp_spi_chipset=parsed.rp_spi_chipset,
             rp_pio_index=parsed.rp_pio_index,
             rp_pio_both=parsed.rp_pio_both,
-            fault_emit_test=parsed.fault_emit_test,
+            test_fault_emit=parsed.test_fault_emit,
             frames=parsed.frames,
             tight_timing=parsed.tight_timing,
             tight_timing_iterations=parsed.tight_timing_iterations,

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -149,7 +149,7 @@ class RunContext:
     ieee754_test_mode: bool
     # Wave2D perf benchmark — None disables, otherwise (W, H).
     # See issue #3124 for the planned --perf-XX convention rename.
-    wave2d_perf_grid: tuple[int, int] | None
+    perf_wave2d_grid: tuple[int, int] | None
     net_server_mode: bool
     net_client_mode: bool
     net_loopback_mode: bool

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -416,11 +416,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     rpc_smoke_mode = args.rpc_smoke
     watchdog_soak_mode = args.watchdog_soak
 
-    # Parse --wave2d-perf "<W>x<H>" — None disables the mode.
+    # Parse --perf-wave2d "<W>x<H>" — None disables the mode.
     # Cf. #3124 for the planned --perf-XX convention rename.
-    wave2d_perf_grid: tuple[int, int] | None = None
-    if args.wave2d_perf is not None:
-        spec = str(args.wave2d_perf).lower().strip()
+    perf_wave2d_grid: tuple[int, int] | None = None
+    if args.perf_wave2d is not None:
+        spec = str(args.perf_wave2d).lower().strip()
         try:
             if "x" not in spec:
                 raise ValueError("expected 'WxH' form")
@@ -429,11 +429,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             h_val = int(h_str)
             if not (4 <= w_val <= 1024 and 4 <= h_val <= 1024):
                 raise ValueError("W and H must be in [4, 1024]")
-            wave2d_perf_grid = (w_val, h_val)
+            perf_wave2d_grid = (w_val, h_val)
         except ValueError as exc:
             print(
-                f"{Fore.RED}❌ --wave2d-perf: invalid grid spec "
-                f"{args.wave2d_perf!r}: {exc}{Style.RESET_ALL}",
+                f"{Fore.RED}❌ --perf-wave2d: invalid grid spec "
+                f"{args.perf_wave2d!r}: {exc}{Style.RESET_ALL}",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -999,7 +999,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             lpc_bench_defines.append(f"FL_LPC_UART_DMA_CLOCKLESS_RX_PIN={args.rx_pin}")
     if getattr(args, "pwm_dma_cl", False):
         lpc_bench_defines.append("FASTLED_LPC_PWM_DMA=1")
-    if getattr(args, "fault_emit_test", False):
+    if getattr(args, "test_fault_emit", False):
         lpc_bench_defines.append("FASTLED_AUTORESEARCH_FAULT_TEST=1")
 
     # Resolve project root (always the user's invocation cwd) and build_dir.
@@ -1108,7 +1108,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         ieee754_test_mode=ieee754_test_mode,
         rpc_smoke_mode=rpc_smoke_mode,
         watchdog_soak_mode=watchdog_soak_mode,
-        wave2d_perf_grid=wave2d_perf_grid,
+        perf_wave2d_grid=perf_wave2d_grid,
         net_server_mode=net_server_mode,
         net_client_mode=net_client_mode,
         net_loopback_mode=net_loopback_mode,
@@ -1326,7 +1326,7 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                 )
         if getattr(args, "pwm_dma_cl", False):
             deferred_defines.append("FASTLED_LPC_PWM_DMA=1")
-        if getattr(args, "fault_emit_test", False):
+        if getattr(args, "test_fault_emit", False):
             deferred_defines.append("FASTLED_AUTORESEARCH_FAULT_TEST=1")
 
         try:
@@ -2140,10 +2140,10 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
                 )
                 return 1
             return await _run_lpc_uart_dma_tests(ctx)
-        if getattr(ctx.args, "fault_emit_test", False):
+        if getattr(ctx.args, "test_fault_emit", False):
             if final_environment not in LPC_WS2812_ENVS:
                 print(
-                    "--fault-emit-test is only supported on LPC845 boards "
+                    "--test-fault-emit is only supported on LPC845 boards "
                     "(lpc845brk, lpc845, lpcxpresso845max)."
                 )
                 return 1
@@ -2237,8 +2237,8 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
         return await _run_ieee754_tests(ctx)
 
     # Wave2D perf benchmark mode (#3113 Task 1 / #3122 A1)
-    if ctx.wave2d_perf_grid is not None:
-        return await _run_wave2d_perf_tests(ctx)
+    if ctx.perf_wave2d_grid is not None:
+        return await _run_perf_wave2d_tests(ctx)
 
     # (LPC bring-up mode short-circuits earlier — see the gpio_only_mode
     # block above; reached only by ESP32/Teensy-class targets.)
@@ -2247,7 +2247,7 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     return await _run_rpc_tests(ctx, qctx)
 
 
-async def _run_wave2d_perf_tests(ctx: RunContext) -> int:
+async def _run_perf_wave2d_tests(ctx: RunContext) -> int:
     """Run the Wave2D perf benchmark via RPC chain.
 
     Implements meta #3113 Task 1 host side. Wires the device-side
@@ -2267,11 +2267,11 @@ async def _run_wave2d_perf_tests(ctx: RunContext) -> int:
     If any probe in 1-3 fails, results are stamped UNTRUSTED in the
     output. (Cf. issue #3124 for the planned --perf-XX flag-rename.)
     """
-    assert ctx.wave2d_perf_grid is not None
+    assert ctx.perf_wave2d_grid is not None
     upload_port = ctx.upload_port
     assert upload_port is not None
     serial_iface = ctx.serial_iface
-    grid_w, grid_h = ctx.wave2d_perf_grid
+    grid_w, grid_h = ctx.perf_wave2d_grid
 
     print()
     print("=" * 60)

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -60,7 +60,7 @@ def _make_args(**overrides) -> Args:
         coroutine=False,
         ieee754=False,
         rpc_smoke=False,
-        wave2d_perf=None,
+        perf_wave2d=None,
         environment=None,
         verbose=False,
         skip_lint=True,
@@ -110,7 +110,7 @@ def _make_args(**overrides) -> Args:
         rp_spi_chipset="apa102",
         rp_pio_index=1,
         rp_pio_both=False,
-        fault_emit_test=False,
+        test_fault_emit=False,
         # Default existing-test behavior: use the legacy root-platformio.ini
         # path so the ``fake_project_dir`` fixture's hand-written ini is the
         # one read. Tests that exercise the new synthesised-ini path (#3281)
@@ -160,7 +160,7 @@ def _make_ctx(**overrides) -> RunContext:
         coroutine_test_mode=False,
         ieee754_test_mode=False,
         rpc_smoke_mode=False,
-        wave2d_perf_grid=None,
+        perf_wave2d_grid=None,
         net_server_mode=False,
         net_client_mode=False,
         net_loopback_mode=False,

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -36,7 +36,7 @@ def _make_ctx(
         simd_test_mode=False,
         coroutine_test_mode=False,
         ieee754_test_mode=False,
-        wave2d_perf_grid=None,
+        perf_wave2d_grid=None,
         net_server_mode=False,
         net_client_mode=False,
         net_loopback_mode=False,


### PR DESCRIPTION
## Summary

Closes #3124. Renames the two autoresearch flags that didn't follow the convention:

| Old | New |
|---|---|
| `--wave2d-perf` | `--perf-wave2d` |
| `--fault-emit-test` | `--test-fault-emit` |

Straight rename, no deprecation alias — per the issue, neither flag has shipped in a release, so there's nothing to migrate.

Also swept the rest of the flag surface: those two were the only non-conforming perf/test flags in `args.py`.

## Notes

**The bash wrapper has its own copy of the flag list.** `autoresearch` hardcodes a `--help` block independent of argparse, and *that* is what users actually see. After renaming the Python side, `bash autoresearch --help` was still advertising `--fault-emit-test` — so the wrapper is updated too. Worth knowing for future flag work: renaming in `args.py` alone leaves the user-visible help wrong.

**Scope of the identifier renames.** The argparse dests and the `RunContext` field move with the flags (argparse derives the dest from the flag name, so they can't diverge). Internal helpers like `_run_lpc_fault_emit_tests` keep their names — the issue is about the flag surface, and renaming them would be pure churn.

## Testing

- `uv run python -m pytest ci/tests/test_autoresearch_phases.py ci/tests/test_autoresearch_rpc_acceptance.py -q` — **116 passed**
- `bash autoresearch --help` — now shows `--test-fault-emit`
- `bash lint` — green
- No stale `wave2d-perf` / `fault-emit-test` references remain anywhere outside the two internal helper names

Not run: the flags drive real LPC845/Teensy hardware benches, so end-to-end exercise needs a bench. The change is a pure rename with full static coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Renamed the Wave2D performance benchmark option to `--perf-wave2d`.
  - Renamed the LPC845 fault-emission validation option to `--test-fault-emit`.
  - Updated CLI help text and hardware validation documentation with the new option names.
  - Updated benchmark and validation configuration handling to use the renamed options consistently.

- **Tests**
  - Updated automated test setup to reflect the renamed configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->