### PR TITLE
fix(core): adaptive yield in show()'s refresh throttle (#3762, fixes #2994)

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -16,7 +16,8 @@
 #include "fl/system/yield.h"  // for fl::yield
 #include "fl/system/sketch_macros.h"
 #if SKETCH_HAS_LARGE_MEMORY
-#include "fl/task/executor.h"  // for task::run (WiFi yield in show() spin loop)
+#include "fl/task/executor.h"
+#include "fl/net/network_detector.h"  // adaptive yield gate in the refresh throttle (#3762)
 #endif
 #include "fl/log/log.h"  // for FL_WARN
 #include "fl/stl/assert.h"  // for FL_ASSERT
@@ -232,14 +233,61 @@ void CFastLED::clear(ClearFlags flags) {
 // FL_LINT_ALLOW_GLOBAL(intentional ATtiny85 code-size optimization — moving to Singleton<T> reverses the size win documented above)
 static void* gControllersData[MAX_CLED_CONTROLLERS];
 
+// Refresh-rate throttle shared by show() and showColor().
+//
+// This mirrors the tiered wait already shipped in
+// IChannelDriver::waitForCondition (refs #2818 for the spin tier, #2815/#2817
+// for the adaptive yield). show() was the last call site still taking an
+// UNCONDITIONAL deep yield, which is the root cause of FastLED#2994.
+//
+// Why it matters: fl::task::run(<non-zero>, SYSTEM) routes to
+// pumpCoroutines(), which on ESP32 floors at one FreeRTOS tick
+// (coroutine_esp32.impl.hpp, the `if (ticks == 0) ticks = 1` branch added for
+// the #2254 websocket-starvation fix). That is >=1 ms at
+// CONFIG_FREERTOS_HZ=1000 and >=10 ms at the 100 Hz default. With
+// setMaxRefreshRate(800) the throttle only needs 1250 us, so every frame
+// overshot to a tick boundary -- ~500 shows per sequence x sub-ms jitter is
+// the 63-300 ms drift reported in #2994, against a rock-steady 2495 ms on
+// 3.10.3 (which used a plain busy-wait).
+//
+// Two tiers:
+//   - No radio up: taskYIELD() only. Equal-priority tasks still run, and there
+//     is no tick floor, so the wait stays microsecond-accurate.
+//   - Radio up: keep the deep yield -- WiFi/lwIP/BT genuinely need the CPU --
+//     but stop taking it once less than the spin budget remains, so the final
+//     stretch is spun out instead of overshooting past our deadline.
+static void throttleToMaxRefreshRate(fl::u32 minMicros) FL_NO_EXCEPT {
+	if (!minMicros) {
+		return;
+	}
+#if SKETCH_HAS_LARGE_MEMORY
+	const fl::u32 spinBudget = fl::detail::getWaitSpinBudgetUs();
+#endif
+	while (true) {
+		const fl::u32 elapsed = fl::micros() - lastshow;
+		if (elapsed >= minMicros) {
+			return;
+		}
+#if SKETCH_HAS_LARGE_MEMORY
+		const fl::u32 remaining = minMicros - elapsed;
+		// Deep yield only while a radio is up AND there is more than the spin
+		// budget left to burn. Once inside the budget we spin, because a deep
+		// yield costs a whole tick and would overshoot the deadline.
+		if (remaining > spinBudget && fl::NetworkDetector::isAnyNetworkActive()) {
+			fl::task::run(250, fl::task::ExecFlags::SYSTEM);
+		} else {
+			// taskYIELD()-equivalent: equal-priority tasks still get CPU, but
+			// there is no FreeRTOS tick floor, so this stays sub-microsecond.
+			fl::task::run(0, fl::task::ExecFlags::SYSTEM);
+		}
+#endif
+	}
+}
+
 FL_KEEP_ALIVE void CFastLED::show(fl::u8 scale) {
 	FL_SCOPED_TRACE;
 	onBeginFrame();
-	while(mNMinMicros && ((fl::micros()-lastshow) < mNMinMicros)) {
-#if SKETCH_HAS_LARGE_MEMORY
-		fl::task::run(250, fl::task::ExecFlags::SYSTEM);
-#endif
-	}
+	throttleToMaxRefreshRate(mNMinMicros);
 	lastshow = fl::micros();
 
 	// If we have a function for computing power, use it!
@@ -314,11 +362,7 @@ CLEDController & CFastLED::operator[](int x) {
 }
 
 void CFastLED::showColor(const CRGB & color, fl::u8 scale) {
-	while(mNMinMicros && ((fl::micros()-lastshow) < mNMinMicros)) {
-#if SKETCH_HAS_LARGE_MEMORY
-		fl::task::run(250, fl::task::ExecFlags::SYSTEM);
-#endif
-	}
+	throttleToMaxRefreshRate(mNMinMicros);
 	lastshow = fl::micros();
 
 	// If we have a function for computing power, use it!


### PR DESCRIPTION
Implements #3762. Fixes #2994.

`show()` and `showColor()` were the **last call sites** still taking an unconditional deep yield in their refresh-rate wait. Every sibling wait loop was already fixed — `9d71de01d0` (skip the `vTaskDelay(1)` floor), #2817 (runtime `NetworkDetector` gating), #2818 (bounded spin tier) — but the throttle in `FastLED.cpp.hpp` never got the treatment.

## Mechanism

`fl::task::run(<non-zero>, SYSTEM)` → `pumpCoroutines()` → on ESP32 the `if (ticks == 0) ticks = 1` branch (added for the #2254 websocket-starvation fix) → `vTaskDelay(≥1 tick)`. That's **≥1 ms** at `CONFIG_FREERTOS_HZ=1000`, **≥10 ms** at the 100 Hz default.

`setMaxRefreshRate(800)` needs only **1250 µs**, so every frame overshot to a tick boundary. ~500 shows/sequence × sub-ms jitter = the **63–300 ms** drift in #2994. 3.10.3's plain busy-wait was microsecond-accurate — hence its rock-steady 2495 ms.

## Why gating alone is not the fix

Worth stating because it drove the design: **with a radio up, a gated deep yield still hits the tick floor and still drifts.** Gating alone would have looked correct for #2994's reporter — their sketch has no WiFi — while leaving every networked user broken.

The **spin tier** is what actually restores precision. The gate is the complement, not the fix. So this ships both, mirroring `waitForCondition`:

| condition | behavior |
|---|---|
| no radio up | `task::run(0)` only — equal-priority tasks still get CPU, no tick floor, microsecond-accurate |
| radio up, `remaining > spinBudget` | deep yield — WiFi/lwIP/BT genuinely need the CPU |
| radio up, inside the budget | spin the last stretch instead of overshooting the deadline |

Reuses the existing `FastLED.setWaitSpinBudgetUs()` knob (default 250 µs) rather than inventing a second one, and factors both loops into one helper so they can't drift apart again.

`isAnyNetworkActive()` deliberately, **not** `isAnyNetworkConnected()` — scanning and association are exactly when the stack most needs CPU, and it matches the existing channel sites.

**AVR and other small-memory targets are unchanged**: without `SKETCH_HAS_LARGE_MEMORY` the helper compiles to the same plain busy-wait as before.

## Verification

- 357/357 host tests
- `bash lint --cpp` exit 0

**Not yet validated on hardware.** Two claims need a board, and I'd like them checked before this lands:

1. #2994's sequence returns to a steady 2495 ms with no radio up (ESP32-S3)
2. #2254's websocket throughput is unaffected with a radio up

I have an ESP32-C6 on the bench and can run both if you want the numbers attached here first.

## Not in this PR

Two related bugs found while investigating, deliberately left out to keep this reviewable — both noted in #3762:

- `executor.cpp.hpp:138` discards its `microseconds` argument and hardcodes `pumpCoroutines(1000)`, so every caller asking for a shorter yield silently gets 1000 µs
- `ICoroutineRuntime::needsDeepYield()` is dead code (implemented, called from nowhere) duplicating `NetworkDetector` with weaker semantics — no BT, no Ethernet

## Open question from #3762

Whether the deep yield is needed at all anymore now that transposition is fast. This PR keeps it for radio-up cases, which is the conservative choice. If bench numbers show no throughput regression without it, the radio-up branch could be dropped entirely in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved refresh-rate timing for display updates.
  * Reduced the risk of overshooting refresh deadlines when network activity is present.
  * Updated color and display rendering to use more consistent timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->