### PR TITLE
fix(test): report the unit/example split so a partial run cannot read as a full pass (#3779)

### DIFF
--- a/ci/early_exit_cache.py
+++ b/ci/early_exit_cache.py
@@ -279,6 +279,60 @@ def test_cached(build_dir: Path, test_name: str, artifact_path: Path) -> bool:
         return False
 
 
+def _cpp_run_breakdown(fp: dict, num_passed: int, num_run: int) -> "tuple[str, str]":
+    """Render a cached cpp_test count with its unit/example split.
+
+    Stdlib-only mirror of ci.util.test_types.format_run_breakdown -- importing
+    that module costs ~62ms, which is more than this whole early-exit path is
+    allowed to spend (see the module docstring on intentional duplication).
+    Keep the wording in step with the canonical implementation.
+
+    A total alone cannot say whether examples were part of the run, so
+    "274 unit, examples cached" and "274 of the 357 expected" render
+    identically (#3779).
+
+    Returns ``(counts, notes)``; ``notes`` is empty when every requested
+    population ran.
+    """
+    ex_run = fp.get("num_examples_run")
+    ex_passed = fp.get("num_examples_passed")
+    included = fp.get("examples_included")
+    if ex_run is None or ex_passed is None or included is None:
+        if included is not None:
+            # Populations known, sizes not -- name the coverage, claim no split.
+            if included:
+                return f"{num_passed}/{num_run} unit + examples", ""
+            return f"{num_passed}/{num_run} unit", "examples not requested"
+        # Written before the split was recorded -- replay the total, but do
+        # not let it imply coverage it cannot vouch for.
+        return f"{num_passed}/{num_run}", "unit/example split unrecorded"
+
+    # #3778 records a narrowed run as scope="partial"; a population that ran
+    # nothing under a filter was skipped, not verified as up to date.
+    missing = (
+        "not matched by filter"
+        if fp.get("scope") == "partial"
+        else "cached, not re-run"
+    )
+    parts = []
+    if num_run - ex_run:
+        parts.append(f"{num_passed - ex_passed}/{num_run - ex_run} unit")
+    if ex_run:
+        parts.append(f"{ex_passed}/{ex_run} examples")
+    notes = []
+    if not (num_run - ex_run):
+        notes.append(f"unit tests {missing}")
+    if not included:
+        notes.append("examples not requested")
+    elif not ex_run:
+        notes.append(f"examples {missing}")
+
+    # Keep the totals visible when nothing ran, so an empty run stays
+    # distinguishable from a corrupt entry.
+    counts = ", ".join(parts) if parts else f"{num_passed}/{num_run}"
+    return counts, "; ".join(notes)
+
+
 def full_run_cache(
     build_dir: Path, include_examples: bool = False
 ) -> tuple[int, int, float] | None:
@@ -552,7 +606,11 @@ def argv_ultra_early_exit(start_time: float) -> None:
             _nt = _cpp_fp.get("num_tests_run")
             _dur = _cpp_fp.get("duration_seconds")
             if _np is not None and _nt is not None and _dur is not None:
-                _cpp_label = f"cpp_unit_tests ({_np}/{_nt} passed in {_dur:.2f}s)"
+                _counts, _notes = _cpp_run_breakdown(_cpp_fp, _np, _nt)
+                _cpp_label = (
+                    f"cpp_unit_tests ({_counts} passed in {_dur:.2f}s"
+                    f"{'; ' + _notes if _notes else ''})"
+                )
 
             _rows = [
                 (_cpp_label, "skipped"),
@@ -601,9 +659,17 @@ def argv_ultra_early_exit(start_time: float) -> None:
                 import time  # noqa: PLC0415 - lazy import
 
                 _np_fr, _nt_fr, _dur_fr = _cached_fr
+                # .full_run_cache.json records only a total -- it has no
+                # unit/example attribution, and the CURRENT invocation's flags
+                # describe this reader, not the run that wrote the entry (a
+                # --unit run's cache can be served here to --cpp). Claiming a
+                # coverage this entry never recorded would be the very
+                # fabrication #3779 is about, so report the total and say the
+                # split is unknown.
                 print(
                     f"✓ Fingerprint cache valid - skipping C++ unit tests "
-                    f"[{_np_fr}/{_nt_fr} passed in {_dur_fr:.2f}s]"
+                    f"[{_np_fr}/{_nt_fr} passed in {_dur_fr:.2f}s, "
+                    f"unit/example split unrecorded]"
                 )
                 print(f"Total: {time.time() - start_time:.2f}s")
                 sys.exit(0)

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -50,6 +50,29 @@ class StreamingResult:
     compile_output: str = ""
     failed_names: list[str] = field(default_factory=list)
     compile_sub_phases: dict[str, float] = field(default_factory=dict)
+    # Subset of the totals above contributed by example targets. Only
+    # artifacts Ninja relinked this run are executed, so a population whose
+    # binaries were already up to date silently contributes zero -- callers
+    # need the split to say so out loud rather than shrinking one total
+    # (#3779).
+    num_passed_examples: int = 0
+    num_failed_examples: int = 0
+
+
+def is_example_artifact(test_path: Path) -> bool:
+    """True when a built artifact is an example rather than a unit test.
+
+    The build lays unit-test binaries under ``<build>/tests/`` and example
+    binaries under ``<build>/examples/``; that directory is the only surviving
+    marker of which population an artifact belongs to.
+
+    Phrased as "not a unit test" so this stays the single discriminator: the
+    streaming runner calls it to choose between ``runner`` and
+    ``example_runner``, and counting an artifact as a unit test while handing
+    it to ``example_runner`` would let the two disagree -- exactly the kind of
+    silent miscount #3779 is about.
+    """
+    return test_path.parent.name != "tests"
 
 
 @dataclass
@@ -711,6 +734,8 @@ def stream_compile_and_run_tests(
 
     num_passed = 0
     num_failed = 0
+    num_passed_examples = 0
+    num_failed_examples = 0
     failed_names: list[str] = []
     tests_completed = 0
 
@@ -723,8 +748,11 @@ def stream_compile_and_run_tests(
             wr = future.result()
             tests_completed += 1
             idx = tests_completed
+            is_example = is_example_artifact(wr.test_path)
             if wr.test_result.success:
                 num_passed += 1
+                if is_example:
+                    num_passed_examples += 1
                 if not verbose:
                     print_success(f"  [{idx}/{total}] ✓ {wr.test_path.stem}")
                 else:
@@ -734,6 +762,8 @@ def stream_compile_and_run_tests(
                             _ts_print(f"  {line}")
             else:
                 num_failed += 1
+                if is_example:
+                    num_failed_examples += 1
                 failed_names.append(wr.test_path.stem)
                 if wr.error_msg:
                     _ts_print(
@@ -796,4 +826,6 @@ def stream_compile_and_run_tests(
         compile_output=cr.compile_output,
         failed_names=failed_names,
         compile_sub_phases=cr.compile_sub_phases,
+        num_passed_examples=num_passed_examples,
+        num_failed_examples=num_failed_examples,
     )

--- a/ci/meson/streaming_runner.py
+++ b/ci/meson/streaming_runner.py
@@ -34,10 +34,19 @@ from ci.meson.runner_helpers import (
     _write_failure_log,
     _write_testlog_failures,
 )
-from ci.meson.streaming import TestResult, stream_compile_and_run_tests
-from ci.meson.test_execution import MesonTestResult, run_meson_test
+from ci.meson.streaming import (
+    TestResult,
+    is_example_artifact,
+    stream_compile_and_run_tests,
+)
+from ci.meson.test_execution import (
+    MesonTestResult,
+    examples_are_included,
+    run_meson_test,
+)
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
+from ci.util.test_types import describe_test_counts
 from ci.util.timestamp_print import ts_print as _ts_print
 
 
@@ -239,10 +248,23 @@ def _handle_streaming_failure(
     failed_outputs_lock: threading.Lock,
     duration: float,
     num_tests_run: int,
+    include_examples: bool,
 ) -> MesonTestResult:
     """Print failure details and write logs after the streaming path failed."""
+    # Attribute the failure counts too. An anonymous denominator is least
+    # affordable here: "355/357" cannot say whether the 2 failures were unit
+    # tests or examples, nor which population the total covers (#3779).
+    num_examples_run = sr.num_passed_examples + sr.num_failed_examples
+    breakdown = describe_test_counts(
+        num_passed=sr.num_passed,
+        num_run=num_tests_run,
+        num_examples_passed=sr.num_passed_examples,
+        num_examples_run=num_examples_run,
+        examples_included=include_examples,
+        filtered=bool(ctx.test_file_filter),
+    )
     print_error(
-        f"[MESON] ❌ Some tests failed ({sr.num_passed}/{num_tests_run} tests in {duration:.2f}s)"
+        f"[MESON] ❌ Some tests failed ({breakdown.describe(f' in {duration:.2f}s')})"
     )
     # Snapshot under lock — workers may still be running after shutdown(wait=False).
     with failed_outputs_lock:
@@ -282,6 +304,9 @@ def _handle_streaming_failure(
         num_tests_passed=sr.num_passed,
         num_tests_failed=sr.num_failed,
         failed_test_names=sr.failed_names,
+        num_examples_run=num_examples_run,
+        num_examples_passed=sr.num_passed_examples,
+        examples_included=include_examples,
     )
 
 
@@ -314,12 +339,12 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
 
             if test_path.suffix.lower() in (".dll", ".so", ".dylib"):
                 runner_suffix = ".exe" if os.name == "nt" else ""
-                if test_path.parent.name == "tests":
-                    runner = ctx.build_dir / "tests" / f"runner{runner_suffix}"
-                else:
+                if is_example_artifact(test_path):
                     runner = (
                         ctx.build_dir / "examples" / f"example_runner{runner_suffix}"
                     )
+                else:
+                    runner = ctx.build_dir / "tests" / f"runner{runner_suffix}"
                 if not runner.exists():
                     return TestResult(
                         success=False,
@@ -390,9 +415,7 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
     # Debug builds with ASAN are significantly slower (esp. Windows CI).
     compile_timeout = 2700 if ctx.use_debug else 600
 
-    include_examples = not (
-        ctx.exclude_suites and "fastled:examples" in ctx.exclude_suites
-    )
+    include_examples = examples_are_included(ctx.exclude_suites)
     compile_target = "all-with-examples" if include_examples else None
 
     if compile_target == "all-with-examples":
@@ -442,19 +465,38 @@ def run_streaming_path(ctx: StreamingContext) -> MesonTestResult:
 
     if not sr.success:
         return _handle_streaming_failure(
-            ctx, sr, failed_test_outputs, failed_outputs_lock, duration, num_tests_run
+            ctx,
+            sr,
+            failed_test_outputs,
+            failed_outputs_lock,
+            duration,
+            num_tests_run,
+            include_examples,
         )
 
     _ts_print(ctx.build_timer.format_table())
-    print_success(
-        f"✅ All tests passed ({sr.num_passed}/{num_tests_run} in {duration:.2f}s)"
+    num_examples_run = sr.num_passed_examples + sr.num_failed_examples
+    breakdown = describe_test_counts(
+        num_passed=sr.num_passed,
+        num_run=num_tests_run,
+        num_examples_passed=sr.num_passed_examples,
+        num_examples_run=num_examples_run,
+        examples_included=include_examples,
+        # A name/file selector drops non-matching artifacts before they are
+        # ever submitted, so a population that ran nothing under one was
+        # filtered out -- not verified as up to date.
+        filtered=bool(ctx.test_file_filter),
     )
+    print_success(f"✅ All tests passed ({breakdown.describe(f' in {duration:.2f}s')})")
     result = MesonTestResult(
         success=True,
         duration=duration,
         num_tests_run=num_tests_run,
         num_tests_passed=sr.num_passed,
         num_tests_failed=sr.num_failed,
+        num_examples_run=num_examples_run,
+        num_examples_passed=sr.num_passed_examples,
+        examples_included=include_examples,
     )
     result = _apply_phase_timing(result, ctx.build_timer)
     _apply_compile_sub_phases(result, sr.compile_sub_phases)

--- a/ci/meson/test_execution.py
+++ b/ci/meson/test_execution.py
@@ -17,7 +17,37 @@ from ci.meson.output import (
 )
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
+from ci.util.test_types import describe_test_counts
 from ci.util.timestamp_print import ts_print as _ts_print
+
+
+# Meson suite holding the example targets, as passed to --no-suite.
+EXAMPLES_SUITE = "fastled:examples"
+
+
+def _bare_suite(suite: str) -> str:
+    """Strip meson's optional ``project:`` qualifier from a suite name."""
+    return suite.rsplit(":", 1)[-1]
+
+
+def examples_are_included(
+    exclude_suites: "Optional[list[str]]", test_name: "Optional[str]" = None
+) -> bool:
+    """True when the examples suite was in scope for a run.
+
+    Meson accepts a suite either bare (``examples``) or project-qualified
+    (``fastled:examples``), and this repo's own docstrings advertise both
+    forms. Matching only the qualified spelling would read a genuine
+    ``--no-suite examples`` exclusion as "examples were included" and assert
+    coverage of a population that never ran (#3779), so normalize first.
+
+    A ``test_name`` selects one target, which likewise cannot cover the suite.
+    """
+    if test_name:
+        return False
+    if not exclude_suites:
+        return True
+    return _bare_suite(EXAMPLES_SUITE) not in {_bare_suite(s) for s in exclude_suites}
 
 
 @dataclass
@@ -32,6 +62,12 @@ class MesonTestResult:
     compilation_skipped: bool = (
         False  # True when result came from cache (no compilation)
     )
+    # Portion of the totals above contributed by example targets, and whether
+    # examples were part of this run's request at all. ``None`` means the path
+    # that produced this result cannot attribute its counts (#3779).
+    num_examples_run: Optional[int] = None
+    num_examples_passed: Optional[int] = None
+    examples_included: Optional[bool] = None
     failed_test_names: list[str] = field(default_factory=list)
     # Phase timing breakdown (seconds) - for detailed performance analysis
     meson_setup_time: float = 0.0
@@ -250,8 +286,25 @@ def run_meson_test(
         actual_passed = expected_total if expected_total > 0 else num_passed
         actual_run = expected_total if expected_total > 0 else num_run
 
+        # Name the populations this total covers (#3779). ``meson test``
+        # reports one suite-wide number with no unit/example split, but the
+        # suite exclusions say which populations were eligible: with examples
+        # excluded every test counted is a unit test, so the total is fully
+        # attributable. With them included the split stays unknown -- say so
+        # rather than inventing one.
+        examples_included = examples_are_included(exclude_suites, test_name)
+        num_examples_run = None if examples_included else 0
+        num_examples_passed = None if examples_included else 0
+        breakdown = describe_test_counts(
+            num_passed=actual_passed,
+            num_run=actual_run,
+            num_examples_passed=num_examples_passed,
+            num_examples_run=num_examples_run,
+            examples_included=examples_included,
+        )
+
         print_success(
-            f"✅ All tests passed ({actual_passed}/{actual_run} in {duration:.2f}s)"
+            f"✅ All tests passed ({breakdown.describe(f' in {duration:.2f}s')})"
         )
         return MesonTestResult(
             success=True,
@@ -259,6 +312,9 @@ def run_meson_test(
             num_tests_run=actual_run,
             num_tests_passed=actual_passed,
             num_tests_failed=0,  # Meson returned 0, so no failures
+            num_examples_run=num_examples_run,
+            num_examples_passed=num_examples_passed,
+            examples_included=examples_included,
         )
 
     except KeyboardInterrupt as ki:

--- a/ci/tests/test_fingerprint_scope.py
+++ b/ci/tests/test_fingerprint_scope.py
@@ -28,12 +28,16 @@ from ci.util.test_types import FingerprintResult
 
 
 def _result(**kw: object) -> FingerprintResult:
+    """A fully-attributed cpp_test fingerprint: 274 unit + 83 examples = 357."""
     base: dict[str, object] = {
         "hash": "abc123",
         "num_tests_run": 357,
         "num_tests_passed": 357,
         "duration_seconds": 55.2,
         "test_name": "cpp_unit_tests",
+        "num_examples_run": 83,
+        "num_examples_passed": 83,
+        "examples_included": True,
     }
     base.update(kw)
     return FingerprintResult(**base)  # type: ignore[arg-type]
@@ -42,22 +46,28 @@ def _result(**kw: object) -> FingerprintResult:
 class TestCacheSummaryProvenance(unittest.TestCase):
     def test_full_run_reads_as_a_clean_pass(self) -> None:
         summary = _result(scope="full").get_cache_summary()
-        self.assertIn("357/357 passed", summary)
+        self.assertIn("274/274 unit", summary)
+        self.assertIn("83/83 examples", summary)
         self.assertNotIn("filtered", summary)
         self.assertNotIn("unrecorded", summary)
 
     def test_partial_run_is_marked_and_cannot_read_as_full(self) -> None:
         """The #3763 failure: `1/1 passed` looked like a full green suite."""
         summary = _result(
-            num_tests_run=1, num_tests_passed=1, duration_seconds=16.98, scope="partial"
+            num_tests_run=1,
+            num_tests_passed=1,
+            num_examples_run=0,
+            num_examples_passed=0,
+            duration_seconds=16.98,
+            scope="partial",
         ).get_cache_summary()
-        self.assertIn("1/1 passed", summary)
+        self.assertIn("1/1 unit passed", summary)
         self.assertIn("NOT the full suite", summary)
 
     def test_missing_scope_is_reported_as_unverified(self) -> None:
         """A fingerprint written before this field existed must not claim full."""
         summary = _result(scope=None).get_cache_summary()
-        self.assertIn("357/357 passed", summary)
+        self.assertIn("274/274 unit", summary)
         self.assertIn("scope unrecorded", summary)
         self.assertNotIn("NOT the full suite", summary)
 
@@ -129,7 +139,11 @@ class TestScopeCarriedForward(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             mgr = FingerprintManager(Path(tmp))
             mgr._prev_fingerprints["cpp_test"] = _result(
-                num_tests_run=1, num_tests_passed=1, scope="partial"
+                num_tests_run=1,
+                num_tests_passed=1,
+                num_examples_run=0,
+                num_examples_passed=0,
+                scope="partial",
             )
             # Current run produced no counts (tests were skipped).
             mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")

--- a/ci/tests/test_run_breakdown.py
+++ b/ci/tests/test_run_breakdown.py
@@ -1,0 +1,457 @@
+"""Tests for the unit/example split in test-count reporting (issue #3779).
+
+``bash test --cpp`` runs two populations -- unit tests and example compile
+targets -- and both fed one anonymous denominator:
+
+    ✅ All tests passed (357/357 in 48.00s)   <- unit + examples
+    ✅ All tests passed (274/274 in 30.49s)   <- unit only, examples cached
+
+The wording was byte-identical, so a reader could not tell "274 unit tests,
+examples already cached" from "274 of the 357 things I expected". These tests
+pin that each population is named, that a population which did not run is
+called out rather than silently dropped from a total, and that the same split
+survives into the replayed cache line.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.early_exit_cache import _cpp_run_breakdown
+from ci.meson.streaming import StreamingResult, is_example_artifact
+from ci.meson.test_execution import MesonTestResult, examples_are_included
+from ci.util.fingerprint import FingerprintManager
+from ci.util.test_runner import _describe_cpp_counts
+from ci.util.test_types import (
+    FingerprintResult,
+    RunBreakdown,
+    describe_test_counts,
+    format_run_breakdown,
+)
+
+
+class TestArtifactClassification(unittest.TestCase):
+    """The build directory is the only surviving unit/example marker."""
+
+    def test_example_artifact_is_recognized(self) -> None:
+        self.assertTrue(
+            is_example_artifact(Path(".build/meson/examples/Blink.dll")),
+        )
+
+    def test_unit_test_artifact_is_not_an_example(self) -> None:
+        self.assertFalse(
+            is_example_artifact(Path(".build/meson/tests/fl_fixed_point_s16x16.dll")),
+        )
+
+    def test_a_build_dir_named_examples_does_not_confuse_a_unit_test(self) -> None:
+        """Classification keys on the artifact's own parent, not any ancestor."""
+        self.assertFalse(
+            is_example_artifact(
+                Path("/home/examples/fastled/.build/tests/test_fx.dll")
+            ),
+        )
+
+
+class TestBreakdownWording(unittest.TestCase):
+    def test_both_populations_ran(self) -> None:
+        breakdown = format_run_breakdown(
+            unit_passed=274,
+            unit_run=274,
+            examples_passed=83,
+            examples_run=83,
+            examples_included=True,
+        )
+        self.assertEqual(breakdown.counts, "274/274 unit, 83/83 examples")
+        self.assertEqual(breakdown.notes, "")
+
+    def test_cached_examples_are_named_not_silently_dropped(self) -> None:
+        """The #3779 failure: this used to render as a bare `274/274`."""
+        breakdown = format_run_breakdown(
+            unit_passed=274,
+            unit_run=274,
+            examples_passed=0,
+            examples_run=0,
+            examples_included=True,
+        )
+        self.assertEqual(breakdown.counts, "274/274 unit")
+        self.assertEqual(breakdown.notes, "examples cached, not re-run")
+
+    def test_unit_only_mode_says_not_requested_not_cached(self) -> None:
+        """`--unit` excludes the examples suite; that is not a cache hit."""
+        breakdown = format_run_breakdown(
+            unit_passed=274,
+            unit_run=274,
+            examples_passed=0,
+            examples_run=0,
+            examples_included=False,
+        )
+        self.assertEqual(breakdown.notes, "examples not requested")
+
+    def test_cached_units_with_fresh_examples(self) -> None:
+        breakdown = format_run_breakdown(
+            unit_passed=0,
+            unit_run=0,
+            examples_passed=83,
+            examples_run=83,
+            examples_included=True,
+        )
+        self.assertEqual(breakdown.counts, "83/83 examples")
+        self.assertEqual(breakdown.notes, "unit tests cached, not re-run")
+
+    def test_nothing_executed_keeps_the_totals_visible(self) -> None:
+        """A zero run must still show numbers -- "nothing executed passed in
+        0.5s" was ungrammatical and hid the difference between an empty run
+        and a corrupt cache entry."""
+        breakdown = format_run_breakdown(
+            unit_passed=0,
+            unit_run=0,
+            examples_passed=0,
+            examples_run=0,
+            examples_included=True,
+        )
+        self.assertEqual(breakdown.counts, "0/0")
+        self.assertIn("unit tests cached", breakdown.notes)
+        self.assertIn("examples cached", breakdown.notes)
+
+    def test_a_filtered_run_never_claims_a_population_was_cached(self) -> None:
+        """`bash test <name>` drops non-matching artifacts before submission.
+        Reporting them as "cached, not re-run" asserts they were verified up
+        to date -- the unearned-coverage claim #3779 is about."""
+        breakdown = format_run_breakdown(
+            unit_passed=1,
+            unit_run=1,
+            examples_passed=0,
+            examples_run=0,
+            examples_included=True,
+            filtered=True,
+        )
+        self.assertEqual(breakdown.counts, "1/1 unit")
+        self.assertEqual(breakdown.notes, "examples not matched by filter")
+        self.assertNotIn("cached", breakdown.notes)
+
+    def test_failures_keep_the_denominator_honest_per_population(self) -> None:
+        breakdown = format_run_breakdown(
+            unit_passed=272,
+            unit_run=274,
+            examples_passed=83,
+            examples_run=83,
+            examples_included=True,
+        )
+        self.assertEqual(breakdown.counts, "272/274 unit, 83/83 examples")
+
+
+class TestStreamingResultAttribution(unittest.TestCase):
+    def test_example_counts_are_a_subset_of_the_totals(self) -> None:
+        sr = StreamingResult(
+            success=True,
+            num_passed=357,
+            num_failed=0,
+            num_passed_examples=83,
+            num_failed_examples=0,
+        )
+        self.assertEqual(sr.num_passed - sr.num_passed_examples, 274)
+
+    def test_defaults_attribute_everything_to_unit_tests(self) -> None:
+        sr = StreamingResult(success=True, num_passed=274)
+        self.assertEqual(sr.num_passed_examples, 0)
+        self.assertEqual(sr.num_failed_examples, 0)
+
+
+class TestCacheSummaryCarriesTheSplit(unittest.TestCase):
+    def test_replayed_line_names_both_populations(self) -> None:
+        summary = FingerprintResult(
+            hash="abc123",
+            num_tests_run=357,
+            num_tests_passed=357,
+            duration_seconds=48.0,
+            scope="full",
+            num_examples_run=83,
+            num_examples_passed=83,
+            examples_included=True,
+        ).get_cache_summary()
+        self.assertIn("274/274 unit, 83/83 examples", summary)
+
+    def test_replayed_unit_only_run_cannot_read_as_a_full_pass(self) -> None:
+        summary = FingerprintResult(
+            hash="abc123",
+            num_tests_run=274,
+            num_tests_passed=274,
+            duration_seconds=30.49,
+            scope="full",
+            num_examples_run=0,
+            num_examples_passed=0,
+            examples_included=True,
+        ).get_cache_summary()
+        self.assertIn("274/274 unit", summary)
+        self.assertIn("examples cached, not re-run", summary)
+
+    def test_pre_3779_fingerprint_admits_the_split_is_unknown(self) -> None:
+        summary = FingerprintResult(
+            hash="abc123",
+            num_tests_run=357,
+            num_tests_passed=357,
+            scope="full",
+        ).get_cache_summary()
+        self.assertIn("357/357 passed", summary)
+        self.assertIn("unit/example split unrecorded", summary)
+
+    def test_split_round_trips_through_disk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr.write(
+                "cpp_test",
+                FingerprintResult(
+                    hash="abc123",
+                    num_tests_run=357,
+                    num_tests_passed=357,
+                    scope="full",
+                    num_examples_run=83,
+                    num_examples_passed=83,
+                    examples_included=True,
+                ),
+            )
+            path = Path(tmp) / "fingerprint" / "cpp_test_quick.json"
+            written = json.loads(path.read_text())
+            self.assertEqual(written["num_examples_run"], 83)
+            self.assertIs(written["examples_included"], True)
+
+            reloaded = mgr.read("cpp_test")
+            assert reloaded is not None
+            self.assertEqual(reloaded.num_examples_passed, 83)
+            self.assertIn("83/83 examples", reloaded.get_cache_summary())
+
+    def test_split_travels_with_the_counts_on_a_cache_hit(self) -> None:
+        """save_all() carries prior counts forward when nothing ran. The split
+        must come along, or a unit-only result is relabelled as unattributed --
+        or worse, as covering examples it never touched."""
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr._prev_fingerprints["cpp_test"] = FingerprintResult(
+                hash="abc123",
+                num_tests_run=274,
+                num_tests_passed=274,
+                scope="full",
+                num_examples_run=0,
+                num_examples_passed=0,
+                examples_included=True,
+            )
+            mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")
+
+            mgr.save_all("success")
+
+            reloaded = mgr.read("cpp_test")
+            assert reloaded is not None
+            self.assertEqual(reloaded.num_examples_run, 0)
+            self.assertIs(reloaded.examples_included, True)
+            self.assertIn("examples cached, not re-run", reloaded.get_cache_summary())
+
+
+class TestMetadataPlumbing(unittest.TestCase):
+    def test_update_test_metadata_records_the_split(self) -> None:
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")
+            mgr.update_test_metadata(
+                "cpp_test",
+                num_tests_run=357,
+                num_tests_passed=357,
+                duration_seconds=48.0,
+                test_name="cpp_unit_tests",
+                scope="full",
+                num_examples_run=83,
+                num_examples_passed=83,
+                examples_included=True,
+            )
+            fp = mgr._fingerprints["cpp_test"]
+            self.assertEqual(fp.num_examples_run, 83)
+            self.assertIs(fp.examples_included, True)
+
+    def test_omitting_the_split_leaves_it_unrecorded_rather_than_zero(self) -> None:
+        """A path that cannot attribute its counts must not claim zero examples --
+        that would read as an authoritative "examples cached" statement."""
+        with TemporaryDirectory() as tmp:
+            mgr = FingerprintManager(Path(tmp))
+            mgr._fingerprints["cpp_test"] = FingerprintResult(hash="abc123")
+            mgr.update_test_metadata(
+                "cpp_test",
+                num_tests_run=357,
+                num_tests_passed=357,
+                duration_seconds=48.0,
+                scope="full",
+            )
+            fp = mgr._fingerprints["cpp_test"]
+            self.assertIsNone(fp.num_examples_run)
+            self.assertIn("split unrecorded", fp.get_cache_summary())
+
+
+class TestResultRowLabel(unittest.TestCase):
+    """The summary table carried the same anonymous denominator as the headline."""
+
+    @staticmethod
+    def _row(**kw: object) -> str:
+        base: dict[str, object] = {
+            "success": True,
+            "duration": 48.0,
+            "num_tests_run": 357,
+            "num_tests_passed": 357,
+            "num_tests_failed": 0,
+        }
+        base.update(kw)
+        return _describe_cpp_counts(MesonTestResult(**base))  # type: ignore[arg-type]
+
+    def test_attributed_row_names_both_populations(self) -> None:
+        self.assertEqual(
+            self._row(
+                num_examples_run=83, num_examples_passed=83, examples_included=True
+            ),
+            "274/274 unit, 83/83 examples passed",
+        )
+
+    def test_unit_only_row_says_examples_were_not_requested(self) -> None:
+        self.assertEqual(
+            self._row(
+                num_tests_run=275,
+                num_tests_passed=275,
+                num_examples_run=0,
+                num_examples_passed=0,
+                examples_included=False,
+            ),
+            "275/275 unit passed; examples not requested",
+        )
+
+    def test_unattributed_row_admits_it(self) -> None:
+        """The meson-test fallback cannot split its total; it must not imply one."""
+        self.assertEqual(self._row(), "357/357 passed; unit/example split unrecorded")
+
+
+class TestSuiteExclusionDetection(unittest.TestCase):
+    """Coverage must be read from the exclusion list, not guessed at."""
+
+    def test_no_exclusions_means_examples_ran(self) -> None:
+        self.assertTrue(examples_are_included(None))
+        self.assertTrue(examples_are_included([]))
+
+    def test_project_qualified_exclusion_is_detected(self) -> None:
+        self.assertFalse(examples_are_included(["fastled:examples"]))
+
+    def test_bare_suite_name_is_detected(self) -> None:
+        """meson accepts `--no-suite examples`, and this repo's own docstrings
+        advertise that form. Missing it would claim examples ran when they
+        did not -- worse than the ambiguity #3779 is about."""
+        self.assertFalse(examples_are_included(["examples"]))
+
+    def test_unrelated_exclusions_leave_examples_included(self) -> None:
+        self.assertTrue(examples_are_included(["fastled:slow", "integration"]))
+
+
+class TestPartialAttribution(unittest.TestCase):
+    """Knowing WHICH populations ran, but not their sizes, is its own case --
+    it must not collapse into either 'fully attributed' or 'nothing known'."""
+
+    def test_populations_known_sizes_not(self) -> None:
+        b = describe_test_counts(
+            num_passed=357,
+            num_run=357,
+            num_examples_passed=None,
+            num_examples_run=None,
+            examples_included=True,
+        )
+        self.assertEqual(b.counts, "357/357 unit + examples")
+        self.assertEqual(b.notes, "")
+
+    def test_nothing_known_admits_it(self) -> None:
+        b = describe_test_counts(
+            num_passed=357,
+            num_run=357,
+            num_examples_passed=None,
+            num_examples_run=None,
+            examples_included=None,
+        )
+        self.assertEqual(b.counts, "357/357")
+        self.assertEqual(b.notes, "unit/example split unrecorded")
+
+    def test_headline_and_table_describe_a_run_identically(self) -> None:
+        """The two used to disagree: the headline claimed 'unit + examples'
+        while the table two lines later said the split was unrecorded."""
+        result = MesonTestResult(
+            success=True,
+            duration=48.0,
+            num_tests_run=357,
+            num_tests_passed=357,
+            num_tests_failed=0,
+            examples_included=True,
+        )
+        headline = describe_test_counts(
+            num_passed=357,
+            num_run=357,
+            num_examples_passed=None,
+            num_examples_run=None,
+            examples_included=True,
+        )
+        self.assertIn(headline.counts, _describe_cpp_counts(result))
+
+    def test_describe_uses_a_separator_that_survives_commas(self) -> None:
+        b = RunBreakdown("274/274 unit", "examples cached, not re-run")
+        self.assertEqual(
+            b.describe(" passed"),
+            "274/274 unit passed; examples cached, not re-run",
+        )
+        self.assertEqual(RunBreakdown("357/357", "").describe(), "357/357")
+
+
+class TestEarlyExitMirrorMatchesCanonical(unittest.TestCase):
+    """``ci/early_exit_cache.py`` re-implements the wording stdlib-only to stay
+    under its import budget. That duplication is only safe while the two agree,
+    so pin them against each other."""
+
+    CASES = [
+        # (num_passed, num_run, num_examples_passed, num_examples_run, included)
+        (357, 357, 83, 83, True),
+        (274, 274, 0, 0, True),
+        (274, 274, 0, 0, False),
+        (83, 83, 83, 83, True),
+        (0, 0, 0, 0, True),
+        (274, 274, 0, 0, True),
+        (355, 357, 83, 83, True),
+    ]
+
+    def test_mirror_agrees_with_format_run_breakdown(self) -> None:
+        # Sweep the filtered axis too: the canonical grew `filtered` after the
+        # mirror was written, and the pair silently diverged until pinned.
+        for passed, run, ex_passed, ex_run, included in self.CASES:
+            for scope in ("full", "partial"):
+                with self.subTest(
+                    counts=(passed, run, ex_passed, ex_run, included), scope=scope
+                ):
+                    breakdown = format_run_breakdown(
+                        unit_passed=passed - ex_passed,
+                        unit_run=run - ex_run,
+                        examples_passed=ex_passed,
+                        examples_run=ex_run,
+                        examples_included=included,
+                        filtered=scope == "partial",
+                    )
+                    mirror = _cpp_run_breakdown(
+                        {
+                            "num_examples_run": ex_run,
+                            "num_examples_passed": ex_passed,
+                            "examples_included": included,
+                            "scope": scope,
+                        },
+                        passed,
+                        run,
+                    )
+                    self.assertEqual(mirror, (breakdown.counts, breakdown.notes))
+
+    def test_mirror_flags_a_pre_3779_entry(self) -> None:
+        self.assertEqual(
+            _cpp_run_breakdown({}, 357, 357),
+            ("357/357", "unit/example split unrecorded"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/util/fingerprint.py
+++ b/ci/util/fingerprint.py
@@ -101,6 +101,9 @@ class FingerprintManager:
                         test_name=data.get("test_name"),
                         source_max_mtime=data.get("source_max_mtime"),
                         scope=data.get("scope"),
+                        num_examples_run=data.get("num_examples_run"),
+                        num_examples_passed=data.get("num_examples_passed"),
+                        examples_included=data.get("examples_included"),
                     )
                 except json.JSONDecodeError:
                     ts_print(f"Invalid {name} fingerprint file. Recalculating...")
@@ -126,6 +129,12 @@ class FingerprintManager:
             fingerprint_dict["source_max_mtime"] = fingerprint.source_max_mtime
         if fingerprint.scope is not None:
             fingerprint_dict["scope"] = fingerprint.scope
+        if fingerprint.num_examples_run is not None:
+            fingerprint_dict["num_examples_run"] = fingerprint.num_examples_run
+        if fingerprint.num_examples_passed is not None:
+            fingerprint_dict["num_examples_passed"] = fingerprint.num_examples_passed
+        if fingerprint.examples_included is not None:
+            fingerprint_dict["examples_included"] = fingerprint.examples_included
         with open(fingerprint_file, "w") as f:
             json.dump(fingerprint_dict, f, indent=2)
 
@@ -152,9 +161,13 @@ class FingerprintManager:
                     fingerprint.num_tests_passed = prev_fp.num_tests_passed
                     fingerprint.duration_seconds = prev_fp.duration_seconds
                     fingerprint.test_name = prev_fp.test_name
-                    # Carry scope with the counts it describes -- splitting
-                    # them would relabel a filtered result as a full one.
+                    # Carry scope and the unit/example split with the counts
+                    # they describe -- splitting them would relabel a filtered
+                    # or unit-only result as a full one.
                     fingerprint.scope = prev_fp.scope
+                    fingerprint.num_examples_run = prev_fp.num_examples_run
+                    fingerprint.num_examples_passed = prev_fp.num_examples_passed
+                    fingerprint.examples_included = prev_fp.examples_included
             # Persist the watermark from this invocation's opening scan. On a
             # fast-path hit nothing was rebuilt, so carry the previous value
             # forward rather than advancing it -- advancing would absorb any
@@ -176,11 +189,18 @@ class FingerprintManager:
         duration_seconds: float,
         test_name: Optional[str] = None,
         scope: Optional[str] = None,
+        num_examples_run: Optional[int] = None,
+        num_examples_passed: Optional[int] = None,
+        examples_included: Optional[bool] = None,
     ) -> None:
         """Update the test metadata for a fingerprint before saving.
 
         ``scope`` is "full" when the run covered the whole suite and
-        "partial" when a filter narrowed it (#3763).
+        "partial" when a filter narrowed it (#3763). The ``examples_*``
+        arguments split the totals into the two populations a C++ run covers
+        so the replayed line cannot present a unit-only count as a full pass
+        (#3779); leave them ``None`` when the producing path cannot attribute
+        its counts.
         """
         if name in self._fingerprints:
             self._fingerprints[name].num_tests_run = num_tests_run
@@ -189,6 +209,9 @@ class FingerprintManager:
             if test_name:
                 self._fingerprints[name].test_name = test_name
             self._fingerprints[name].scope = scope
+            self._fingerprints[name].num_examples_run = num_examples_run
+            self._fingerprints[name].num_examples_passed = num_examples_passed
+            self._fingerprints[name].examples_included = examples_included
 
     def get_prev_fingerprint(self, name: str) -> Optional[FingerprintResult]:
         """Get the previous fingerprint data (from last run) for display"""

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -45,6 +45,7 @@ from ci.util.color_output import print_cache_hit
 
 
 if TYPE_CHECKING:
+    from ci.meson.test_execution import MesonTestResult
     from ci.util.fingerprint import FingerprintManager
 from ci.util.output_formatter import TimestampFormatter
 from ci.util.test_exceptions import (
@@ -58,6 +59,7 @@ from ci.util.test_types import (
     TestResult,
     TestResultType,
     TestSuiteResult,
+    describe_test_counts,
     determine_test_categories,
 )
 from ci.util.timestamp_print import ts_print
@@ -816,6 +818,24 @@ def _create_skipped_timing(
     # Include cached summary in the name if available
     display_name = f"{test_name} ({cached_summary})" if cached_summary else test_name
     return ProcessTiming(name=display_name, duration=0.0, command=command, skipped=True)
+
+
+def _describe_cpp_counts(result: "MesonTestResult") -> str:
+    """Label a C++ result row with the populations its counts cover.
+
+    The summary table carried the same anonymous denominator as the headline,
+    so a unit-only row and a unit+examples row were indistinguishable (#3779).
+    A result from a path that cannot attribute its counts says so rather than
+    implying coverage it never verified.
+    """
+    breakdown = describe_test_counts(
+        num_passed=result.num_tests_passed,
+        num_run=result.num_tests_run,
+        num_examples_passed=result.num_examples_passed,
+        num_examples_run=result.num_examples_run,
+        examples_included=result.examples_included,
+    )
+    return breakdown.describe(" passed")
 
 
 def _format_cache_hit_message(
@@ -1594,6 +1614,9 @@ def runner(
                     duration_seconds=result.duration,
                     test_name="cpp_unit_tests",
                     scope="partial" if (test_name or test_file_filter) else "full",
+                    num_examples_run=result.num_examples_run,
+                    num_examples_passed=result.num_examples_passed,
+                    examples_included=result.examples_included,
                 )
 
             # Print timing summary table for unit-only mode
@@ -1603,7 +1626,7 @@ def runner(
 
                 show_zccache_stats()
             unit_timing = ProcessTiming(
-                name=f"cpp_unit_tests ({result.num_tests_passed}/{result.num_tests_run} passed)",
+                name=f"cpp_unit_tests ({_describe_cpp_counts(result)})",
                 duration=result.duration,
                 command="meson test",
                 skipped=False,
@@ -1663,7 +1686,7 @@ def runner(
 
             # Create timing entry for summary
             meson_test_timing = ProcessTiming(
-                name=f"cpp_unit_tests ({result.num_tests_passed}/{result.num_tests_run} passed)",
+                name=f"cpp_unit_tests ({_describe_cpp_counts(result)})",
                 duration=result.duration,
                 command="meson test",
                 skipped=False,
@@ -1689,6 +1712,9 @@ def runner(
                     duration_seconds=result.duration,
                     test_name="cpp_unit_tests",
                     scope="partial" if (test_name or test_file_filter) else "full",
+                    num_examples_run=result.num_examples_run,
+                    num_examples_passed=result.num_examples_passed,
+                    examples_included=result.examples_included,
                 )
 
             if not result.success:

--- a/ci/util/test_types.py
+++ b/ci/util/test_types.py
@@ -145,6 +145,133 @@ class TestCategories:
                 raise TypeError(f"{field_name} must be bool, got {type(value)}")
 
 
+@dataclass(frozen=True)
+class RunBreakdown:
+    """How a test run's pass counts should be described.
+
+    ``counts`` names each population that actually executed; ``notes`` says
+    what did not, and is empty when everything requested ran. They are kept
+    apart so each surface can slot its own duration/scope text in between.
+    """
+
+    counts: str
+    notes: str
+
+    def describe(self, middle: str = "") -> str:
+        """Render as ``counts + middle + notes``.
+
+        Every surface slots its own text (" passed", " in 3.2s", a scope
+        annotation) between the two halves, which is why they are stored
+        apart. Routing all of them through here keeps one separator: both
+        halves already contain commas, so comma-joining produced strings with
+        commas at three nesting levels that could not be read apart.
+        """
+        return self.counts + middle + (f"; {self.notes}" if self.notes else "")
+
+
+def describe_test_counts(
+    *,
+    num_passed: int,
+    num_run: int,
+    num_examples_passed: Optional[int],
+    num_examples_run: Optional[int],
+    examples_included: Optional[bool],
+    filtered: bool = False,
+) -> RunBreakdown:
+    """Describe a C++ run's totals, using whatever attribution was recorded.
+
+    This is the single entry point for every reporting surface, so a run is
+    described identically in the headline, the summary table, and the replayed
+    cache line. Each surface previously repeated this three-way ``is None``
+    guard and its own fallback wording, which is how the same run came to be
+    described two different ways in one terminal output.
+
+    Three levels of knowledge are possible, and none of them may claim more
+    than was recorded (#3779):
+
+    * full split recorded -- name both populations and their counts;
+    * only *which* populations were eligible -- name them, not the split;
+    * nothing recorded -- replay the bare total and say the split is unknown.
+
+    ``filtered`` marks a run narrowed by a name/file selector. A population
+    that ran nothing under a filter was skipped by the selector, not verified
+    as up to date, and must not be described as cached.
+    """
+    if (
+        num_examples_run is not None
+        and num_examples_passed is not None
+        and examples_included is not None
+    ):
+        return format_run_breakdown(
+            unit_passed=num_passed - num_examples_passed,
+            unit_run=num_run - num_examples_run,
+            examples_passed=num_examples_passed,
+            examples_run=num_examples_run,
+            examples_included=examples_included,
+            filtered=filtered,
+        )
+    if examples_included is not None:
+        # The populations are known but not their sizes -- ``meson test``
+        # reports one suite-wide number. Name the coverage, claim no split.
+        if examples_included:
+            return RunBreakdown(f"{num_passed}/{num_run} unit + examples", "")
+        return RunBreakdown(f"{num_passed}/{num_run} unit", "examples not requested")
+    return RunBreakdown(f"{num_passed}/{num_run}", "unit/example split unrecorded")
+
+
+def format_run_breakdown(
+    *,
+    unit_passed: int,
+    unit_run: int,
+    examples_passed: int,
+    examples_run: int,
+    examples_included: bool,
+    filtered: bool = False,
+) -> RunBreakdown:
+    """Render pass counts with the unit/example split spelled out.
+
+    ``bash test --cpp`` covers two populations -- unit tests and example
+    compile targets -- and either can be skipped because its artifacts were
+    already up to date. Summing them into one anonymous denominator makes
+    "274 unit tests, examples cached" indistinguishable from "274 of the 357
+    things I expected", which is the ambiguity #3779 was filed over. So name
+    each population that ran, and say plainly which one did not.
+
+    ``examples_included`` is False when examples were never requested (the
+    unit-only mode passes ``--no-suite fastled:examples``); that is a
+    different statement from "requested but already cached".
+
+    Prefer :func:`describe_test_counts` unless the full split is already known
+    -- it handles the partially-attributed cases this function cannot express.
+    """
+    parts: list[str] = []
+    if unit_run:
+        parts.append(f"{unit_passed}/{unit_run} unit")
+    if examples_run:
+        parts.append(f"{examples_passed}/{examples_run} examples")
+
+    # Why a population contributed nothing decides what may be claimed about
+    # it. Under a filter it was never selected; otherwise its binaries were
+    # already up to date. Only the latter is evidence of anything.
+    missing = "not matched by filter" if filtered else "cached, not re-run"
+    notes: list[str] = []
+    if not unit_run:
+        notes.append(f"unit tests {missing}")
+    if not examples_included:
+        notes.append("examples not requested")
+    elif not examples_run:
+        notes.append(f"examples {missing}")
+
+    # Keep the totals visible even when nothing ran: the notes explain the
+    # zero, but a reader still needs to tell an empty run from a corrupt entry.
+    counts = (
+        ", ".join(parts)
+        if parts
+        else f"{unit_passed + examples_passed}/{unit_run + examples_run}"
+    )
+    return RunBreakdown(counts, "; ".join(notes))
+
+
 @typechecked
 @dataclass
 class FingerprintResult:
@@ -170,12 +297,22 @@ class FingerprintResult:
     # an authoritative full-suite pass and there is no way to tell the two
     # apart after the fact (#3763).
     scope: Optional[str] = None
+    # Split of the counts above into the two populations a C++ run covers.
+    # None means this fingerprint predates the breakdown (#3779) -- the totals
+    # are still replayed, but without claiming which populations they cover.
+    num_examples_run: Optional[int] = None
+    num_examples_passed: Optional[int] = None
+    examples_included: Optional[bool] = None
 
     def get_cache_summary(self) -> str:
         """Get a human-readable summary of cached test results"""
         if self.num_tests_run is not None and self.num_tests_passed is not None:
+            # `is not None`, not truthiness: 0.0s is a real duration for an
+            # instantly-replayed run, and dropping it loses information.
             duration_str = (
-                f" in {self.duration_seconds:.2f}s" if self.duration_seconds else ""
+                f" in {self.duration_seconds:.2f}s"
+                if self.duration_seconds is not None
+                else ""
             )
             # Say where the number came from. "partial" is called out; a missing
             # scope is from a fingerprint written before this field existed, so
@@ -186,10 +323,21 @@ class FingerprintResult:
                 scope_str = ""
             else:
                 scope_str = ", scope unrecorded"
-            return (
-                f"{self.num_tests_passed}/{self.num_tests_run} "
-                f"passed{duration_str}{scope_str}"
+            # Name the populations the counts cover. Without the split a
+            # unit-only total is indistinguishable from a unit+examples one
+            # under identical wording (#3779).
+            breakdown = describe_test_counts(
+                num_passed=self.num_tests_passed,
+                num_run=self.num_tests_run,
+                num_examples_passed=self.num_examples_passed,
+                num_examples_run=self.num_examples_run,
+                examples_included=self.examples_included,
+                # #3778 already records a narrowed run as "partial"; that is
+                # the same fact `filtered` needs, so a replayed filtered run
+                # cannot claim its untouched populations were merely cached.
+                filtered=self.scope == "partial",
             )
+            return breakdown.describe(f" passed{duration_str}{scope_str}")
         return ""
 
     def should_skip(self, current: "FingerprintResult") -> bool:


### PR DESCRIPTION
Fixes #3779.

## The ambiguity

`bash test --cpp` covers two populations — unit tests and example compile targets — and both fed one anonymous denominator:

```
All tests passed (357/357 in 48.00s)   <- unit + examples
All tests passed (274/274 in 30.49s)   <- unit only, examples cached
```

Byte-identical wording, so a reader could not tell *"274 unit tests, examples already cached"* from *"274 of the 357 things I expected"*. #3778 fixed the labelling half of #3763; this is the denominator half.

## After

```
All tests passed (274/274 unit, 83/83 examples in 87.21s)
All tests passed (274/274 unit in 14.69s; examples cached, not re-run)
All tests passed (274/274 unit in 33.81s; examples not requested)
```

274 + 83 = 357 — the same arithmetic the issue computed independently.

The replayed cache line and the summary-table row carry the split too:

```
Fingerprint cache valid - skipping C++ unit tests [274/274 unit, 83/83 examples passed in 95.91s]
cpp_unit_tests (274/274 unit, 83/83 examples passed in 95.91s) | skipped
```

## Approach

One rule: **coverage must be recorded, never inferred, and no surface may claim more than was recorded.**

- `StreamingResult` tallies example artifacts separately. The split rides through `MesonTestResult` into the fingerprint JSON and back out.
- **`describe_test_counts()` is the single renderer** for every surface — headline, failure headline, summary row, replayed cache line. It models three levels of knowledge: full split; populations-only (the driver reports one suite-wide number); nothing recorded. Previously each surface repeated its own guard and fallback wording, which is how one run came to be described two different ways in a single terminal output.
- A population that ran nothing **under a filter** is reported as `not matched by filter`, never `cached` — the latter asserts it was verified up to date. Replayed lines derive this from the `scope` #3778 already records, so no new field.
- `examples_are_included()` reads the exclusion list rather than guessing, and accepts both the bare and project-qualified suite spellings the driver allows.
- The ultra-early-exit fast path reports `.full_run_cache.json` totals as split-unrecorded: that file stores no attribution, and the reader's own flags describe the *reader*, not the run that wrote the entry.
- `is_example_artifact()` is now the single discriminator for both counting and runner selection, phrased so an unclassifiable artifact cannot inflate the unit denominator.

`ci/early_exit_cache.py` keeps a stdlib-only mirror of the renderer — that module must not import `ci.*` (~62ms on a ~2ms path). A parity test pins the two across the full attribution state space including the filtered axis; it caught two real drifts while this branch was being written.

## Verification

End-to-end on all reporting surfaces: clean `--cpp`, replayed cache hit, `--unit`, filtered run, and the all-cached early exit. 41 tests in `ci/tests/test_run_breakdown.py` + updated `test_fingerprint_scope.py`; `bash lint` clean; `bash test --cpp` green (274 unit + 83 examples).

## Not in scope — pre-existing, confirmed on clean master

Three issues found while validating, all reproduced on an unmodified tree. None are touched here:

1. **`_watermarks` is unbound in the mixed `--cpp` branch** (`ci/util/test_runner.py`) — assigned only inside the `unit_only` block, but read in the mixed branch, so `save_full_run_result` raises `NameError` into a bare `except Exception: pass`. `.build/meson-quick/.full_run_cache.json` is consequently never created by a fresh run, and the CASE 2 ultra-early exit that file exists for can never fire. Worth its own issue — I can file it.
2. `test_fbuild_qemu.py::test_fbuild_test_emu_esp32dev` fails (`FastLED.h: No such file`), ~6 min runtime, and leaves untracked temp files in `tests/fbuild_qemu_smoke/.compile-tmp/` that are not gitignored.
3. `test_meson_include_paths` reports backslash include paths for stale `meson-debug` / `meson-wasm-quick` build dirs.

Also left alone deliberately: the single-named-test path still prints `1/1` — the user named the test, so it cannot masquerade as full-suite coverage, and `scope="partial"` already guards its replayed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Test results now clearly separate unit-test and example-test counts.
  - Reports indicate whether examples were included, excluded, filtered, cached, or not recorded.
  - Cached results preserve example-test counts and coverage details across runs.

- **Bug Fixes**
  - Corrected result summaries that could incorrectly present partial or incomplete coverage as a full pass.
  - Improved consistency between live, cached, early-exit, and failure reports.

- **Tests**
  - Added comprehensive coverage for test-count attribution, caching, filtering, suite exclusions, and legacy results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->