### PR TITLE
fix(ci): treat fbuild `build error:` as failure even on exit code 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,8 @@ ci/lint_cpp_rs/target/
 
 # Compile failure logs (./compile --log-failures failures)
 failures/
+
+# Agent scratch: per-issue worktrees and session task notes. Checked-in
+# copies of the tree here also trip the meson/path linters on stale files.
+.worktrees/
+TASK.md

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -161,6 +161,53 @@ def test_run_fbuild_ci_fails_when_output_is_partially_unparseable(
     assert "weird output format" in result.output
 
 
+def test_run_fbuild_compile_fails_on_build_error_with_zero_returncode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeRunningProcess:
+        def __init__(
+            self,
+            cmd: list[str],
+            timeout: int,
+            auto_run: bool,
+            capture: bool,
+            env: dict[str, str] | None = None,
+        ) -> None:
+            assert cmd[:4] == ["fbuild.exe", str(tmp_path), "build", "-e"]
+            assert timeout == 1800
+            assert auto_run is False
+            assert capture is True
+            assert env is not None
+            self.stdout = "\n".join(
+                [
+                    "   0.00 =   BUILDING lpc845brk   =",
+                    "build error: build failed: local library 'FastLED' compilation failed",
+                    "fbuild version: 2.2.30",
+                ]
+            )
+            self.returncode = 0
+
+        def start(self) -> None:
+            pass
+
+        def wait(self, echo: bool) -> int:
+            assert echo is True
+            return 0
+
+    monkeypatch.setattr(fbuild_runner, "get_fbuild_executable", lambda: "fbuild.exe")
+    monkeypatch.setattr("running_process.RunningProcess", FakeRunningProcess)
+
+    result = fbuild_runner.run_fbuild_compile(
+        tmp_path,
+        environment="lpc845brk",
+        verbose=False,
+    )
+
+    assert result.success is False
+    assert result.returncode == 0
+    assert "build error:" in result.output
+
+
 def test_pio_compiler_build_prefers_ci_results(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/ci/tests/test_fbuild_deploy_streaming.py
+++ b/ci/tests/test_fbuild_deploy_streaming.py
@@ -189,6 +189,30 @@ def test_deploy_reports_failure_exit_code(
     assert "undefined reference" in result.output
 
 
+def test_deploy_fails_on_build_error_with_zero_returncode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A `build error:` marker outweighs a zero exit code."""
+    sink = _RecordingSink()
+    _install_fake_fbuild(
+        monkeypatch,
+        tmp_path,
+        script_body=(
+            "print('   0.00 =   BUILDING esp32s3   =', flush=True)\n"
+            'print("build error: build failed: local library "\n'
+            "      \"'FastLED' compilation failed\", flush=True)\n"
+        ),
+        sink=sink,
+    )
+
+    result = fbuild_runner.run_fbuild_deploy(
+        build_dir=tmp_path, environment="esp32s3", timeout=60
+    )
+    assert result.success is False
+    assert result.returncode == 0
+    assert "build error:" in result.output
+
+
 def test_deploy_writes_to_log_file_in_quiet_mode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -250,6 +250,25 @@ def fbuild_supports_compile_many() -> bool:
 # can render it back without unit conversion.
 _FLASH_SIZE_RE = re.compile(r"^\s*Flash:\s+([0-9.]+(?:\s*KB|\s*MB|\s*bytes))\s*/")
 _RAM_SIZE_RE = re.compile(r"^\s*RAM:\s+([0-9.]+(?:\s*KB|\s*MB|\s*bytes))\s*/")
+_FBUILD_BUILD_ERROR_RE = re.compile(r"(?m)^\s*build error:\s+")
+
+
+def _output_contains_fbuild_build_error(output: str) -> bool:
+    """Return True when fbuild emitted its explicit build-failure marker.
+
+    fbuild's daemon formats build failures as a bare ``build error: <msg>``
+    log line (fbuild ``handlers/operations/build.rs`` + ``deploy.rs``) and the
+    CLI exits with the response's ``exit_code`` verbatim. fbuild already
+    guards against a zero ``exit_code`` arriving alongside ``success=false``
+    in ``cli/deploy.rs`` (fbuild issue #130), but only on the ``test-emu``
+    path -- ``cli/build.rs`` and the main ``cli/deploy.rs`` exit unclamped. A
+    zero exit there would silently read as a green build, so corroborate the
+    return code against the marker.
+
+    Only matches at line start: ``compile-many`` embeds the same text
+    mid-line in its per-sketch summary, where it is not a whole-run failure.
+    """
+    return _FBUILD_BUILD_ERROR_RE.search(output) is not None
 
 
 def _parse_size_info_from_log(log_path: Path | None) -> tuple[str | None, str | None]:
@@ -379,6 +398,8 @@ def run_fbuild_compile(
         )
         output = str(process.stdout)
         success = returncode == 0
+        if success and _output_contains_fbuild_build_error(output):
+            success = False
     except KeyboardInterrupt as ki:
         from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
@@ -474,6 +495,10 @@ def _run_fbuild_batch_command(
         )
         output = str(process.stdout)
         sketch_results = _parse_compile_many_results(output)
+        # No _output_contains_fbuild_build_error() guard here on purpose:
+        # compile-many reports `build error` mid-line per sketch, so it does
+        # not indicate whole-run failure. The result-count check below is this
+        # path's equivalent corroboration.
         success = returncode == 0
         expected_results = len(sketch_project_dirs)
         if success and len(sketch_results) != expected_results:
@@ -761,6 +786,11 @@ def run_fbuild_deploy(
         stdout_text = "\n".join(collected)
         returncode = proc.returncode
         success = returncode == 0
+        # `fbuild deploy` builds before it flashes, so it can emit the same
+        # build-failure marker on a zero exit. See
+        # _output_contains_fbuild_build_error().
+        if success and _output_contains_fbuild_build_error(stdout_text):
+            success = False
 
         elapsed = time.monotonic() - t0
         if quiet:


### PR DESCRIPTION
## Problem

fbuild's daemon formats build failures as a bare `build error: <msg>` log line, and the CLI exits with the response's `exit_code` verbatim. fbuild already guards against a zero `exit_code` arriving alongside `success=false` — but **only on the `test-emu` path** (`cli/deploy.rs:485-498`, referencing fbuild issue #130):

```rust
// ...if the daemon handler or an intermediate proxy returns 0 alongside
// success=false (issue #130), we must still surface failure to the shell
// rather than silently exiting 0.
let code = if resp.exit_code == 0 { 1 } else { resp.exit_code };
```

The two paths FastLED actually uses have no such clamp — `cli/build.rs:141-146` and the main `cli/deploy.rs:241-247` both `exit(resp.exit_code)` raw, and `daemon_client.rs:386` reads that code out of untyped JSON (`unwrap_or(1)`). A zero arriving there silently reads as a green build.

## Change

Corroborate the return code against the stdout marker in the two affected entry points:

| `ci/util/fbuild_runner.py` | Function | Action |
|---|---|---|
| ~387 | `run_fbuild_compile` | guard added |
| ~771 | `run_fbuild_deploy` | guard added — deploy builds before it flashes, same exposure |
| ~485 | `_run_fbuild_batch_command` | **intentionally not guarded**, now commented |

`compile-many` embeds the same `build error` text *mid-line* in its per-sketch summary (`compile_many.rs:171-179`), where it does not indicate whole-run failure — hence the `^\s*` anchor, and hence that path keeps its existing result-count corroboration instead.

## False-positive review

- Echoed command line goes to the Python-side stream, not `process.stdout` — never enters the matched text.
- Compiler diagnostics use `file:line:col: error:`, never `build error:` at column 0.
- fbuild's startup banner emits only tracing/stderr lines; no log replay on the build path.

## Testing

Two tests, one per guarded path. Both were mutation-checked — removing the guards fails exactly these two and nothing else:

```
$ uv run pytest ci/tests/test_fbuild_deploy_streaming.py ci/tests/test_fbuild_compile_many.py -q
11 passed

# with both guards deleted:
FAILED test_deploy_fails_on_build_error_with_zero_returncode
FAILED test_run_fbuild_compile_fails_on_build_error_with_zero_returncode
2 failed, 9 passed
```

`bash lint` clean.

## Upstream follow-up

The real fix belongs in fbuild: apply the same clamp already present in `cli/deploy.rs:485-498` to `cli/build.rs:145` and `cli/deploy.rs:246`. That would make this guard belt-and-braces rather than load-bearing.

## Also included

`chore(gitignore)`: ignore `.worktrees/` and `TASK.md`. Stale per-issue worktrees were being walked by the build-file path linter, producing 4 phantom `PathNormJoinChecker` violations against copies of files that no longer exist in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and deployment failure detection when an error message appears despite a successful process exit code.
  * Ensured build error details remain available in captured output.
  * Preserved result-count validation for batched compile operations.

* **Tests**
  * Added regression coverage for compile and deployment error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->