### PR TITLE
fix(esp32): make MCPWM_TIMER_TAG a compile-time constant (#3483)

### DIFF
--- a/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/mcpwm_timer.cpp.hpp
@@ -73,7 +73,10 @@ using fl::u32;
 // Constants
 // ============================================================================
 
-static const char* MCPWM_TIMER_TAG = "mcpwm_timer";
+// constexpr, not `const char*`: the latter is a mutable pointer that occupies
+// storage of its own on top of the string literal. As a compile-time constant
+// it emits nothing unless its address is taken (FastLED#3483).
+static constexpr const char* MCPWM_TIMER_TAG = "mcpwm_timer";
 
 // MCPWM configuration
 #define MCPWM_GROUP_ID 0


### PR DESCRIPTION
Closes out the last remaining item of #3483.

## The change

`static const char* MCPWM_TIMER_TAG` is a **mutable pointer** — it occupies storage of its own in addition to the string literal it points at. As `static constexpr const char*` it emits nothing unless its address is taken.

Verified safe: the tag is only ever *read*, as the first argument to `ESP_LOGE`/`ESP_LOGI`/`ESP_LOGW`. There is no assignment to it anywhere in the file, so nothing depended on the pointer being mutable.

## Most of #3483 was already done

The issue was filed against ~30 integer constants. **None of its cited examples still appear** in `fastled-lint --checker singleton_elision` on master:

| Cited file | Cited hits | Actual now |
|---|---|---|
| `channel_manager_esp32.cpp.hpp` (`PRIORITY_FORCE` etc.) | 14 | **0** |
| `equalizer.cpp.hpp` (`kBassStart`, `kBassEnd`) | 6 | **0** |

The original count came from `ci/scan_singleton_elision.py`, which still reports 101 where the Rust checker reports 34. That gap is mostly #3754's real literal tokenizer removing false positives — so 34 is the truer number, and the constant-splitting work has largely already happened. Full accounting is in [the issue comment](https://github.com/FastLED/FastLED/issues/3483).

## One thing I deliberately did NOT do

`objectfled_spi_mode.cpp.hpp:100` is still flagged:

```cpp
static constexpr u32 kSpiMaxOutputWords = kSpiMaxInputBytes * kSpiWordsPerByte;
```

It is **already `static constexpr`** — already what a "split constants out" fix would produce. It's flagged only because the triviality test accepts a *literal* RHS but not one computed from other constants.

This blocks **#3492** (promote to hard-fail at zero): the finding can't be driven to zero, because "wrap in `fl::Singleton<T>`" is not meaningful advice for a compile-time scalar.

I prototyped skipping `constexpr` **scalars** while keeping `constexpr` **tables** flagged (an array is far more likely to be ODR-used through a pointer, and then really does occupy flash) — then **reverted it**. `singleton_elision_still_flags_non_literal_constexpr` in `lint_core/tests.rs` deliberately pins the current behaviour for exactly those RHS forms, added under #3486. That's a documented decision, so I raised it on the issue rather than flipping it unilaterally.

## Validation

- 357/357 host tests, `bash lint` green
- Checker no longer reports `MCPWM_TIMER_TAG`
- **Not yet locally confirmed:** this is ESP-only code, so the 357 host tests do not
  exercise it. A local `esp32dev` compile was still running when this was opened, so
  I am relying on CI's ESP32 job for that leg rather than claiming a green build I
  have not seen. The change is a `const char*` -> `constexpr const char*` on a symbol
  that is only ever read, so the risk surface is a reassignment somewhere -- and I
  grepped: there is none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
