### PR TITLE
build(tests): pass test sources relatively so object names stay short (#2887)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -180,9 +180,12 @@ shared_test_cpp_args = test_abs_include_args + unit_test_compile_args + [
 
 test_shared_objs_lib = static_library('test_shared_objs',
   [
-    path_norm_root + '/tests/doctest_main.cpp',
-    path_norm_root + '/tests/shared/fl_unittest.cpp',
-    path_norm_root + '/tests/misc/coroutine_impl.cpp',
+    # Relative, for the same reason as test_sources below: an absolute source
+    # path makes meson flatten the whole path into the object file's name
+    # (FastLED#2887).
+    'doctest_main.cpp',
+    'shared/fl_unittest.cpp',
+    'misc/coroutine_impl.cpp',
     test_pch,
   ],
   cpp_args: shared_test_cpp_args,
@@ -199,9 +202,16 @@ foreach test_name : test_names
 
   # Test sources: only the unique test file + PCH dependency
   # doctest_main.cpp and fl_unittest.cpp are pre-compiled in shared_test_objects
-  test_source_abs = path_norm_root + '/tests/' + test_file
+  # Relative, not absolute. Meson derives each object file's name from the
+  # source path it is given; an absolute source gets the entire path flattened
+  # into that name, e.g.
+  #   C__Users_me_dev_fastled_.claude_worktrees_my-branch_tests_misc_foo.cpp.obj
+  # `test_file` is already relative to this directory, so passing it directly
+  # collapses the object name to misc_foo.cpp.obj -- around 90 characters
+  # shorter per object. That matters on Windows, where the encoded name is what
+  # pushed builds under .claude/worktrees/<branch>/ past MAX_PATH (FastLED#2887).
   test_sources = [
-    test_source_abs,
+    test_file,
     test_pch,
   ]
   test_cpp_args = shared_test_cpp_args


### PR DESCRIPTION
Closes #2887.

## Root cause — not what the issue guessed

The build system derives each object file's name from the source path it is handed. `tests/meson.build` passed **absolute** paths:

```meson
test_source_abs = path_norm_root + '/tests/' + test_file
```

so the entire absolute path got flattened into the object name:

```
C__Users_niteris_dev_fastled_.claude_worktrees_<branch>_tests_misc_foo.cpp.obj
```

In a normal checkout that's merely ugly. Under `.claude/worktrees/<branch>/` the encoded name **grows with the worktree path** — it's the worktree path, twice: once as the real directory, once flattened inside the filename. That's what pushed object paths past Windows MAX_PATH.

`test_file` is already relative to `tests/`, so the absolute prefix was pure overhead. Passing it directly collapses the object name to `misc_foo.cpp.obj`. The same applies to the three `test_shared_objs` sources.

## Measured, in a real worktree

Reproduced in a worktree with a 91-character root path:

| | before | after |
|---|---|---|
| longest object path | **289** chars | **237** chars |
| objects with absolute-mangled names | 403 | **0** |

**237 is under MAX_PATH (260)**, so the build no longer depends on the host having long-path support enabled.

That also explains the reporting gap: this machine has `LongPathsEnabled=1` and `core.longpaths=true`, and I confirmed a 289-char object path building fine here. The bug is real, it just needs a host without long-path support — which is the default on Windows.

## Why not the suggested fixes

The issue proposed shortening the worktree path, moving worktrees outside the repo, or requiring long-path setup. None is needed, and each has a cost:

- moving worktrees defeats the isolation the `clud-pr` workflow relies on
- requiring `LongPathsEnabled` pushes per-developer machine setup onto every contributor, and silently doesn't help the ones who skip it

This changes nothing about path layout and requires no machine setup — the encoded name simply stops carrying a path it never needed.

## Validation

- **357/357** on clean builds in **both** the main checkout and a worktree
- `bash lint` green
- Verified `0 of 403` objects still use absolute-mangled names after the change

Repro worktrees were removed afterwards; no leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test build path handling by using relative source paths.
  * Reduced generated object-file path lengths, helping avoid Windows path-length limitations.
* **Tests**
  * Updated shared and per-test build configuration without changing test execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->