### PR TITLE
fix(build): stop the example-change detector false-firing on a clean tree (#3761)

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
 from colorama import Fore, Style
 
@@ -3583,10 +3583,14 @@ def _validate_test_rpc_response(
         if not isinstance(patterns, list) or not patterns:
             errors.append("WS2814 response requires a non-empty patterns list")
         else:
-            for index, pattern in enumerate(patterns):
-                if not isinstance(pattern, dict):
+            for index, entry in enumerate(patterns):
+                if not isinstance(entry, dict):
                     errors.append(f"patterns[{index}] must be an object for WS2814")
                     continue
+                # `entry` comes off an untyped JSON payload; narrowing it with a
+                # bare `dict` leaves ty with dict[Never, Never], which rejects
+                # every string key. Re-state the payload shape explicitly.
+                pattern = cast("dict[str, Any]", entry)
                 total_leds = pattern.get("totalLeds")
                 total_bytes = pattern.get("totalBytes")
                 if not _is_plain_int(total_leds):

--- a/ci/meson/build_config.py
+++ b/ci/meson/build_config.py
@@ -202,10 +202,12 @@ def setup_meson_build(
         force_reconfigure = True
         force_reconfigure_reason = "test files changed"
 
-    # Example files added/removed/modified → reconfigure.
-    if already_configured and detect_example_file_changes(source_dir, build_dir):
-        force_reconfigure = True
-        force_reconfigure_reason = "example files changed"
+    # Example files added/removed/modified (or unprovable) → reconfigure.
+    if already_configured:
+        example_reason = detect_example_file_changes(source_dir, build_dir)
+        if example_reason:
+            force_reconfigure = True
+            force_reconfigure_reason = example_reason
 
     skip_meson_setup = already_configured and not reconfigure and not force_reconfigure
     native_file_path = build_dir / "meson_native.txt"

--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -43,7 +43,7 @@ _SOURCE_EXTS = frozenset([".cpp", ".h", ".hpp", ".c", ".ino"])
 _PY_SOURCE_EXTS = frozenset([".py"])
 
 
-def _should_skip_scan_dir(name: str) -> bool:
+def should_skip_scan_dir(name: str) -> bool:
     """Return True if this directory should be excluded from source file scanning."""
     if name in _SKIP_DIR_NAMES:
         return True
@@ -86,7 +86,7 @@ def get_max_dir_mtime(root: Path) -> float:
                 for entry in it:
                     try:
                         if entry.is_dir(follow_symlinks=False):
-                            if not _should_skip_scan_dir(entry.name):
+                            if not should_skip_scan_dir(entry.name):
                                 stack.append(entry.path)
                     except OSError:
                         pass
@@ -126,7 +126,7 @@ def _get_max_source_file_mtime(
                     try:
                         name = entry.name
                         if entry.is_dir(follow_symlinks=False):
-                            if not _should_skip_scan_dir(name):
+                            if not should_skip_scan_dir(name):
                                 stack.append(entry.path)
                         elif entry.is_file(follow_symlinks=False):
                             _, ext = os.path.splitext(name)

--- a/ci/meson/example_metadata_cache.py
+++ b/ci/meson/example_metadata_cache.py
@@ -2,8 +2,13 @@
 Example metadata caching for Meson build system.
 
 This module provides hash-based caching to avoid re-running example discovery scripts
-when example files haven't changed. It tracks all example file metadata (path + mtime + size)
+when example files haven't changed. It tracks all example file paths and contents,
 and invalidates the cache only when examples are added, deleted, or modified.
+
+The hash is deliberately content-based rather than mtime-based: ``git checkout``,
+``git worktree add`` and branch switches rewrite example mtimes with byte-identical
+content, and an mtime hash treated every one of those as an example change — which
+cost a full ~20-30s meson reconfigure each time (issue #3761).
 
 Usage:
   # Check cache validity (exit 0 if valid, 1 if invalid)
@@ -19,40 +24,54 @@ Usage:
 import argparse
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
+
+from ci.meson.cache_utils import should_skip_scan_dir
 
 
 CACHE_FILENAME = "example_metadata.cache"
 
 
-def compute_example_files_hash(examples_dir: Path) -> str:
-    """
-    Compute a hash of all example file metadata (path + mtime + size).
+_EXAMPLE_SOURCE_EXTS = (".ino", ".cpp", ".h")
 
-    This provides a fast way to detect if any example files have been added,
-    deleted, or modified without re-parsing all example files.
+
+def iter_example_files(examples_dir: Path) -> list[Path]:
+    """
+    Return every file whose content the example metadata depends on.
+
+    That is the ``.ino`` / ``.cpp`` / ``.h`` tree under *examples_dir* plus the
+    discovery script itself, deduplicated and in a stable order.
+
+    Build-artifact directories (``.build``, ``.fbuild``, ``build``, ``bin``,
+    ``.vscode``, ...) are pruned via :func:`should_skip_scan_dir`. They are
+    already invisible to ``discover_examples_all.py`` (which skips dot-dirs)
+    and to the mtime fast path (which uses the same predicate), so hashing
+    them would make a plain ``bash compile <board> --examples Blink`` look like
+    an example-source change and force a needless reconfigure — the very
+    false-positive class issue #3761 is about.
 
     Args:
         examples_dir: Root directory containing example files
 
     Returns:
-        SHA256 hash of all example file metadata
+        Deduplicated list of paths, sorted within each extension group
     """
-    # Find all .ino files and additional .cpp files
+    by_ext: dict[str, list[Path]] = {ext: [] for ext in _EXAMPLE_SOURCE_EXTS}
+
+    for dirpath, dirnames, filenames in os.walk(examples_dir):
+        # Prune in place so os.walk never descends into build artifacts.
+        dirnames[:] = [d for d in dirnames if not should_skip_scan_dir(d)]
+        for name in filenames:
+            ext = os.path.splitext(name)[1]
+            if ext in by_ext:
+                by_ext[ext].append(Path(dirpath) / name)
+
+    # Preserve the historical grouping: all .ino, then .cpp, then .h.
     example_files: list[Path] = []
-
-    # Find all .ino files recursively
-    for f in sorted(examples_dir.rglob("*.ino")):
-        example_files.append(f)
-
-    # Find all .cpp files in example subdirectories
-    for f in sorted(examples_dir.rglob("*.cpp")):
-        example_files.append(f)
-
-    # Find all .h files in example subdirectories (for dependencies)
-    for f in sorted(examples_dir.rglob("*.h")):
-        example_files.append(f)
+    for ext in _EXAMPLE_SOURCE_EXTS:
+        example_files.extend(sorted(by_ext[ext]))
 
     # Also include the discovery script itself so changes to it invalidate the cache
     this_script = Path(__file__).parent / "discover_examples_all.py"
@@ -67,24 +86,67 @@ def compute_example_files_hash(examples_dir: Path) -> str:
             seen.add(f)
             unique_files.append(f)
 
-    # Create hash input from file metadata
-    hash_input: list[str] = []
-    for f in unique_files:
-        if f.is_file():
-            from os import stat_result
+    return unique_files
 
-            stat: stat_result = f.stat()
-            # Use absolute path for scripts outside examples_dir
-            try:
-                rel_path: str = f.relative_to(examples_dir).as_posix()
-            except ValueError:
-                rel_path = f.as_posix()
-            # Include path, mtime, and size in hash
-            hash_input.append(f"{rel_path}:{stat.st_mtime:.6f}:{stat.st_size}")
 
-    # Compute SHA256 hash
-    hash_str = "\n".join(hash_input)
-    return hashlib.sha256(hash_str.encode()).hexdigest()
+def max_example_files_mtime(examples_dir: Path) -> float:
+    """
+    Return the newest mtime across every example file (0.0 if there are none).
+
+    This is the cheap probe that guards the full content hash: an in-place edit
+    bumps the edited file's mtime, so a tree whose files are all older than a
+    known-good marker cannot have been edited since. It does *not* observe
+    additions or deletions — pair it with :func:`get_max_dir_mtime`, which
+    catches those via the parent directory's mtime.
+    """
+    newest = 0.0
+    for f in iter_example_files(examples_dir):
+        try:
+            mtime = f.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > newest:
+            newest = mtime
+    return newest
+
+
+def compute_example_files_hash(examples_dir: Path) -> str:
+    """
+    Compute a hash of all example file paths and contents.
+
+    This detects examples being added, deleted, or modified without re-parsing
+    all example files. See the module docstring for why this hashes content
+    rather than mtimes (issue #3761).
+
+    Args:
+        examples_dir: Root directory containing example files
+
+    Returns:
+        SHA256 hash of all example file paths + contents
+    """
+    digest = hashlib.sha256()
+    for f in iter_example_files(examples_dir):
+        if not f.is_file():
+            continue
+        # Use absolute path for scripts outside examples_dir
+        try:
+            rel_path: str = f.relative_to(examples_dir).as_posix()
+        except ValueError:
+            rel_path = f.as_posix()
+        try:
+            content_digest = hashlib.sha256(f.read_bytes()).digest()
+        except OSError:
+            # Unreadable (Windows AV/indexer lock, permissions). Use a distinct
+            # marker so it cannot collide with a genuinely empty file, and so
+            # the hash still differs from the readable version — failing toward
+            # a reconfigure rather than silently reporting "unchanged".
+            content_digest = b"<unreadable>".ljust(32, b"\0")
+        digest.update(rel_path.encode())
+        digest.update(b"\0")
+        digest.update(content_digest)
+        digest.update(b"\n")
+
+    return digest.hexdigest()
 
 
 def load_cache(build_dir: Path) -> dict[str, str | float] | None:

--- a/ci/meson/meson_setup_phases.py
+++ b/ci/meson/meson_setup_phases.py
@@ -11,6 +11,8 @@ invocation.
 # pyright: reportMissingImports=false, reportUnknownVariableType=false
 
 import json
+import os
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -527,60 +529,93 @@ def detect_test_file_changes(
         return True
 
 
-def detect_example_file_changes(source_dir: Path, build_dir: Path) -> bool:
-    """Return True when ``examples/`` files have been added/removed/modified."""
+def detect_example_file_changes(source_dir: Path, build_dir: Path) -> "str | None":
+    """Return a reconfigure reason when ``examples/`` needs re-discovery, else None.
+
+    The reason is distinct for "cache missing" vs "files actually changed": a
+    missing cache means we *cannot prove* the examples are unchanged, which is
+    not the same claim as having observed a change (issue #3761). The caller
+    prints the returned reason, so this does not print one itself.
+
+    This never deletes the cache. Deleting it made a single false positive
+    self-perpetuating: only meson's ``--update`` rewrites the file, so any run
+    that was fully fingerprint-cached (meson never invoked) left the cache
+    missing and guaranteed another false "example files changed" next time.
+
+    The cache file's mtime doubles as a "contents last verified at" marker, and
+    is re-stamped whenever the content hash matches. Without that re-stamp a
+    single ``git checkout`` would leave every later run paying the full content
+    hash (~0.2s for ~300 files) forever, because the checkout's mtimes stay
+    newer than the cache the fast path compares against.
+    """
     try:
-        from ci.meson.example_metadata_cache import compute_example_files_hash
+        from ci.meson.example_metadata_cache import (
+            compute_example_files_hash,
+            max_example_files_mtime,
+        )
 
         examples_dir = source_dir / "examples"
         example_cache_file = build_dir / "examples" / "example_metadata.cache"
 
         if not examples_dir.exists():
-            return False
+            return None
 
-        skip_example_hash = False
-        if example_cache_file.exists():
-            try:
-                cache_mtime = example_cache_file.stat().st_mtime
-                max_example_dir_mtime = get_max_dir_mtime(examples_dir)
-                if max_example_dir_mtime <= cache_mtime:
-                    skip_example_hash = True
-            except OSError:
-                pass
+        if not example_cache_file.exists():
+            return "example metadata cache missing - cannot prove examples unchanged"
 
-        if skip_example_hash:
-            return False
-
-        current_example_hash = compute_example_files_hash(examples_dir)
-        cached_example_hash = ""
-        if example_cache_file.exists():
-            try:
-                with open(example_cache_file, "r") as f:
-                    cache_data = json.load(f)
-                cached_example_hash = cache_data.get("hash", "")
-            except KeyboardInterrupt as ki:
-                handle_keyboard_interrupt(ki)
-            except Exception:
-                cached_example_hash = ""
-
-        if current_example_hash != cached_example_hash:
-            print_warning(
-                "[MESON] ⚠️  Detected example file changes (files added/removed/modified)"
+        # Fast path: if nothing under examples/ is newer than the last-verified
+        # marker, the contents cannot have changed since. Both probes are
+        # needed — file mtimes catch in-place edits, directory mtimes catch
+        # additions and deletions (which leave sibling files untouched).
+        try:
+            verified_at = example_cache_file.stat().st_mtime
+            newest = max(
+                get_max_dir_mtime(examples_dir), max_example_files_mtime(examples_dir)
             )
-            if example_cache_file.exists():
-                try:
-                    example_cache_file.unlink()
-                except OSError:
-                    pass
-            return True
-        return False
+            # Strict `<`: an entry whose mtime lands in the same clock tick as
+            # the marker (Windows' system clock granularity is ~15ms) must fall
+            # through to the hash rather than be assumed unchanged.
+            if newest < verified_at:
+                return None
+        except OSError:
+            pass
+
+        cached_example_hash = ""
+        try:
+            # save_cache() writes UTF-8; reading with the platform locale codec
+            # (cp1252 on Windows) turns any non-ASCII example path or @filter
+            # string into a permanent decode failure, and therefore a
+            # reconfigure on every single run.
+            with open(example_cache_file, "r", encoding="utf-8") as f:
+                cache_data = json.load(f)
+            cached_example_hash = cache_data.get("hash", "")
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+        except Exception:
+            cached_example_hash = ""
+
+        if not cached_example_hash:
+            return "example metadata cache unreadable - cannot prove examples unchanged"
+
+        # Stamp the marker from *before* the hash, so an edit that lands while
+        # we are hashing still looks newer than the marker on the next run.
+        verify_started = time.time()
+        if compute_example_files_hash(examples_dir) != cached_example_hash:
+            return "example files changed"
+
+        # Contents match: re-arm the fast path so the next run skips the hash.
+        try:
+            os.utime(example_cache_file, (verify_started, verify_started))
+        except OSError:
+            pass
+        return None
 
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
         raise
     except Exception as e:
         _ts_print(f"[MESON] Warning: Could not check example file changes: {e}")
-        return True
+        return "example file check failed"
 
 
 def check_obsolete_zig_wrappers(source_dir: Path) -> None:

--- a/ci/meson/runner_helpers.py
+++ b/ci/meson/runner_helpers.py
@@ -144,7 +144,9 @@ def _recover_stale_build(
             build_dir / "test_list_cache.txt",
             build_dir / ".source_files_hash",
             build_dir / "tests" / "test_metadata.cache",
-            build_dir / "example_metadata.cache",
+            # Nested under examples/ — save_cache() writes it to meson's
+            # current_build_dir. The flat path here was a silent no-op.
+            build_dir / "examples" / "example_metadata.cache",
         ]
         for cache_file in cache_files:
             if cache_file.exists():

--- a/ci/tests/test_example_change_detector.py
+++ b/ci/tests/test_example_change_detector.py
@@ -1,0 +1,263 @@
+"""Tests for the meson example-change detector (issue #3761).
+
+The detector decides whether ``bash test`` must pay a full meson reconfigure
+(~20-30s) because ``examples/`` changed. Several bugs made it fire on a clean
+tree, or miss real changes:
+
+  1. A missing cache was reported as "example files changed" — conflating
+     "cannot prove unchanged" with "observed a change".
+  2. Firing *deleted* the cache, and only meson's ``--update`` rewrites it. A
+     following run that was fully fingerprint-cached never invoked meson, so
+     the cache stayed missing and guaranteed another false positive.
+  3. The hash was mtime-based, so ``git checkout`` / ``git worktree add``
+     invalidated it even though the file contents were byte-identical.
+  4. The mtime fast path consulted directory mtimes only, which do not move on
+     an in-place edit — so a content edit to an existing example was reported
+     as "unchanged" and the content hash was never consulted.
+  5. Nothing re-armed the fast path after a hash match, so one git checkout
+     left every later run paying the full content hash forever.
+  6. The file set included build artifacts under ``examples/*/.build`` etc.,
+     which a plain ``bash compile`` rewrites — a fresh false-positive source.
+  7. The cache was written UTF-8 but read with the platform locale codec.
+
+These tests pin all of those.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.meson.example_metadata_cache import (
+    compute_example_files_hash,
+    iter_example_files,
+)
+from ci.meson.meson_setup_phases import detect_example_file_changes
+
+
+def _make_source_tree(root: Path) -> Path:
+    examples = root / "examples"
+    (examples / "Blink").mkdir(parents=True)
+    (examples / "Blink" / "Blink.ino").write_text("void setup() {}\n")
+    (examples / "Blink" / "helper.h").write_text("#pragma once\n")
+    return examples
+
+
+def _write_cache(build_dir: Path, examples_dir: Path, metadata: str = "") -> Path:
+    cache_file = build_dir / "examples" / "example_metadata.cache"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "hash": compute_example_files_hash(examples_dir),
+                "timestamp": 0.0,
+                "metadata": metadata or "EXAMPLE|Blink|Blink",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return cache_file
+
+
+def _age_tree(examples_dir: Path, cache_file: Path) -> None:
+    """Make every example entry older than the cache, arming the fast path."""
+    past = cache_file.stat().st_mtime - 10_000
+    for f in list(examples_dir.rglob("*")) + [examples_dir]:
+        os.utime(f, (past, past))
+
+
+class TestExampleHashIsContentBased(unittest.TestCase):
+    def test_mtime_bump_alone_does_not_change_hash(self) -> None:
+        """git checkout rewrites mtimes with identical content — must not invalidate."""
+        with TemporaryDirectory() as tmp:
+            examples = _make_source_tree(Path(tmp))
+            before = compute_example_files_hash(examples)
+
+            for f in examples.rglob("*"):
+                if f.is_file():
+                    stat = f.stat()
+                    os.utime(f, (stat.st_atime + 10_000, stat.st_mtime + 10_000))
+
+            self.assertEqual(before, compute_example_files_hash(examples))
+
+    def test_content_edit_changes_hash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            examples = _make_source_tree(Path(tmp))
+            before = compute_example_files_hash(examples)
+            (examples / "Blink" / "Blink.ino").write_text("void setup() { x(); }\n")
+            self.assertNotEqual(before, compute_example_files_hash(examples))
+
+    def test_added_and_removed_files_change_hash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            examples = _make_source_tree(Path(tmp))
+            before = compute_example_files_hash(examples)
+
+            new_file = examples / "Fade" / "Fade.ino"
+            new_file.parent.mkdir()
+            new_file.write_text("void setup() {}\n")
+            self.assertNotEqual(before, compute_example_files_hash(examples))
+
+            new_file.unlink()
+            new_file.parent.rmdir()
+            self.assertEqual(before, compute_example_files_hash(examples))
+
+    def test_identical_content_under_different_names_differs(self) -> None:
+        """Paths participate in the hash, so a rename is a change."""
+        with TemporaryDirectory() as tmp:
+            examples = _make_source_tree(Path(tmp))
+            before = compute_example_files_hash(examples)
+            (examples / "Blink" / "Blink.ino").rename(
+                examples / "Blink" / "Renamed.ino"
+            )
+            self.assertNotEqual(before, compute_example_files_hash(examples))
+
+    def test_build_artifacts_are_pruned(self) -> None:
+        """`bash compile` writes .h/.cpp under examples/*/.build — not a source change."""
+        with TemporaryDirectory() as tmp:
+            examples = _make_source_tree(Path(tmp))
+            before = compute_example_files_hash(examples)
+
+            for artifact_dir in (".build", ".fbuild", "build", "bin", ".vscode"):
+                generated = examples / "Blink" / artifact_dir / "generated.h"
+                generated.parent.mkdir(parents=True)
+                generated.write_text("// generated\n")
+
+            self.assertEqual(before, compute_example_files_hash(examples))
+            listed = {p.name for p in iter_example_files(examples)}
+            self.assertNotIn("generated.h", listed)
+            self.assertIn("Blink.ino", listed)
+
+
+class TestDetectExampleFileChanges(unittest.TestCase):
+    def test_clean_tree_with_valid_cache_reports_no_change(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            examples = _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            _write_cache(build_dir, examples)
+
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+
+    def test_missing_cache_is_not_reported_as_a_file_change(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            build_dir.mkdir(parents=True)
+
+            reason = detect_example_file_changes(root, build_dir)
+            # Still reconfigures (safe default) but says why accurately.
+            self.assertIsNotNone(reason)
+            assert reason is not None
+            self.assertIn("cache missing", reason)
+            self.assertNotIn("files changed", reason)
+
+    def test_detector_never_deletes_the_cache(self) -> None:
+        """Deleting the cache is what made one false positive self-perpetuate."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            examples = _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            cache_file = _write_cache(build_dir, examples)
+
+            target = examples / "Blink" / "Blink.ino"
+            target.write_text("void setup() { y(); }\n")
+            future = cache_file.stat().st_mtime + 10_000
+            os.utime(target, (future, future))
+
+            self.assertEqual(
+                detect_example_file_changes(root, build_dir), "example files changed"
+            )
+            self.assertTrue(
+                cache_file.exists(), "detector must leave the cache in place"
+            )
+
+    def test_in_place_content_edit_is_detected(self) -> None:
+        """Directory mtimes do not move on an edit — the file mtime probe must."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            examples = _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            cache_file = _write_cache(build_dir, examples)
+            _age_tree(examples, cache_file)
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+
+            # Edit content without touching any directory entry.
+            target = examples / "Blink" / "Blink.ino"
+            target.write_text("// @filter: esp32\nvoid setup() {}\n")
+            future = cache_file.stat().st_mtime + 10_000
+            os.utime(target, (future, future))
+
+            self.assertEqual(
+                detect_example_file_changes(root, build_dir), "example files changed"
+            )
+
+    def test_fast_path_is_rearmed_after_a_matching_hash(self) -> None:
+        """A git checkout must cost one content hash, not one on every later run."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            examples = _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            cache_file = _write_cache(build_dir, examples)
+
+            # Simulate `git checkout`: content identical, but the working tree's
+            # mtimes are now newer than the cache, so the fast path cannot fire
+            # and the detector must fall through to the content hash.
+            past = cache_file.stat().st_mtime - 10_000
+            os.utime(cache_file, (past, past))
+
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+            self.assertGreater(
+                cache_file.stat().st_mtime,
+                past,
+                "cache mtime must be re-stamped so the fast path re-arms",
+            )
+
+            # The fast path is armed again. Prove the hash is now skipped: edit
+            # content but keep every mtime older than the re-stamped marker —
+            # only a run that skipped the hash reports "no change".
+            target = examples / "Blink" / "Blink.ino"
+            target.write_bytes(b"void setup() { z(); }\n")
+            for f in (target, target.parent, examples):
+                os.utime(f, (past, past))
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+
+    def test_unreadable_cache_is_distinguished_from_a_file_change(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            cache_file = build_dir / "examples" / "example_metadata.cache"
+            cache_file.parent.mkdir(parents=True)
+            cache_file.write_text("{ not json")
+            past = cache_file.stat().st_mtime - 10_000
+            os.utime(cache_file, (past, past))
+
+            reason = detect_example_file_changes(root, build_dir)
+            self.assertIsNotNone(reason)
+            assert reason is not None
+            self.assertIn("unreadable", reason)
+
+    def test_non_ascii_metadata_round_trips(self) -> None:
+        """The cache is written UTF-8; reading it with the locale codec broke it."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            examples = _make_source_tree(root)
+            build_dir = root / ".build" / "meson-quick"
+            _write_cache(build_dir, examples, metadata="EXAMPLE|Blink|Blink — café")
+
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+
+    def test_no_examples_dir_means_no_reconfigure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_dir = root / ".build" / "meson-quick"
+            build_dir.mkdir(parents=True)
+            self.assertIsNone(detect_example_file_changes(root, build_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3761.

## What was wrong

`bash test` paid a full ~20-30s reconfigure on an otherwise clean, fully cached tree, while the build system reported "Using cached example metadata (no changes detected)" in the same run. Two caches, one run, opposite answers.

The three causes named in the issue, all in `detect_example_file_changes`:

1. **"Cache missing" was reported as "example files changed."** With the cache absent there was no path to "unchanged" — the outcome was a guaranteed reconfigure under a misleading reason.
2. **Firing deleted the cache.** Only the `--update` step rewrites it, so any following run that was fully fingerprint-cached left the cache missing and primed the next false positive. One false fire perpetuated itself indefinitely — which is the state the repo was actually in.
3. **The hash was mtime-based.** `git checkout`, `git worktree add` and branch switches rewrite example mtimes with byte-identical content, so every one of them invalidated the cache.

## What changed

- "cache missing / unreadable — cannot prove examples unchanged" is now reported distinctly from "example files changed", and the reason string is returned to the caller (which already prints it) instead of being printed twice with wording that could drift.
- The detector never deletes the cache.
- The hash is content-based. `compute_example_files_hash` hashes path + SHA256(content) per file.

## Further defects found while reviewing the above

4. **The mtime fast path missed in-place edits.** `get_max_dir_mtime` stats directories, never files, and directory mtimes do not move on an edit. So editing an existing example — adding an `// @filter:` line, say — was reported "unchanged" and the content hash was never consulted. Now paired with a file-mtime probe, and compared with a strict `<` so an entry landing in the same clock tick as the marker (Windows' clock granularity is ~15ms) falls through to the hash instead of being assumed unchanged.
5. **Nothing re-armed the fast path** after a matching hash, so one `git checkout` would leave every later run paying the full ~0.2s content hash forever. The cache mtime now doubles as a "contents verified at" marker, stamped from *before* the hash so an edit landing mid-hash is still caught next run.
6. **Build artifacts were in the hash.** `examples/*/.build`, `.fbuild`, `build`, `bin` were included, and a plain `bash compile <board> --examples Blink` rewrites those — re-creating the same false positive from artifact content instead of artifact mtimes. Pruned with the predicate the mtime scan already used (`should_skip_scan_dir`, promoted from private so there is one source of truth). 302 → 268 files hashed.

Two more fixed in passing:

- The cache was written UTF-8 but read back with the platform locale codec (cp1252 on Windows). Any non-ASCII example path or filter string made `json.load` raise — and combined with no longer deleting the cache, that would have been a *permanent* per-run reconfigure.
- `_recover_stale_build` cleared `<build>/example_metadata.cache`, but the file lives at `<build>/examples/example_metadata.cache`. The delete was a silent no-op, so recovery re-adopted the stale example set it was meant to discard.

## Verification

On the real tree, before → after:

| scenario | before | after |
|---|---|---|
| repeated `bash test` on a clean tree | reconfigure every run | 0 reconfigures across 3 runs, cache persists |
| after a `git checkout` (identical content) | 20-30s reconfigure, every run | one 200ms content hash, then 80ms fast path |

The reconfigure reason is now accurate and printed once:

```
[MESON] Reconfiguring build directory (example metadata cache missing - cannot prove examples unchanged)
```

13 regression tests in `ci/tests/test_example_change_detector.py` pin each behavior, including the two that are easy to regress silently: in-place content edits must be detected, and the fast path must re-arm.

`bash lint` clean. Full C++ suite **357/357** (forced, not a replayed cached number — cf. #3763).

## Notes for the reviewer

- **Second commit is unrelated.** `bash lint` was already failing on master with two `ty` diagnostics in `ci/autoresearch/phases.py` (from the WS2814 change). Fixed here under the repo's fix-all-encountered-errors policy so lint is green; no behavior change.
- **`fl_task_executor` is flaky, pre-existing.** `fl::task::run SYSTEM yield paths` failed in two full-suite runs and passed in two others, passes in isolation on unmodified master, and passes clean under ASAN/UBSAN (`--debug`). This PR is Python-only and cannot affect C++ runtime behavior. Filed separately.
- **Not done here:** `compute_src_files_hash` and `compute_test_files_hash` still use the same mtime-based scheme and have the same git-checkout weakness; `detect_test_file_changes` still conflates a missing cache with "added N test files" (bounded to one run, so far less costly). Both left out to keep this reviewable — filed as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of example-file additions, removals, renames, and content changes.
  * Corrected stale-build recovery to remove the appropriate example metadata cache.
  * Unreadable files and invalid caches now trigger reliable reconfiguration instead of appearing unchanged.
  * Reconfiguration messages now explain the detected cause.

* **Tests**
  * Added comprehensive coverage for cache validation, file changes, artifact filtering, and repositories without examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->