### PR TITLE
fix(task): clamp the SYSTEM yield to the caller's budget; drop dead needsDeepYield (#3765)

### DIFF
--- a/src/fl/task/executor.cpp.hpp
+++ b/src/fl/task/executor.cpp.hpp
@@ -132,9 +132,26 @@ void run(fl::u32 microseconds, ExecFlags flags) {
         // When microseconds == 0 the caller wants the cheapest possible
         // yield (we are between other pumped subsystems and will loop
         // again immediately), so we keep the lightweight fl::yield() path.
+        //
+        // The sleep is clamped to whatever is left of the caller's budget,
+        // mirroring the COROUTINES branch below. This used to be a hardcoded
+        // pumpCoroutines(1000) that ignored `microseconds` entirely, so a
+        // caller asking for run(250, SYSTEM) slept 1000 us and overshot its
+        // own deadline by 750 us on every platform where pumpCoroutines
+        // honors the requested duration (host/stub -- CoroutineRunner::run).
+        //
+        // ESP32 behavior is unchanged: pumpCoroutines() there converts us to
+        // FreeRTOS ticks and floors at one tick for ANY non-zero request
+        // (coroutine_esp32.impl.hpp, the `if (ticks == 0) ticks = 1` branch
+        // added for #2254), so 250 and 1000 both yield exactly one tick. The
+        // deep-yield guarantee #2254 depends on still holds.
         if (do_system) {
             if (microseconds > 0) {
-                fl::platforms::ICoroutineRuntime::instance().pumpCoroutines(1000);
+                const fl::u32 time_left = remaining();
+                if (time_left) {
+                    fl::platforms::ICoroutineRuntime::instance().pumpCoroutines(
+                        fl::min(1000u, time_left));
+                }
             } else {
                 fl::yield();
             }

--- a/src/platforms/coroutine_runtime.h
+++ b/src/platforms/coroutine_runtime.h
@@ -41,11 +41,6 @@ public:
     /// @param us Microseconds budget for background work
     virtual void pumpCoroutines(fl::u32 us) FL_NO_EXCEPT = 0;
 
-    /// Check if the platform needs deep yields (≥1 FreeRTOS tick) to prevent
-    /// WiFi/lwIP task starvation. On ESP32, returns true when WiFi is active.
-    /// Other platforms return false (no RTOS priority inversion).
-    virtual bool needsDeepYield() const FL_NO_EXCEPT { return false; }
-
     /// Yield the current execution context for approximately `us` microseconds.
     /// Safe to call from ANY context (main thread, coroutine thread, worker thread).
     /// Used by fl::platforms::await() to yield while polling a promise.

--- a/src/platforms/esp/32/coroutine_esp32.impl.hpp
+++ b/src/platforms/esp/32/coroutine_esp32.impl.hpp
@@ -39,14 +39,6 @@ FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
 #include "soc/soc_caps.h"
 // IWYU pragma: end_keep
-#ifndef SOC_WIFI_SUPPORTED
-#define SOC_WIFI_SUPPORTED 0
-#endif
-#if SOC_WIFI_SUPPORTED
-#include "esp_wifi.h"
-// Weak symbol: resolves to nullptr when WiFi component is not linked
-FL_LINK_WEAK esp_err_t esp_wifi_get_mode(wifi_mode_t *mode);
-#endif
 FL_EXTERN_C_END
 
 namespace fl {
@@ -85,31 +77,6 @@ public:
         vTaskDelay(ticks);
     }
 
-    bool needsDeepYield() const FL_NO_EXCEPT override {
-        // Cache WiFi detection — recheck at most once per second.
-        static TickType_t s_lastCheck = 0;
-        static bool s_cached = false;
-        TickType_t now = xTaskGetTickCount();
-        if ((now - s_lastCheck) >= pdMS_TO_TICKS(1000)) {
-            s_lastCheck = now;
-            s_cached = isWiFiActive();
-        }
-        return s_cached;
-    }
-
-private:
-    static bool isWiFiActive() FL_NO_EXCEPT {
-#if SOC_WIFI_SUPPORTED
-        if (esp_wifi_get_mode == nullptr) {
-            return false; // WiFi component not linked
-        }
-        wifi_mode_t mode;
-        if (esp_wifi_get_mode(&mode) == ESP_OK && mode != WIFI_MODE_NULL) {
-            return true;
-        }
-#endif
-        return false;
-    }
 };
 
 //=============================================================================

--- a/tests/fl/task/executor.cpp
+++ b/tests/fl/task/executor.cpp
@@ -1,3 +1,4 @@
+#include "fl/stl/chrono.h"  // fl::micros
 #include "fl/task/executor.h"
 #include "fl/task/task.h"
 #include "fl/task/promise.h"
@@ -1070,3 +1071,46 @@ FL_TEST_CASE("global coordination - await releases lock for other threads") {
 #endif // FASTLED_STUB_IMPL
 
 } // FL_TEST_FILE
+
+FL_TEST_CASE("fl::task::run SYSTEM yield paths") {
+    // FastLED#3765.
+    //
+    // NOTE ON COVERAGE, because it is easy to over-read this test: the
+    // microseconds>0 branch is NOT observable here. Host CoroutineRunner::run()
+    // early-returns when no coroutine is registered (coroutine_context.cpp.hpp,
+    // `if (mCount == 0) return;`), and on ESP32 any non-zero request floors to
+    // one FreeRTOS tick regardless of the value. So clamping the request to the
+    // caller's remaining budget is a correctness/consistency change with no
+    // behavior change on either platform as exercised by this suite. It is only
+    // observable with coroutines registered, where the old hardcoded 1000 would
+    // pump them past the caller's deadline.
+    //
+    // What IS observable, and what this pins, is the zero-budget path: it must
+    // take the cheap fl::yield() and must not sleep.
+    using fl::task::ExecFlags;
+
+    FL_SUBCASE("a zero budget does not sleep") {
+        run(0, ExecFlags::SYSTEM);  // warm up lazy init
+
+        fl::u32 best = 0xFFFFFFFFu;
+        for (int i = 0; i < 5; ++i) {
+            const fl::u32 t0 = fl::micros();
+            run(0, ExecFlags::SYSTEM);
+            const fl::u32 dt = fl::micros() - t0;
+            if (dt < best) {
+                best = dt;
+            }
+        }
+        // Best-of-N: this bounds a wall clock, so a single sample can be
+        // inflated by OS preemption. A regression that made this path sleep
+        // would raise every sample, which best-of-N cannot hide.
+        FL_CHECK_LT(best, 250u);
+    }
+
+    FL_SUBCASE("a small budget still terminates") {
+        // Guards against the deadline loop failing to make progress.
+        const fl::u32 t0 = fl::micros();
+        run(50, ExecFlags::SYSTEM);
+        FL_CHECK_LT(fl::micros() - t0, 100000u);
+    }
+}


### PR DESCRIPTION
Two items from the #3765 meta-tracker — the two that are actually landable while on-device work is blocked by FastLED/fbuild#1213.

## 1. `task::run()` ignored its own `microseconds` budget

`executor.cpp.hpp` called `pumpCoroutines(1000)` with a literal `1000`, discarding the caller's `microseconds`. Because `run()` is a `do/while` loop against a deadline, `run(250, SYSTEM)` could pump past its own budget.

Now clamped to `fl::min(1000u, remaining())` — exactly what the `COROUTINES` branch three lines below already does.

**Scope, stated plainly because it is narrower than I claimed on #3765.** This is a correctness/consistency fix, **not** an observable bug fix on either platform this suite exercises:

| platform | behavior |
|---|---|
| ESP32 | `pumpCoroutines()` floors any non-zero request at one FreeRTOS tick (the `if (ticks == 0) ticks = 1` branch from #2254) — 250 and 1000 are identical. The #2254 deep-yield guarantee is untouched. |
| host | `CoroutineRunner::run()` early-returns when no coroutine is registered (`if (mCount == 0) return;`) — both are no-ops. |

It only bites with coroutines registered, where the hardcoded 1000 pumps them past the caller's deadline.

## 2. `needsDeepYield()` was dead code

Declared in `coroutine_runtime.h`, overridden in `coroutine_esp32.impl.hpp`, **called from nowhere**. It duplicated `fl::NetworkDetector` with weaker semantics — `WIFI_MODE_NULL` only, no Bluetooth, no Ethernet — and was superseded by the `NetworkDetector` gating in #2817 / #3764.

Removed along with its only helper `isWiFiActive()` and the `esp_wifi.h` include plus weak-symbol declaration that existed solely to serve it.

`soc/soc_caps.h` is deliberately **left**: it sits inside an `IWYU pragma: keep` block, other ESP headers may rely on it transitively, and this file cannot be compiled locally — not worth the risk for a dead include.

## A note on the test, because it matters

My first version of this change shipped a wall-clock test asserting `run(250, SYSTEM)` does not sleep ~1000 µs. **It passed against the un-fixed code** — the `mCount == 0` early return above means neither value sleeps on host. That is false assurance, so I deleted it rather than keep a green test that proves nothing. It also corrected my own understanding of the bug's scope, which is why the framing above differs from #3765.

What remains pins the contract that *is* observable here: the zero-budget path must take the cheap `fl::yield()` and must not sleep, and a small budget must terminate.

## Verification

- 357/357 host tests, clean build
- `bash lint --cpp` exit 0
- The ESP32 deletion is compile-verified by **CI's ESP32 jobs**, not locally — flagging that explicitly since I could not build for that target on this bench

## Not in this PR

Remaining #3765 items, all needing hardware or further investigation:

- the decisive measurement: `show()` duration on 3.10.3 vs master
- a host driver for the existing `timingDriftTest` reproducer (it has none, so it has never been run)
- #3764's own threshold (guards on `spinBudget` = 250 µs when a deep yield costs a full 1000 µs tick)
- reopening #2994, which is closed on the retracted root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task scheduling so coroutine processing respects the caller’s available time budget.
  * Prevented zero-duration task runs from introducing unnecessary delays.
  * Ensured short-duration runs complete promptly without exceeding their intended timing.

* **Tests**
  * Added coverage for system-yield execution paths and timing behavior across zero and short time budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->