### PR TITLE
fix(build): re-raise KeyboardInterrupt from the example cache read (#3771 follow-up)

### DIFF
--- a/ci/meson/meson_setup_phases.py
+++ b/ci/meson/meson_setup_phases.py
@@ -590,7 +590,13 @@ def detect_example_file_changes(source_dir: Path, build_dir: Path) -> "str | Non
                 cache_data = json.load(f)
             cached_example_hash = cache_data.get("hash", "")
         except KeyboardInterrupt as ki:
+            # Re-raise like the outer handler does. handle_keyboard_interrupt()
+            # only raises on the main thread; from a worker it just notifies and
+            # returns, so without this a Ctrl-C would fall through and be
+            # reported as "cache unreadable" — forcing a reconfigure out of an
+            # interrupt instead of unwinding.
             handle_keyboard_interrupt(ki)
+            raise
         except Exception:
             cached_example_hash = ""
 


### PR DESCRIPTION
@
Addresses the one unresolved CodeRabbit comment on #3771, which was merged before the fix commit landed on the branch.

## Problem

In `detect_example_file_changes()` (`ci/meson/meson_setup_phases.py`), the inner `except KeyboardInterrupt` called `handle_keyboard_interrupt(ki)` but did not re-raise.

`handle_keyboard_interrupt()` only raises when it runs on the main thread. From a worker thread it notifies the main thread and returns normally. Without an explicit `raise`, the interrupt was swallowed: execution fell through, `cached_example_hash` stayed empty, and the function returned `"example metadata cache unreadable"` — turning a Ctrl-C into a forced reconfigure instead of unwinding the thread.

## Fix

Add `raise` after `handle_keyboard_interrupt(ki)`, matching the outer `except KeyboardInterrupt` handler in the same function.

`bash lint` clean.

CodeRabbit comment: https://github.com/FastLED/FastLED/pull/3771#discussion_r3687664537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interruption handling during setup checks so manual cancellations are no longer reported as cache-read errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->