### PR TITLE
singleton: sweep the safe <=2-hit files (Tier 1e, #3488)

### DIFF
--- a/src/fl/sensors/pir.cpp.hpp
+++ b/src/fl/sensors/pir.cpp.hpp
@@ -8,22 +8,29 @@
 #include "fl/stl/strstream.h"
 #include "fl/log/log.h"
 #include "fl/stl/assert.h"
+#include "fl/stl/singleton.h"
 #include "fl/sensors/pir.h"
 
 namespace fl {
 
 namespace {
-int g_counter = 0;
+// Auto-naming counter for unnamed PIR buttons. Behind Singleton<T> so
+// --gc-sections can drop the storage with the accessor when a sketch never
+// constructs a PIR (FastLED#3488).
+struct PirNameCounter {
+    int value = 0;
+};
+
 string getButtonName(const char *button_name) {
     if (button_name) {
         return string(button_name);
     }
-    int count = g_counter++;
+    int count = fl::Singleton<PirNameCounter>::instance().value++;
     if (count == 0) {
         return string("PIR");
     }
     sstream s;
-    s << "PirLowLevel " << g_counter++;
+    s << "PirLowLevel " << fl::Singleton<PirNameCounter>::instance().value++;
     return s.str();
 }
 } // namespace

--- a/src/fl/test/fltest.cpp.hpp
+++ b/src/fl/test/fltest.cpp.hpp
@@ -5,6 +5,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/stdio.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 
 namespace fl {
 namespace test {
@@ -227,9 +228,17 @@ bool TestContext::matchesFilter(const char* name, const char* filter) const FL_N
 }
 
 // Skip test support - global state
-// Thread-local would be ideal, but for embedded compatibility we use a global
-static bool sCurrentTestSkipped = false;
-static const char* sSkipReason = nullptr;
+// Thread-local would be ideal, but for embedded compatibility we use a global.
+// Held behind Singleton<T> rather than as namespace-scope variables so
+// --gc-sections can drop the storage with its accessor (FastLED#3488).
+struct SkipState {
+    bool skipped = false;
+    const char* reason = nullptr;
+};
+
+static SkipState& skipState() FL_NO_EXCEPT {
+    return fl::Singleton<SkipState>::instance();
+}
 
 void TestContext::runTestCase(const TestCaseInfo& info) FL_NO_EXCEPT {
     mStats.mTestCasesRun++;
@@ -246,7 +255,7 @@ void TestContext::runTestCase(const TestCaseInfo& info) FL_NO_EXCEPT {
     mShouldReenter = true;
 
     // Reset skip flag for this test
-    sCurrentTestSkipped = false;
+    skipState().skipped = false;
 
     // Record test start time if we have a time function
     if (mGetMillis) {
@@ -255,7 +264,7 @@ void TestContext::runTestCase(const TestCaseInfo& info) FL_NO_EXCEPT {
 
     // Run the test multiple times to explore all subcase paths
     // On each run, we follow the path in mNextSubcaseStack and then discover one new subcase
-    while (mShouldReenter && !mCurrentTestTimedOut && !sCurrentTestSkipped) {
+    while (mShouldReenter && !mCurrentTestTimedOut && !skipState().skipped) {
         mShouldReenter = false;
         mCurrentSubcaseDepth = 0;
         mSubcaseDiscoveryDepth = 0;
@@ -268,7 +277,7 @@ void TestContext::runTestCase(const TestCaseInfo& info) FL_NO_EXCEPT {
         info.mFunc();
 
         // Check for skip (FL_SKIP was called)
-        if (sCurrentTestSkipped) {
+        if (skipState().skipped) {
             break;
         }
 
@@ -287,7 +296,7 @@ void TestContext::runTestCase(const TestCaseInfo& info) FL_NO_EXCEPT {
         mStats.mTotalDurationMs += testDurationMs;
     }
 
-    if (sCurrentTestSkipped) {
+    if (skipState().skipped) {
         mStats.mTestCasesSkipped++;
         mReporter->testCaseEnd(true, testDurationMs);  // Skipped tests count as "not failed"
     } else if (mCurrentTestFailed || mCurrentTestTimedOut) {
@@ -483,16 +492,16 @@ void fail(const char* msg, const char* file, int line, bool isFatal) FL_NO_EXCEP
 // Skip test support functions
 // =============================================================================
 
-// Note: sCurrentTestSkipped and sSkipReason are defined above runTestCase()
+// Note: the skip state singleton is defined above runTestCase()
 
 void skipTest(const char* reason, const char* file, int line) FL_NO_EXCEPT {
-    sCurrentTestSkipped = true;
-    sSkipReason = reason;
+    skipState().skipped = true;
+    skipState().reason = reason;
     fl::printf("  [SKIPPED] %s:%d: %s\n", file, line, reason);
 }
 
 bool isTestSkipped() FL_NO_EXCEPT {
-    return sCurrentTestSkipped;
+    return skipState().skipped;
 }
 
 // =============================================================================

--- a/src/platforms/shared/coroutine_context.cpp.hpp
+++ b/src/platforms/shared/coroutine_context.cpp.hpp
@@ -17,34 +17,39 @@ namespace fl {
 namespace platforms {
 
 //=============================================================================
-// ICoroutinePlatform singleton — settable, defaults to NullCoroutinePlatform
-//=============================================================================
-
-static ICoroutinePlatform* sCoroutinePlatformInstance = nullptr;
-
-ICoroutinePlatform& ICoroutinePlatform::instance() FL_NO_EXCEPT {
-    if (sCoroutinePlatformInstance) {
-        return *sCoroutinePlatformInstance;
-    }
-    return fl::Singleton<NullCoroutinePlatform>::instance();
-}
-
-void ICoroutinePlatform::setInstance(ICoroutinePlatform* p) FL_NO_EXCEPT {
-    sCoroutinePlatformInstance = p;
-}
-
-//=============================================================================
 // Global coroutine state
 //=============================================================================
 
-/// @brief Global coroutine state — runner context and current coroutine pointer.
+/// @brief Global coroutine state — registered platform, runner context, and
+/// current coroutine pointer.
+///
+/// Held behind Singleton<T> rather than as namespace-scope variables so
+/// --gc-sections can drop the storage together with the accessor when a
+/// sketch never touches coroutines (FastLED#3488).
 struct CoroutineGlobals {
+    ICoroutinePlatform* platform = nullptr; ///< Registered platform, if any
     void* runner_ctx = nullptr;        ///< Platform handle for runner (main thread)
     CoroutineContext* current = nullptr; ///< Currently executing coroutine
 };
 
 static CoroutineGlobals& globals() FL_NO_EXCEPT {
     return fl::Singleton<CoroutineGlobals>::instance();
+}
+
+//=============================================================================
+// ICoroutinePlatform singleton — settable, defaults to NullCoroutinePlatform
+//=============================================================================
+
+ICoroutinePlatform& ICoroutinePlatform::instance() FL_NO_EXCEPT {
+    ICoroutinePlatform* registered = globals().platform;
+    if (registered) {
+        return *registered;
+    }
+    return fl::Singleton<NullCoroutinePlatform>::instance();
+}
+
+void ICoroutinePlatform::setInstance(ICoroutinePlatform* p) FL_NO_EXCEPT {
+    globals().platform = p;
 }
 
 /// @brief Lazy-init the runner's platform context (created on first use)

--- a/src/platforms/wasm/audio_input_wasm.cpp.hpp
+++ b/src/platforms/wasm/audio_input_wasm.cpp.hpp
@@ -8,6 +8,7 @@
 #include "fl/log/log.h"
 #include "fl/log/log.h"
 #include "fl/stl/stdio.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/string.h"
 // IWYU pragma: begin_keep
 #include <emscripten.h>
@@ -16,8 +17,15 @@
 
 namespace fl {
 
-// Global instance pointer for C callback
-static WasmAudioInput* g_wasmAudioInput = nullptr;
+// Global instance pointer for the JS -> C callback. Held behind
+// Singleton<T> rather than as a namespace-scope variable so --gc-sections
+// can drop the storage with its accessor when a sketch never creates a
+// WasmAudioInput (FastLED#3488).
+namespace {
+struct WasmAudioInputHolder {
+    WasmAudioInput* ptr = nullptr;
+};
+}  // namespace
 
 WasmAudioInput::WasmAudioInput()
     : mHead(0)
@@ -34,15 +42,16 @@ WasmAudioInput::WasmAudioInput()
     }
 
     // Set global instance for C callback
-    g_wasmAudioInput = this;
+    fl::Singleton<WasmAudioInputHolder>::instance().ptr = this;
 
     FL_DBG_F("WasmAudioInput created - ring buffer: %s slots x %s samples", RING_BUFFER_SLOTS, BLOCK_SIZE);
 }
 
 WasmAudioInput::~WasmAudioInput() {
     stop();
-    if (g_wasmAudioInput == this) {
-        g_wasmAudioInput = nullptr;
+    WasmAudioInputHolder& holder = fl::Singleton<WasmAudioInputHolder>::instance();
+    if (holder.ptr == this) {
+        holder.ptr = nullptr;
     }
 }
 
@@ -196,7 +205,7 @@ fl::shared_ptr<audio::IInput> wasm_create_audio_input(const audio::Config& confi
 }
 
 WasmAudioInput* wasm_get_audio_input() {
-    return g_wasmAudioInput;
+    return fl::Singleton<WasmAudioInputHolder>::instance().ptr;
 }
 
 } // namespace fl
@@ -214,7 +223,8 @@ extern "C" {
  */
 EMSCRIPTEN_KEEPALIVE
 void pushAudioSamples(const fl::i16* samples, int count, fl::u32 timestamp) {
-    if (!fl::g_wasmAudioInput) {
+    fl::WasmAudioInput* input = fl::wasm_get_audio_input();
+    if (!input) {
         static bool warned = false;
         if (!warned) {
             warned = true;
@@ -229,7 +239,7 @@ void pushAudioSamples(const fl::i16* samples, int count, fl::u32 timestamp) {
         return;
     }
 
-    fl::g_wasmAudioInput->pushSamples(samples, count, timestamp);
+    input->pushSamples(samples, count, timestamp);
 }
 
 } // extern "C"


### PR DESCRIPTION
Part of #3481. Addresses the **safe portion** of #3488 — deliberately not all of it, see below.

Moves five namespace-scope variables behind `Singleton<T>` so `--gc-sections` can drop the storage together with its accessor when a sketch never reaches the code.

| File | Variable(s) |
|---|---|
| `fl/test/fltest.cpp.hpp` | `sCurrentTestSkipped` + `sSkipReason` → `SkipState` |
| `fl/sensors/pir.cpp.hpp` | `g_counter` → `PirNameCounter` |
| `platforms/wasm/audio_input_wasm.cpp.hpp` | `g_wasmAudioInput` → holder |
| `platforms/shared/coroutine_context.cpp.hpp` | `sCoroutinePlatformInstance` folded into the `CoroutineGlobals` singleton **already in that file**, rather than adding a second one |

**SingletonElisionChecker: 39 → 34.**

## Two behaviour notes

- `pir.cpp.hpp` increments the counter at **two** sites, the second reachable only when the first returned non-zero. Both now hit the same singleton field, so the existing (slightly odd) numbering is preserved exactly rather than quietly normalised.
- `audio_input_wasm.cpp.hpp` had its `extern "C"` JS callback reaching directly at `fl::g_wasmAudioInput` even though `fl::wasm_get_audio_input()` already existed. The callback now goes through that accessor.

## Deliberately NOT migrated

These are the rest of the ≤2-hit set. Each is a worse candidate than it looks, and the reason matters: `Singleton<T>::instance()` lazily constructs behind an `if (!ptr)` check, so it is **not free and not ISR-safe**.

- **`platform_time_lpc.cpp.hpp`** — `g_millis` is `volatile` and written by the **SysTick ISR**; `g_systick_started` likewise. Routing an ISR-updated counter through a lazily-constructing accessor adds a branch and a construction race. Belongs to the ISR tier (#3491).
- **`avr/attiny/clockless_blocking.cpp.hpp`** — `gTimeErrorAccum256ths` sits in an ATtiny bit-banging path where the extra indirection risks the very timing the file exists to hold.
- **`gpio_isr_rx/mcpwm_timer.cpp.hpp`** — `MCPWM_TIMER_TAG` is a `const char*` log tag. That's constant-splitting work (**#3483**), not `Singleton` work.
- **`FastLED.cpp.hpp`** — `pSmartMatrix` is public API surface, explicitly out of scope per the issue.
- **`asio/http/server.cpp.hpp`** — `s_esp_request_queue` / `s_esp_httpd` are FreeRTOS handles touched from the httpd task; same safety question as the LPC pair.

I'd rather leave #3488 partially open with these documented than migrate them and introduce an ISR race to close a lint count.

## Validation

- **357/357** on a clean build. Worth noting the `fltest.cpp.hpp` change is to the **test framework itself**, so the suite exercises the reset and read paths on all 357 cases.
- **wasm compile clean**, with an `#error` negative control confirming `audio_input_wasm.cpp.hpp` is actually *in* that build (2 hits) — a green compile of a file that isn't compiled proves nothing.
- `bash lint` green.

**Not covered:** `skipTest()`'s write path. The `FL_SKIP` test that would exercise it is `#if 0` upstream, so those two assignments are compiled but never executed by CI. I left it disabled rather than flipping it on, since the surrounding comment says enabling it perturbs suite results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PIR sensor naming across repeated initialization.
  * Stabilized test skipping and result tracking.
  * Improved coroutine platform registration and fallback behavior.
  * Improved WASM audio input instance handling, including safe cleanup and sample delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->