### PR TITLE
fix(test): record scope provenance so a partial run cannot read as a full pass (#3763)

### DIFF
--- a/ci/tests/test_fingerprint_scope.py
+++ b/ci/tests/test_fingerprint_scope.py
@@ -1,0 +1,150 @@
+"""Tests for test-result scope provenance in the fingerprint cache (issue #3763).
+
+A cached test result is replayed verbatim on later runs:
+
+    ✓ Fingerprint cache valid - skipping C++ unit tests [357/357 passed in 55.20s]
+
+Nothing in that line said whether the number came from a full-suite run or from
+a filtered one, so a partial result was indistinguishable from a full pass and
+was reported as authoritative until something invalidated the fingerprint. The
+reporter of #3763 acted on a `1/1 passed` line once, believing it was evidence
+of suite health.
+
+The fix records the run's *scope* alongside the counts and renders it. These
+tests pin that the annotation exists, survives a round trip, and — the part
+that actually matters — that a partial result can never render as a clean full
+pass.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.util.fingerprint import FingerprintManager
+from ci.util.test_types import FingerprintResult
+
+
+def _result(**kw: object) -> FingerprintResult:
+    base: dict[str, object] = {
+        "hash": "abc123",
+        "num_tests_run": 357,
+        "num_tests_passed": 357,
+        "duration_seconds": 55.2,
+        "test_name": "cpp_unit_tests",
+    }
+    base.update(kw)
+    return FingerprintResult(**base)  # type: ignore[arg-type]
+
+
+class TestCacheSummaryProvenance(unittest.TestCase):
+    def test_full_run_reads_as_a_clean_pass(self) -> None:
+        summary = _result(scope="full").get_cache_summary()
+        self.assertIn("357/357 passed", summary)
+        self.assertNotIn("filtered", summary)
+        self.assertNotIn("unrecorded", summary)
+
+    def test_partial_run_is_marked_and_cannot_read_as_full(self) -> None:
+        """The #3763 failure: `1/1 passed` looked like a full green suite."""
+        summary = _result(
+            num_tests_run=1, num_tests_passed=1, duration_seconds=16.98, scope="partial"
+        ).get_cache_summary()
+        self.assertIn("1/1 passed", summary)
+        self.assertIn("NOT the full suite", summary)
+
+    def test_missing_scope_is_reported_as_unverified(self) -> None:
+        """A fingerprint written before this field existed must not claim full."""
+        summary = _result(scope=None).get_cache_summary()
+        self.assertIn("357/357 passed", summary)
+        self.assertIn("scope unrecorded", summary)
+        self.assertNotIn("NOT the full suite", summary)
+
+    def test_no_counts_still_yields_empty_summary(self) -> None:
+        self.assertEqual(
+            FingerprintResult(hash="abc").get_cache_summary(),
+            "",
+        )
+
+
+class TestScopePersistence(unittest.TestCase):
+    def test_scope_round_trips_through_disk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr.write("cpp_test", _result(scope="partial"))
+
+            reloaded = mgr.read("cpp_test")
+            self.assertIsNotNone(reloaded)
+            assert reloaded is not None
+            self.assertEqual(reloaded.scope, "partial")
+            self.assertIn("NOT the full suite", reloaded.get_cache_summary())
+
+    def test_scope_is_written_into_the_json(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr.write("cpp_test", _result(scope="full"))
+            path = Path(tmp) / "fingerprint" / "cpp_test_quick.json"
+            self.assertEqual(json.loads(path.read_text())["scope"], "full")
+
+    def test_legacy_fingerprint_without_scope_loads_as_none(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            path = Path(tmp) / "fingerprint" / "cpp_test_quick.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "hash": "abc123",
+                        "status": "success",
+                        "num_tests_run": 274,
+                        "num_tests_passed": 274,
+                    }
+                )
+            )
+            reloaded = mgr.read("cpp_test")
+            assert reloaded is not None
+            self.assertIsNone(reloaded.scope)
+            self.assertIn("scope unrecorded", reloaded.get_cache_summary())
+
+
+class TestScopeCarriedForward(unittest.TestCase):
+    def test_update_test_metadata_records_scope(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")
+            mgr.update_test_metadata(
+                "cpp_test",
+                num_tests_run=1,
+                num_tests_passed=1,
+                duration_seconds=0.1,
+                test_name="cpp_unit_tests",
+                scope="partial",
+            )
+            self.assertEqual(mgr._fingerprints["cpp_test"].scope, "partial")
+
+    def test_scope_travels_with_the_counts_on_a_cache_hit(self) -> None:
+        """save_all() carries prior counts forward when nothing ran — the scope
+        that labels those counts must come with them, or a filtered result gets
+        silently relabelled as a full pass on the very next run."""
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr._prev_fingerprints["cpp_test"] = _result(
+                num_tests_run=1, num_tests_passed=1, scope="partial"
+            )
+            # Current run produced no counts (tests were skipped).
+            mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")
+
+            mgr.save_all("success")
+
+            reloaded = mgr.read("cpp_test")
+            assert reloaded is not None
+            self.assertEqual(reloaded.num_tests_run, 1)
+            self.assertEqual(
+                reloaded.scope,
+                "partial",
+                "counts carried forward without their scope would read as a full pass",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/util/fingerprint.py
+++ b/ci/util/fingerprint.py
@@ -100,6 +100,7 @@ class FingerprintManager:
                         duration_seconds=data.get("duration_seconds"),
                         test_name=data.get("test_name"),
                         source_max_mtime=data.get("source_max_mtime"),
+                        scope=data.get("scope"),
                     )
                 except json.JSONDecodeError:
                     ts_print(f"Invalid {name} fingerprint file. Recalculating...")
@@ -123,6 +124,8 @@ class FingerprintManager:
             fingerprint_dict["test_name"] = fingerprint.test_name
         if fingerprint.source_max_mtime is not None:
             fingerprint_dict["source_max_mtime"] = fingerprint.source_max_mtime
+        if fingerprint.scope is not None:
+            fingerprint_dict["scope"] = fingerprint.scope
         with open(fingerprint_file, "w") as f:
             json.dump(fingerprint_dict, f, indent=2)
 
@@ -149,6 +152,9 @@ class FingerprintManager:
                     fingerprint.num_tests_passed = prev_fp.num_tests_passed
                     fingerprint.duration_seconds = prev_fp.duration_seconds
                     fingerprint.test_name = prev_fp.test_name
+                    # Carry scope with the counts it describes -- splitting
+                    # them would relabel a filtered result as a full one.
+                    fingerprint.scope = prev_fp.scope
             # Persist the watermark from this invocation's opening scan. On a
             # fast-path hit nothing was rebuilt, so carry the previous value
             # forward rather than advancing it -- advancing would absorb any
@@ -169,14 +175,20 @@ class FingerprintManager:
         num_tests_passed: int,
         duration_seconds: float,
         test_name: Optional[str] = None,
+        scope: Optional[str] = None,
     ) -> None:
-        """Update the test metadata for a fingerprint before saving"""
+        """Update the test metadata for a fingerprint before saving.
+
+        ``scope`` is "full" when the run covered the whole suite and
+        "partial" when a filter narrowed it (#3763).
+        """
         if name in self._fingerprints:
             self._fingerprints[name].num_tests_run = num_tests_run
             self._fingerprints[name].num_tests_passed = num_tests_passed
             self._fingerprints[name].duration_seconds = duration_seconds
             if test_name:
                 self._fingerprints[name].test_name = test_name
+            self._fingerprints[name].scope = scope
 
     def get_prev_fingerprint(self, name: str) -> Optional[FingerprintResult]:
         """Get the previous fingerprint data (from last run) for display"""

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1582,7 +1582,10 @@ def runner(
                     print(summary)
                 sys.exit(1)
 
-            # Update fingerprint metadata for cache display on next run
+            # Update fingerprint metadata for cache display on next run.
+            # Record whether this run covered the whole suite: the counts are
+            # replayed verbatim on later cache hits, so a filtered run's number
+            # must never be presentable as a full-suite pass (#3763).
             if fingerprint_manager is not None:
                 fingerprint_manager.update_test_metadata(
                     "cpp_test",
@@ -1590,6 +1593,7 @@ def runner(
                     num_tests_passed=result.num_tests_passed,
                     duration_seconds=result.duration,
                     test_name="cpp_unit_tests",
+                    scope="partial" if (test_name or test_file_filter) else "full",
                 )
 
             # Print timing summary table for unit-only mode
@@ -1673,7 +1677,10 @@ def runner(
                 compile_test_link_time=result.compile_test_link_time,
             )
 
-            # Update fingerprint metadata for cache display on next run
+            # Update fingerprint metadata for cache display on next run.
+            # Record whether this run covered the whole suite: the counts are
+            # replayed verbatim on later cache hits, so a filtered run's number
+            # must never be presentable as a full-suite pass (#3763).
             if fingerprint_manager is not None:
                 fingerprint_manager.update_test_metadata(
                     "cpp_test",
@@ -1681,6 +1688,7 @@ def runner(
                     num_tests_passed=result.num_tests_passed,
                     duration_seconds=result.duration,
                     test_name="cpp_unit_tests",
+                    scope="partial" if (test_name or test_file_filter) else "full",
                 )
 
             if not result.success:

--- a/ci/util/test_types.py
+++ b/ci/util/test_types.py
@@ -164,6 +164,12 @@ class FingerprintResult:
     # while the run was in flight looks older than the cache and gets skipped
     # on every later run while the suite still reports green.
     source_max_mtime: Optional[float] = None
+    # Provenance of the counts above: "full" when the run covered the whole
+    # suite, "partial" when a filter/selection narrowed it. Cached counts are
+    # replayed verbatim on later runs, so without this a subset result reads as
+    # an authoritative full-suite pass and there is no way to tell the two
+    # apart after the fact (#3763).
+    scope: Optional[str] = None
 
     def get_cache_summary(self) -> str:
         """Get a human-readable summary of cached test results"""
@@ -171,7 +177,19 @@ class FingerprintResult:
             duration_str = (
                 f" in {self.duration_seconds:.2f}s" if self.duration_seconds else ""
             )
-            return f"{self.num_tests_passed}/{self.num_tests_run} passed{duration_str}"
+            # Say where the number came from. "partial" is called out; a missing
+            # scope is from a fingerprint written before this field existed, so
+            # it is reported as unverified rather than silently as a full pass.
+            if self.scope == "partial":
+                scope_str = ", filtered run - NOT the full suite"
+            elif self.scope == "full":
+                scope_str = ""
+            else:
+                scope_str = ", scope unrecorded"
+            return (
+                f"{self.num_tests_passed}/{self.num_tests_run} "
+                f"passed{duration_str}{scope_str}"
+            )
         return ""
 
     def should_skip(self, current: "FingerprintResult") -> bool:


### PR DESCRIPTION
Refs #3763. Implements the mitigation the issue asks for, plus the structural half of it.

## The problem

Cached test counts are replayed verbatim:

```
✓ Fingerprint cache valid - skipping C++ unit tests [357/357 passed in 55.20s]
```

Nothing said whether that number came from a full-suite run or a narrowed one. A partial result read as an authoritative green until something invalidated the fingerprint — and the reporter acted on a `1/1 passed` line once, believing it was evidence of suite health.

## What changed

`FingerprintResult` gains a `scope` field recorded alongside the counts, and `get_cache_summary()` renders it:

| run | rendered |
|---|---|
| full | `274/274 passed in 30.47s` |
| filtered | `1/1 passed in 16.98s, filtered run - NOT the full suite` |
| written before this field existed | `357/357 passed in 55.20s, scope unrecorded` |

The third row is deliberate: an unknown provenance is **not** evidence of a full pass, so legacy entries are never silently promoted to "full".

`save_all()` carries `scope` forward together with the counts it labels — carrying counts without their scope would relabel a filtered result as a full one on the very next cache hit, which would have been a fresh instance of this same bug.

## Verified end to end

```
$ bash test --cpp
✅ All tests passed (274/274 in 30.49s)
after FULL run -> {'num_tests_run': 274, 'num_tests_passed': 274, 'scope': 'full'}
```

9 new tests in `ci/tests/test_fingerprint_scope.py` cover rendering for all three scopes, JSON round-trip, legacy load, and the carry-forward-with-counts invariant. `bash lint` clean; 85 related Python tests pass.

## What I found while doing this — worth reading

I root-caused the `274` in the issue, and **it is not a truncated suite**. Full write-up in [the issue](https://github.com/FastLED/FastLED/issues/3763#issuecomment-5139297675), short version:

| measure | count |
|---|---|
| test sources discovered by `discover_test_files()` (authoritative) | 274 |
| test `.dll` binaries built | 274 |
| `test_list_cache.txt` entries | 274 |
| reporter's clean-run baseline | 357 |

`357 - 274 = 83`, which is exactly the "83 test binaries" the reporter computed. Those are the **example** targets. `--cpp` runs unit tests *and* examples, and both feed the same `✅ All tests passed (N/N)` line — so the headline silently means *unit + examples* on one run and *unit only* on the next, with no wording change. Reproducible on demand by deleting `.cache/fingerprint/cpp_test_quick.json` and re-running.

Also worth recording: the replayed number does **not** come from `.full_run_cache.json` (which the reporter checked and correctly found keyed separately). It comes from the fingerprint metadata for the `cpp_test` key. That is the slot a wrong `N` lands in.

## Scope of this PR, honestly

This makes the *labelling* trustworthy. It does **not** fix the unit-vs-examples denominator ambiguity above — that is the larger and riskier half, and I would rather land honest labelling first than bundle them. Filing that separately.

One thing I want to be straight about: I could not reproduce the `1/1` case, and filtered runs currently do not persist a `cpp_test` fingerprint at all, so the filtered-write path does not fire today. The two write sites still had no guard, so the safety was incidental rather than structural — this makes it structural, and the `scope unrecorded` behaviour is what actually changes day-to-day output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test cache summaries now indicate whether results represent the full test suite or a partial selection.
  * Cached test metadata preserves scope information across saves and reloads.
  * Legacy cache entries without scope metadata are clearly identified as unrecorded.

* **Bug Fixes**
  * Prevented partial test-run counts from being misrepresented as full-suite results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->