### PR TITLE
fix(autoresearch): stream fbuild deploy output instead of buffering it (#3441)

### DIFF
--- a/ci/tests/test_fbuild_deploy_streaming.py
+++ b/ci/tests/test_fbuild_deploy_streaming.py
@@ -1,0 +1,221 @@
+"""Regression tests for streaming fbuild deploy output (FastLED#3441).
+
+Before this, run_fbuild_deploy() used subprocess.run(stdout=PIPE) and printed
+everything only after the child exited, so a multi-minute board build looked
+stalled and a failing build hid its error until the wait was over.
+
+The interesting property is not "the output eventually appears" -- the buffered
+version did that too. It is that a line becomes visible BEFORE the process
+exits. These tests assert that directly, by having the fake fbuild block on a
+sentinel file until the test observes its first line.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import IO, Any
+
+import pytest
+
+from ci.util import fbuild_runner
+
+
+class _RecordingSink:
+    """Output sink that timestamps every write, so ordering is checkable."""
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[float, str]] = []
+        self._lock = threading.Lock()
+
+    def write(self, text: str) -> int:
+        if text.strip():
+            with self._lock:
+                self.lines.append((time.monotonic(), text.strip()))
+        return len(text)
+
+    def flush(self) -> None:  # pragma: no cover - required by the IO protocol
+        pass
+
+    def texts(self) -> list[str]:
+        with self._lock:
+            return [line for _, line in self.lines]
+
+    def first_time_containing(self, needle: str) -> float | None:
+        with self._lock:
+            for stamp, line in self.lines:
+                if needle in line:
+                    return stamp
+        return None
+
+
+def _install_fake_fbuild(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    script_body: str,
+    sink: _RecordingSink,
+) -> Path:
+    """Point run_fbuild_deploy at a fake fbuild that runs `script_body`."""
+    script = tmp_path / "fake_fbuild.py"
+    script.write_text(script_body, encoding="utf-8")
+
+    # The real code builds argv as [fbuild_exe, build_dir, "deploy", ...]. Using
+    # the interpreter as the executable and the script as the first arg keeps
+    # that shape intact while running our fake.
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: sys.executable)
+
+    real_ctor = fbuild_runner.RunningProcess
+
+    def patched(command: Any, *args: Any, **kwargs: Any) -> Any:
+        # command == [python, <build_dir>, "deploy", "-e", env, ...]
+        # Replace the positional build_dir with our script path.
+        cmd = list(command)
+        cmd[1] = str(script)
+        return real_ctor(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(fbuild_runner, "RunningProcess", patched)
+    monkeypatch.setattr(fbuild_runner, "_get_output", lambda quiet, log_file: sink)
+    return script
+
+
+def test_deploy_output_is_visible_before_process_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The core guarantee: a line surfaces while the child is still running."""
+    gate = tmp_path / "gate"
+    sink = _RecordingSink()
+    _install_fake_fbuild(
+        monkeypatch,
+        tmp_path,
+        script_body=(
+            "import sys, time, pathlib\n"
+            "print('COMPILING early-line', flush=True)\n"
+            f"gate = pathlib.Path(r'{gate}')\n"
+            # Block until the test confirms it already saw the first line.
+            "for _ in range(600):\n"
+            "    if gate.exists():\n"
+            "        break\n"
+            "    time.sleep(0.05)\n"
+            "print('DONE late-line', flush=True)\n"
+        ),
+        sink=sink,
+    )
+
+    result_box: dict[str, Any] = {}
+
+    def run() -> None:
+        result_box["result"] = fbuild_runner.run_fbuild_deploy(
+            build_dir=tmp_path, environment="esp32s3", timeout=60
+        )
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+
+    # Wait for the early line WITHOUT letting the child finish. If output were
+    # still buffered until exit, this would time out -- the child cannot exit
+    # until we touch the gate, which we have not done yet.
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        if sink.first_time_containing("early-line") is not None:
+            break
+        time.sleep(0.05)
+
+    saw_early = sink.first_time_containing("early-line")
+    assert saw_early is not None, (
+        "no output surfaced while the child was still running -- "
+        f"output was buffered. Sink contained: {sink.texts()}"
+    )
+    assert sink.first_time_containing("late-line") is None, (
+        "the child should still be blocked on the gate at this point"
+    )
+
+    gate.write_text("go", encoding="utf-8")
+    worker.join(timeout=30)
+    assert not worker.is_alive(), "run_fbuild_deploy did not return"
+
+    result = result_box["result"]
+    assert result.success is True
+    # Accumulated output is still preserved for logs/diagnostics.
+    assert "early-line" in result.output
+    assert "late-line" in result.output
+
+
+def test_deploy_parses_port_marker_from_streamed_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """FBUILD_DEPLOY_PORT= is still picked up when parsed line-by-line."""
+    sink = _RecordingSink()
+    _install_fake_fbuild(
+        monkeypatch,
+        tmp_path,
+        script_body=(
+            "print('starting', flush=True)\n"
+            "print('FBUILD_DEPLOY_PORT=COM42 extra', flush=True)\n"
+            "print('finished', flush=True)\n"
+        ),
+        sink=sink,
+    )
+
+    result = fbuild_runner.run_fbuild_deploy(
+        build_dir=tmp_path, environment="esp32s3", timeout=60
+    )
+    assert result.success is True
+    assert result.port == "COM42"
+
+
+def test_deploy_reports_failure_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failing build still reports failure, and its output is retained."""
+    sink = _RecordingSink()
+    _install_fake_fbuild(
+        monkeypatch,
+        tmp_path,
+        script_body=(
+            "import sys\n"
+            "print('error: undefined reference to foo', flush=True)\n"
+            "sys.exit(3)\n"
+        ),
+        sink=sink,
+    )
+
+    result = fbuild_runner.run_fbuild_deploy(
+        build_dir=tmp_path, environment="esp32s3", timeout=60
+    )
+    assert result.success is False
+    assert result.returncode == 3
+    assert "undefined reference" in result.output
+
+
+def test_deploy_writes_to_log_file_in_quiet_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Quiet mode routes the streamed lines to log_file, not stdout."""
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: sys.executable)
+    script = tmp_path / "fake_fbuild.py"
+    script.write_text("print('quiet-mode-line', flush=True)\n", encoding="utf-8")
+
+    real_ctor = fbuild_runner.RunningProcess
+
+    def patched(command: Any, *args: Any, **kwargs: Any) -> Any:
+        cmd = list(command)
+        cmd[1] = str(script)
+        return real_ctor(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(fbuild_runner, "RunningProcess", patched)
+
+    log_path = tmp_path / "deploy.log"
+    with open(log_path, "w", encoding="utf-8") as handle:
+        log_io: IO[str] = handle
+        result = fbuild_runner.run_fbuild_deploy(
+            build_dir=tmp_path,
+            environment="esp32s3",
+            timeout=60,
+            quiet=True,
+            log_file=log_io,
+        )
+
+    assert result.success is True
+    assert "quiet-mode-line" in log_path.read_text(encoding="utf-8")

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import IO, Any, cast
 
 from fbuild import Daemon, connect_daemon
+from running_process import EndOfStream, RunningProcess
 from typeguard import typechecked
 
 from ci.util.cpu_count import cpu_count
@@ -133,6 +134,25 @@ def fbuild_subprocess_env() -> dict[str, str]:
 def ensure_fbuild_daemon() -> None:
     """Ensure the fbuild daemon is running."""
     Daemon.ensure_running()
+
+
+def _kill_quietly(proc: Any) -> None:
+    """Best-effort kill of a RunningProcess, ignoring teardown failures.
+
+    Used on the timeout and interrupt paths: subprocess.run() reaped the child
+    for us, RunningProcess does not, and a still-running board build keeps the
+    fbuild daemon lock held after this function returns (FastLED#3441).
+    """
+    if proc is None:
+        return
+    try:
+        proc.kill()
+    except (OSError, RuntimeError, ValueError):
+        # Already exited, never started, or the handle is gone -- all fine, the
+        # goal is just "not still running". Deliberately NOT a blanket
+        # `except Exception`: a KeyboardInterrupt arriving during teardown must
+        # keep propagating to the caller's handler.
+        pass
 
 
 def _get_output(quiet: bool, log_file: IO[str] | None) -> IO[str]:
@@ -696,27 +716,51 @@ def run_fbuild_deploy(
     try:
         print(f"Running: {subprocess.list2cmdline(cmd)}", file=out)
         print(file=out)
-        proc = subprocess.run(
+        # Stream fbuild's output line-by-line instead of buffering it until the
+        # process exits (FastLED#3441). A board build can run for minutes, and
+        # with subprocess.run(stdout=PIPE) none of the compile progress -- or
+        # the actual failure, for a failing build -- appeared until after the
+        # wait. `out` is already the quiet/log_file-aware sink from
+        # _get_output(), so writing lines to it preserves both destinations.
+        #
+        # RunningProcess is the repo's standard streaming runner (see
+        # ci/compiler/pio.py); it also gives us the timeout and interrupt
+        # handling this function relied on subprocess.run for.
+        proc = RunningProcess(
             cmd,
             timeout=int(timeout),
             env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
             check=False,
+            auto_run=True,
         )
-        if proc.stdout:
-            print(proc.stdout, file=out, end="")
-        returncode = proc.returncode
-        success = returncode == 0
+        collected: list[str] = []
         returned_port: str | None = None
-        for line in proc.stdout.splitlines() if proc.stdout else []:
-            marker = "FBUILD_DEPLOY_PORT="
+        marker = "FBUILD_DEPLOY_PORT="
+        while (raw_line := proc.get_next_line(timeout=int(timeout))) is not None:
+            if isinstance(raw_line, EndOfStream):
+                break
+            # get_next_line() is typed str | bytes | EndOfStream | None. We run
+            # with RunningProcess's default text=True so it is str in practice,
+            # but decode defensively rather than casting the type away.
+            line = (
+                raw_line
+                if isinstance(raw_line, str)
+                else raw_line.decode("utf-8", errors="replace")
+            )
+            print(line, file=out, flush=True)
+            collected.append(line)
+            # Parse as we stream so the port is still captured when the run
+            # later times out or is interrupted mid-flight.
             if marker in line:
                 suffix = line.split(marker, 1)[1].strip()
                 candidate = suffix.split()[0] if suffix else ""
                 if candidate:
                     returned_port = candidate
+
+        proc.wait()
+        stdout_text = "\n".join(collected)
+        returncode = proc.returncode
+        success = returncode == 0
 
         elapsed = time.monotonic() - t0
         if quiet:
@@ -730,7 +774,7 @@ def run_fbuild_deploy(
 
         return FbuildCommandResult(
             success=success,
-            output=proc.stdout or "",
+            output=stdout_text,
             returncode=returncode,
             port=returned_port,
         )
@@ -739,10 +783,17 @@ def run_fbuild_deploy(
         from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
         print("\nKeyboardInterrupt: Stopping deploy")
+        _kill_quietly(locals().get("proc"))
         handle_keyboard_interrupt(ki)
         raise
     except subprocess.TimeoutExpired:
+        # running_process.TimeoutExpired subclasses subprocess.TimeoutExpired,
+        # so this still catches the streaming runner's timeout.
         elapsed = time.monotonic() - t0
+        # subprocess.run() reaped the child on timeout; RunningProcess does
+        # not, so kill it explicitly or a multi-minute board build keeps
+        # running (and keeps holding the fbuild daemon lock) after we return.
+        _kill_quietly(locals().get("proc"))
         print(f"BUILD+FLASH FAIL timeout after {elapsed:.1f}s")
         return FbuildCommandResult(
             success=False, output=f"deploy timeout after {elapsed:.1f}s"


### PR DESCRIPTION
Closes #3441.

`run_fbuild_deploy()` used `subprocess.run(stdout=PIPE, stderr=STDOUT)` and printed `proc.stdout` only after the child exited. On a multi-minute ESP32 board build that meant no compile progress at all until the process returned — and for a failing build, the real error stayed hidden for the entire wait, which is exactly the slow part of hardware iteration.

## Approach

The issue asked to reuse an existing streaming helper if one exists. There is one: **`RunningProcess`**, already used across `ci/` (`ci/compiler/pio.py`, `ci/compiler/build_config.py`, …). This uses the same `get_next_line()` / `EndOfStream` idiom rather than open-coding another runner.

`out` is already the quiet/`log_file`-aware sink from `_get_output()`, so writing each line to it preserves both destinations with no extra plumbing.

**Preserved from the old path:**
- accumulated output for `FbuildCommandResult.output`
- `FBUILD_DEPLOY_PORT=` parsing — now done per-line as it streams, so the port survives a run that later times out or is interrupted
- quiet-mode summary semantics
- timeout handling: `running_process.TimeoutExpired` **subclasses** `subprocess.TimeoutExpired`, so the existing handler still catches it

## One gap the swap introduced, fixed explicitly

`subprocess.run()` reaped the child on timeout; `RunningProcess` does not. Without an explicit kill, a timed-out board build keeps running **and keeps holding the fbuild daemon lock** after the function returns — which would have been a nastier failure than the one being fixed.

Added `_kill_quietly()` on both the timeout and `KeyboardInterrupt` paths. It catches `(OSError, RuntimeError, ValueError)` rather than a blanket `Exception`, so a `KeyboardInterrupt` during teardown still propagates — which is also what the `KBI001` lint rule requires.

## Tests

`ci/tests/test_fbuild_deploy_streaming.py` (4 cases).

The one that matters asserts the property the old code actually failed, not merely that output eventually appears — the buffered version did that too. The fake fbuild **blocks on a sentinel file** until the test observes its first line, so the assertion can only pass if a line surfaced *before* the child exited.

Verified by mutation — restoring the buffered form fails it with exactly the right diagnosis:

```
AssertionError: no output surfaced while the child was still running --
output was buffered. Sink contained: [... banner lines only ...]
```

Plus coverage for port parsing, non-zero exit propagation, and quiet-mode `log_file` routing.

## Verification

- `ci/tests/test_fbuild_deploy_streaming.py` — 4/4, and mutation-checked
- `test_fbuild_compile_many`, `test_fbuild_default_selection`, `test_override_prog_path_for_fbuild` — 17/17, no regressions
- `bash lint` — exit 0 (`ty` and the KBI checker both clean)

**Not verified on hardware.** The issue's acceptance criterion is a live `bash autoresearch esp32s3 --all --skip-lint --timeout 180` showing progress, which needs an attached board. The streaming behavior itself is pinned by the test above; the end-to-end run is worth a sanity check next time you have an S3 on the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment output is now displayed line by line while the build is running.
  * Deployment port information is recognized as soon as it appears in the output.
  * Quiet mode writes streamed output to the configured log file.

* **Bug Fixes**
  * Improved handling of interrupted or timed-out deployments.
  * Deployment results now retain streamed output and accurately report failure exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->