### PR TITLE
fix(lint): SingletonElisionChecker was a silent no-op; add warn-only severity

### DIFF
--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -30,6 +30,28 @@ SRC_ROOT = PROJECT_ROOT / "src"
 EXAMPLES_ROOT = PROJECT_ROOT / "examples"
 TESTS_ROOT = PROJECT_ROOT / "tests"
 
+# Checkers whose findings are printed but do NOT fail the run.
+#
+# Lets a checker be rolled out against a tree that already violates it: the
+# findings are visible immediately while the migration lands incrementally,
+# and the checker is promoted to hard-fail once the count reaches zero.
+# Without this, enabling a checker on a dirty tree is all-or-nothing -- either
+# CI breaks at once or the checker stays off and silently guards nothing.
+#
+# Must stay in sync with WARN_ONLY_CHECKERS in
+# ci/lint_cpp_rs/src/lint_core/warn_only.rs -- the Rust binary
+# owns its own exit code, and this orchestrator tallies the same findings a
+# second time, so both layers have to agree or the stricter one wins.
+# ci/tests/test_warn_only_checkers_sync.py asserts the two lists match.
+WARN_ONLY_CHECKERS = frozenset(
+    {
+        # FastLED#3482 -- pre-existing namespace-scope globals; migration to
+        # fl::Singleton<T> tracked under FastLED#3481. Promote to hard-fail
+        # via FastLED#3492 when the count reaches zero.
+        "SingletonElisionChecker",
+    }
+)
+
 
 def collect_all_files_by_directory() -> dict[str, list[str]]:
     """Collect files organized by directory for targeted checker application."""
@@ -285,6 +307,7 @@ def format_and_print_results(
             truncating output. Set to 0 for unlimited.
     """
     total_violations = 0
+    warn_only_violations = 0
 
     for checker_name, checker_results in sorted(results.items()):
         if not checker_results.has_violations():
@@ -292,11 +315,17 @@ def format_and_print_results(
 
         file_count = checker_results.file_count()
         violation_count = checker_results.total_violations()
-        total_violations += violation_count
+        warn_only = checker_name in WARN_ONLY_CHECKERS
+        if warn_only:
+            warn_only_violations += violation_count
+        else:
+            total_violations += violation_count
 
+        suffix = " (warn-only — not failing CI)" if warn_only else ""
         print(f"\n{'=' * 80}")
         print(
-            f"[{checker_name}] Found {violation_count} violation(s) in {file_count} file(s):"
+            f"[{checker_name}] Found {violation_count} violation(s) "
+            f"in {file_count} file(s):{suffix}"
         )
         print("=" * 80)
 
@@ -331,6 +360,14 @@ def format_and_print_results(
                 f"\n  ... stopped after {max_violations_per_checker} violations"
                 f" ({remaining} more not shown)"
             )
+
+    if warn_only_violations > 0:
+        print(f"\n{'=' * 80}")
+        print(
+            f"⚠️  {warn_only_violations} warn-only violation(s) "
+            "— reported, not failing CI."
+        )
+        print("=" * 80)
 
     if total_violations > 0:
         print(f"\n{'=' * 80}")

--- a/ci/lint_cpp/run_all_checkers.py
+++ b/ci/lint_cpp/run_all_checkers.py
@@ -374,6 +374,13 @@ def format_and_print_results(
         print(f"❌ Total violations: {total_violations}")
         print("=" * 80)
         return 1
+    elif warn_only_violations > 0:
+        # Not "all checks passed" -- findings exist, they just do not block.
+        # Saying otherwise is how a warn-only rollout gets forgotten.
+        print("\n" + "=" * 80)
+        print("✅ No blocking C++ lint violations.")
+        print("=" * 80)
+        return 0
     else:
         print("\n" + "=" * 80)
         print("✅ All C++ linting checks passed!")

--- a/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
+++ b/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
@@ -305,7 +305,18 @@ impl FileContentChecker for SingletonElisionChecker {
             let end_pos = code
                 .find(|c: char| end_marker.contains(&c))
                 .unwrap_or(code.len());
-            let head = &code[..end_pos];
+            // Trim before the split below. `end_pos` stops just *before* the
+            // `=` / `;` / `[`, so for the ordinary spelling `int x = 0;` the
+            // head is "int x " -- with a trailing space. The `rsplit` on
+            // non-identifier characters would then split on that trailing
+            // space and hand back the empty tail, the name would come out as
+            // "" and the `name.is_empty()` guard below would skip the line.
+            //
+            // Since virtually every real declaration puts a space before the
+            // initializer, that made the whole checker a silent no-op: it
+            // reported zero violations tree-wide while the Python scanner
+            // found 101. See FastLED#3482.
+            let head = code[..end_pos].trim();
 
             // Class-static-member out-of-class definitions like
             // `constexpr bool numeric_limits<char>::is_signed = true;` or

--- a/ci/lint_cpp_rs/src/lib.rs
+++ b/ci/lint_cpp_rs/src/lib.rs
@@ -1,6 +1,7 @@
 // Keep lib.rs as the crate-level dispatch surface; implementation lives in small source files.
 include!("lint_core/prelude_constants.rs");
 include!("lint_core/banned_header_data.rs");
+include!("lint_core/warn_only.rs");
 include!("lint_core/processor_registry_cli.rs");
 include!("lint_core/regexes.rs");
 include!("lint_core/path_helpers.rs");

--- a/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
+++ b/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
@@ -657,7 +657,12 @@ where
         OutputFormat::Text => print_text_results(&violations, &config.project_root),
     }
 
-    Ok(if violations.is_empty() { 0 } else { 1 })
+    // Warn-only checkers are reported but must not affect the exit code --
+    // that is the whole point of the rollout mechanism.
+    let blocking = violations
+        .iter()
+        .any(|violation| !is_warn_only(&violation.checker));
+    Ok(if blocking { 1 } else { 0 })
 }
 
 fn selected_contains_structural_alias(selected: &HashSet<String>, checker_name: &str) -> bool {
@@ -767,23 +772,6 @@ Usage:\n\
 When no files are supplied, scans src/, examples/, and tests/ under --project-root.\n\
 Use --list-checkers to print the Rust-supported checker names."
     );
-}
-
-fn print_text_results(violations: &[LintViolation], project_root: &Path) {
-    if violations.is_empty() {
-        println!("All Rust C++ linting checks passed!");
-        return;
-    }
-
-    let mut current_checker = "";
-    for violation in violations {
-        if violation.checker != current_checker {
-            current_checker = &violation.checker;
-            println!("\n[{current_checker}]");
-        }
-        let display_path = relative_display_path(&violation.path, project_root);
-        println!("  {display_path}:{}: {}", violation.line, violation.message);
-    }
 }
 
 fn collect_input_files(project_root: &Path, inputs: &[String]) -> Result<Vec<PathBuf>, DynError> {

--- a/ci/lint_cpp_rs/src/lint_core/warn_only.rs
+++ b/ci/lint_cpp_rs/src/lint_core/warn_only.rs
@@ -1,0 +1,67 @@
+// Warn-only checker policy.
+//
+// Checkers listed here have their findings reported but do NOT fail the run.
+//
+// This exists so a checker can be rolled out against a tree that already
+// violates it: the findings are visible from day one while the migration
+// lands incrementally, and the checker is promoted to hard-fail once the
+// count reaches zero. Without it, enabling a checker on a dirty tree is
+// all-or-nothing -- either CI breaks immediately, or the checker stays
+// switched off and silently guards nothing, which is the worse failure
+// because it still looks installed.
+//
+// Must stay in sync with WARN_ONLY_CHECKERS in
+// ci/lint_cpp/run_all_checkers.py. The Rust binary owns its own exit code
+// and the Python orchestrator tallies the same findings a second time to
+// decide its own, so both layers have to agree or the stricter one wins
+// silently. ci/tests/test_warn_only_checkers_sync.py asserts they match.
+
+/// Checker names whose violations are reported but never block.
+pub const WARN_ONLY_CHECKERS: &[&str] = &[
+    // FastLED#3482 -- pre-existing namespace-scope globals; migration to
+    // fl::Singleton<T> is tracked by the sub-issues under FastLED#3481.
+    // Promote to hard-fail via FastLED#3492 once the count reaches zero.
+    "SingletonElisionChecker",
+];
+
+/// True when `checker`'s findings must not affect the exit code.
+pub fn is_warn_only(checker: &str) -> bool {
+    WARN_ONLY_CHECKERS.contains(&checker)
+}
+
+fn print_text_results(violations: &[LintViolation], project_root: &Path) {
+    let (warnings, errors): (Vec<_>, Vec<_>) = violations
+        .iter()
+        .partition(|violation| is_warn_only(&violation.checker));
+
+    let print_group = |group: &[&LintViolation]| {
+        let mut current_checker = "";
+        for violation in group {
+            if violation.checker != current_checker {
+                current_checker = &violation.checker;
+                println!("\n[{current_checker}]");
+            }
+            let display_path = relative_display_path(&violation.path, project_root);
+            println!("  {display_path}:{}: {}", violation.line, violation.message);
+        }
+    };
+
+    if !warnings.is_empty() {
+        print_group(&warnings);
+        println!(
+            "\n{} warn-only violation(s) above -- reported, not failing the build.",
+            warnings.len()
+        );
+    }
+
+    if errors.is_empty() {
+        if warnings.is_empty() {
+            println!("All Rust C++ linting checks passed!");
+        } else {
+            println!("No blocking Rust C++ lint violations.");
+        }
+        return;
+    }
+
+    print_group(&errors);
+}

--- a/ci/tests/test_warn_only_checkers_sync.py
+++ b/ci/tests/test_warn_only_checkers_sync.py
@@ -1,0 +1,53 @@
+"""The warn-only checker list is duplicated in Rust and Python; keep them equal.
+
+The Rust binary decides its own exit code, and the Python orchestrator tallies
+the same findings a second time to decide its own. If the two lists drift, the
+stricter layer wins silently: a checker meant to be warn-only starts failing
+CI, or -- worse -- one meant to block stops blocking.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ci.lint_cpp.run_all_checkers import WARN_ONLY_CHECKERS
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUST_SOURCE = PROJECT_ROOT / "ci" / "lint_cpp_rs" / "src" / "lint_core" / "warn_only.rs"
+
+
+def _parse_rust_warn_only() -> set[str]:
+    """Extract the string literals from the Rust WARN_ONLY_CHECKERS slice."""
+    text = RUST_SOURCE.read_text(encoding="utf-8")
+    match = re.search(
+        r"pub const WARN_ONLY_CHECKERS:\s*&\[&str\]\s*=\s*&\[(.*?)\];",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, f"WARN_ONLY_CHECKERS not found in {RUST_SOURCE}"
+
+    body = match.group(1)
+    # Strip line comments so a checker name mentioned in prose is not counted.
+    body = re.sub(r"//[^\n]*", "", body)
+    return set(re.findall(r'"([^"]+)"', body))
+
+
+def test_warn_only_lists_match() -> None:
+    rust = _parse_rust_warn_only()
+    python = set(WARN_ONLY_CHECKERS)
+    assert rust == python, (
+        "warn-only checker lists have drifted.\n"
+        f"  only in Rust:   {sorted(rust - python)}\n"
+        f"  only in Python: {sorted(python - rust)}"
+    )
+
+
+def test_warn_only_list_is_not_empty() -> None:
+    """Guards the parser itself.
+
+    An empty result would make test_warn_only_lists_match pass vacuously if
+    the regex ever stopped matching.
+    """
+    assert _parse_rust_warn_only(), "parsed an empty Rust warn-only list"


### PR DESCRIPTION
Closes #3482.

## The wiring was already done; the checker was broken

The issue asks to register `SingletonElisionChecker` so `bash lint` runs it. That registration is already on master — it's in `supported_checker_names()`, constructed in `create_checkers()`, and shows up in `--list-checkers`. It reported nothing because of a bug in the checker itself.

**Root cause**, in the name extraction:

```rust
let head = &code[..end_pos];                            // "int x " — end_pos stops before '='
let name = head.rsplit(|c| !alnum && c != '_').next();  // -> ""
if name.is_empty() { continue; }                        // every line skipped
```

`end_pos` lands just before the `=` / `;` / `[`, so for the ordinary spelling `int x = 0;` the head retains a **trailing space**. `rsplit` splits on that space and returns the empty tail, the name comes out empty, and the guard skips the line.

Since essentially every real declaration puts a space before the initializer, this made the checker a **universal no-op** — zero violations tree-wide, while `ci/scan_singleton_elision.py` found 101. Trimming the head fixes it: **76 violations across 23 files** now surface.

I confirmed the diagnosis rather than inferring it — the checker *was* selected and *did* process files (`FASTLED_LINT_PROFILE=1` showed `1 files x 1 checkers`), the binary was current (rebuild was a no-op, and it already contained the message string), and a three-line synthetic global still produced nothing. Instrumenting the loop showed execution reaching name-extraction but never the `push`.

## Why warn-only ships in the same PR

The detection fix **alone breaks the build**. There was no severity concept in the Rust linter at all — any violation meant exit 1 — so re-enabling detection would have failed CI on 76 pre-existing globals. That's exactly why the issue specifies warn severity; it just didn't exist yet.

Added a warn-only list: findings are printed and labelled, but don't affect the exit code.

```
[SingletonElisionChecker] Found 76 violation(s) in 23 file(s): (warn-only — not failing CI)
⚠️  76 warn-only violation(s) — reported, not failing CI.
```

## The duplicated list

`WARN_ONLY_CHECKERS` exists in both `lint_core/warn_only.rs` and `run_all_checkers.py` because **both layers independently decide an exit status** — the Rust binary for its own run, and the Python orchestrator after re-tallying the same findings. Making only one warn-aware isn't enough; I hit precisely that (Rust exited 0, `bash lint` still failed).

Since drift means the stricter layer wins silently, `ci/tests/test_warn_only_checkers_sync.py` asserts the two match, plus a non-empty guard so the regex can't make the comparison pass vacuously. That test earned its keep immediately: it caught my own drift when I moved the constant into a new module.

## Validation

- **warn-only path**: `bash lint` exits **0** while reporting all 76
- **blocking path intact**: emptying the warn list → exit **1**; an injected real violation fails `bash lint --cpp` → exit **1**
- `558 passed, 39 skipped` in `ci/tests`; 24/25 Rust tests pass

The one failing Rust test (`rust_lint_source_files_stay_under_one_thousand_lines`) is **pre-existing on master** — `checkers/unity_build.rs` is 1205 lines and untouched here; I verified it fails identically with my changes stashed. My additions *did* push `processor_registry_cli.rs` to 1038, so the warn-only policy and reporting moved into `lint_core/warn_only.rs`, bringing it back to **982**.

## Note for #3492

#3492 proposes promoting this checker to hard-fail. Before this PR that would have been a **no-op promotion** — passing trivially while guarding nothing. It's now meaningful, and gated on the 76 findings reaching zero via the #3481 sub-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warn-only policy for selected C++ lint checkers, reporting their findings without failing CI.
  * Updated command output to label warn-only results and emit a consolidated non-blocking summary.
* **Bug Fixes**
  * Improved detection for declarations with whitespace before initializers so relevant lint findings are reliably reported.
* **Tests**
  * Added tests to ensure Rust and Python warn-only checker lists stay synchronized and that the warn-only list is non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->