### PR TITLE
fix(profile): repair `bash profile`, add a show() CPU-cost benchmark (#3765)

### DIFF
--- a/ci/SYMBOL_ANALYSIS.md
+++ b/ci/SYMBOL_ANALYSIS.md
@@ -180,8 +180,9 @@ Successfully tested platforms:
 esp32_boards = ["esp32dev", "esp32", "esp32s2", ...]
 
 # FastLED-specific filtering
-if any(keyword in search_text for keyword in [
-    "fastled", "cfastled", "crgb", "hsv", ...]):
+if any(
+    keyword in search_text for keyword in ["fastled", "cfastled", "crgb", "hsv", ...]
+):
     fastled_symbols.append(symbol_info)
 ```
 

--- a/ci/docker_utils/avr8js/README.md
+++ b/ci/docker_utils/avr8js/README.md
@@ -57,10 +57,7 @@ from ci.docker_utils.avr8js_docker import DockerAVR8jsRunner
 
 runner = DockerAVR8jsRunner()
 exit_code = runner.run(
-    elf_path=Path("firmware.elf"),
-    mcu="atmega328p",
-    frequency=16000000,
-    timeout=30
+    elf_path=Path("firmware.elf"), mcu="atmega328p", frequency=16000000, timeout=30
 )
 ```
 

--- a/ci/fingerprint/README.md
+++ b/ci/fingerprint/README.md
@@ -151,7 +151,7 @@ config = CacheConfig(
     cache_type=CacheType.TWO_LAYER,
     cache_dir=Path(".cache"),
     build_mode=BuildMode.DEBUG,
-    description="My custom cache for XYZ"
+    description="My custom cache for XYZ",
 )
 
 # Cache file: .cache/fingerprint/my_custom_cache_debug.json

--- a/ci/profile_runner.py
+++ b/ci/profile_runner.py
@@ -133,7 +133,11 @@ class ProfileRunner:
             "test.py",
             self.test_name,
             "--cpp",
-            "--build",  # Build-only mode
+            # NOTE: no "--build" here. test.py has no such flag, and because
+            # "--build" is a unique prefix of "--build-mode", argparse
+            # abbreviation-matching consumed the real flag's value and every
+            # `bash profile <target>` invocation died with
+            # "--build-mode: expected one argument". See FastLED#3765.
             "--build-mode",
             self.build_mode,
         ]

--- a/ci/util/FINGERPRINT.md
+++ b/ci/util/FINGERPRINT.md
@@ -151,11 +151,14 @@ class FingerprintResult:
 def calculate_fingerprint() -> FingerprintResult:
     """Fingerprint entire src/ directory"""
 
+
 def calculate_cpp_test_fingerprint(args: TestArgs) -> FingerprintResult:
     """Fingerprint for C++ tests (includes debug flag)"""
 
+
 def calculate_examples_fingerprint() -> FingerprintResult:
     """Fingerprint for example compilation"""
+
 
 def calculate_python_test_fingerprint() -> FingerprintResult:
     """Fingerprint for Python tests"""

--- a/tests/profile/fastled_show.cpp
+++ b/tests/profile/fastled_show.cpp
@@ -1,0 +1,130 @@
+// ok standalone
+// FastLED.show() per-frame CPU cost profile
+//
+// Built for FastLED#3765 / #2994. The reporter of #2994 sees 68-257 ms of
+// drift accumulated over 254 fade steps -- 268-1012 us per step -- against a
+// theoretical 2495 ms sequence that 3.10.3 hit exactly. That per-step excess
+// is the same order of magnitude as one WS2812 show() for their 35-LED strip
+// (~1050 us of wire time), which points at show()'s DURATION rather than at
+// the refresh-rate throttle (the throttle provably never engages in their
+// sketch: show() is gated at 5 ms, far above the 1250 us threshold).
+//
+// WHAT THIS DOES AND DOES NOT COVER -- read before drawing conclusions.
+//
+// Covered: the CPU-side per-frame path visible on host -- EngineEvents, the
+// three-pass controller walk in CFastLED::show(), dithering, scaling, and the
+// channels dispatch introduced by #2428.
+//
+// NOT covered: wire time, DMA, and -- importantly -- per-frame encoding and
+// bit transposition, because the host driver is a stub. A regression living
+// in the encoder or in a driver wait loop will NOT show up here.
+//
+// First measurement on a desktop host: ~1.7 us/frame for 35 LEDs. That is far
+// below #2994's 268-1012 us of excess, which is itself useful evidence -- the
+// regression is almost certainly NOT in the CPU-side dispatch path -- but it
+// does not localize where the regression IS.
+//
+// Usage:
+//   ./fastled_show                 # human-readable
+//   ./fastled_show baseline        # JSON for the profiling pipeline
+//   bash profile fastled_show --iterations 50
+
+#include "FastLED.h"
+#include "fl/stl/int.h"
+#include "fl/stl/stdio.h"
+#include "fl/stl/chrono.h"
+#include "profile_result.h"
+
+namespace fl {
+
+namespace {
+
+constexpr int kDataPin = 2;
+
+/// One timing sample set for a strip.
+struct ShowStats {
+    fl::u32 min_us;
+    fl::u32 max_us;
+    fl::u32 mean_us;
+    fl::u32 total_us;
+    int frames;
+};
+
+/// Time `frames` successive FastLED.show() calls.
+///
+/// Reports the MINIMUM as the headline number, not the mean: this measures a
+/// code path, and on a loaded desktop the mean is dominated by scheduler
+/// noise the firmware would never see. The minimum is the closest stable
+/// estimate of the actual work, and a regression raises it just as reliably.
+ShowStats timeShow(int frames) {
+    ShowStats stats;
+    stats.min_us = 0xFFFFFFFFu;
+    stats.max_us = 0;
+    stats.total_us = 0;
+    stats.frames = frames;
+
+    for (int i = 0; i < frames; ++i) {
+        const fl::u32 t0 = fl::micros();
+        FastLED.show();
+        const fl::u32 dt = fl::micros() - t0;
+        if (dt < stats.min_us) {
+            stats.min_us = dt;
+        }
+        if (dt > stats.max_us) {
+            stats.max_us = dt;
+        }
+        stats.total_us += dt;
+    }
+    stats.mean_us = frames > 0 ? stats.total_us / static_cast<fl::u32>(frames) : 0;
+    return stats;
+}
+
+} // namespace
+
+} // namespace fl
+
+int main(int argc, char** argv) {
+    const bool json_mode = (argc > 1);
+    const char* variant = json_mode ? argv[1] : "baseline";
+
+    // #2994's exact geometry: 35-LED WS2812 ring on the legacy addLeds path.
+    static CRGB leds35[35];
+    FastLED.addLeds<WS2812, fl::kDataPin, GRB>(leds35, 35);
+
+    // Disable the refresh throttle so it cannot contaminate the measurement.
+    // The whole point of #3765 is that the throttle is NOT the cause; leaving
+    // it on would sometimes add a wait and muddy the per-frame number.
+    FastLED.setMaxRefreshRate(0);
+
+    for (int i = 0; i < 35; ++i) {
+        leds35[i] = CRGB(i * 7, 255 - i * 7, 128);
+    }
+
+    // Warm up: the first shows pay lazy driver binding and any one-time
+    // allocation, which is not what we are measuring.
+    for (int i = 0; i < 32; ++i) {
+        FastLED.show();
+    }
+
+    const int kFrames = 512;
+    const fl::ShowStats s35 = fl::timeShow(kFrames);
+
+    if (json_mode) {
+        // parse_results.py builds a fixed ProfileResult dataclass, so extra
+        // keys make it raise. Stick to the standard emitter.
+        ProfileResultBuilder::print_result(variant, "fastled_show", kFrames,
+                                           s35.total_us);
+    } else {
+        fl::printf("FastLED.show() CPU-side cost, 35-LED WS2812 (#2994 geometry)\n");
+        fl::printf("  frames   : %d\n", kFrames);
+        fl::printf("  min      : %u us   <- headline; least scheduler noise\n",
+                   static_cast<unsigned>(s35.min_us));
+        fl::printf("  mean     : %u us\n", static_cast<unsigned>(s35.mean_us));
+        fl::printf("  max      : %u us\n", static_cast<unsigned>(s35.max_us));
+        fl::printf("\n");
+        fl::printf("Reference: #2994 reports 268-1012 us of excess per fade step.\n");
+        fl::printf("Encoding/transposition and wire time are NOT included (host stub).\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Two more #3765 items: repair the profiling harness, then use it to narrow the #2994 search.

## 1. `bash profile` was broken for every target

`ci/profile_runner.py` built with:

```
test.py <name> --cpp --build --build-mode <mode>
```

but `test.py` has no `--build` flag. Because `--build` is a unique prefix of `--build-mode`, argparse abbreviation-matching swallowed the real flag's value, so **every** `bash profile <target>` invocation died with:

```
test.py: error: argument --build-mode: expected one argument
```

Dropping the invalid flag fixes it — `test.py` builds the target either way.

## 2. A `show()` CPU-cost benchmark

`tests/profile/fastled_show.cpp` measures per-frame cost using **#2994's exact geometry**: 35-LED WS2812 on the legacy `addLeds` path, with the refresh throttle explicitly disabled so it cannot contaminate the number.

**First result: ~1.7–2.3 µs/frame** on a desktop host.

That is three orders of magnitude below the **268–1012 µs** of per-step excess #2994 reports. Useful evidence in itself: whatever regressed between 3.10.3 and master is almost certainly **not** in the CPU-side dispatch path — `EngineEvents`, the three-pass controller walk, dithering/scaling, or the #2428 channels dispatch.

### What it deliberately does not cover

The header says this loudly, because the limit matters more than the number. The host driver is a **stub**, so wire time, DMA, and per-frame **encoding / bit transposition** are all excluded. A regression living in the encoder or in a driver wait loop **will not appear here**.

So this narrows the search — it does not localize the cause. The remaining suspects are exactly the ones this cannot see, which is why #3765 still needs the on-device measurement.

## Verification

- benchmark runs end-to-end via `bash profile fastled_show` — build, execute, parse, analyze
- 357/357 host tests
- `bash lint` exit 0, `ty` clean on the runner

## Still open on #3765

- the decisive on-device `show()` duration comparison, 3.10.3 vs master (blocked by FastLED/fbuild#1213)
- a host driver for the existing `timingDriftTest` reproducer — it has none, so it has never been run
- #3764's threshold guards on `spinBudget` (250 µs) when a deep yield costs a full 1000 µs tick

#2994 has been reopened with the root-cause retraction posted for the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profiling utility to measure `FastLED.show()` performance and report frame timing statistics in readable or JSON formats.

* **Documentation**
  * Updated symbol analysis guidance to cover all detected platforms and symbols.
  * Improved formatting and examples across CI and fingerprint documentation.

* **Bug Fixes**
  * Corrected the profiling build invocation to use supported command-line options and avoid argument parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->