### PR TITLE
fix(ci): pin UTF-8 when decoding clang-query output

### DIFF
--- a/ci/tools/check_array_params.py
+++ b/ci/tools/check_array_params.py
@@ -376,6 +376,12 @@ def _run_clang_query(
         input=build_query(file_regex),
         capture_output=True,
         text=True,
+        # clang-query emits UTF-8. Without pinning it, text=True decodes with
+        # the locale codec (cp1252 on Windows), which raises inside the
+        # subprocess reader thread and leaves stdout as None -- the check then
+        # dies on `None + str` instead of reporting findings.
+        encoding="utf-8",
+        errors="replace",
         cwd=str(PROJECT_ROOT),
         timeout=300,
     )

--- a/ci/tools/check_noexcept.py
+++ b/ci/tools/check_noexcept.py
@@ -321,6 +321,11 @@ def _run_clang_query(
         input=build_query(file_regex),
         capture_output=True,
         text=True,
+        # See check_array_params._run_clang_query: text=True without an
+        # explicit encoding decodes clang-query's UTF-8 output with the
+        # locale codec and crashes on Windows.
+        encoding="utf-8",
+        errors="replace",
         cwd=str(PROJECT_ROOT),
         timeout=300,
     )


### PR DESCRIPTION
## Problem

`ci/tools/check_array_params.py` and `ci/tools/check_noexcept.py` both call:

```python
subprocess.run([...], capture_output=True, text=True, ...)
```

`text=True` with no `encoding` decodes using the locale codec. On Windows that is cp1252, and clang-query emits UTF-8. The decode raises inside the subprocess reader thread, which does not propagate as a clean error — it leaves `result.stdout` as `None`, so the next line fails:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 85530
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

## Impact

Both AST ratchets **crash instead of running** for Windows contributors:

- the decayed-array-parameter ratchet (`array_param_baseline.txt`)
- the `FL_NO_EXCEPT` ratchet

So new violations of either rule aren't caught locally and only surface later in CI.

## Fix

Pin `encoding="utf-8"` with `errors="replace"` at both call sites. `errors="replace"` means a stray byte degrades to a replacement character inside a diagnostic string rather than taking down the whole check — these are error-reporting paths, so failing to decode one byte should never be fatal.

## Validation

`uv run python ci/tools/check_array_params.py --scope all` goes from the traceback above to completing normally:

```
NOTE: 2 stale array parameter baseline entrie(s) can be pruned.
All non-baselined owned src functions avoid decayed array parameters.
Known baseline entries: 34
```

`bash lint` green (ruff + ty pass).

Note: I did **not** act on that "2 stale entries" hint. Regenerating the baseline locally drops two entries in files this branch never touched, which suggests the local run under-detects relative to CI rather than that the entries are genuinely dead. Pruning it belongs in a separate change made from a run that's trusted to be complete.

Found while verifying a signature change on #3746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for code-quality checks by ensuring tool output is decoded consistently.
  * Prevented locale-related decoding errors that could cause checks to fail or produce incorrect results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->