### PR TITLE
test(task): make the zero-budget sleep check robust to a contended machine (#3772)

### DIFF
--- a/tests/fl/task/executor.cpp
+++ b/tests/fl/task/executor.cpp
@@ -16,6 +16,7 @@
 #include "fl/stl/utility.h"
 #include "fl/stl/atomic.h"
 #include "fl/system/delay.h"
+#include "fl/system/yield.h"  // fl::yield — control for the timing check
 #include "platforms/stub/mutex_stub_stl.h"
 #include "platforms/stub/thread_stub_stl.h"
 #include "fl/stl/vector.h"
@@ -1092,19 +1093,51 @@ FL_TEST_CASE("fl::task::run SYSTEM yield paths") {
     FL_SUBCASE("a zero budget does not sleep") {
         run(0, ExecFlags::SYSTEM);  // warm up lazy init
 
-        fl::u32 best = 0xFFFFFFFFu;
-        for (int i = 0; i < 5; ++i) {
+        // This bounds a wall clock, so it is only meaningful when the machine
+        // is idle enough to measure. Alongside the candidate we time a bare
+        // fl::yield() -- the very call the zero-budget path is supposed to
+        // take, and one that by definition cannot sleep. Interleaving the two
+        // means OS preemption inflates both together, so the control tells us
+        // whether the measurement is trustworthy at all.
+        //
+        // Why a control and not just a bigger threshold (FastLED#3772): under
+        // real full-suite load the *minimum* of 5 samples was measured at
+        // 6.6ms and 17ms on a 16-core box -- 26x and 69x the 250us bound. At
+        // that noise level a 1ms sleep is undetectable by any wall-clock
+        // method, so raising the threshold cannot fix it and would only blunt
+        // the check on the idle machines where it does work. Instead: keep the
+        // tight bound, and decline to assert when the control proves the
+        // environment cannot support the measurement.
+        const int kSamples = 32;
+        fl::u32 best_run = 0xFFFFFFFFu;
+        fl::u32 best_yield = 0xFFFFFFFFu;
+        for (int i = 0; i < kSamples; ++i) {
             const fl::u32 t0 = fl::micros();
             run(0, ExecFlags::SYSTEM);
-            const fl::u32 dt = fl::micros() - t0;
-            if (dt < best) {
-                best = dt;
+            const fl::u32 dt_run = fl::micros() - t0;
+            if (dt_run < best_run) {
+                best_run = dt_run;
+            }
+
+            const fl::u32 t1 = fl::micros();
+            fl::yield();
+            const fl::u32 dt_yield = fl::micros() - t1;
+            if (dt_yield < best_yield) {
+                best_yield = dt_yield;
             }
         }
-        // Best-of-N: this bounds a wall clock, so a single sample can be
-        // inflated by OS preemption. A regression that made this path sleep
-        // would raise every sample, which best-of-N cannot hide.
-        FL_CHECK_LT(best, 250u);
+
+        // The control cannot sleep. If even it exceeds the bound, the box is
+        // too contended for this to mean anything -- report inconclusive
+        // rather than a false failure.
+        if (best_yield < 250u) {
+            FL_CHECK_LT(best_run, 250u);
+        } else {
+            FL_WARN("zero-budget sleep check skipped: machine too contended "
+                    "to measure (bare fl::yield() best-of-"
+                    << kSamples << " was " << best_yield
+                    << "us, over the 250us bound)");
+        }
     }
 
     FL_SUBCASE("a small budget still terminates") {


### PR DESCRIPTION
Closes #3772.

`fl::task::run SYSTEM yield paths` failed intermittently in the full suite while always passing in isolation and clean under sanitizers. It hit two of my own PRs this week (#3771, #3778) on both Windows and the macOS runner, so it is producing real false reds on the gate used to decide whether to merge.

## Measured before changing anything

| condition | best of 5 samples |
|---|---|
| idle | **0–1µs** |
| under 48 busy procs on 16 cores | **6650µs** |
| under 48 busy procs on 16 cores | **17259µs** |

The bound is 250µs. Idle, the path has 250x headroom — so the assertion is nowhere near marginal. Under load the *minimum* is 26–69x over.

## Why the obvious fixes don't work

**Raising the threshold cannot work.** At 6–17ms of scheduling noise, a 1ms sleep is undetectable by any wall-clock method. Any threshold that survives the noise sits far above the thing it exists to catch, and it would blunt the check on the idle machines where it does work.

**More samples alone doesn't work either.** Under sustained contention *every* sample is inflated. That is precisely the case the existing comment assumed away:

> A regression that made this path sleep would raise every sample, which best-of-N cannot hide.

True of a regression; not true of a loaded machine, where contention also raises every sample. Best-of-N cannot tell the two apart.

## What this does instead

Time a bare `fl::yield()` as a **control**, interleaved with the candidate. It is the exact call the zero-budget path is supposed to take (`executor.cpp.hpp:156`) and by definition cannot sleep, so preemption inflates both together.

The tight 250µs bound is **kept** and asserted normally. When even the control exceeds it, the environment cannot support a wall-clock measurement at all, so the test reports inconclusive rather than a false failure. Samples raised 5 → 32 to sharpen both minima.

## Verified in both directions

This is the part that matters — a flake "fix" that just stops asserting is worse than the flake.

- **No longer false-fails:** under the same synthetic load that previously failed **2 of 10** runs, the revised test passed **12 of 12**.
- **Still catches the regression:** injecting a 2ms cost into the zero-budget path in `src/fl/task/executor.cpp.hpp` makes the test **fail** as intended. The probe was reverted; only `tests/fl/task/executor.cpp` is changed in this PR.

Full C++ suite 274/274. Passes clean under `--debug` (ASAN/LSAN/UBSAN). `bash lint` clean.

## Note

I deliberately left this alone earlier in the week when it was blocking #3771, because relaxing an unrelated regression guard to unblock my own PR is the wrong shape of change even when the guard is the thing at fault. Doing it now as its own task, with the numbers measured and the guard proven still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of system-yield responsiveness and timing behavior.
  * Added more representative repeated measurements to reduce flaky results.
  * Tests now account for temporary system contention and provide a warning when timing conditions are inconclusive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->