### PR TITLE
refactor(esp32): hoist fractional clock-divider solver to core (#3562)

### DIFF
--- a/src/platforms/esp/32/core/clock_divider.h
+++ b/src/platforms/esp/32/core/clock_divider.h
@@ -27,12 +27,23 @@ namespace esp32 {
 /// Reference clock for APB-derived peripherals on the classic ESP32.
 constexpr u32 kApbClockHz = 80000000u;
 
-/// Solved divider triple: `f_out = base_hz / (N + B/A)`.
+/// Solved divider triple: `f_out = base_hz / (n + b/a)`.
+///
+/// Lowercase members per the plain-aggregate convention; the uppercase
+/// N/A/B in the formulas below is the register-datasheet spelling
+/// (`clkm_conf.clkm_div_{num,a,b}`).
 struct ClkDividerNAB {
-    int N;
-    int A;
-    int B;
+    int n;
+    int a;
+    int b;
 };
+
+/// Largest integer divider the solver will report. The real hardware fields
+/// are far narrower (I2S `clkm_div_num` is 8 bits), so this is not a
+/// hardware limit — it exists so `base_hz / target_hz` cannot overflow the
+/// `int` it is cast into. A u32 base over a target of 1 Hz reaches ~4.29e9,
+/// which is past INT_MAX and would make the cast undefined.
+constexpr int kMaxDivider = 2147483000;
 
 /// @brief Solve `base_hz / (N + B/A)` for the closest match to `target_hz`.
 ///
@@ -58,17 +69,30 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
                                             int min_N = 2) FL_NO_EXCEPT {
     ClkDividerNAB out;
     if (target_hz == 0 || base_hz == 0) {
-        out.N = min_N;
-        out.A = 1;
-        out.B = 0;
+        out.n = min_N;
+        out.a = 1;
+        out.b = 0;
         return out;
     }
 
     const double f_target = static_cast<double>(target_hz);
     const double f_base = static_cast<double>(base_hz);
-    int N = static_cast<int>(f_base / f_target);
+
+    // Clamp before the cast, not after: a ratio past INT_MAX makes
+    // static_cast<int> undefined, so there would be no well-defined value
+    // left to clamp. Saturating here keeps the result monotonic and
+    // representable for any u32 pair.
+    const double ratio = f_base / f_target;
+    if (ratio >= static_cast<double>(kMaxDivider)) {
+        out.n = kMaxDivider;
+        out.a = 1;
+        out.b = 0;
+        return out;
+    }
+
+    int N = static_cast<int>(ratio);
     if (N < min_N) N = min_N;
-    const double residual = (f_base / f_target) - static_cast<double>(N);
+    const double residual = ratio - static_cast<double>(N);
 
     // Fractional part B/A. Sweep A within the hardware limit and pick the
     // (A, B) minimising |residual - B/A|. Seeding best_err with `residual`
@@ -96,9 +120,9 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
         ++N;
     }
 
-    out.N = N;
-    out.A = best_A;
-    out.B = best_B;
+    out.n = N;
+    out.a = best_A;
+    out.b = best_B;
     return out;
 }
 

--- a/src/platforms/esp/32/core/clock_divider.h
+++ b/src/platforms/esp/32/core/clock_divider.h
@@ -1,0 +1,107 @@
+// IWYU pragma: private
+
+#pragma once
+
+/// @file platforms/esp/32/core/clock_divider.h
+/// Fractional clock-divider solver shared by ESP32 peripherals (FastLED#3562).
+///
+/// Several classic-ESP32 peripherals derive their clock from a reference
+/// (usually the 80 MHz APB) through an `(N, A, B)` triple, where
+///
+///     f_out = base_hz / (N + B/A)
+///
+/// I2S spells it `clkm_conf.clkm_div_{num,a,b}`; SPI and RMT use different
+/// register layouts but the same arithmetic. This header owns the math once so
+/// each driver only has to marshal the result into its own registers.
+///
+/// Pure integer/double arithmetic with no ESP headers, so it compiles and is
+/// unit-testable on the host.
+
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace platforms {
+namespace esp32 {
+
+/// Reference clock for APB-derived peripherals on the classic ESP32.
+constexpr u32 kApbClockHz = 80000000u;
+
+/// Solved divider triple: `f_out = base_hz / (N + B/A)`.
+struct ClkDividerNAB {
+    int N;
+    int A;
+    int B;
+};
+
+/// @brief Solve `base_hz / (N + B/A)` for the closest match to `target_hz`.
+///
+/// Adapted from Yves's `i2s_define_bit_patterns` clock math, generalised over
+/// the base clock and the hardware limits.
+///
+/// @param base_hz  Reference clock feeding the divider (e.g. kApbClockHz).
+/// @param target_hz Desired output frequency. Must be non-zero — see below.
+/// @param max_A    Largest denominator the hardware accepts (inclusive).
+///                 I2S allows 63.
+/// @param min_N    Smallest integer divider the hardware accepts. I2S needs 2.
+///
+/// @return The `(N, A, B)` minimising `|target_hz - base_hz/(N + B/A)|` within
+///         those limits.
+///
+/// A `target_hz` of 0 has no meaningful answer (the divider would be
+/// infinite), so it is clamped to `min_N` with no fractional part rather than
+/// dividing by zero. Callers that want a specific fallback frequency should
+/// substitute it themselves before calling — that keeps the policy choice at
+/// the call site instead of buried in shared math.
+inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
+                                            int max_A = 63,
+                                            int min_N = 2) FL_NO_EXCEPT {
+    ClkDividerNAB out;
+    if (target_hz == 0 || base_hz == 0) {
+        out.N = min_N;
+        out.A = 1;
+        out.B = 0;
+        return out;
+    }
+
+    const double f_target = static_cast<double>(target_hz);
+    const double f_base = static_cast<double>(base_hz);
+    int N = static_cast<int>(f_base / f_target);
+    if (N < min_N) N = min_N;
+    const double residual = (f_base / f_target) - static_cast<double>(N);
+
+    // Fractional part B/A. Sweep A within the hardware limit and pick the
+    // (A, B) minimising |residual - B/A|. Seeding best_err with `residual`
+    // means B/A = 0/1 stays the answer unless some pair beats it.
+    int best_A = 1;
+    int best_B = 0;
+    double best_err = residual;
+    for (int A = 1; A <= max_A; ++A) {
+        for (int B = 0; B < A; ++B) {
+            const double err = residual - (static_cast<double>(B) / A);
+            const double abs_err = err < 0 ? -err : err;
+            if (abs_err < best_err) {
+                best_err = abs_err;
+                best_A = A;
+                best_B = B;
+            }
+        }
+    }
+
+    // Double-precision 0.9999 corner: A == B collapses to the next integer
+    // up. Kept from Yves's original code.
+    if (best_A == best_B) {
+        best_A = 1;
+        best_B = 0;
+        ++N;
+    }
+
+    out.N = N;
+    out.A = best_A;
+    out.B = best_B;
+    return out;
+}
+
+}  // namespace esp32
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -45,6 +45,7 @@
 #include "platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.h"
 #include "platforms/esp/32/drivers/i2s/i2s_periph_compat.h"  // fl_i2s_periph_enable — IDF-version-safe power gate
 #include "platforms/esp/32/drivers/i2s/i2s_port_claim.h"     // cross-driver I2S port ownership (FastLED#3576)
+#include "platforms/esp/32/core/clock_divider.h"             // shared fractional divider solver (FastLED#3562)
 
 #include "fl/log/log.h"
 #include "fl/stl/noexcept.h"
@@ -83,51 +84,23 @@ constexpr const char *kI2sClocklessOwner = "I2S_CLOCKLESS";
 /// @brief Solve the classic-ESP32 I2S1 fractional clock divider
 ///        (`clkm_conf.clkm_div_{num,a,b}`) for a target frequency.
 ///
-/// Selects `(N, A, B)` such that `80 MHz / (N + B/A)` best matches
-/// `target_hz`. Adapted from Yves's `i2s_define_bit_patterns` — same
-/// algorithm, just wrapped so it produces the divider triple without
-/// building the per-chipset pulse LUT (the modern engine uses wave8
-/// encoding, not per-chipset pulse patterns).
+/// Thin wrapper over the shared solver (FastLED#3562) that pins the base
+/// clock to the 80 MHz APB reference and the I2S hardware limits (A <= 63,
+/// N >= 2). The math itself lives in `platforms/esp/32/core/clock_divider.h`
+/// so SPI/RMT can reuse it.
 inline void solveI2sClockDivider(u32 target_hz,
                                   int* out_N, int* out_A, int* out_B) FL_NO_EXCEPT {
-    if (target_hz == 0) {
-        *out_N = 10;   // Default to 8 MHz (wave8 @ 800 kHz)
-        *out_A = 1;
-        *out_B = 0;
-        return;
-    }
-    const double f_target = static_cast<double>(target_hz);
-    const double f_base   = static_cast<double>(kI2sBaseClkHz);
-    int N = static_cast<int>(f_base / f_target);
-    if (N < 2) N = 2;
-    const double residual = (f_base / f_target) - static_cast<double>(N);
-
-    // Fractional part B/A — A ≤ 63 hardware limit. Sweep A, pick the
-    // (A, B) that minimises |residual - B/A|.
-    int best_A = 1;
-    int best_B = 0;
-    double best_err = residual;
-    for (int A = 1; A < 64; ++A) {
-        for (int B = 0; B < A; ++B) {
-            const double err = residual - (static_cast<double>(B) / A);
-            const double abs_err = err < 0 ? -err : err;
-            if (abs_err < best_err) {
-                best_err = abs_err;
-                best_A = A;
-                best_B = B;
-            }
-        }
-    }
-    // Double-precision 0.9999 corner: `A == B` collapses to the integer
-    // next up. Kept from Yves's original code.
-    if (best_A == best_B) {
-        best_A = 1;
-        best_B = 0;
-        ++N;
-    }
-    *out_N = N;
-    *out_A = best_A;
-    *out_B = best_B;
+    // 8 MHz (wave8 @ 800 kHz) is the I2S clockless default when no pixel
+    // clock is configured. The fallback lives here, not in the shared solver:
+    // "what frequency do we want when unspecified" is a driver policy, not
+    // divider arithmetic.
+    const u32 effective_hz = (target_hz == 0) ? 8000000u : target_hz;
+    const fl::platforms::esp32::ClkDividerNAB d =
+        fl::platforms::esp32::solveFractionalDivider(kI2sBaseClkHz, effective_hz,
+                                                     /*max_A=*/63, /*min_N=*/2);
+    *out_N = d.N;
+    *out_A = d.A;
+    *out_B = d.B;
 }
 
 // Register-level reset helpers — inline replacements for Yves's

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -98,9 +98,9 @@ inline void solveI2sClockDivider(u32 target_hz,
     const fl::platforms::esp32::ClkDividerNAB d =
         fl::platforms::esp32::solveFractionalDivider(kI2sBaseClkHz, effective_hz,
                                                      /*max_A=*/63, /*min_N=*/2);
-    *out_N = d.N;
-    *out_A = d.A;
-    *out_B = d.B;
+    *out_N = d.n;
+    *out_A = d.a;
+    *out_B = d.b;
 }
 
 // Register-level reset helpers — inline replacements for Yves's

--- a/tests/platforms/esp/32/core/clock_divider.cpp
+++ b/tests/platforms/esp/32/core/clock_divider.cpp
@@ -60,7 +60,7 @@ void referenceSolve(fl::u32 target_hz, int *out_N, int *out_A, int *out_B) {
 // Realised output frequency for a solved triple.
 double realisedHz(fl::u32 base_hz, const ClkDividerNAB &d) {
     return static_cast<double>(base_hz) /
-           (static_cast<double>(d.N) + static_cast<double>(d.B) / d.A);
+           (static_cast<double>(d.n) + static_cast<double>(d.b) / d.a);
 }
 
 }  // namespace
@@ -77,9 +77,9 @@ FL_TEST_CASE("esp32 clock divider: matches the pre-hoist I2S solver") {
         int rN = 0, rA = 0, rB = 0;
         referenceSolve(hz, &rN, &rA, &rB);
         const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, hz, 63, 2);
-        FL_CHECK(d.N == rN);
-        FL_CHECK(d.A == rA);
-        FL_CHECK(d.B == rB);
+        FL_CHECK(d.n == rN);
+        FL_CHECK(d.a == rA);
+        FL_CHECK(d.b == rB);
     }
 }
 
@@ -87,19 +87,19 @@ FL_TEST_CASE("esp32 clock divider: 8 MHz default resolves to N=10") {
     // The wave8 @ 800 kHz default. 80 MHz / 10 == 8 MHz exactly, so the
     // fractional part must stay empty rather than picking a near-equal B/A.
     const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, 8000000u);
-    FL_CHECK(d.N == 10);
-    FL_CHECK(d.A == 1);
-    FL_CHECK(d.B == 0);
+    FL_CHECK(d.n == 10);
+    FL_CHECK(d.a == 1);
+    FL_CHECK(d.b == 0);
 }
 
 FL_TEST_CASE("esp32 clock divider: respects hardware limits") {
     for (fl::u32 hz = 300000u; hz <= 20000000u; hz += 700000u) {
         const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, hz, 63, 2);
-        FL_CHECK(d.N >= 2);          // min_N floor
-        FL_CHECK(d.A >= 1);          // never a zero denominator
-        FL_CHECK(d.A <= 63);         // I2S clkm_div_a field width
-        FL_CHECK(d.B >= 0);
-        FL_CHECK(d.B < d.A);         // B/A stays a proper fraction
+        FL_CHECK(d.n >= 2);          // min_N floor
+        FL_CHECK(d.a >= 1);          // never a zero denominator
+        FL_CHECK(d.a <= 63);         // I2S clkm_div_a field width
+        FL_CHECK(d.b >= 0);
+        FL_CHECK(d.b < d.a);         // B/A stays a proper fraction
     }
 }
 
@@ -120,30 +120,53 @@ FL_TEST_CASE("esp32 clock divider: generalises over base clock") {
     // target.
     const ClkDividerNAB apb = solveFractionalDivider(80000000u, 8000000u);
     const ClkDividerNAB half = solveFractionalDivider(40000000u, 8000000u);
-    FL_CHECK(apb.N == 10);
-    FL_CHECK(half.N == 5);
+    FL_CHECK(apb.n == 10);
+    FL_CHECK(half.n == 5);
 }
 
 FL_TEST_CASE("esp32 clock divider: min_N floor is honoured") {
     // Target above base/min_N cannot be reached; the solver must clamp to
     // min_N rather than emitting N=1 or N=0 that the hardware would reject.
     const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, 79000000u, 63, 2);
-    FL_CHECK(d.N >= 2);
+    FL_CHECK(d.n >= 2);
 
     const ClkDividerNAB d4 = solveFractionalDivider(kApbClockHz, 79000000u, 63, 4);
-    FL_CHECK(d4.N >= 4);
+    FL_CHECK(d4.n >= 4);
+}
+
+FL_TEST_CASE("esp32 clock divider: oversized ratios stay representable") {
+    using fl::platforms::esp32::kMaxDivider;
+
+    // base/target can exceed INT_MAX for extreme u32 pairs -- 4.29e9 / 1 is
+    // past 2.147e9. Casting that to int is undefined, so the solver has to
+    // saturate *before* the cast; there would be no defined value to clamp
+    // afterwards.
+    const ClkDividerNAB huge = solveFractionalDivider(4294967295u, 1u);
+    FL_CHECK(huge.n == kMaxDivider);
+    FL_CHECK(huge.a == 1);
+    FL_CHECK(huge.b == 0);
+
+    // Just under the clamp: still a normal solve, no saturation.
+    const ClkDividerNAB ok = solveFractionalDivider(kApbClockHz, 1u);
+    FL_CHECK(ok.n > 0);
+    FL_CHECK(ok.n < kMaxDivider);
+    FL_CHECK(ok.a >= 1);
+    FL_CHECK(ok.b < ok.a);
+
+    // Saturation must never produce a divider the caller can't use.
+    FL_CHECK(huge.n > 0);
 }
 
 FL_TEST_CASE("esp32 clock divider: degenerate inputs do not divide by zero") {
     // Callers are expected to substitute their own fallback frequency, but a
     // zero must not produce inf/NaN or an out-of-range divider.
     const ClkDividerNAB zero_target = solveFractionalDivider(kApbClockHz, 0u);
-    FL_CHECK(zero_target.N == 2);
-    FL_CHECK(zero_target.A == 1);
-    FL_CHECK(zero_target.B == 0);
+    FL_CHECK(zero_target.n == 2);
+    FL_CHECK(zero_target.a == 1);
+    FL_CHECK(zero_target.b == 0);
 
     const ClkDividerNAB zero_base = solveFractionalDivider(0u, 8000000u);
-    FL_CHECK(zero_base.N == 2);
-    FL_CHECK(zero_base.A == 1);
-    FL_CHECK(zero_base.B == 0);
+    FL_CHECK(zero_base.n == 2);
+    FL_CHECK(zero_base.a == 1);
+    FL_CHECK(zero_base.b == 0);
 }

--- a/tests/platforms/esp/32/core/clock_divider.cpp
+++ b/tests/platforms/esp/32/core/clock_divider.cpp
@@ -1,0 +1,149 @@
+/// @file tests/platforms/esp/32/core/clock_divider.cpp
+/// Host tests for the shared ESP32 fractional clock-divider solver (#3562).
+///
+/// The solver was hoisted out of the I2S peripheral impl, so the most useful
+/// thing these tests can do is pin the arithmetic: a refactor that quietly
+/// changed the chosen (N, A, B) would retune every driver's output clock
+/// without any build failure to catch it.
+
+#include "test.h"
+
+#include "platforms/esp/32/core/clock_divider.h"
+
+using fl::platforms::esp32::ClkDividerNAB;
+using fl::platforms::esp32::kApbClockHz;
+using fl::platforms::esp32::solveFractionalDivider;
+
+namespace {
+
+// Reference implementation: the exact pre-hoist body from
+// i2s_peripheral_esp32dev_esp.cpp.hpp, kept verbatim so the tests below
+// compare against what the driver used to do rather than against the new
+// code restated.
+void referenceSolve(fl::u32 target_hz, int *out_N, int *out_A, int *out_B) {
+    if (target_hz == 0) {
+        *out_N = 10;
+        *out_A = 1;
+        *out_B = 0;
+        return;
+    }
+    const double f_target = static_cast<double>(target_hz);
+    const double f_base = static_cast<double>(80000000u);
+    int N = static_cast<int>(f_base / f_target);
+    if (N < 2) N = 2;
+    const double residual = (f_base / f_target) - static_cast<double>(N);
+
+    int best_A = 1;
+    int best_B = 0;
+    double best_err = residual;
+    for (int A = 1; A < 64; ++A) {
+        for (int B = 0; B < A; ++B) {
+            const double err = residual - (static_cast<double>(B) / A);
+            const double abs_err = err < 0 ? -err : err;
+            if (abs_err < best_err) {
+                best_err = abs_err;
+                best_A = A;
+                best_B = B;
+            }
+        }
+    }
+    if (best_A == best_B) {
+        best_A = 1;
+        best_B = 0;
+        ++N;
+    }
+    *out_N = N;
+    *out_A = best_A;
+    *out_B = best_B;
+}
+
+// Realised output frequency for a solved triple.
+double realisedHz(fl::u32 base_hz, const ClkDividerNAB &d) {
+    return static_cast<double>(base_hz) /
+           (static_cast<double>(d.N) + static_cast<double>(d.B) / d.A);
+}
+
+}  // namespace
+
+FL_TEST_CASE("esp32 clock divider: matches the pre-hoist I2S solver") {
+    // Sweep the band the I2S clockless driver actually uses, plus the edges.
+    const fl::u32 targets[] = {
+        100000u,   500000u,   800000u,   1000000u,  2000000u,
+        3200000u,  4000000u,  6400000u,  8000000u,  10000000u,
+        13333333u, 16000000u, 20000000u, 26666666u, 40000000u,
+    };
+
+    for (fl::u32 hz : targets) {
+        int rN = 0, rA = 0, rB = 0;
+        referenceSolve(hz, &rN, &rA, &rB);
+        const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, hz, 63, 2);
+        FL_CHECK(d.N == rN);
+        FL_CHECK(d.A == rA);
+        FL_CHECK(d.B == rB);
+    }
+}
+
+FL_TEST_CASE("esp32 clock divider: 8 MHz default resolves to N=10") {
+    // The wave8 @ 800 kHz default. 80 MHz / 10 == 8 MHz exactly, so the
+    // fractional part must stay empty rather than picking a near-equal B/A.
+    const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, 8000000u);
+    FL_CHECK(d.N == 10);
+    FL_CHECK(d.A == 1);
+    FL_CHECK(d.B == 0);
+}
+
+FL_TEST_CASE("esp32 clock divider: respects hardware limits") {
+    for (fl::u32 hz = 300000u; hz <= 20000000u; hz += 700000u) {
+        const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, hz, 63, 2);
+        FL_CHECK(d.N >= 2);          // min_N floor
+        FL_CHECK(d.A >= 1);          // never a zero denominator
+        FL_CHECK(d.A <= 63);         // I2S clkm_div_a field width
+        FL_CHECK(d.B >= 0);
+        FL_CHECK(d.B < d.A);         // B/A stays a proper fraction
+    }
+}
+
+FL_TEST_CASE("esp32 clock divider: lands close to the requested frequency") {
+    // Not an exactness claim -- the divider is quantised. But a solver that
+    // silently degraded would show up as a large relative error here.
+    for (fl::u32 hz = 1000000u; hz <= 20000000u; hz += 1000000u) {
+        const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, hz, 63, 2);
+        const double got = realisedHz(kApbClockHz, d);
+        const double rel = (got - static_cast<double>(hz)) / static_cast<double>(hz);
+        FL_CHECK((rel < 0 ? -rel : rel) < 0.02);
+    }
+}
+
+FL_TEST_CASE("esp32 clock divider: generalises over base clock") {
+    // The point of the hoist: peripherals on a different reference get the
+    // same math. Halving the base halves the integer divider for the same
+    // target.
+    const ClkDividerNAB apb = solveFractionalDivider(80000000u, 8000000u);
+    const ClkDividerNAB half = solveFractionalDivider(40000000u, 8000000u);
+    FL_CHECK(apb.N == 10);
+    FL_CHECK(half.N == 5);
+}
+
+FL_TEST_CASE("esp32 clock divider: min_N floor is honoured") {
+    // Target above base/min_N cannot be reached; the solver must clamp to
+    // min_N rather than emitting N=1 or N=0 that the hardware would reject.
+    const ClkDividerNAB d = solveFractionalDivider(kApbClockHz, 79000000u, 63, 2);
+    FL_CHECK(d.N >= 2);
+
+    const ClkDividerNAB d4 = solveFractionalDivider(kApbClockHz, 79000000u, 63, 4);
+    FL_CHECK(d4.N >= 4);
+}
+
+FL_TEST_CASE("esp32 clock divider: degenerate inputs do not divide by zero") {
+    // Callers are expected to substitute their own fallback frequency, but a
+    // zero must not produce inf/NaN or an out-of-range divider.
+    const ClkDividerNAB zero_target = solveFractionalDivider(kApbClockHz, 0u);
+    FL_CHECK(zero_target.N == 2);
+    FL_CHECK(zero_target.A == 1);
+    FL_CHECK(zero_target.B == 0);
+
+    const ClkDividerNAB zero_base = solveFractionalDivider(0u, 8000000u);
+    FL_CHECK(zero_base.N == 2);
+    FL_CHECK(zero_base.A == 1);
+    FL_CHECK(zero_base.B == 0);
+}


### PR DESCRIPTION
## Summary

Closes #3562.

`solveI2sClockDivider()` lived inside the I2S peripheral impl, but the `80 MHz APB / (N + B/A)` math applies to every classic-ESP32 peripheral that takes a `clkm_div_{num,a,b}` triple — SPI, RMT4, I2S0.

Moved to `platforms/esp/32/core/clock_divider.h` as:

```cpp
namespace fl { namespace platforms { namespace esp32 {
  struct ClkDividerNAB { int N; int A; int B; };
  ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
                                       int max_A = 63, int min_N = 2) FL_NO_EXCEPT;
}}}
```

Pure arithmetic, no ESP headers — so it compiles and unit-tests on the host.

### One deliberate design choice

The I2S call site **keeps its own 8 MHz fallback** instead of pushing it into the shared solver. "What frequency do we want when none is configured" is driver policy, not divider arithmetic — baking `N=10` into shared math would silently hand every future consumer an I2S-specific default. The solver treats a zero target as degenerate and clamps to `min_N` rather than dividing by zero.

## Verification — behaviour-preserving, checked two ways

**1. Equivalence test.** `tests/platforms/esp/32/core/clock_divider.cpp` keeps a *verbatim copy* of the pre-hoist function and asserts the new solver returns identical `(N, A, B)` across the band the I2S driver actually uses (100 kHz → 40 MHz). This matters because a refactor that quietly retuned the divider would **not** fail any build — it would just shift every driver's output clock. Plus coverage for hardware limits (`A ≤ 63`, `B < A`, `N ≥ min_N`), realised-frequency error, base-clock generalisation, and degenerate inputs.

**2. Binary comparison.** `esp32dev` Blink is **391543 bytes before and after** — byte-identical.

### Why that size comparison is trustworthy

It nearly wasn't. `compile_commands.json` for `esp32dev` shows **zero** TUs matching `i2s`, which looks like the changed code isn't in the build at all — making a byte-identical size meaningless.

It isn't excluded; the drivers are **unity-built**, so the individual file path never appears. I confirmed the header really is compiled with a negative control: a temporary `#error` in it **failed the build, reported from 8 unity TUs**. Then reverted and re-verified green.

Flagging that because "grep compile_commands.json for the filename" is the obvious way to check this and it gives the wrong answer here.

## Testing

- `bash test --cpp` — all pass, including the new `clock_divider` target
- `bash compile esp32dev --examples Blink` — succeeds, flash unchanged at 391543 bytes
- `bash lint` — green

## Follow-on

This only hoists the math and repoints I2S at it. Actually adopting it in SPI / RMT4 (the rest of #3562's "apply to other drivers") is left alone — each needs its own register marshalling and bench validation, and bundling that here would make an intentionally byte-identical refactor into a behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/standardized fractional clock-divider solving for ESP32, including safe behavior for unspecified and extreme inputs.
* **Bug Fixes**
  * Improved divider robustness with explicit clamping for zero inputs and ratio saturation to avoid undefined math.
  * Enhanced output accuracy via a fractional search approach and precision corner-case handling.
* **Refactor**
  * Updated the ESP32 I2S clock-divider calculation to reuse the shared solver for consistent results.
* **Tests**
  * Added host-side tests validating exact expected dividers, accuracy bounds, constraints, scaling, and saturation/degenerate cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->