### PR TITLE
chore(api): take DiodeProfile by reference in set_input_gamut (#3234)

### DIFF
--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -244,7 +244,7 @@ constexpr NamedGamut kDciP3D60  = {{0.6800f, 0.3200f}, {0.2650f, 0.6900f},
 namespace { void invalidate_colorimetric_caches_for(const DiodeProfile* profile) FL_NO_EXCEPT; }
 
 void set_input_gamut(DiodeProfile& profile_ref, InputGamut g,
-                     const float white_xy[2]) FL_NO_EXCEPT {
+                     const float* white_xy) FL_NO_EXCEPT {
     DiodeProfile* const profile = &profile_ref;
     auto apply = [profile](const float r[2], const float gp[2],
                            const float b[2], const float w[2]) {

--- a/src/fl/gfx/rgbw.cpp.hpp
+++ b/src/fl/gfx/rgbw.cpp.hpp
@@ -243,9 +243,9 @@ constexpr NamedGamut kDciP3D60  = {{0.6800f, 0.3200f}, {0.2650f, 0.6900f},
 // after a gamut switch on the currently active profile.
 namespace { void invalidate_colorimetric_caches_for(const DiodeProfile* profile) FL_NO_EXCEPT; }
 
-void set_input_gamut(DiodeProfile* profile, InputGamut g,
+void set_input_gamut(DiodeProfile& profile_ref, InputGamut g,
                      const float white_xy[2]) FL_NO_EXCEPT {
-    if (profile == nullptr) return;
+    DiodeProfile* const profile = &profile_ref;
     auto apply = [profile](const float r[2], const float gp[2],
                            const float b[2], const float w[2]) {
         profile->input_xy_r[0] = r[0];  profile->input_xy_r[1] = r[1];
@@ -280,8 +280,22 @@ void set_input_gamut(DiodeProfile* profile, InputGamut g,
     // leave the profile's input_xy_* untouched — also nothing to invalidate.
 }
 
-void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NO_EXCEPT {
+void set_input_gamut(DiodeProfile& profile, InputGamut g) FL_NO_EXCEPT {
     set_input_gamut(profile, g, nullptr);
+}
+
+// Deprecated pointer forwarders (FastLED#3234). The historical contract was a
+// silent no-op on nullptr, so that is preserved here rather than dereferencing
+// -- a sketch that relied on it must not start crashing at the deprecation.
+void set_input_gamut(DiodeProfile* profile, InputGamut g,
+                     const float white_xy[2]) FL_NO_EXCEPT {
+    if (profile == nullptr) return;
+    set_input_gamut(*profile, g, white_xy);
+}
+
+void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NO_EXCEPT {
+    if (profile == nullptr) return;
+    set_input_gamut(*profile, g, nullptr);
 }
 
 fl::shared_ptr<const DiodeProfile> make_diode_profile(
@@ -299,7 +313,7 @@ fl::shared_ptr<const DiodeProfile> make_diode_profile(
     const DiodeProfile& profile, InputGamut g,
     const float white_xy[2]) FL_NO_EXCEPT {
     DiodeProfile copy = profile;
-    set_input_gamut(&copy, g, white_xy);
+    set_input_gamut(copy, g, white_xy);
     return make_diode_profile(copy);
 }
 

--- a/src/fl/gfx/rgbw.h
+++ b/src/fl/gfx/rgbw.h
@@ -89,16 +89,31 @@ enum class InputGamut : u8 {
 // input_xy_r/g/b and sets input_xy_w to D65. For named gamuts, uses the
 // standard published primary chromaticities + that gamut's reference white.
 // Mutates `profile` in place; subsequent solver calls observe the new gamut
-// (the cache is keyed on the profile pointer and rebuilds automatically).
-// No-op if `profile == nullptr`.
-void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NO_EXCEPT;
+// (the cache is keyed on the profile address and rebuilds automatically).
+//
+// Takes a reference: the profile is required and is mutated, so there is no
+// meaningful "no profile" call. A nullable pointer would advertise an
+// optional argument that does not exist (FastLED#3234).
+void set_input_gamut(DiodeProfile& profile, InputGamut g) FL_NO_EXCEPT;
 
 // Same as the above, but lets you optionally override the input white point.
-// `white_xy` either points to a 2-float (x, y) chromaticity OR is `nullptr`
-// to fall back to the gamut's standard reference white (equivalent to the
-// 2-argument overload above). Use the override for niche cases (D50
-// photography workflow, D60 ACES cinema, a custom calibration target) where
-// the standard gamut's reference white doesn't match your content.
+// `white_xy` stays a POINTER because it is genuinely optional: either a
+// 2-float (x, y) chromaticity OR `nullptr` to fall back to the gamut's
+// standard reference white (equivalent to the 2-argument overload). Use the
+// override for niche cases (D50 photography workflow, D60 ACES cinema, a
+// custom calibration target) where the standard reference white doesn't
+// match your content.
+void set_input_gamut(DiodeProfile& profile, InputGamut g,
+                     const float white_xy[2]) FL_NO_EXCEPT;
+
+// Deprecated pointer overloads — kept so existing sketches calling
+// `set_input_gamut(&profile, ...)` keep compiling. They forward to the
+// reference forms above and preserve the historical silent no-op on
+// `nullptr`. Prefer the reference overloads in new code.
+FL_DEPRECATED("Pass the profile by reference: set_input_gamut(profile, g)")
+void set_input_gamut(DiodeProfile* profile, InputGamut g) FL_NO_EXCEPT;
+
+FL_DEPRECATED("Pass the profile by reference: set_input_gamut(profile, g, white_xy)")
 void set_input_gamut(DiodeProfile* profile, InputGamut g,
                      const float white_xy[2]) FL_NO_EXCEPT;
 

--- a/src/fl/gfx/rgbw.h
+++ b/src/fl/gfx/rgbw.h
@@ -103,10 +103,17 @@ void set_input_gamut(DiodeProfile& profile, InputGamut g) FL_NO_EXCEPT;
 // override for niche cases (D50 photography workflow, D60 ACES cinema, a
 // custom calibration target) where the standard reference white doesn't
 // match your content.
+//
+// Spelled `const float*` rather than `const float[2]`: an array-spelled
+// parameter decays to a pointer anyway, so the extent would be an unenforced
+// promise, and this repo bans the misleading spelling outright (see
+// ci/tools/check_array_params.py). Nullability is the real contract here, so
+// the pointer says what it means; the required length lives in this comment
+// because no signature can encode both "exactly 2" and "or null".
 void set_input_gamut(DiodeProfile& profile, InputGamut g,
-                     const float white_xy[2]) FL_NO_EXCEPT;
+                     const float* white_xy) FL_NO_EXCEPT;
 
-// Deprecated pointer overloads — kept so existing sketches calling
+// Deprecated pointer overloads -- kept so existing sketches calling
 // `set_input_gamut(&profile, ...)` keep compiling. They forward to the
 // reference forms above and preserve the historical silent no-op on
 // `nullptr`. Prefer the reference overloads in new code.

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -429,9 +429,36 @@ FL_TEST_CASE("set_input_gamut: deprecated pointer overloads still work") {
     FL_DISABLE_WARNING_POP
     set_input_gamut(via_ref, InputGamut::Rec2020);
 
+    // All eight mutated coordinates, not a sample: a forwarder that dropped or
+    // transposed a single component would otherwise slip through.
     FL_CHECK_CLOSE(via_ptr.input_xy_r[0], via_ref.input_xy_r[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_r[1], via_ref.input_xy_r[1], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_g[0], via_ref.input_xy_g[0], 1e-9f);
     FL_CHECK_CLOSE(via_ptr.input_xy_g[1], via_ref.input_xy_g[1], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_b[0], via_ref.input_xy_b[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_b[1], via_ref.input_xy_b[1], 1e-9f);
     FL_CHECK_CLOSE(via_ptr.input_xy_w[0], via_ref.input_xy_w[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[1], via_ref.input_xy_w[1], 1e-9f);
+}
+
+FL_TEST_CASE("set_input_gamut: deprecated pointer overload forwards white_xy") {
+    // The 3-argument forwarder has an extra argument to lose; check it lands.
+    DiodeProfile via_ptr = kRgbwDefaultProfile;
+    DiodeProfile via_ref = kRgbwDefaultProfile;
+    const float custom_white[2] = {0.3457f, 0.3585f};  // D50
+
+    FL_DISABLE_WARNING_PUSH
+    FL_DISABLE_WARNING(deprecated-declarations)
+    set_input_gamut(&via_ptr, InputGamut::Rec709, custom_white);
+    FL_DISABLE_WARNING_POP
+    set_input_gamut(via_ref, InputGamut::Rec709, custom_white);
+
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[0], custom_white[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[1], custom_white[1], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[0], via_ref.input_xy_w[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[1], via_ref.input_xy_w[1], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_r[0], via_ref.input_xy_r[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_b[1], via_ref.input_xy_b[1], 1e-9f);
 }
 
 FL_TEST_CASE("set_input_gamut: null pointer stays a silent no-op") {

--- a/tests/fl/gfx/rgbw_colorimetric.cpp
+++ b/tests/fl/gfx/rgbw_colorimetric.cpp
@@ -350,7 +350,7 @@ FL_TEST_CASE("source matrix matches published sRGB->XYZ matrix (Rec709 opt-in)")
     //   Y = 0.2126729 R + 0.7151522 G + 0.0721750 B
     //   Z = 0.0193339 R + 0.1191920 G + 0.9503041 B
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     float M[3][3];
     FL_CHECK(build_source_matrix(p.input_xy_r, p.input_xy_g,
                                  p.input_xy_b, p.input_xy_w, M));
@@ -416,6 +416,37 @@ FL_TEST_CASE("rgb colorimetric cache: source space solve is finite and normalize
 }
 
 
+FL_TEST_CASE("set_input_gamut: deprecated pointer overloads still work") {
+    // The pointer forms are kept so existing sketches calling
+    // set_input_gamut(&profile, ...) keep compiling (FastLED#3234). They must
+    // stay behaviourally identical to the reference forms.
+    DiodeProfile via_ptr = kRgbwDefaultProfile;
+    DiodeProfile via_ref = kRgbwDefaultProfile;
+
+    FL_DISABLE_WARNING_PUSH
+    FL_DISABLE_WARNING(deprecated-declarations)
+    set_input_gamut(&via_ptr, InputGamut::Rec2020);
+    FL_DISABLE_WARNING_POP
+    set_input_gamut(via_ref, InputGamut::Rec2020);
+
+    FL_CHECK_CLOSE(via_ptr.input_xy_r[0], via_ref.input_xy_r[0], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_g[1], via_ref.input_xy_g[1], 1e-9f);
+    FL_CHECK_CLOSE(via_ptr.input_xy_w[0], via_ref.input_xy_w[0], 1e-9f);
+}
+
+FL_TEST_CASE("set_input_gamut: null pointer stays a silent no-op") {
+    // Historical contract. A sketch that relied on passing a null profile must
+    // not start crashing just because the pointer form is now deprecated --
+    // which is why the forwarder null-checks instead of dereferencing.
+    FL_DISABLE_WARNING_PUSH
+    FL_DISABLE_WARNING(deprecated-declarations)
+    set_input_gamut(static_cast<DiodeProfile*>(nullptr), InputGamut::Rec709);
+    const float w[2] = {0.3f, 0.3f};
+    set_input_gamut(static_cast<DiodeProfile*>(nullptr), InputGamut::Rec709, w);
+    FL_DISABLE_WARNING_POP
+    FL_CHECK(true);  // reaching here without a crash is the assertion
+}
+
 FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
     DiodeProfile p = kRgbwDefaultProfile;
     // First trash input_xy_* so we can prove Native restored them.
@@ -423,7 +454,7 @@ FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
     p.input_xy_g[0] = 0; p.input_xy_g[1] = 0;
     p.input_xy_b[0] = 0; p.input_xy_b[1] = 0;
     p.input_xy_w[0] = 0; p.input_xy_w[1] = 0;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK_CLOSE(p.input_xy_r[0], p.xy_r[0], 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], p.xy_g[0], 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_b[0], p.xy_b[0], 1e-6f);
@@ -435,21 +466,21 @@ FL_TEST_CASE("set_input_gamut: Native copies LED primaries") {
 
 FL_TEST_CASE("set_input_gamut: named gamuts populate canonical primaries") {
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6400f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[1], 0.6000f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.31272f, 1e-5f);
 
-    set_input_gamut(&p, InputGamut::Rec2020);
+    set_input_gamut(p, InputGamut::Rec2020);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.7080f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], 0.1700f, 1e-6f);
 
-    set_input_gamut(&p, InputGamut::DciP3D65);
+    set_input_gamut(p, InputGamut::DciP3D65);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6800f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_g[0], 0.2650f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.31272f, 1e-5f);  // D65
 
-    set_input_gamut(&p, InputGamut::DciP3D60);
+    set_input_gamut(p, InputGamut::DciP3D60);
     // Same primaries as DciP3D65, different white (ACES D60).
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6800f, 1e-6f);
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.32168f, 1e-5f);
@@ -460,7 +491,7 @@ FL_TEST_CASE("set_input_gamut: named gamuts populate canonical primaries") {
 FL_TEST_CASE("set_input_gamut: white override honored") {
     DiodeProfile p = kRgbwDefaultProfile;
     const float custom_white[2] = {0.34567f, 0.35850f};  // D50
-    set_input_gamut(&p, InputGamut::Rec709, custom_white);
+    set_input_gamut(p, InputGamut::Rec709, custom_white);
     FL_CHECK_CLOSE(p.input_xy_r[0], 0.6400f, 1e-6f);  // primaries: Rec709
     FL_CHECK_CLOSE(p.input_xy_w[0], 0.34567f, 1e-6f); // white: override
     FL_CHECK_CLOSE(p.input_xy_w[1], 0.35850f, 1e-6f);
@@ -1430,7 +1461,7 @@ inline DiodeProfile native_profile() {
     // can just copy it. Explicit set_input_gamut(InputGamut::Native) makes
     // the contract obvious in the test source.
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     return p;
 }
 
@@ -1631,7 +1662,7 @@ FL_TEST_CASE("issue #2748: non-native input gamut bypasses topology guard") {
     // contract, sRGB pure blue (out of LED hull) would be passed through
     // verbatim and produce a black output once quantized.
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Rec709);  // input != LED native
+    set_input_gamut(p, InputGamut::Rec709);  // input != LED native
     ProfileCache cache; fastled_mirror::build_cache(&p, &cache);
 
     float rgbw[4] = {0};
@@ -1757,20 +1788,20 @@ FL_TEST_CASE("issue #2748: public dispatch — boosted mode preserves native top
 
 FL_TEST_CASE("issue #2748: is_native_input_gamut helper agrees with profile flags") {
     DiodeProfile p = kRgbwDefaultProfile;
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK(is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::Rec709);
+    set_input_gamut(p, InputGamut::Rec709);
     FL_CHECK(!is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::Rec2020);
+    set_input_gamut(p, InputGamut::Rec2020);
     FL_CHECK(!is_native_input_gamut(p));
 
-    set_input_gamut(&p, InputGamut::DciP3D65);
+    set_input_gamut(p, InputGamut::DciP3D65);
     FL_CHECK(!is_native_input_gamut(p));
 
     // Restore Native so subsequent tests in this TU see expected defaults.
-    set_input_gamut(&p, InputGamut::Native);
+    set_input_gamut(p, InputGamut::Native);
     FL_CHECK(is_native_input_gamut(p));
 }
 


### PR DESCRIPTION
## Summary

Closes #3234.

**Audit result:** `profile` is required and mutated, so the nullable pointer advertised an optional argument that doesn't exist. Every call site already passed a real address (`&copy` internally, `&p` throughout the tests) — the `if (profile == nullptr) return;` was defensive, not a contract. And silently doing nothing is a poor answer to "you gave me no profile to configure": the caller gets no gamut applied and no signal.

So `DiodeProfile*` → `DiodeProfile&`.

## What deliberately did *not* change

`white_xy` **stays a pointer.** It is genuinely optional — `nullptr` means "use the gamut's standard reference white" — so the nullable pointer is telling the truth there. The goal is matching the shape to the semantics, not removing pointers on principle.

Answering the issue's questions directly:

| Question | Answer |
|---|---|
| Is `nullptr` an intentional contract? | No — defensive implementation detail, no caller relies on it |
| Should it become `DiodeProfile&`? | Yes |
| Does any overload need `const DiodeProfile&`? | No — every path mutates |
| Should a wrapper keep nullable behaviour? | Yes, as a deprecated forwarder (below) |

## Migration — no sketch breaks

The pointer overloads are kept and marked `FL_DEPRECATED`, forwarding to the reference forms. Existing `set_input_gamut(&profile, ...)` calls keep compiling and get a pointed deprecation message.

The forwarders **preserve the silent no-op on `nullptr`** rather than dereferencing. A sketch that relied on that behaviour must not start crashing at the moment we deprecate it — the deprecation is the signal, not a segfault.

## Testing

- `bash test --cpp` — **357/357**, including all **730 examples linking**, so the new deprecation doesn't break example builds
- `bash lint` — green
- Two new tests: one asserting the pointer and reference paths produce identical output, one pinning the null no-op

Both use `FL_DISABLE_WARNING(deprecated-declarations)` locally so exercising the deprecated path doesn't add warning noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reference-based APIs to configure input color gamut for RGBW colorimetric modes, with an optional white-point override.
- **Improvements**
  - Updated gamut configuration so colorimetric results refresh immediately after changes.
  - Kept pointer-based configuration for compatibility, including null-pointer no-op behavior.
- **Bug Fixes**
  - Ensured deprecated pointer overloads forward correctly and match reference overload results for valid profiles.
- **Tests**
  - Expanded coverage to verify correct forwarding, deprecation behavior, and crash-free null handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->