### PR TITLE
fix(lint): port the real literal tokenizer to SingletonElisionChecker (#3486)

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
+++ b/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
@@ -23,6 +23,41 @@
 // `fl::detail::singleton_registry` backing itself, ISR-only IRAM handles
 // where the ISR path is invisible to the linker, etc.).
 
+// Recognizes a right-hand side that is a pure compile-time literal, so a
+// `constexpr` bound to it emits no storage and must not be flagged.
+//
+// This is a direct port of `TRIVIAL_RHS_RE` in `ci/scan_singleton_elision.py`
+// (whose docstring declares that scanner mirrors this checker). Do NOT
+// reimplement with `str::parse` — Rust's numeric parsers reject the `0x`/`0b`
+// prefixes AND the C++ `u`/`l`/`f` suffixes, so hex register masks like
+// `constexpr u32 kMask = 0x8000u;` get misreported as non-literal. Keep the
+// two implementations in sync; `test_singleton_elision_rust_python_parity`
+// pins the shared cases.
+fn trivial_rhs_regex() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(concat!(
+            r"^\s*(",
+            r"[-+]?0[xX][0-9a-fA-F]+[uUlL]*",             // hex literal
+            r"|[-+]?0[bB][01]+[uUlL]*",                   // binary literal
+            r"|[-+]?\d+[uUlL]*",                          // int literal
+            r"|[-+]?\d*\.\d+[fF]?",                       // float literal
+            r"|nullptr|NULL|true|false",                  // symbolic constants
+            r#"|"[^"]*""#,                                // string literal
+            r"|'.'",                                      // char literal
+            r"|[A-Z_][A-Z0-9_]*",                         // single all-caps macro
+            r"|\(\s*[-+]?0[xX][0-9a-fA-F]+[uUlL]*\s*<<\s*\d+\s*\)", // (0x1u << N)
+            r"|\(\s*[-+]?\d+[uUlL]*\s*<<\s*\d+\s*\)",     // (1u << N)
+            r")\s*$",
+        ))
+        .expect("trivial-RHS regex must compile")
+    })
+}
+
+fn is_trivial_rhs(rhs: &str) -> bool {
+    trivial_rhs_regex().is_match(rhs)
+}
+
 struct SingletonElisionChecker;
 
 impl FileContentChecker for SingletonElisionChecker {
@@ -272,8 +307,6 @@ impl FileContentChecker for SingletonElisionChecker {
             // Skip `constexpr` when the value is a pure literal (compiler
             // will inline; no storage). Keep the check when it's not
             // literal-shaped since address-taken constexpr still emits.
-            // Simple heuristic: if the RHS after `=` is a simple integer
-            // literal, string literal, or `nullptr`, skip.
             // (We deliberately keep other constexpr in the violation set —
             // author can inspect and move to Singleton<T> or annotate.)
             let is_constexpr = trimmed.starts_with("constexpr ")
@@ -282,14 +315,7 @@ impl FileContentChecker for SingletonElisionChecker {
             if is_constexpr {
                 if let Some(eq_pos) = code.find('=') {
                     let rhs = code[eq_pos + 1..].trim_end_matches(';').trim();
-                    let is_trivial = rhs.parse::<i64>().is_ok()
-                        || rhs.parse::<f64>().is_ok()
-                        || rhs == "nullptr"
-                        || rhs == "true"
-                        || rhs == "false"
-                        || (rhs.starts_with('"') && rhs.ends_with('"'))
-                        || (rhs.starts_with('\'') && rhs.ends_with('\''));
-                    if is_trivial {
+                    if is_trivial_rhs(rhs) {
                         continue;
                     }
                 }

--- a/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
+++ b/ci/lint_cpp_rs/src/checkers/singleton_elision.rs
@@ -30,9 +30,13 @@
 // (whose docstring declares that scanner mirrors this checker). Do NOT
 // reimplement with `str::parse` — Rust's numeric parsers reject the `0x`/`0b`
 // prefixes AND the C++ `u`/`l`/`f` suffixes, so hex register masks like
-// `constexpr u32 kMask = 0x8000u;` get misreported as non-literal. Keep the
-// two implementations in sync; `test_singleton_elision_rust_python_parity`
-// pins the shared cases.
+// `constexpr u32 kMask = 0x8000u;` get misreported as non-literal.
+//
+// Keep this grammar and TRIVIAL_RHS_RE in sync by hand — there is no
+// cross-language parity test. The Rust side is pinned by
+// `singleton_elision_accepts_suffixed_and_prefixed_literals` and
+// `singleton_elision_still_flags_non_literal_constexpr` in
+// lint_core/tests.rs.
 fn trivial_rhs_regex() -> &'static regex::Regex {
     static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
     RE.get_or_init(|| {
@@ -41,7 +45,8 @@ fn trivial_rhs_regex() -> &'static regex::Regex {
             r"[-+]?0[xX][0-9a-fA-F]+[uUlL]*",             // hex literal
             r"|[-+]?0[bB][01]+[uUlL]*",                   // binary literal
             r"|[-+]?\d+[uUlL]*",                          // int literal
-            r"|[-+]?\d*\.\d+[fF]?",                       // float literal
+            // float literal, incl. `10.f`, `1e-6f`, `2.5e3f`, `1.5L`
+            r"|[-+]?(?:\d*\.\d+|\d+\.\d*|\d+)(?:[eE][-+]?\d+)?[fFlL]?",
             r"|nullptr|NULL|true|false",                  // symbolic constants
             r#"|"[^"]*""#,                                // string literal
             r"|'.'",                                      // char literal

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -363,4 +363,95 @@ FL_WARN(\"still checked because remote files are always guarded\");\n",
         assert_eq!(json["line"], 7);
         assert_eq!(json["message"], "example message");
     }
+
+    // ---- SingletonElisionChecker (FastLED#3486) ----
+
+    fn singleton_elision_violations(src: &str) -> Vec<(usize, String)> {
+        SingletonElisionChecker.check_file_content(&file("src/fl/probe.cpp.hpp", src))
+    }
+
+    #[test]
+    fn singleton_elision_accepts_suffixed_and_prefixed_literals() {
+        // Rust's numeric parsers reject BOTH the `0x`/`0b` prefixes and the
+        // C++ `u`/`l`/`f` suffixes, so a parse-based triviality test
+        // misreports register masks as non-literal. Cases mirror
+        // TRIVIAL_RHS_RE in ci/scan_singleton_elision.py.
+        for rhs in [
+            "100.0f", "10000.0f", "64u", "1uLL", "64", "-3",
+            "0x80000000u", "0xFF", "0b1010", "0x8000uL",
+            "nullptr", "NULL", "true", "false",
+            "\"text\"", "'c'", "MAX_LEDS", "(1u << 3)", "(0x1u << 12)",
+        ] {
+            let src = format!("namespace fl {{\nconstexpr auto kX = {rhs};\n}}\n");
+            assert!(
+                singleton_elision_violations(&src).is_empty(),
+                "expected `{rhs}` to be treated as a trivial literal",
+            );
+        }
+    }
+
+    #[test]
+    fn singleton_elision_still_flags_non_literal_constexpr() {
+        // Suffix/prefix tolerance must not swallow real initializers.
+        // Only expression RHS forms are pinned here. `compute()` and
+        // `Table{1, 2, 3}` are deliberately absent: the checker skips lines
+        // containing `(` as probable function declarations, and `{` opens a
+        // brace depth so the decl no longer reads as namespace-scope. Both
+        // predate this change and are not what these cases pin down.
+        for rhs in ["kMin * 2.0f", "kOther + 1", "0xFF + 1"] {
+            let src = format!("namespace fl {{\nconstexpr auto kX = {rhs};\n}}\n");
+            assert_eq!(
+                singleton_elision_violations(&src).len(),
+                1,
+                "expected `{rhs}` to stay flagged",
+            );
+        }
+    }
+
+    #[test]
+    fn singleton_elision_honors_allow_global_marker() {
+        let src = "namespace fl {\n\
+                   // FL_LINT_ALLOW_GLOBAL(deliberate)\n\
+                   static int sCounter = 0;\n\
+                   }\n";
+        assert!(singleton_elision_violations(src).is_empty());
+
+        let unannotated = "namespace fl {\nstatic int sCounter = 0;\n}\n";
+        assert_eq!(singleton_elision_violations(unannotated).len(), 1);
+    }
+
+    #[test]
+    fn singleton_elision_ignores_third_party() {
+        let checker = SingletonElisionChecker;
+        let project_root = std::env::current_dir().unwrap();
+        let project_root = project_root
+            .ancestors()
+            .find(|candidate| candidate.join("src").join("fl").exists())
+            .map(|path| path.to_path_buf())
+            .unwrap_or(project_root);
+
+        let third_party = normalize_path(
+            &project_root
+                .join("src")
+                .join("third_party")
+                .join("vendor.cpp")
+                .to_string_lossy(),
+        );
+        assert!(!checker.should_process_file(&third_party, &project_root));
+
+        let ours = normalize_path(
+            &project_root
+                .join("src")
+                .join("fl")
+                .join("probe.cpp.hpp")
+                .to_string_lossy(),
+        );
+        assert!(checker.should_process_file(&ours, &project_root));
+
+        // Headers are StaticInHeaderChecker's job, not this checker's.
+        let header = normalize_path(
+            &project_root.join("src").join("fl").join("probe.h").to_string_lossy(),
+        );
+        assert!(!checker.should_process_file(&header, &project_root));
+    }
 }

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -381,6 +381,11 @@ FL_WARN(\"still checked because remote files are always guarded\");\n",
             "0x80000000u", "0xFF", "0b1010", "0x8000uL",
             "nullptr", "NULL", "true", "false",
             "\"text\"", "'c'", "MAX_LEDS", "(1u << 3)", "(0x1u << 12)",
+            // Exponent / trailing-dot / long-double float spellings. FastLED
+            // timing and gamma tables use these freely; missing them keeps
+            // the warn-only stream noisy and #3492 (hard-fail at zero)
+            // unreachable.
+            "1e-6f", "2.5e3f", "10.f", "1.5L", "1E9",
         ] {
             let src = format!("namespace fl {{\nconstexpr auto kX = {rhs};\n}}\n");
             assert!(

--- a/ci/scan_singleton_elision.py
+++ b/ci/scan_singleton_elision.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """
 Scan the FastLED tree for namespace-scope variables that should be wrapped
-in `fl::Singleton<T>` for `--gc-sections` elision. Mirrors the logic that
-`ci/lint_cpp_rs/src/checkers/singleton_elision.rs` will implement once the
-Rust linter integration is fully wired.
+in `fl::Singleton<T>` for `--gc-sections` elision.
+
+NOT authoritative. `ci/lint_cpp_rs/src/checkers/singleton_elision.rs` is the
+enforcement path that `bash lint` runs; this is an ad-hoc reporting tool that
+approximates it. The two share the TRIVIAL_RHS_RE literal grammar and the
+FL_LINT_ALLOW_GLOBAL / FL_LINT_ALLOW_GLOBAL_FILE opt-outs, but they still
+report different totals (62 here vs 39 there as of FastLED#3754) because the
+Rust checker carries additional skip heuristics this scanner lacks. Trust the
+Rust checker; use this only for a rough bucketed overview.
 
 Report shape:
   - Per-file violation count (top-N)
@@ -49,7 +55,7 @@ TRIVIAL_RHS_RE = re.compile(
     r"[-+]?0[xX][0-9a-fA-F]+[uUlL]*"  # hex literal
     r"|[-+]?0[bB][01]+[uUlL]*"  # binary literal
     r"|[-+]?\d+[uUlL]*"  # int literal
-    r"|[-+]?\d*\.\d+[fF]?"  # float literal
+    r"|[-+]?(?:\d*\.\d+|\d+\.\d*|\d+)(?:[eE][-+]?\d+)?[fFlL]?"  # float literal (incl. 10.f, 1e-6f, 1.5L)
     r"|nullptr|NULL|true|false"  # symbolic constants
     r"|\".*\""  # string literal
     r"|'.'"  # char literal
@@ -218,12 +224,29 @@ def scan_file(path: Path) -> list[tuple[int, str, str]]:
     except OSError:
         return []
 
+    # File-level opt-out, matching the Rust checker's first-15-lines scan.
+    for line in lines[:15]:
+        if "FL_LINT_ALLOW_GLOBAL_FILE" in line:
+            return []
+
     violations: list[tuple[int, str, str]] = []
     depth = 0
     namespace_stack: list[int] = []  # depths that are inside a `namespace X {`
     in_block_comment = False
+    # `FL_LINT_ALLOW_GLOBAL` is a comment-only marker, so it is invisible
+    # after strip_comments(). Track it off the raw line, and let a
+    # comment-only marker line carry over to the declaration beneath it --
+    # the preferred style, and what the Rust checker accepts.
+    prev_line_had_marker = False
 
     for idx, raw in enumerate(lines):
+        raw_stripped = raw.strip()
+        carry_marker = prev_line_had_marker
+        this_line_marker = "FL_LINT_ALLOW_GLOBAL" in raw
+        prev_line_had_marker = this_line_marker and (
+            raw_stripped.startswith("//") or raw_stripped.startswith("/*")
+        )
+
         code, in_block_comment = strip_comments(raw, in_block_comment)
 
         stripped = code.strip()
@@ -253,6 +276,8 @@ def scan_file(path: Path) -> list[tuple[int, str, str]]:
         # Namespace-scope means line_depth == 0 (TU scope) or line_depth is
         # in namespace_stack (we're inside `namespace X { … }`).
         if line_depth == 0 or line_depth in namespace_stack:
+            if this_line_marker or carry_marker:
+                continue
             is_def, name, type_pretty = looks_like_var_def(code)
             if is_def:
                 violations.append((idx + 1, name, type_pretty))

--- a/src/fl/audio/detector/equalizer.cpp.hpp
+++ b/src/fl/audio/detector/equalizer.cpp.hpp
@@ -14,12 +14,12 @@ namespace {
 // Bass:   bins 0-3   (~90-320 Hz)
 // Mid:    bins 4-10  (~320-2560 Hz)
 // Treble: bins 11-15 (~2560-5120 Hz)
-const int kBassStart = 0;
-const int kBassEnd = 3;
-const int kMidStart = 4;
-const int kMidEnd = 10;
-const int kTrebleStart = 11;
-const int kTrebleEnd = 15;
+constexpr int kBassStart = 0;
+constexpr int kBassEnd = 3;
+constexpr int kMidStart = 4;
+constexpr int kMidEnd = 10;
+constexpr int kTrebleStart = 11;
+constexpr int kTrebleEnd = 15;
 
 /// Apply fft::FFT scaling mode to a single bin value
 inline float applyScaling(float value, FFTScalingMode mode) {

--- a/src/fl/audio/detector/frequency_bands.cpp.hpp
+++ b/src/fl/audio/detector/frequency_bands.cpp.hpp
@@ -8,23 +8,27 @@ namespace fl {
 namespace audio {
 namespace detector {
 
+// Diagnostic FFT counter. Deliberately a plain constant-initialized static,
+// NOT a fl::Singleton -- see the rationale on `sVibeFFTCount` in vibe.cpp.hpp
+// and FastLED#3486.
+// FL_LINT_ALLOW_GLOBAL(constant-initialized POD scalar -- already elidable under -fdata-sections; Singleton wrapping is a net size regression and loses constant-initialization. See FastLED#3486.)
 static int sFrequencyBandsFFTCount = 0;
-int FrequencyBands::getPrivateFFTCount() { return sFrequencyBandsFFTCount; }
-void FrequencyBands::resetPrivateFFTCount() { sFrequencyBandsFFTCount = 0; }
+int FrequencyBands::getPrivateFFTCount() FL_NO_EXCEPT { return sFrequencyBandsFFTCount; }
+void FrequencyBands::resetPrivateFFTCount() FL_NO_EXCEPT { sFrequencyBandsFFTCount = 0; }
 
 namespace {
 // Number of fft::FFT bins — higher count gives better frequency resolution
 // and cleaner band separation. With 64 bins, the CQ kernel provides
 // good frequency isolation for all three bands (bass, mid, treble).
-const int kNumBands = 64;
+constexpr int kNumBands = 64;
 
 // fft::FFT frequency range covering bass through treble.
 // Range [100, 10000] covers the bass (20-250), mid (250-4000), and treble
 // (4000-20000) ranges with good CQ kernel resolution. The ratio of 100x
 // keeps the highest-frequency kernel window large enough for the 512-sample
 // fft::FFT (N_window = 512 / (10000/100) = 5 samples minimum).
-const float kFFTMinFreq = 100.0f;
-const float kFFTMaxFreq = 10000.0f;
+constexpr float kFFTMinFreq = 100.0f;
+constexpr float kFFTMaxFreq = 10000.0f;
 
 } // namespace
 

--- a/src/fl/audio/detector/frequency_bands.h
+++ b/src/fl/audio/detector/frequency_bands.h
@@ -50,8 +50,8 @@ public:
     int getSampleRate() const { return mSampleRate; }
 
     // Diagnostic counters
-    static int getPrivateFFTCount();
-    static void resetPrivateFFTCount();
+    static int getPrivateFFTCount() FL_NO_EXCEPT;
+    static void resetPrivateFFTCount() FL_NO_EXCEPT;
 
 private:
     int mSampleRate = 44100;

--- a/src/fl/audio/detector/vibe.cpp.hpp
+++ b/src/fl/audio/detector/vibe.cpp.hpp
@@ -16,9 +16,18 @@ namespace fl {
 namespace audio {
 namespace detector {
 
+// Diagnostic FFT counter. Deliberately a plain constant-initialized static,
+// NOT a fl::Singleton -- see FastLED#3486. Builds pass -fdata-sections
+// (ci/boards.py), so this lands in its own `.bss` section and --gc-sections
+// already drops it in sketches that never link Vibe. Wrapping it in a
+// Singleton would add a second word for the instance pointer, a lazy-init
+// branch at every access, and -- because Singleton<T>::instance() hand-rolls
+// `if (!ptr)` instead of using a magic static -- an init race between the
+// audio task and loop() on multi-core targets.
+// FL_LINT_ALLOW_GLOBAL(constant-initialized POD scalar -- already elidable under -fdata-sections; Singleton wrapping is a net size regression and loses constant-initialization. See FastLED#3486.)
 static int sVibeFFTCount = 0;
-int Vibe::getPrivateFFTCount() { return sVibeFFTCount; }
-void Vibe::resetPrivateFFTCount() { sVibeFFTCount = 0; }
+int Vibe::getPrivateFFTCount() FL_NO_EXCEPT { return sVibeFFTCount; }
+void Vibe::resetPrivateFFTCount() FL_NO_EXCEPT { sVibeFFTCount = 0; }
 
 
 Vibe::Vibe() {

--- a/tests/fl/audio/detector/frequency_bands.hpp
+++ b/tests/fl/audio/detector/frequency_bands.hpp
@@ -208,3 +208,24 @@ FL_TEST_CASE("audio::detector::FrequencyBands - tone sweep normalized levels tra
     FL_CHECK_LT(midMaxDelta, 0.5f);
     FL_CHECK_LT(trebMaxDelta, 0.5f);
 }
+
+FL_TEST_CASE("audio::detector::FrequencyBands - private FFT counter tracks updates") {
+    // Coverage for the diagnostic counter API, which had none. Delta form:
+    // the counter is process-wide and this header is linked into a DLL
+    // alongside the other detector suites. See FastLED#3486.
+    audio::detector::FrequencyBands::resetPrivateFFTCount();
+    FL_CHECK_EQ(audio::detector::FrequencyBands::getPrivateFFTCount(), 0);
+
+    audio::detector::FrequencyBands detector;
+    const int before = audio::detector::FrequencyBands::getPrivateFFTCount();
+    for (int i = 0; i < 4; ++i) {
+        auto sample = makeSample(440.0f, i * 12, 16000.0f);
+        auto ctx = fl::make_shared<audio::Context>(sample);
+        ctx->setSampleRate(44100);
+        detector.update(ctx);
+    }
+    FL_CHECK_EQ(audio::detector::FrequencyBands::getPrivateFFTCount(), before + 4);
+
+    audio::detector::FrequencyBands::resetPrivateFFTCount();
+    FL_CHECK_EQ(audio::detector::FrequencyBands::getPrivateFFTCount(), 0);
+}

--- a/tests/fl/audio/detector/vibe.hpp
+++ b/tests/fl/audio/detector/vibe.hpp
@@ -1129,3 +1129,23 @@ FL_TEST_CASE("audio::detector::Vibe - silence-to-audio transition snaps back (no
     // bass should exceed 1.0 — no attack lag from the envelope.
     FL_CHECK_GT(detector.getBass(), 0.5f);
 }
+
+FL_TEST_CASE("audio::detector::Vibe - private FFT counter tracks updates") {
+    // Coverage for the diagnostic counter API, which had none. Guards the
+    // reset/increment/read contract so a future storage change (FastLED#3486
+    // considered and rejected a fl::Singleton wrap) cannot silently break it.
+    //
+    // Delta form on purpose: the counter is process-wide and this header is
+    // linked into a DLL alongside the other detector suites, so an absolute
+    // total is not stable against unrelated test cases.
+    audio::detector::Vibe::resetPrivateFFTCount();
+    FL_CHECK_EQ(audio::detector::Vibe::getPrivateFFTCount(), 0);
+
+    audio::detector::Vibe detector;
+    const int before = audio::detector::Vibe::getPrivateFFTCount();
+    feedFrames(detector, 3, 440.0f);
+    FL_CHECK_EQ(audio::detector::Vibe::getPrivateFFTCount(), before + 3);
+
+    audio::detector::Vibe::resetPrivateFFTCount();
+    FL_CHECK_EQ(audio::detector::Vibe::getPrivateFFTCount(), 0);
+}


### PR DESCRIPTION
Investigating #3486 (migrate `fl/audio/detector` state to `fl::Singleton`) showed that **all 11 flagged sites in that directory were false positives**. So this fixes the checker rather than performing the migration.

## Why the migration was not performed

I implemented it first, then measured it. It is a regression on every axis it claims to improve:

- **Zero elision gained.** Builds already pass `-ffunction-sections -fdata-sections` (`ci/boards.py:795`). A file-scope `static int` therefore lands in its own `.bss` section, and `--gc-sections` already drops it in sketches that never link the detector.
- **Strictly larger when the detector *is* used.** Storage grows from one 4-byte object to aligned storage **plus** a `T*` (8-12 B), and each access site gains a null-check plus a cold placement-new tail — roughly +100-140 B flash on Thumb-2 `-Os` across the six sites.
- **Introduces an init data race.** `Singleton<T>::instance()` hand-rolls `if (!ptr) { ptr = new (&storage) T(); }`, bypassing the C++11 magic-static guard. The old constant-initialized static had no init window at all. On ESP32 the audio task calling `Vibe::update()` and `loop()` calling `getPrivateFFTCount()` can both first-touch, both placement-new, and the second construction silently re-zeroes the counter.

The two diagnostic counters therefore stay plain statics, now carrying `FL_LINT_ALLOW_GLOBAL` with that rationale inline.

## The actual defect

The checker's `constexpr`-triviality test used `str::parse`. Rust's numeric parsers reject **both** the `0x`/`0b` prefixes and the C++ `u`/`l`/`f` suffixes, so ordinary constants were misreported as non-literal and flagged.

`ci/scan_singleton_elision.py` already contained a correct tokenizer (`TRIVIAL_RHS_RE`), and its docstring states it mirrors this checker — so this ports that regex over instead of re-deriving one.

Tree-wide violations drop **76 -> 39**, entirely by removing false positives. `src/platforms/arm/lpc/rx_sct_capture.cpp.hpp` alone had 41 hex register masks flagged and is now clean — those are exactly the driver files the checker's own header comment says it was written for.

## Also in this PR

- `const` -> `constexpr` for the nine compile-time constants in `equalizer.cpp.hpp` / `frequency_bands.cpp.hpp`. No size change (they were already folded); this just states the intent.
- `FL_NO_EXCEPT` on the four diagnostic accessors — fixes a decl/def mismatch in `vibe.h` and satisfies `NoexceptAstChecker`. `FL_NO_EXCEPT` is a documented no-op, so this is cosmetic.
- **First tests for this checker** (it had none): 4 cases in `lint_core/tests.rs`, the home `agents/docs/linter-architecture.md:109` prescribes, using its `file()` helper so paths get `normalize_path`. Covers the literal grammar, the allow-marker, and the `third_party`/header exclusions.
- **First coverage** for `getPrivateFFTCount`/`resetPrivateFFTCount`. Delta form on purpose — the counter is process-wide and these headers link into a shared DLL alongside the other detector suites.

## Verification

- `bash test --cpp --clean` — 357/357 pass
- `bash lint` — exit 0
- Rust checker unit tests — 4/4 pass
- Both new C++ tests mutation-checked (wrong expected value → they fail), because `bash test --cpp audio` builds `fl_audio` while these compile into `fl_audio_detector_vibe` / `fl_audio_detectors`.

## Notes for the reviewer

- **#3486 should not be closed as "migrated."** The finding generalizes: Singleton elision pays off for objects with *dynamic initialization* (whose `.init_array` entries resist gc), not for constant-initialized PODs. Several sibling issues under #3481 target trivial scalars and likely warrant the same re-scoping. I did not change the checker's policy on those unilaterally.
- **Pre-existing, not fixed here:** the Rust lint test suite fails `rust_lint_source_files_stay_under_one_thousand_lines` because `checkers/unity_build.rs` is 1205 lines. It is 1205 on `master` too.
- **Pre-existing latent bug, not fixed here:** `FrequencyBands::update()` dereferences `context` with no null check, while the sibling `Vibe::update()` guards with `if (!context) return;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of trivial compile-time constants across more numeric, symbolic, string, character, and shift-expression formats.
  - Added support for file- and comment-based lint exclusions.
  - Clarified which scanner provides authoritative lint results.

- **Refactor**
  - Converted audio detector configuration values to compile-time constants.
  - Strengthened diagnostic counter APIs for reliable non-throwing behavior.

- **Tests**
  - Expanded lint coverage for literal handling, exclusions, and file scoping.
  - Added coverage confirming FFT diagnostic counters increment and reset correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->