### PR TITLE
docs(ci): correct stale esp32 size-ceiling attribution (#3298)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -37,18 +37,20 @@ jobs:
       # regression that must be FIXED (in code or in the build system), not
       # hidden by raising the cap.
       #
-      # Current redness is a CODE SIZE gap, not a build-flag gap. #3298 (fbuild
-      # dropping ESP32 board-level build_flags/build_unflags) is FIXED —
-      # verified 2026-07-27 against
+      # Current redness is a CODE SIZE gap, not a build-flag gap. The flag
+      # propagation tracked by #3298 (fbuild dropping ESP32 board-level
+      # build_flags/build_unflags) is FIXED — note that is the propagation
+      # half only; #3298's own ceiling criterion is still unmet. Verified
+      # 2026-07-27 against
       # .build/pio/esp32dev/.fbuild/build/release/compile_commands.json:
       # `-Os -fno-exceptions -fno-rtti -fno-unwind-tables -ffunction-sections
       # -fdata-sections` are present in all 58 translation units, and
       # build_unflags strips both `-Og` and `-g` (token-exact scan finds no
       # `-g*` and no `-O` other than `-Os`).
       #
-      # With the flags fully applied, esp32dev Blink is 391543 bytes (382 KB) —
-      # down from the 401240 bytes recorded in #3298, but still ~52 KB over
-      # this ceiling. Closing that remainder is the ongoing per-symbol bloat
+      # With the flags fully applied, esp32dev Blink is 391543 bytes — down
+      # from the 401240 bytes recorded in #3298, but still 61543 bytes
+      # (~61.5 KB) over this ceiling. Closing that remainder is the per-symbol bloat
       # work (#2974 / #2886 and children), NOT a flag-plumbing fix. Do not
       # raise this number to chase it.
       #

--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -35,9 +35,22 @@ jobs:
       #
       # 330 KB is the canonical ceiling. CI being red on esp32dev means a real
       # regression that must be FIXED (in code or in the build system), not
-      # hidden by raising the cap. The known cause of current redness is #3298
-      # (fbuild does not propagate ESP32 board-level build_flags/build_unflags
-      # to the toolchain) — fix #3298, do not raise this number.
+      # hidden by raising the cap.
+      #
+      # Current redness is a CODE SIZE gap, not a build-flag gap. #3298 (fbuild
+      # dropping ESP32 board-level build_flags/build_unflags) is FIXED —
+      # verified 2026-07-27 against
+      # .build/pio/esp32dev/.fbuild/build/release/compile_commands.json:
+      # `-Os -fno-exceptions -fno-rtti -fno-unwind-tables -ffunction-sections
+      # -fdata-sections` are present in all 58 translation units, and
+      # build_unflags strips both `-Og` and `-g` (token-exact scan finds no
+      # `-g*` and no `-O` other than `-Os`).
+      #
+      # With the flags fully applied, esp32dev Blink is 391543 bytes (382 KB) —
+      # down from the 401240 bytes recorded in #3298, but still ~52 KB over
+      # this ceiling. Closing that remainder is the ongoing per-symbol bloat
+      # work (#2974 / #2886 and children), NOT a flag-plumbing fix. Do not
+      # raise this number to chase it.
       #
       # The value here is mirror-locked by `ci/lint/check_size_thresholds.py`:
       # changing this number without updating the frozen-list constant in that


### PR DESCRIPTION
## Summary

`check_esp32_size.yml` currently tells readers the 330 KB ceiling is red because *"fbuild does not propagate ESP32 board-level build_flags/build_unflags to the toolchain — fix #3298"*.

**That is no longer true.** The flag plumbing works. Anyone following that comment would go hunting for a bug that is already fixed, which is worse than no comment at all.

## Evidence

Built `bash compile esp32dev --examples Blink` and inspected `.build/pio/esp32dev/.fbuild/build/release/compile_commands.json` (58 translation units):

| flag | present in |
|---|---|
| `-Os` | 58/58 |
| `-fno-exceptions` | 58/58 |
| `-fno-rtti` | 58/58 |
| `-fno-unwind-tables` | 58/58 |
| `-ffunction-sections` | 58/58 |
| `-fdata-sections` | 58/58 |

And `build_unflags` works — a **token-exact** scan across all entries finds no `-g*` at all and no `-O` other than `-Os`. Both `-Og` and `-g` are correctly stripped.

> Method note: a substring grep for `-g` initially reported it surviving in 58/58. That was a false positive from matching inside longer flags. Anyone re-checking this should tokenize rather than substring-match, or they will "confirm" a bug that isn't there.

## What's actually left

With the flags fully applied, esp32dev Blink is **391543 bytes (382 KB)** — down from the **401240** recorded in #3298, but still ~52 KB over the ceiling.

So the redness is now a genuine **code size** gap, which belongs to the ongoing per-symbol bloat work (#2974 / #2886 and children), not to flag plumbing. The comment now says that, so the next person reads an accurate pointer.

## Scope

Comment-only. `max_size` and `max_size_apa102` are untouched at 330000, so the `ci/lint/check_size_thresholds.py` mirror lock still passes — confirmed:

```
✅ Size-thresholds lockdown: all 10 check_*_size.yml workflow(s) match frozen values.
```

## Note on #3298

This PR does not close #3298 — I've posted the measurements there separately. Its first acceptance criterion (flags reach the compile commands) is met; the `≤ 330 KB` criterion is not, and that part is really the bloat metas' scope. Worth a maintainer call on whether to close it as "propagation fixed" and track the remainder under #2974, rather than me deciding unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and date-stamped the ESP32 CI size-check guidance to clarify why the current failure is due to remaining code-size overage, not unresolved build-flag propagation.
  * Included verification details (via compile command inspection) and updated Blink size figures relative to the 330 KB ceiling.
  * Reaffirmed that no size thresholds or workflow behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->