### PR TITLE
fix(build): content-hash the src/ and tests/ metadata caches, share one helper (#3773)

### DIFF
--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -50,7 +50,12 @@ def compute_files_content_hash(files: Iterable[Path], root: Path) -> str:
         try:
             rel_path = f.relative_to(root).as_posix()
         except ValueError:
-            rel_path = f.as_posix()
+            # Outside *root*: use the ABSOLUTE path. A bare f.as_posix() would
+            # keep a relative path, which can collide with an identically-named
+            # relative path inside root when the contents match -- and a
+            # collision here means an external file's change is invisible to
+            # the cache.
+            rel_path = f.absolute().as_posix()
         try:
             content_digest = hashlib.sha256(f.read_bytes()).digest()
         except OSError:

--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -8,11 +8,62 @@ All functions here are pure data-reading/writing utilities that gate build skip
 decisions. They must remain free of any non-stdlib imports.
 """
 
+import hashlib
 import json
 import os
 import platform
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Content hashing
+# ---------------------------------------------------------------------------
+
+
+def compute_files_content_hash(files: Iterable[Path], root: Path) -> str:
+    """
+    Hash each file's path plus a digest of its contents.
+
+    Deliberately *content*-based rather than mtime-based. ``git checkout``,
+    ``git worktree add`` and branch switches rewrite mtimes with byte-identical
+    content, so an mtime hash treats every one of those as a source change and
+    forces the expensive rediscovery the cache exists to avoid (issue #3761 for
+    ``examples/``, #3773 for ``src/`` and ``tests/``).
+
+    Callers pass their own file list: the three metadata caches select files
+    very differently, and folding that selection in here would be how a real
+    source directory quietly stops being hashed.
+
+    Args:
+        files: Files to hash, in a stable order (the order is significant).
+        root: Directory paths are reported relative to. Files outside it fall
+            back to their absolute path so they still contribute uniquely.
+
+    Returns:
+        SHA256 hex digest over the (path, content) pairs.
+    """
+    digest = hashlib.sha256()
+    for f in files:
+        if not f.is_file():
+            continue
+        try:
+            rel_path = f.relative_to(root).as_posix()
+        except ValueError:
+            rel_path = f.as_posix()
+        try:
+            content_digest = hashlib.sha256(f.read_bytes()).digest()
+        except OSError:
+            # Unreadable (AV/indexer lock, permissions). Use a distinct marker
+            # so it cannot collide with a genuinely empty file, and so the hash
+            # still differs from the readable version -- failing toward a
+            # rediscovery rather than silently reporting "unchanged".
+            content_digest = b"<unreadable>".ljust(32, b"\0")
+        digest.update(rel_path.encode())
+        digest.update(b"\0")
+        digest.update(content_digest)
+        digest.update(b"\n")
+    return digest.hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/ci/meson/example_metadata_cache.py
+++ b/ci/meson/example_metadata_cache.py
@@ -28,7 +28,10 @@ import os
 import sys
 from pathlib import Path
 
-from ci.meson.cache_utils import should_skip_scan_dir
+from ci.meson.cache_utils import (
+    compute_files_content_hash,
+    should_skip_scan_dir,
+)
 
 
 CACHE_FILENAME = "example_metadata.cache"
@@ -124,29 +127,9 @@ def compute_example_files_hash(examples_dir: Path) -> str:
     Returns:
         SHA256 hash of all example file paths + contents
     """
-    digest = hashlib.sha256()
-    for f in iter_example_files(examples_dir):
-        if not f.is_file():
-            continue
-        # Use absolute path for scripts outside examples_dir
-        try:
-            rel_path: str = f.relative_to(examples_dir).as_posix()
-        except ValueError:
-            rel_path = f.as_posix()
-        try:
-            content_digest = hashlib.sha256(f.read_bytes()).digest()
-        except OSError:
-            # Unreadable (Windows AV/indexer lock, permissions). Use a distinct
-            # marker so it cannot collide with a genuinely empty file, and so
-            # the hash still differs from the readable version — failing toward
-            # a reconfigure rather than silently reporting "unchanged".
-            content_digest = b"<unreadable>".ljust(32, b"\0")
-        digest.update(rel_path.encode())
-        digest.update(b"\0")
-        digest.update(content_digest)
-        digest.update(b"\n")
-
-    return digest.hexdigest()
+    # Paths outside examples_dir (the discovery script) fall back to their
+    # absolute path inside the helper, so they still contribute uniquely.
+    return compute_files_content_hash(iter_example_files(examples_dir), examples_dir)
 
 
 def load_cache(build_dir: Path) -> dict[str, str | float] | None:

--- a/ci/meson/src_metadata_cache.py
+++ b/ci/meson/src_metadata_cache.py
@@ -2,7 +2,7 @@
 Source file metadata caching for Meson build system.
 
 This module provides hash-based caching to avoid re-running source discovery scripts
-when source files haven't changed. It tracks all .cpp file metadata (path + mtime + size)
+when source files haven't changed. It tracks all .cpp file paths and contents
 and invalidates the cache only when sources are added, deleted, or modified.
 
 Usage:
@@ -17,18 +17,20 @@ Usage:
 """
 
 import argparse
-import hashlib
 import json
 import sys
 from dataclasses import dataclass
-from os import stat_result
 from pathlib import Path
 
 from typeguard import typechecked
 
+from ci.meson.cache_utils import compute_files_content_hash
+
 
 CACHE_FILENAME = "src_metadata.cache"
-CACHE_VERSION = 2
+# Bumped to 3: the hash switched from mtime-based to content-based (#3773),
+# so entries written by an older version are not comparable.
+CACHE_VERSION = 3
 
 
 @typechecked
@@ -44,33 +46,30 @@ class CacheEntry:
 
 def compute_src_files_hash(src_dir: Path, pattern: str) -> str:
     """
-    Compute a hash of all source file metadata (path + mtime + size).
+    Compute a hash of all source file paths and contents.
 
     This provides a fast way to detect if any source files have been added,
     deleted, or modified without re-parsing all source files.
+
+    Content-based, not mtime-based: ``git checkout``, ``git worktree add`` and
+    branch switches rewrite mtimes with byte-identical content, and an mtime
+    hash treated every one of those as a source change, re-running discovery
+    inside each configure for nothing (issue #3773; #3761 was the same bug in
+    the examples cache).
+
+    The file selection is deliberately left as a plain ``rglob`` with no
+    build-artifact pruning: ``src/fl/build/`` is a real source directory (see
+    ``library.json`` -> ``build.srcFilter``), so a name-based "skip build dirs"
+    filter here would silently stop hashing shipped sources.
 
     Args:
         src_dir: Root directory containing source files
         pattern: File pattern to match (default: "*.cpp")
 
     Returns:
-        SHA256 hash of all source file metadata
+        SHA256 hash of all source file paths + contents
     """
-    # Find all files matching pattern recursively
-    source_files = sorted(src_dir.rglob(pattern))
-
-    # Create hash input from file metadata
-    hash_input: list[str] = []
-    for f in source_files:
-        if f.is_file():
-            stat: stat_result = f.stat()
-            rel_path: str = f.relative_to(src_dir).as_posix()
-            # Include path, mtime, and size in hash
-            hash_input.append(f"{rel_path}:{stat.st_mtime:.6f}:{stat.st_size}")
-
-    # Compute SHA256 hash
-    hash_str = "\n".join(hash_input)
-    return hashlib.sha256(hash_str.encode()).hexdigest()
+    return compute_files_content_hash(sorted(src_dir.rglob(pattern)), src_dir)
 
 
 def load_cache(build_dir: Path) -> CacheEntry | None:

--- a/ci/tests/test_content_hash.py
+++ b/ci/tests/test_content_hash.py
@@ -105,6 +105,34 @@ class TestContentHash(unittest.TestCase):
                 with_outside, compute_files_content_hash(files + [outside], root)
             )
 
+    def test_relative_path_outside_root_cannot_collide_with_one_inside(self) -> None:
+        """An outside-root file is keyed by its ABSOLUTE path.
+
+        Keying it by the relative path it was passed as lets it collide with an
+        identically-named path inside *root* whenever the contents match, and a
+        collision means the external file's edits are invisible to the cache.
+        """
+        with TemporaryDirectory() as tmp:
+            work = Path(tmp) / "work"
+            root = work / "inside"
+            root.mkdir(parents=True)
+            files = _tree(root)  # root/pkg/a.cpp, root/pkg/b.h
+
+            # Same relative path, same content, but OUTSIDE root.
+            (work / "pkg").mkdir()
+            (work / "pkg" / "a.cpp").write_bytes(files[0].read_bytes())
+
+            prev = os.getcwd()
+            os.chdir(work)
+            try:
+                outside_rel = Path("pkg") / "a.cpp"
+                self.assertNotEqual(
+                    compute_files_content_hash([files[0]], root),
+                    compute_files_content_hash([outside_rel], root),
+                )
+            finally:
+                os.chdir(prev)
+
     def test_unreadable_file_is_distinct_from_an_empty_one(self) -> None:
         """An unreadable file must not hash the same as a genuinely empty one,
         or a transient lock would silently read as 'unchanged'."""

--- a/ci/tests/test_content_hash.py
+++ b/ci/tests/test_content_hash.py
@@ -123,10 +123,22 @@ class TestContentHash(unittest.TestCase):
             (work / "pkg").mkdir()
             (work / "pkg" / "a.cpp").write_bytes(files[0].read_bytes())
 
+            # The collision only exists when the caller passes a *relative*
+            # path, because Path.as_posix() on an absolute path is already
+            # absolute. Reproducing it therefore requires the cwd to be `work`
+            # so that "pkg/a.cpp" names the outside file -- os.path.relpath()
+            # from the ambient cwd yields a long "../.." form that collides
+            # with nothing and would make this test vacuous.
+            #
+            # cwd is restored in finally. Note this is process-global: it is
+            # safe under pytest's default in-process serial execution and under
+            # xdist (separate worker processes), but do not make this class
+            # thread-parallel without revisiting it.
             prev = os.getcwd()
             os.chdir(work)
             try:
                 outside_rel = Path("pkg") / "a.cpp"
+                self.assertFalse(outside_rel.is_absolute())
                 self.assertNotEqual(
                     compute_files_content_hash([files[0]], root),
                     compute_files_content_hash([outside_rel], root),

--- a/ci/tests/test_content_hash.py
+++ b/ci/tests/test_content_hash.py
@@ -1,0 +1,131 @@
+"""Tests for the shared content-hash helper (issue #3773, follows #3761).
+
+The three metadata caches (src/, tests/, examples/) used to key on
+``path:mtime:size``. ``git checkout``, ``git worktree add`` and branch switches
+rewrite mtimes with byte-identical content, so every one of those invalidated
+the cache and forced the rediscovery the cache exists to avoid. #3761 fixed the
+examples cache; this covers the extracted helper all three now share.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.meson.cache_utils import compute_files_content_hash
+
+
+def _tree(root: Path) -> list[Path]:
+    (root / "pkg").mkdir(parents=True)
+    a = root / "pkg" / "a.cpp"
+    b = root / "pkg" / "b.h"
+    a.write_text("int a() { return 1; }\n")
+    b.write_text("#pragma once\n")
+    return [a, b]
+
+
+class TestContentHash(unittest.TestCase):
+    def test_mtime_churn_does_not_change_the_hash(self) -> None:
+        """The whole point: a git checkout must not invalidate the cache."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            before = compute_files_content_hash(files, root)
+
+            for f in files:
+                st = f.stat()
+                os.utime(f, (st.st_atime + 10_000, st.st_mtime + 10_000))
+
+            self.assertEqual(before, compute_files_content_hash(files, root))
+
+    def test_content_edit_changes_the_hash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            before = compute_files_content_hash(files, root)
+            files[0].write_text("int a() { return 2; }\n")
+            self.assertNotEqual(before, compute_files_content_hash(files, root))
+
+    def test_rename_changes_the_hash(self) -> None:
+        """Paths participate, so identical content under a new name differs."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            before = compute_files_content_hash(files, root)
+            renamed = files[0].with_name("renamed.cpp")
+            files[0].rename(renamed)
+            self.assertNotEqual(
+                before, compute_files_content_hash([renamed, files[1]], root)
+            )
+
+    def test_order_is_significant_so_callers_must_sort(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            self.assertNotEqual(
+                compute_files_content_hash(files, root),
+                compute_files_content_hash(list(reversed(files)), root),
+            )
+
+    def test_dropping_a_file_changes_the_hash(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            self.assertNotEqual(
+                compute_files_content_hash(files, root),
+                compute_files_content_hash(files[:1], root),
+            )
+
+    def test_missing_files_are_skipped_not_fatal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            files = _tree(root)
+            expected = compute_files_content_hash(files, root)
+            with_ghost = files + [root / "pkg" / "does_not_exist.cpp"]
+            self.assertEqual(expected, compute_files_content_hash(with_ghost, root))
+
+    def test_file_outside_root_still_contributes(self) -> None:
+        """The examples cache hashes its discovery script, which lives outside."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / "inside"
+            root.mkdir()
+            files = _tree(root)
+            outside = Path(tmp) / "outside.py"
+            outside.write_text("# discovery script\n")
+
+            base = compute_files_content_hash(files, root)
+            with_outside = compute_files_content_hash(files + [outside], root)
+            self.assertNotEqual(base, with_outside)
+
+            # And its *content* matters, not just its presence.
+            outside.write_text("# discovery script, changed\n")
+            self.assertNotEqual(
+                with_outside, compute_files_content_hash(files + [outside], root)
+            )
+
+    def test_unreadable_file_is_distinct_from_an_empty_one(self) -> None:
+        """An unreadable file must not hash the same as a genuinely empty one,
+        or a transient lock would silently read as 'unchanged'."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pkg").mkdir()
+            empty = root / "pkg" / "empty.cpp"
+            empty.write_text("")
+            empty_hash = compute_files_content_hash([empty], root)
+
+            # The marker used for an unreadable file is a fixed 32-byte token;
+            # assert it does not collide with sha256(b"") for the same path.
+            import hashlib
+
+            digest = hashlib.sha256()
+            digest.update("pkg/empty.cpp".encode())
+            digest.update(b"\0")
+            digest.update(b"<unreadable>".ljust(32, b"\0"))
+            digest.update(b"\n")
+            self.assertNotEqual(empty_hash, digest.hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_content_hash.py
+++ b/ci/tests/test_content_hash.py
@@ -13,6 +13,7 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 from ci.meson.cache_utils import compute_files_content_hash
 
@@ -134,25 +135,41 @@ class TestContentHash(unittest.TestCase):
                 os.chdir(prev)
 
     def test_unreadable_file_is_distinct_from_an_empty_one(self) -> None:
-        """An unreadable file must not hash the same as a genuinely empty one,
-        or a transient lock would silently read as 'unchanged'."""
+        """An unreadable file must not hash the same as a genuinely empty one.
+
+        If it did, a file locked by AV or an indexer would hash identically to
+        an empty file, and a later edit made while it was still unlocked-but-
+        empty-looking would read as "unchanged". Drives the helper against a
+        real read failure rather than asserting against a hand-built digest,
+        so it would catch the helper skipping the file or hashing it as b"".
+        """
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "pkg").mkdir()
-            empty = root / "pkg" / "empty.cpp"
-            empty.write_text("")
-            empty_hash = compute_files_content_hash([empty], root)
+            target = root / "pkg" / "empty.cpp"
+            target.write_text("")
 
-            # The marker used for an unreadable file is a fixed 32-byte token;
-            # assert it does not collide with sha256(b"") for the same path.
-            import hashlib
+            empty_hash = compute_files_content_hash([target], root)
 
-            digest = hashlib.sha256()
-            digest.update("pkg/empty.cpp".encode())
-            digest.update(b"\0")
-            digest.update(b"<unreadable>".ljust(32, b"\0"))
-            digest.update(b"\n")
-            self.assertNotEqual(empty_hash, digest.hexdigest())
+            real_read_bytes = Path.read_bytes
+
+            def deny(self: Path) -> bytes:
+                if self == target:
+                    raise PermissionError(13, "locked by another process")
+                return real_read_bytes(self)
+
+            with mock.patch.object(Path, "read_bytes", deny):
+                unreadable_hash = compute_files_content_hash([target], root)
+
+            self.assertNotEqual(
+                empty_hash,
+                unreadable_hash,
+                "an unreadable file must not hash like an empty one",
+            )
+
+            # And it must still be hashed, not silently dropped: a skipped file
+            # would collapse to the digest of an empty file list.
+            self.assertNotEqual(unreadable_hash, compute_files_content_hash([], root))
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -2,7 +2,7 @@
 Test metadata caching for Meson build system.
 
 This module provides hash-based caching to avoid re-running organize_tests.py
-when test files haven't changed. It tracks all test file metadata (path + mtime + size)
+when test files haven't changed. It tracks all test file paths and contents
 and invalidates the cache only when tests are added, deleted, or modified.
 
 Usage:
@@ -20,12 +20,13 @@ Usage:
 """
 
 import argparse
-import hashlib
 import json
 import sys
 from itertools import chain
 from pathlib import Path
 from typing import Dict, List, Set
+
+from ci.meson.cache_utils import compute_files_content_hash
 
 
 CACHE_FILENAME = "test_metadata.cache"
@@ -33,16 +34,22 @@ CACHE_FILENAME = "test_metadata.cache"
 
 def compute_test_files_hash(tests_dir: Path) -> str:
     """
-    Compute a hash of all test file metadata (path + mtime + size).
+    Compute a hash of all test file paths and contents.
 
     This provides a fast way to detect if any test files have been added,
     deleted, or modified without re-parsing all test files.
+
+    Content-based, not mtime-based: ``git checkout``, ``git worktree add`` and
+    branch switches rewrite mtimes with byte-identical content, and an mtime
+    hash treated every one of those as a test-tree change, re-running discovery
+    inside each configure for nothing (issue #3773; #3761 was the same bug in
+    the examples cache).
 
     Args:
         tests_dir: Root directory containing test files
 
     Returns:
-        SHA256 hash of all test file metadata
+        SHA256 hash of all test file paths + contents
     """
     # Find all *.cpp / *.ino files recursively, same logic as discover_tests.py
     from discover_tests import TEST_SOURCE_GLOBS
@@ -70,18 +77,7 @@ def compute_test_files_hash(tests_dir: Path) -> str:
 
     unique_files = test_files  # already deduplicated by rglob + sorted
 
-    # Create hash input from file metadata
-    hash_input = []
-    for f in unique_files:
-        if f.is_file():
-            stat = f.stat()
-            rel_path = f.relative_to(tests_dir).as_posix()
-            # Include path, mtime, and size in hash
-            hash_input.append(f"{rel_path}:{stat.st_mtime:.6f}:{stat.st_size}")
-
-    # Compute SHA256 hash
-    hash_str = "\n".join(hash_input)
-    return hashlib.sha256(hash_str.encode()).hexdigest()
+    return compute_files_content_hash(unique_files, tests_dir)
 
 
 def load_cache(build_dir: Path) -> dict | None:


### PR DESCRIPTION
Closes #3773. Follow-up to #3761.

## The problem

#3761 fixed the examples metadata cache, which keyed on `path:mtime:size`. `git checkout`, `git worktree add` and branch switches rewrite mtimes with byte-identical content, so every one of them invalidated the cache and forced the rediscovery the cache exists to avoid.

Two byte-identical copies of that scheme were left behind:

- `ci/meson/src_metadata_cache.py` → `compute_src_files_hash`
- `tests/test_metadata_cache.py` → `compute_test_files_hash`

so `src/` and `tests/` discovery still re-ran inside every configure after any git operation.

## What changed

Both now hash content. The hashing is extracted into one `compute_files_content_hash(files, root)` in `ci/meson/cache_utils.py`, and all three caches use it — including the examples cache, replacing the inline copy #3761 added.

`src` `CACHE_VERSION` 2 → 3, since entries written under the mtime scheme are not comparable.

## The design decision worth reviewing

**Callers keep their own file selection.** It would be tidier to fold selection into the helper, and that would be a bug.

`src/fl/build/` is *shipped source* — it is listed in `library.json` under `build.srcFilter` as `+<fl/build/*.cpp>`. The name-based "skip build dirs" pruning that `examples/` genuinely needs (`should_skip_scan_dir`, which skips any directory named `build`) would have silently stopped hashing it. That is a strictly worse failure than the one being fixed: the cache would go stale on real source edits, rather than merely being over-eager.

So the helper hashes exactly the list it is given, and each cache keeps the selection logic it already had. I looked for this specifically because the pruning was the subtle part of #3761.

## Verified

**The refactor is behavior-preserving** — the examples hash is byte-identical before and after, so nobody pays a spurious reconfigure for it:

```
refactored: 9a67aa1e73a46f3a4c035f8a0bb71ab49cf262b82050ebe575541580b3ece279
master    : 9a67aa1e73a46f3a4c035f8a0bb71ab49cf262b82050ebe575541580b3ece279
```

**End to end on all three caches**, driving the CLIs exactly as the build system does:

| step | src | tests | examples |
|---|---|---|---|
| seed via `--update`, then `--check` | hit | hit | hit |
| after rewriting mtimes on 10,920 files (simulated `git checkout`) | **hit** | **hit** | **hit** |
| after a real content edit | miss | miss | — |
| after reverting that edit | hit | hit | — |

Row 2 is the fix; every one of those was a miss before.

Also confirmed the new cross-tree import (`tests/test_metadata_cache.py` importing `ci.meson.cache_utils`) resolves under the build system's invocation with cwd set to the build directory — I tested that explicitly before relying on it, since `tests/` sits outside the `ci` package.

Clean full build **357/357** with all three discovery scripts running. 8 new tests in `ci/tests/test_content_hash.py`; `bash lint` clean.

## Note

`ci/tests/test_meson_include_paths.py` fails locally for `build_dir='meson-debug'`, but it fails identically on unmodified master — a local-state artifact of having a debug build directory around, not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata cache accuracy by detecting file content changes independently of modification timestamps.
  * Cache hashing now recognizes file renames, additions, removals, and unreadable files.
  * Missing files no longer cause hashing failures.
  * Updated existing cache entries to use the new content-based hashing behavior.
* **Tests**
  * Added coverage for content changes, file ordering, paths outside the project root, and unreadable files.
  * Updated metadata cache tests to validate content-based hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->