### PR TITLE
Avoid I2S include on Renesas boards

### DIFF
--- a/ci/tests/test_renesas_i2s_include_guard.py
+++ b/ci/tests/test_renesas_i2s_include_guard.py
@@ -1,0 +1,53 @@
+"""Regression test for Renesas boards with an unusable Arduino I2S header."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_renesas_guard_skips_poisonous_i2s_header(tmp_path: Path) -> None:
+    compiler = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    if compiler is None:
+        pytest.skip("No C++ preprocessor is available")
+
+    include_dir = tmp_path / "include"
+    include_dir.mkdir()
+    (include_dir / "Arduino.h").write_text("#pragma once\n", encoding="utf-8")
+    (include_dir / "I2S.h").write_text(
+        '#error "Renesas I2S.h must not be included"\n',
+        encoding="utf-8",
+    )
+
+    source = tmp_path / "renesas_i2s_guard.cpp"
+    source.write_text(
+        """
+#include "platforms/arduino/audio_input.hpp"
+
+#if ARDUINO_I2S_FULLY_SUPPORTED
+#error "Renesas I2S support must remain disabled"
+#endif
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            compiler,
+            "-E",
+            "-x",
+            "c++",
+            "-DARDUINO_ARCH_RENESAS",
+            f"-I{include_dir}",
+            f"-I{PROJECT_ROOT / 'src'}",
+            str(source),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )

--- a/src/platforms/arduino/audio_input.hpp
+++ b/src/platforms/arduino/audio_input.hpp
@@ -20,8 +20,15 @@
 // IWYU pragma: end_keep
 #include "platforms/is_platform.h"
 
-// Check for Arduino I2S library availability and completeness
-#if defined(FL_IS_SAMD21)
+// Check known-broken platforms before probing or including I2S.h. On Renesas
+// boards the library header can exist while including it fails because the
+// bundled FSP does not provide r_i2s_api.h.
+#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA) || \
+    defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_RENESAS_UNO) || \
+    defined(_RENESAS_RA_) || defined(ARDUINO_FSP)
+#define ARDUINO_I2S_FULLY_SUPPORTED 0
+#define ARDUINO_I2S_BROKEN_REASON "Renesas FSP missing r_i2s_api.h header"
+#elif defined(FL_IS_SAMD21)
 #define ARDUINO_I2S_FULLY_SUPPORTED 0
 #define ARDUINO_I2S_BROKEN_REASON "I2S not supported on SAMD21"
 #elif FL_HAS_INCLUDE(<I2S.h>)
@@ -31,13 +38,7 @@
 // IWYU pragma: end_keep
 
 // Define ARDUINO_I2S_FULLY_SUPPORTED only when ALL I2S components are present and functional
-#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA) || \
-    defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_RENESAS_UNO) || \
-    defined(_RENESAS_RA_) || defined(ARDUINO_FSP)
-    // Known broken: Renesas RA platforms with incomplete FSP I2S support
-    #define ARDUINO_I2S_FULLY_SUPPORTED 0
-    #define ARDUINO_I2S_BROKEN_REASON "Renesas FSP missing r_i2s_api.h header"
-#elif !defined(I2S_PHILIPS_MODE) || !defined(I2S_LEFT_JUSTIFIED_MODE) || !defined(I2S_RIGHT_JUSTIFIED_MODE)
+#if !defined(I2S_PHILIPS_MODE) || !defined(I2S_LEFT_JUSTIFIED_MODE) || !defined(I2S_RIGHT_JUSTIFIED_MODE)
     // Missing essential I2S mode constants - incomplete library implementation
     #define ARDUINO_I2S_FULLY_SUPPORTED 0
     #define ARDUINO_I2S_BROKEN_REASON "Missing I2S mode constants (incomplete library)"


### PR DESCRIPTION
## Summary

- detect known-broken Renesas Arduino targets before probing for `I2S.h`
- keep Arduino I2S audio disabled on those targets without including the unusable header
- add a regression test with a deliberately poisonous `I2S.h`

On ArduinoCore-renesas, `I2S.h` can be discoverable even though including it fails because the bundled FSP does not provide `r_i2s_api.h`. The existing guard ran only after that include.

Caveat: PlatformIO's Library Dependency Finder may still scan the guarded literal `#include <I2S.h>` without honoring preprocessor flow. Downstream UNO R4 PlatformIO projects therefore still need `lib_ignore = I2S`; FastLED CI already applies that exclusion.

Related: arduino/ArduinoCore-renesas#521

## Validation

- `uv run pytest ci/tests/test_renesas_i2s_include_guard.py -q`
- `uv run ruff check ci/tests/test_renesas_i2s_include_guard.py`
- `uv run ruff format --check ci/tests/test_renesas_i2s_include_guard.py`
- `bash compile uno_r4_wifi Blink --backend platformio`

The default fbuild path was also attempted, but its current macOS ARM toolchain URL returns HTTP 404 before compilation starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arduino I2S compatibility on Renesas and UNO R4 boards by safely disabling unsupported I2S functionality when required platform headers are unavailable.
  * Prevented problematic I2S headers from causing preprocessing failures.
  * Improved detection and reporting of incomplete I2S libraries missing required mode constants.

* **Tests**
  * Added regression coverage to verify Renesas I2S support remains safely disabled under affected conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->