### PR TITLE
fix(ci): stop a narrow subprocess-ratchet scan from wiping the baseline

### DIFF
--- a/ci/lint_python/subprocess_baseline.txt
+++ b/ci/lint_python/subprocess_baseline.txt
@@ -90,11 +90,9 @@ ci/tests/test_wasm_flags.py|SRC004|1
 ci/tools/add_fl_noexcept.py|SRC001|1
 ci/tools/add_fl_noexcept.py|SRC004|1
 ci/tools/check_array_params.py|SRC001|1
-ci/tools/check_array_params.py|SRC004|1
 ci/tools/check_ast_combined.py|SRC001|1
 ci/tools/check_ast_combined.py|SRC004|1
 ci/tools/check_noexcept.py|SRC001|1
-ci/tools/check_noexcept.py|SRC004|1
 ci/tools/coderabbit_addressor.py|SRC001|1
 ci/tools/generate_audio_fixtures.py|SRC001|2
 ci/tools/generate_audio_fixtures.py|SRC004|2

--- a/ci/lint_python/subprocess_capture_checker.py
+++ b/ci/lint_python/subprocess_capture_checker.py
@@ -189,13 +189,22 @@ def check_file(path: str, source: str) -> list[tuple[int, str, str]]:
     return visitor.violations
 
 
+def _rel_path(path: Path) -> str:
+    """Project-relative posix path, or the path itself if outside the tree."""
+    try:
+        return path.resolve().relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
 def _baseline_key(path: Path, code: str) -> str:
     """Stable per-file/per-code key, independent of line numbers."""
-    try:
-        rel = path.resolve().relative_to(PROJECT_ROOT).as_posix()
-    except ValueError:
-        rel = path.as_posix()
-    return f"{rel}|{code}"
+    return f"{_rel_path(path)}|{code}"
+
+
+def _key_file(key: str) -> str:
+    """The file portion of a baseline key."""
+    return key.rsplit("|", 1)[0]
 
 
 def load_baseline(path: Path = DEFAULT_BASELINE) -> Counter[str]:
@@ -283,11 +292,16 @@ def main(argv: list[str] | None = None) -> int:
 
     counts: Counter[str] = Counter()
     detail: dict[str, list[str]] = {}
+    # Which files this invocation actually looked at. A baseline entry for a
+    # file outside this set says nothing about that file -- it was simply not
+    # examined -- so it must never be treated as fixed or dropped.
+    scanned: set[str] = set()
     for path in files:
         try:
             source = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
+        scanned.add(_rel_path(path))
         if not _SUBPROCESS_RE.search(source):
             continue
         for line_no, code, message in check_file(str(path), source):
@@ -296,13 +310,25 @@ def main(argv: list[str] | None = None) -> int:
             detail.setdefault(key, []).append(f"{path}:{line_no}: {message}")
 
     baseline_path = Path(args.baseline)
-    if args.update_baseline:
-        write_baseline(counts, baseline_path)
-        total = sum(counts.values())
-        print(f"Wrote baseline with {total} finding(s) across {len(counts)} entries.")
-        return 0
-
     baseline = load_baseline(baseline_path)
+
+    if args.update_baseline:
+        # Merge rather than overwrite. Running with a narrow path list
+        # (`... check.py some_file.py --update-baseline`) would otherwise
+        # rewrite the whole file from that one file's findings and silently
+        # delete every other entry, turning the ratchet off everywhere.
+        merged = Counter(
+            {k: v for k, v in baseline.items() if _key_file(k) not in scanned}
+        )
+        merged.update(counts)
+        write_baseline(merged, baseline_path)
+        total = sum(merged.values())
+        kept = len(merged) - len(counts)
+        print(
+            f"Wrote baseline with {total} finding(s) across {len(merged)} entries "
+            f"({len(scanned)} file(s) rescanned, {kept} untouched entry(ies) kept)."
+        )
+        return 0
 
     regressions = 0
     for key, count in sorted(counts.items()):
@@ -324,8 +350,14 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    # Only files this run actually scanned can be said to have improved.
+    # Without the `scanned` filter a narrow invocation reports every baselined
+    # entry in the repo as "now gone", which is both wrong and an invitation
+    # to run --update-baseline and wipe them.
     improved = sum(
-        max(0, allowed - counts.get(key, 0)) for key, allowed in baseline.items()
+        max(0, allowed - counts.get(key, 0))
+        for key, allowed in baseline.items()
+        if _key_file(key) in scanned
     )
     if improved:
         print(

--- a/ci/tests/test_subprocess_checker_baseline.py
+++ b/ci/tests/test_subprocess_checker_baseline.py
@@ -1,0 +1,98 @@
+"""Regression tests for the raw-subprocess ratchet's baseline handling.
+
+The dangerous case is a narrow invocation: running the checker against a
+single file with --update-baseline must not rewrite the baseline from just
+that file's findings, because that would silently drop every other entry and
+turn the ratchet off across the repo.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from ci.lint_python import subprocess_capture_checker as checker
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_baseline(path: Path, entries: dict[str, int]) -> None:
+    checker.write_baseline(Counter(entries), path)
+
+
+def test_narrow_update_keeps_unscanned_entries(tmp_path: Path) -> None:
+    """--update-baseline on one file must preserve entries for other files."""
+    scanned = tmp_path / "scanned.py"
+    scanned.write_text(
+        "import subprocess\n"
+        "subprocess.run(['ls'], capture_output=True, encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    baseline = tmp_path / "baseline.txt"
+    _write_baseline(
+        baseline,
+        {
+            "ci/other_file.py|SRC001": 7,
+            "ci/another.py|SRC002": 3,
+        },
+    )
+
+    rc = checker.main([str(scanned), "--baseline", str(baseline), "--update-baseline"])
+    assert rc == 0
+
+    result = checker.load_baseline(baseline)
+    # The two untouched files must survive verbatim.
+    assert result["ci/other_file.py|SRC001"] == 7
+    assert result["ci/another.py|SRC002"] == 3
+
+
+def test_narrow_scan_does_not_claim_unscanned_entries_improved(
+    tmp_path: Path, capsys
+) -> None:
+    """A narrow scan must not report unexamined baseline entries as fixed."""
+    scanned = tmp_path / "clean.py"
+    scanned.write_text("x = 1\n", encoding="utf-8")
+
+    baseline = tmp_path / "baseline.txt"
+    _write_baseline(baseline, {"ci/elsewhere.py|SRC001": 5})
+
+    rc = checker.main([str(scanned), "--baseline", str(baseline)])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    # "now gone" would be a lie -- ci/elsewhere.py was never looked at.
+    assert "now gone" not in out
+
+
+def test_rescanned_file_can_still_shrink(tmp_path: Path) -> None:
+    """A file that genuinely improved must have its count lowered, not frozen."""
+    scanned = tmp_path / "fixed.py"
+    scanned.write_text("x = 1\n", encoding="utf-8")  # no subprocess use left
+
+    baseline = tmp_path / "baseline.txt"
+    key = f"{checker._rel_path(scanned)}|SRC001"
+    _write_baseline(baseline, {key: 4, "ci/untouched.py|SRC003": 2})
+
+    rc = checker.main([str(scanned), "--baseline", str(baseline), "--update-baseline"])
+    assert rc == 0
+
+    result = checker.load_baseline(baseline)
+    assert key not in result  # dropped to zero, so the entry goes away
+    assert result["ci/untouched.py|SRC003"] == 2  # unrelated entry preserved
+
+
+def test_new_violation_still_fails(tmp_path: Path) -> None:
+    """The ratchet must still catch a genuinely new violation."""
+    offender = tmp_path / "offender.py"
+    offender.write_text(
+        "import subprocess\nsubprocess.Popen(['ls'], stdout=subprocess.PIPE)\n",
+        encoding="utf-8",
+    )
+
+    baseline = tmp_path / "baseline.txt"
+    _write_baseline(baseline, {})
+
+    rc = checker.main([str(offender), "--baseline", str(baseline)])
+    assert rc == 1


### PR DESCRIPTION
Follow-up to #3748. Found while checking #3749's new test file against the ratchet.

## The bug

Running the checker against a single file:

```
subprocess_capture_checker.py ci/tests/some_file.py
```

reported **"239 baselined subprocess usage(s) are now gone"** — because the improvement check compared the *entire* baseline against one file's findings. Every entry for a file that was simply never examined counted as fixed.

The wrong message is bad. The action it invites is worse: adding `--update-baseline` to that same narrow command rewrote the baseline from just that file, **silently deleting the other 128 entries** and turning the ratchet off across the repo. The next raw `Popen` would have gone in unnoticed — the failure mode being that a guard reports success while no longer guarding anything.

## Fix

Both halves now key off the set of files actually scanned:

- **`--update-baseline` merges instead of overwriting**, keeping entries for unscanned files verbatim. A file that genuinely improved still shrinks or drops out, so incremental tightening still works — it just can't delete what it didn't look at.
- **The "now gone" note only counts entries for files this run examined.**

## Baseline cleanup

Also drops the two `check_array_params` / `check_noexcept` `SRC004` entries that #3747 resolved. The baseline in #3748 was generated just before #3747 merged, so it was stale by exactly those two. Full scan is now exact — no residual note.

## Tests

`ci/tests/test_subprocess_checker_baseline.py` covers:
- narrow `--update-baseline` preserves unscanned entries
- narrow scan doesn't claim unexamined entries improved
- a rescanned file *can* still shrink (the ratchet must stay tightenable)
- a genuinely new violation still fails

The first three fail against the previous implementation; the fourth passes both, which is the correct split — it's the property that must not regress while fixing the others.

## Validation

`556 passed, 39 skipped` in `ci/tests`; `bash lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved baseline updates so scanning selected files no longer removes findings recorded for files not included in the scan.
  * Prevented misleading “resolved” reports for files that were not examined.
  * Preserved accurate baseline reductions when previously flagged files are rescanned and improved.

* **Tests**
  * Added coverage for baseline preservation, accurate improvement reporting, and detection of new violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->