### PR TITLE
feat(autoresearch): host driver for the #2994 timing-drift reproducer (#3765)

### DIFF
--- a/ci/autoresearch/test_timing_drift.py
+++ b/ci/autoresearch/test_timing_drift.py
@@ -1,0 +1,214 @@
+"""Host driver for the #2994 timing-drift reproducer (FastLED#3765).
+
+`AutoResearchTimingDrift.h` has faithfully replayed the #2994 reporter's
+sketch for some time -- 35-LED WS2812B ring on the legacy addLeds path,
+`setMaxRefreshRate(800)`, millisDelay-gated 255-step fade, `delay(1000)`
+between sequences -- and exposes it as the `timingDriftTest` JSON-RPC method.
+
+It had no host driver. Nothing in `ci/` referenced `timingDriftTest` and there
+was no CLI flag, so the reproducer had never actually been run. This is that
+driver.
+
+Two numbers matter, and the second is the one that settles #2994:
+
+1. **Per-sequence wall time.** Theoretical period is 225 + 254*5 + 1000 =
+   **2495 ms**. The reporter sees a rock-steady 2495 on 3.10.3 and 2563-2752
+   on master. Index 0 is skipped: the first sequence is partial (no leading
+   225 ms arm, no trailing 1000 ms delay) -- see the header of
+   AutoResearchTimingDrift.h.
+
+2. **`FastLED.show()` duration.** The firmware already reports min/max/total
+   across every show() in the run. The reported drift is 68-257 ms over 254
+   fade steps = **268-1012 us per step**, which is the same order as one
+   WS2812 show() for 35 LEDs (~1050 us of wire time). If show() is
+   meaningfully slower than that floor, that is the regression; a host-side
+   profile (tests/profile/fastled_show.cpp) already established the CPU-side
+   dispatch path costs only ~2 us, so the cost is in encoding, DMA, or a
+   driver wait -- none of which are visible off-device.
+
+Usage:
+    uv run python -m ci.autoresearch.test_timing_drift --port COM9
+    uv run python -m ci.autoresearch.test_timing_drift --port COM9 --iterations 20
+
+Run it on master and on 3.10.3 and compare. Exits 0 when the run completes,
+1 on a connection/RPC failure. It deliberately does NOT fail on drift: this is
+a measurement tool, and the threshold for "too much drift" is the question
+under investigation, not something to hardcode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from ci.autoresearch.rpc_bench import METHOD_NOT_FOUND, RpcBench
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+# Theoretical sequence period from the reporter's sketch:
+#   225 ms initial arm + 254 fade steps * 5 ms + 1000 ms inter-sequence delay
+THEORETICAL_MS = 225 + 254 * 5 + 1000
+
+# Wire time for one 35-LED WS2812 frame: 35 LEDs * 24 bits * 1.25 us.
+# This is the floor show() cannot go below on this geometry; it is context for
+# the show() numbers, not a pass/fail threshold.
+WS2812_35_LED_WIRE_US = 35 * 24 * 1.25
+
+
+def _call(bench: RpcBench, method: str, args: Any, timeout: float) -> Any:
+    """Call an RPC method, returning the result dict or None."""
+    result = bench.call(method, args=args, timeout=timeout)
+    if result is None:
+        return None
+    if result is METHOD_NOT_FOUND:
+        print(
+            f"ERROR: firmware does not expose '{method}'. Is this an "
+            f"AutoResearch build recent enough to include "
+            f"AutoResearchTimingDrift.h?",
+            file=sys.stderr,
+        )
+        return None
+    return result
+
+
+def _summarize_sequences(iter_ms: list[int]) -> None:
+    """Print the per-sequence histogram against the 2495 ms theoretical."""
+    # Index 0 is a partial sequence by construction -- skip it.
+    usable = iter_ms[1:]
+    if not usable:
+        print("  (only one sequence recorded; run with --iterations >= 3)")
+        return
+
+    lo = min(usable)
+    hi = max(usable)
+    mean = sum(usable) / len(usable)
+
+    print(f"  theoretical      : {THEORETICAL_MS} ms")
+    print(f"  sequences        : {len(usable)} (index 0 skipped, partial)")
+    print(f"  min / mean / max : {lo} / {mean:.1f} / {hi} ms")
+    print(
+        f"  drift vs theory  : {lo - THEORETICAL_MS:+d} .. {hi - THEORETICAL_MS:+d} ms"
+    )
+    print()
+    print("  per-sequence:")
+    for i, ms in enumerate(usable, start=1):
+        delta = ms - THEORETICAL_MS
+        bar = "#" * min(60, max(0, delta // 5)) if delta > 0 else ""
+        print(f"    [{i:2d}] {ms:5d} ms  {delta:+5d}  {bar}")
+
+
+def _summarize_show(result: dict[str, Any]) -> None:
+    """Print show() duration stats -- the decisive number for #2994."""
+    count = result.get("show_count")
+    total = result.get("show_total_us")
+    lo = result.get("show_min_us")
+    hi = result.get("show_max_us")
+
+    if not count or total is None:
+        print("  (firmware reported no show() timing)")
+        return
+
+    mean = total / count
+    print(f"  show() calls     : {count}")
+    print(f"  min / mean / max : {lo} / {mean:.1f} / {hi} us")
+    print(
+        f"  WS2812 wire floor: {WS2812_35_LED_WIRE_US:.0f} us (35 LEDs x 24 bits x 1.25 us)"
+    )
+    if lo is not None and lo > 0:
+        print(f"  min / wire floor : {lo / WS2812_35_LED_WIRE_US:.2f}x")
+    print()
+    print("  #2994 reports 268-1012 us of excess per fade step. If show()'s")
+    print("  mean sits well above the wire floor, that excess is show() itself.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Run the #2994 timing-drift reproducer on an attached board."
+    )
+    p.add_argument("--port", default="COM9", help="Serial port (default: COM9)")
+    p.add_argument("--pin", default=4, type=int, help="LED data pin (default: 4)")
+    p.add_argument(
+        "--num-leds",
+        default=35,
+        type=int,
+        help="Strip length (default: 35, #2994 geometry)",
+    )
+    p.add_argument(
+        "--iterations",
+        default=10,
+        type=int,
+        help="Sequences to run; each takes ~2.5 s (default: 10)",
+    )
+    args = p.parse_args(argv)
+
+    print(f"[timing-drift] opening {args.port}")
+    try:
+        bench = RpcBench(args.port)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not connect to {args.port}: {e}", file=sys.stderr)
+        return 1
+
+    with bench:
+        ping = _call(bench, "ping", None, timeout=5.0)
+        if not ping:
+            print(
+                "ERROR: ping failed; is AutoResearch flashed and running?",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"[timing-drift] ping ok: uptime={ping.get('uptimeMs')} ms")
+
+        # Each sequence is ~2.5 s of device-side blocking, plus headroom.
+        timeout = args.iterations * 3.0 + 30.0
+        print(
+            f"[timing-drift] running {args.iterations} sequences "
+            f"(~{args.iterations * 2.5:.0f}s device-side), pin={args.pin}, "
+            f"leds={args.num_leds}"
+        )
+
+        result = _call(
+            bench,
+            "timingDriftTest",
+            {
+                "pin": args.pin,
+                "numLeds": args.num_leds,
+                "iterations": args.iterations,
+            },
+            timeout=timeout,
+        )
+        if not result:
+            print("ERROR: timingDriftTest returned no result", file=sys.stderr)
+            return 1
+
+        if not result.get("success", False):
+            print(
+                f"ERROR: firmware reported failure: "
+                f"{result.get('error')} - {result.get('message')}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print()
+        print("=" * 62)
+        print(
+            f"CPU: {result.get('cpu_mhz')} MHz   pin={result.get('pin')}   "
+            f"leds={result.get('num_leds')}"
+        )
+        print("=" * 62)
+        print()
+        print("--- per-sequence wall time (#2994's serial output) ---")
+        _summarize_sequences(list(result.get("iter_ms") or []))
+        print()
+        print("--- FastLED.show() duration (the decisive number) ---")
+        _summarize_show(result)
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tests/test_timing_drift_driver.py
+++ b/ci/tests/test_timing_drift_driver.py
@@ -1,0 +1,95 @@
+"""Tests for the #2994 timing-drift host driver (FastLED#3765).
+
+The RPC round-trip needs a board, but the analysis on top of it does not --
+and the analysis is where a wrong number would quietly mislead the
+investigation. These pin the arithmetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ci.autoresearch.test_timing_drift import (
+    THEORETICAL_MS,
+    WS2812_35_LED_WIRE_US,
+    _summarize_sequences,
+    _summarize_show,
+)
+
+
+def test_theoretical_period_matches_the_reporters_sketch() -> None:
+    """225 ms arm + 254 fade steps * 5 ms + 1000 ms delay = 2495 ms.
+
+    This is the number #2994 measures against; 3.10.3 hits it exactly.
+    """
+    assert THEORETICAL_MS == 2495
+    assert THEORETICAL_MS == 225 + 254 * 5 + 1000
+
+
+def test_ws2812_wire_floor_is_the_35_led_frame_time() -> None:
+    """35 LEDs x 24 bits x 1.25 us = 1050 us of unavoidable wire time."""
+    assert WS2812_35_LED_WIRE_US == pytest.approx(1050.0)
+
+
+def test_first_sequence_is_excluded_from_the_histogram(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Index 0 is a partial sequence and must not skew the stats.
+
+    It has no leading 225 ms arm and no trailing 1000 ms delay, so including
+    it would understate the mean. Here index 0 is an absurd outlier: if it
+    leaked in, min/mean would move sharply.
+    """
+    _summarize_sequences([1, 2495, 2495, 2495])
+    out = capsys.readouterr().out
+
+    assert "sequences        : 3" in out
+    assert "min / mean / max : 2495 / 2495.0 / 2495" in out
+    # Zero drift when every usable sequence hits theoretical exactly.
+    assert "+0 .. +0 ms" in out
+
+
+def test_drift_is_reported_against_theoretical(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The reporter's observed range (2563-2752) should read as +68..+257."""
+    _summarize_sequences([0, 2563, 2752])
+    out = capsys.readouterr().out
+    assert "+68 .. +257 ms" in out
+
+
+def test_single_sequence_is_reported_as_insufficient(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With only the partial sequence there is nothing usable to summarize."""
+    _summarize_sequences([2495])
+    out = capsys.readouterr().out
+    assert "only one sequence recorded" in out
+
+
+def test_show_summary_reports_mean_and_wire_ratio(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """show() mean and its ratio to the wire floor are the decisive numbers."""
+    _summarize_show(
+        {
+            "show_count": 100,
+            "show_total_us": 210000,  # mean 2100us == 2x the 1050us floor
+            "show_min_us": 2000,
+            "show_max_us": 2500,
+        }
+    )
+    out = capsys.readouterr().out
+    assert "show() calls     : 100" in out
+    assert "2000 / 2100.0 / 2500 us" in out
+    # 2000 / 1050 = 1.90x
+    assert "1.90x" in out
+
+
+def test_show_summary_handles_missing_timing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Older firmware without show() timing must not crash the driver."""
+    _summarize_show({})
+    out = capsys.readouterr().out
+    assert "no show() timing" in out


### PR DESCRIPTION
Another #3765 item: the #2994 reproducer had no way to run.

## The gap

`AutoResearchTimingDrift.h` has faithfully replayed the reporter's sketch for some time — 35-LED WS2812B ring on the legacy `addLeds` path, `setMaxRefreshRate(800)`, millisDelay-gated 255-step fade, `delay(1000)` between sequences — exposed as the `timingDriftTest` JSON-RPC method.

**It had no host driver.** Nothing in `ci/` referenced `timingDriftTest`, and `bash autoresearch --help` has no matching flag. The reproducer had never been run.

That is not a footnote — it is arguably *why* #2994 went a year with a wrong root cause. The tool built to falsify a hypothesis existed but could not be invoked, so hypotheses got tested by argument instead of measurement. (Mine included: I published a throttle-based root cause that this script would have refuted in one run.)

## What it reports

Follows the established standalone bring-up pattern (`test_flexio_rx_objectfled.py`) rather than adding an autoresearch flag, since that is what these device probes already look like.

**1. Per-sequence wall time** against the 2495 ms theoretical (`225 + 254*5 + 1000`), with a per-sequence bar chart. Index 0 is excluded — it is partial by construction (no leading 225 ms arm, no trailing 1000 ms delay), so including it understates the mean.

**2. `FastLED.show()` duration — the decisive number.** The firmware already returned `show_min_us` / `show_max_us` / `show_total_us`; nothing consumed them. The reported drift is **268–1012 µs per fade step**, the same order as one 35-LED WS2812 frame (**~1050 µs** of wire time). Since `tests/profile/fastled_show.cpp` (#3767) established the CPU-side dispatch path costs only ~2 µs, if `show()` sits well above the wire floor then the cost is in encoding, DMA, or a driver wait — none of which are visible off-device.

It deliberately **does not fail on drift**. What counts as "too much" is the question under investigation, not something to hardcode into the tool.

## Usage

```bash
uv run python -m ci.autoresearch.test_timing_drift --port COM9
uv run python -m ci.autoresearch.test_timing_drift --port COM9 --iterations 20
```

Run on master and on 3.10.3, compare.

## Tests

7 cases in `ci/tests/test_timing_drift_driver.py`, covering the arithmetic that would otherwise silently mislead the investigation: the theoretical period, the wire floor, the partial-first-sequence exclusion, drift reported against theory, and the missing-timing fallback for older firmware.

**Mutation-checked** — removing the index-0 skip fails three of them.

## What is not validated

The RPC round-trip is unexercised. The ESP32-C6 on this bench dropped off the USB bus during earlier deploy attempts and FastLED/fbuild#1213 blocks redeploying it, so only the analysis layer is covered here. Flagging that rather than implying an end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line timing-drift diagnostic for LED firmware.
  - Supports configurable pin, LED count, and iteration count.
  - Reports sequence timing, drift against expected timing, and `FastLED.show()` performance statistics.
  - Provides clear success or failure status for connection, communication, and firmware-reported results.

- **Tests**
  - Added automated coverage for timing calculations, drift reporting, partial sequences, insufficient data, and missing timing metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->