### PR TITLE
fix(esp32): bound the I2S clock divider to its register field (#3745)

### DIFF
--- a/src/platforms/esp/32/core/clock_divider.h
+++ b/src/platforms/esp/32/core/clock_divider.h
@@ -36,6 +36,13 @@ struct ClkDividerNAB {
     int n;
     int a;
     int b;
+    /// True when `target_hz` was too low to reach with the caller's `max_N`
+    /// and `n` was clamped to it. The returned triple is then the closest
+    /// achievable clock, NOT the requested one. Callers that care about
+    /// accuracy must check this: writing a clamped `n` is still correct
+    /// register-wise, but the peripheral will run faster than asked
+    /// (FastLED#3745).
+    bool saturated;
 };
 
 /// Largest integer divider the solver will report. The real hardware fields
@@ -53,11 +60,24 @@ constexpr int kMaxDivider = 2147483000;
 /// @param base_hz  Reference clock feeding the divider (e.g. kApbClockHz).
 /// @param target_hz Desired output frequency. Must be non-zero — see below.
 /// @param max_A    Largest denominator the hardware accepts (inclusive).
-///                 I2S allows 63.
+///                 I2S allows 63 (6-bit `clkm_div_a`).
 /// @param min_N    Smallest integer divider the hardware accepts. I2S needs 2.
+/// @param max_N    Largest integer divider the caller's destination field can
+///                 hold. I2S `clkm_div_num` is 8 bits, so 255. Defaults to
+///                 `kMaxDivider`, i.e. "no hardware limit, just keep the
+///                 result representable" — so existing callers that do not
+///                 pass a width keep their previous behaviour exactly.
 ///
 /// @return The `(N, A, B)` minimising `|target_hz - base_hz/(N + B/A)|` within
-///         those limits.
+///         those limits, plus a `saturated` flag.
+///
+/// Bounding `N` matters because the result is usually assigned straight into
+/// a narrow hardware bitfield, and C bitfield assignment **silently
+/// truncates**. At an 80 MHz base a 100 kHz target solves to N = 800; writing
+/// that into 8 bits leaves 800 & 0xFF == 32, so the peripheral would run at
+/// 2.5 MHz — a 25x error with no warning, no assert, and for a clockless LED
+/// driver, no symptom other than malformed output. Saturating at `max_N` and
+/// reporting it keeps the failure visible (FastLED#3745).
 ///
 /// A `target_hz` of 0 has no meaningful answer (the divider would be
 /// infinite), so it is clamped to `min_N` with no fractional part rather than
@@ -65,9 +85,16 @@ constexpr int kMaxDivider = 2147483000;
 /// substitute it themselves before calling — that keeps the policy choice at
 /// the call site instead of buried in shared math.
 inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
-                                            int max_A = 63,
-                                            int min_N = 2) FL_NO_EXCEPT {
+                                            int max_A = 63, int min_N = 2,
+                                            int max_N = kMaxDivider) FL_NO_EXCEPT {
+    // A max_N below min_N cannot describe real hardware; treat the floor as
+    // authoritative so the result stays something the peripheral accepts.
+    if (max_N < min_N) {
+        max_N = min_N;
+    }
+
     ClkDividerNAB out;
+    out.saturated = false;
     if (target_hz == 0 || base_hz == 0) {
         out.n = min_N;
         out.a = 1;
@@ -83,10 +110,14 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
     // left to clamp. Saturating here keeps the result monotonic and
     // representable for any u32 pair.
     const double ratio = f_base / f_target;
-    if (ratio >= static_cast<double>(kMaxDivider)) {
-        out.n = kMaxDivider;
+    if (ratio >= static_cast<double>(max_N)) {
+        out.n = max_N;
         out.a = 1;
         out.b = 0;
+        // Only a genuine hardware limit counts as saturation. Hitting the
+        // int-representability guard means the caller asked for something
+        // absurd (a sub-hertz clock), which is a different failure.
+        out.saturated = (max_N < kMaxDivider);
         return out;
     }
 
@@ -118,6 +149,15 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
         best_A = 1;
         best_B = 0;
         ++N;
+    }
+
+    // Clamp last: the ++N above can push an in-range solve one past the
+    // field width, so checking before it would let that case through.
+    if (N > max_N) {
+        N = max_N;
+        best_A = 1;
+        best_B = 0;
+        out.saturated = (max_N < kMaxDivider);
     }
 
     out.n = N;

--- a/src/platforms/esp/32/core/clock_divider.h
+++ b/src/platforms/esp/32/core/clock_divider.h
@@ -110,8 +110,8 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
     // left to clamp. Saturating here keeps the result monotonic and
     // representable for any u32 pair.
     const double ratio = f_base / f_target;
-    if (ratio >= static_cast<double>(max_N)) {
-        out.n = max_N;
+    if (ratio >= static_cast<double>(kMaxDivider)) {
+        out.n = kMaxDivider;
         out.a = 1;
         out.b = 0;
         // Only a genuine hardware limit counts as saturation. Hitting the
@@ -123,6 +123,22 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
 
     int N = static_cast<int>(ratio);
     if (N < min_N) N = min_N;
+    // Clamp N to the field width *before* the fractional search, not by
+    // returning early. max_N bounds N alone, but the divisor is N + B/A, so
+    // the largest representable divisor is max_N + (max_A-1)/max_A -- for
+    // I2S, 255 + 62/63 = 255.984, not 255. Returning max_N/1 as soon as
+    // ratio crossed max_N both discarded that fractional headroom and
+    // wrongly reported saturation for targets in the 80MHz/255.984 ..
+    // 80MHz/255 band (312520..313725 Hz), which are perfectly reachable.
+    //
+    // Clamping here instead leaves a residual > 1 for genuinely
+    // out-of-range targets, and the sweep below then naturally settles on
+    // the largest legal fraction -- the closest bounded triple rather than
+    // an arbitrarily coarse one.
+    if (N > max_N) {
+        N = max_N;
+        out.saturated = true;
+    }
     const double residual = ratio - static_cast<double>(N);
 
     // Fractional part B/A. Sweep A within the hardware limit and pick the
@@ -151,12 +167,19 @@ inline ClkDividerNAB solveFractionalDivider(u32 base_hz, u32 target_hz,
         ++N;
     }
 
-    // Clamp last: the ++N above can push an in-range solve one past the
-    // field width, so checking before it would let that case through.
+    // The ++N above can push an in-range solve one past the field width.
+    // Fall back to the largest legal divisor -- max_N with the biggest
+    // fraction the denominator allows -- rather than max_N/1, which would
+    // throw away nearly a whole count of division.
     if (N > max_N) {
         N = max_N;
-        best_A = 1;
-        best_B = 0;
+        if (max_A >= 2) {
+            best_A = max_A;
+            best_B = max_A - 1;
+        } else {
+            best_A = 1;
+            best_B = 0;
+        }
         out.saturated = (max_N < kMaxDivider);
     }
 

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -77,6 +77,13 @@ namespace {
 // `f_out = I2S_BASE_CLK / (N + B/A)`.
 constexpr u32 kI2sBaseClkHz = 80000000u;
 
+// Width of the destination bitfield for the integer divider. `clkm_div_num`
+// is 8 bits in soc/esp32/include/soc/i2s_struct.h (verified against the
+// vendor header, not just the TRM), so 255 is the largest value that
+// survives the assignment. Its siblings clkm_div_a / clkm_div_b are 6 bits,
+// which is where the solver's max_A = 63 comes from.
+constexpr int kI2sMaxDivN = 255;
+
 // Owner tag for the cross-driver port-claim registry. Stable literal —
 // claim identity is the pointer.
 constexpr const char *kI2sClocklessOwner = "I2S_CLOCKLESS";
@@ -97,7 +104,18 @@ inline void solveI2sClockDivider(u32 target_hz,
     const u32 effective_hz = (target_hz == 0) ? 8000000u : target_hz;
     const fl::platforms::esp32::ClkDividerNAB d =
         fl::platforms::esp32::solveFractionalDivider(kI2sBaseClkHz, effective_hz,
-                                                     /*max_A=*/63, /*min_N=*/2);
+                                                     /*max_A=*/63, /*min_N=*/2,
+                                                     /*max_N=*/kI2sMaxDivN);
+    if (d.saturated) {
+        // Below ~313 kHz (80 MHz / 255) the divider no longer fits
+        // clkm_div_num. The solver clamped instead of letting the bitfield
+        // assignment below wrap silently, so the peripheral runs at the
+        // slowest rate it can rather than at a wrapped-around fast one.
+        FL_WARN_F("I2S: pixel clock %u Hz is below the minimum this divider "
+                  "can reach; clamping to ~%u Hz",
+                  static_cast<unsigned>(effective_hz),
+                  static_cast<unsigned>(kI2sBaseClkHz / kI2sMaxDivN));
+    }
     *out_N = d.n;
     *out_A = d.a;
     *out_B = d.b;

--- a/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/i2s_peripheral_esp32dev_esp.cpp.hpp
@@ -107,14 +107,23 @@ inline void solveI2sClockDivider(u32 target_hz,
                                                      /*max_A=*/63, /*min_N=*/2,
                                                      /*max_N=*/kI2sMaxDivN);
     if (d.saturated) {
-        // Below ~313 kHz (80 MHz / 255) the divider no longer fits
-        // clkm_div_num. The solver clamped instead of letting the bitfield
+        // The requested clock needs a bigger divider than clkm_div_num can
+        // hold. The solver clamped instead of letting the bitfield
         // assignment below wrap silently, so the peripheral runs at the
         // slowest rate it can rather than at a wrapped-around fast one.
+        //
+        // Report the clock actually programmed, computed from the solved
+        // triple: the floor is base / (N + B/A), not base / N, so quoting
+        // 80 MHz / 255 would understate the divider by nearly a full count.
+        // u64 because base * a overflows u32 (80e6 * 63 = 5.04e9).
+        const u32 achieved_hz = static_cast<u32>(
+            (static_cast<u64>(kI2sBaseClkHz) * static_cast<u64>(d.a)) /
+            (static_cast<u64>(d.n) * static_cast<u64>(d.a) +
+             static_cast<u64>(d.b)));
         FL_WARN_F("I2S: pixel clock %u Hz is below the minimum this divider "
                   "can reach; clamping to ~%u Hz",
                   static_cast<unsigned>(effective_hz),
-                  static_cast<unsigned>(kI2sBaseClkHz / kI2sMaxDivN));
+                  static_cast<unsigned>(achieved_hz));
     }
     *out_N = d.n;
     *out_A = d.a;

--- a/tests/platforms/esp/32/core/clock_divider.cpp
+++ b/tests/platforms/esp/32/core/clock_divider.cpp
@@ -179,27 +179,41 @@ FL_TEST_CASE("esp32 clock divider: max_N bounds the integer divider (#3745)") {
     // with no diagnostic. The solver clamps instead.
     constexpr int kFieldMax = 255;
 
-    // 80 MHz / 255 == 313725.49 Hz is the slowest reachable clock. Just above
-    // it still solves normally.
+    constexpr int kMaxA = 63;
+
     const ClkDividerNAB reachable =
-        solveFractionalDivider(kApbClockHz, 320000u, 63, 2, kFieldMax);
+        solveFractionalDivider(kApbClockHz, 320000u, kMaxA, 2, kFieldMax);
     FL_CHECK(reachable.n <= kFieldMax);
     FL_CHECK(!reachable.saturated);
 
+    // The divisor is N + B/A, so the slowest reachable clock is
+    // 80 MHz / (255 + 62/63) == 312519 Hz, NOT 80 MHz / 255 == 313725 Hz.
+    // Targets in that band need N == 255 *plus* a fraction; bounding N must
+    // not cost them their fractional part or mislabel them unreachable.
+    const ClkDividerNAB in_fractional_band =
+        solveFractionalDivider(kApbClockHz, 313000u, kMaxA, 2, kFieldMax);
+    FL_CHECK(in_fractional_band.n == kFieldMax);
+    FL_CHECK(in_fractional_band.b > 0);       // fraction preserved
+    FL_CHECK(!in_fractional_band.saturated);  // genuinely reachable
+
     // The exact boundary: 80 MHz / 255 must land on N == 255 and not tip over.
     const ClkDividerNAB boundary =
-        solveFractionalDivider(kApbClockHz, kApbClockHz / kFieldMax, 63, 2,
+        solveFractionalDivider(kApbClockHz, kApbClockHz / kFieldMax, kMaxA, 2,
                                kFieldMax);
     FL_CHECK(boundary.n <= kFieldMax);
+    FL_CHECK(!boundary.saturated);
 
-    // Just over: 100 kHz would solve to N == 800. Must clamp and say so.
+    // Genuinely out of range: 100 kHz needs N == 800. Must clamp, say so, and
+    // still return the *closest* bounded triple -- 255 + 62/63, the largest
+    // legal divisor -- rather than a coarse 255/1 that discards the fraction.
     const ClkDividerNAB over =
-        solveFractionalDivider(kApbClockHz, 100000u, 63, 2, kFieldMax);
+        solveFractionalDivider(kApbClockHz, 100000u, kMaxA, 2, kFieldMax);
     FL_CHECK(over.n == kFieldMax);
     FL_CHECK(over.saturated);
+    FL_CHECK(over.a == kMaxA);
+    FL_CHECK(over.b == kMaxA - 1);
     // A clamped result must still be a legal triple, not a half-updated one.
-    FL_CHECK(over.a == 1);
-    FL_CHECK(over.b == 0);
+    FL_CHECK(over.b < over.a);
 
     // The truncation this guards against: without the bound the solver
     // returns 800, and 800 & 0xFF is 32 -- a value that looks perfectly
@@ -241,6 +255,11 @@ FL_TEST_CASE("esp32 clock divider: max_N below min_N cannot fabricate an illegal
         solveFractionalDivider(kApbClockHz, 8000000u, 63, /*min_N=*/2,
                                /*max_N=*/1);
     FL_CHECK(d.n == 2);
-    FL_CHECK(d.a == 1);
-    FL_CHECK(d.b == 0);
+    // 8 MHz needs a divisor of 10, unreachable once N is pinned to 2, so this
+    // saturates and returns the largest legal fraction on top of that N. The
+    // point of the case is that `n` never drops below min_N to chase the
+    // target -- an N the hardware cannot encode is worse than a slow clock.
+    FL_CHECK(d.saturated);
+    FL_CHECK(d.b < d.a);
+    FL_CHECK(d.a <= 63);
 }

--- a/tests/platforms/esp/32/core/clock_divider.cpp
+++ b/tests/platforms/esp/32/core/clock_divider.cpp
@@ -170,3 +170,77 @@ FL_TEST_CASE("esp32 clock divider: degenerate inputs do not divide by zero") {
     FL_CHECK(zero_base.a == 1);
     FL_CHECK(zero_base.b == 0);
 }
+
+FL_TEST_CASE("esp32 clock divider: max_N bounds the integer divider (#3745)") {
+    // clkm_div_num on classic-ESP32 I2S is 8 bits, so 255 is the largest
+    // value that survives the register assignment. Assigning 800 to it would
+    // silently truncate to 800 & 0xFF == 32, running the peripheral at
+    // 80 MHz / 32 = 2.5 MHz instead of the requested 100 kHz -- a 25x error
+    // with no diagnostic. The solver clamps instead.
+    constexpr int kFieldMax = 255;
+
+    // 80 MHz / 255 == 313725.49 Hz is the slowest reachable clock. Just above
+    // it still solves normally.
+    const ClkDividerNAB reachable =
+        solveFractionalDivider(kApbClockHz, 320000u, 63, 2, kFieldMax);
+    FL_CHECK(reachable.n <= kFieldMax);
+    FL_CHECK(!reachable.saturated);
+
+    // The exact boundary: 80 MHz / 255 must land on N == 255 and not tip over.
+    const ClkDividerNAB boundary =
+        solveFractionalDivider(kApbClockHz, kApbClockHz / kFieldMax, 63, 2,
+                               kFieldMax);
+    FL_CHECK(boundary.n <= kFieldMax);
+
+    // Just over: 100 kHz would solve to N == 800. Must clamp and say so.
+    const ClkDividerNAB over =
+        solveFractionalDivider(kApbClockHz, 100000u, 63, 2, kFieldMax);
+    FL_CHECK(over.n == kFieldMax);
+    FL_CHECK(over.saturated);
+    // A clamped result must still be a legal triple, not a half-updated one.
+    FL_CHECK(over.a == 1);
+    FL_CHECK(over.b == 0);
+
+    // The truncation this guards against: without the bound the solver
+    // returns 800, and 800 & 0xFF is 32 -- a value that looks perfectly
+    // plausible in the register.
+    const ClkDividerNAB unbounded =
+        solveFractionalDivider(kApbClockHz, 100000u, 63, 2);
+    FL_CHECK(unbounded.n == 800);
+    FL_CHECK((unbounded.n & 0xFF) == 32);
+    FL_CHECK(!unbounded.saturated);
+}
+
+FL_TEST_CASE("esp32 clock divider: existing callers keep their behavior") {
+    // max_N defaults to kMaxDivider, so every pre-#3745 call site must solve
+    // to exactly what it did before and never report saturation.
+    using fl::platforms::esp32::kMaxDivider;
+
+    const u32 rates[] = {8000000u, 3200000u, 2400000u, 1000000u, 400000u};
+    for (u32 hz : rates) {
+        const ClkDividerNAB with_default = solveFractionalDivider(kApbClockHz, hz);
+        const ClkDividerNAB explicit_max =
+            solveFractionalDivider(kApbClockHz, hz, 63, 2, kMaxDivider);
+        FL_CHECK(with_default.n == explicit_max.n);
+        FL_CHECK(with_default.a == explicit_max.a);
+        FL_CHECK(with_default.b == explicit_max.b);
+        FL_CHECK(!with_default.saturated);
+    }
+
+    // Hitting the int-representability guard is not a hardware saturation --
+    // it means the caller asked for a sub-hertz clock, a different failure.
+    const ClkDividerNAB huge = solveFractionalDivider(4294967295u, 1u);
+    FL_CHECK(huge.n == kMaxDivider);
+    FL_CHECK(!huge.saturated);
+}
+
+FL_TEST_CASE("esp32 clock divider: max_N below min_N cannot fabricate an illegal N") {
+    // Nonsensical limits must still yield something the hardware accepts:
+    // the min_N floor wins, because a divider under it is unwritable.
+    const ClkDividerNAB d =
+        solveFractionalDivider(kApbClockHz, 8000000u, 63, /*min_N=*/2,
+                               /*max_N=*/1);
+    FL_CHECK(d.n == 2);
+    FL_CHECK(d.a == 1);
+    FL_CHECK(d.b == 0);
+}


### PR DESCRIPTION
Closes #3745.

## The defect

`solveFractionalDivider()` returned an integer divider `N` with no upper bound tied to the destination register. The I2S driver assigned it straight into a hardware bitfield:

```cpp
i2s->clkm_conf.clkm_div_num = div_N;   // 8-bit field, no range check
```

C bitfield assignment **silently truncates**. At the 80 MHz APB base a 100 kHz target solves to `N = 800`; into 8 bits that is `800 & 0xFF == 32`, so the peripheral runs at 80 MHz / 32 = **2.5 MHz instead of 100 kHz** — a 25× error with no warning, no assert, and for a clockless LED driver, no symptom other than malformed WS2812 timing. Anything below ~313 kHz (80 MHz / 255) wrapped.

The real defect was the asymmetry: `max_A = 63` already encoded the 6-bit `clkm_div_a` field, while its 8-bit sibling had no equivalent.

## Field widths — verified, as the issue asked

The issue explicitly asked not to take the TRM's word for this. Checked against the vendor header in this checkout, `soc/esp32/include/soc/i2s_struct.h:385-387`:

```c
uint32_t clkm_div_num: 8;
uint32_t clkm_div_b:   6;
uint32_t clkm_div_a:   6;
```

That confirms 255 / 63 / 63, and independently explains where the existing `max_A = 63` came from. Widths are not guaranteed identical across peripherals, which is why this is a parameter rather than a baked-in constant.

## Changes

- `solveFractionalDivider()` takes `max_N`, defaulting to `kMaxDivider` — so **every existing call site keeps its exact previous behaviour**. There is a regression test asserting this for the five real pixel-clock rates.
- `ClkDividerNAB` gains a `saturated` flag, so an unreachable target is *detectable* rather than silently wrong.
- Clamping happens **after** the `A == B` adjustment, because that `++N` can push an otherwise in-range solve one past the field width.
- Hitting the int-representability guard does **not** set `saturated` — that means a sub-hertz request, which is a different failure from a hardware limit.
- The I2S wrapper passes `kI2sMaxDivN = 255` and warns on saturation.

## Tests

Boundary (80 MHz / 255) and just-over cases, per the acceptance criteria. The truncation itself is pinned rather than merely described:

```cpp
const ClkDividerNAB unbounded = solveFractionalDivider(kApbClockHz, 100000u, 63, 2);
FL_CHECK(unbounded.n == 800);
FL_CHECK((unbounded.n & 0xFF) == 32);
```

If someone later changes the solver so this no longer truncates, the test says so.

## Validation

- **357/357** host tests on a clean build; `bash lint` green.
- `bash compile esp32dev --examples Blink` clean.
- The modified TU was **confirmed to actually compile** via an `#error` negative control (8 unity TUs hit it) — not inferred from a passing build, since a file that isn't in the build also produces a passing build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added saturation reporting for ESP32 fractional clock divider solving, indicating when `N` is clamped to fit hardware limits.
  - Extended the divider solver with a configurable `max_N` bound.

- **Bug Fixes**
  - Prevented out-of-range `N` values by enforcing the `max_N` cap and ensuring the chosen divider reflects the closest achievable frequency.
  - Clarified failure/limit behavior so clamping impacts the resulting hardware divider as expected.

- **Tests**
  - Added host-side tests validating `max_N` bounds, default compatibility, and handling of invalid limit combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->