### PR TITLE
fix(test): bind _watermarks at function scope so the full-run cache is actually written (#3783)

### DIFF
--- a/ci/early_exit_cache.py
+++ b/ci/early_exit_cache.py
@@ -335,7 +335,7 @@ def _cpp_run_breakdown(fp: dict, num_passed: int, num_run: int) -> "tuple[str, s
 
 def full_run_cache(
     build_dir: Path, include_examples: bool = False
-) -> tuple[int, int, float] | None:
+) -> tuple[int, int, float, dict] | None:
     """Check if full test suite result is cached (stdlib only, no ci.* imports).
 
     Verifies that:
@@ -352,7 +352,8 @@ def full_run_cache(
         include_examples: If True, also check examples/ for changes.
 
     Returns:
-        Tuple of (num_passed, num_tests, duration) on cache hit, else None.
+        Tuple of (num_passed, num_tests, duration, raw_entry) on cache hit,
+        else None. ``raw_entry`` carries any recorded unit/example split.
     """
     cache_file = build_dir / ".full_run_cache.json"
     if not cache_file.exists():
@@ -399,10 +400,18 @@ def full_run_cache(
             ex_max = max_file_mtime(Path("examples"))
             if ex_max > saved.get("examples_max_file_mtime", -1.0) + 0.001:
                 return None
+            # Fail closed: never serve an entry that recorded no example
+            # coverage to a caller that asked for examples. Comparing mtimes
+            # alone would replay a unit-only pass as though examples had run.
+            if saved.get("examples_included") is False:
+                return None
+        # Hand back the raw entry too: it carries the unit/example attribution
+        # when the writing run recorded one (#3779).
         return (
             int(saved.get("num_passed", 0)),
             int(saved.get("num_tests", 0)),
             float(saved.get("duration", 0.0)),
+            saved,
         )
     except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
         return None
@@ -658,18 +667,17 @@ def argv_ultra_early_exit(start_time: float) -> None:
             if _cached_fr:
                 import time  # noqa: PLC0415 - lazy import
 
-                _np_fr, _nt_fr, _dur_fr = _cached_fr
-                # .full_run_cache.json records only a total -- it has no
-                # unit/example attribution, and the CURRENT invocation's flags
-                # describe this reader, not the run that wrote the entry (a
-                # --unit run's cache can be served here to --cpp). Claiming a
-                # coverage this entry never recorded would be the very
-                # fabrication #3779 is about, so report the total and say the
-                # split is unknown.
+                _np_fr, _nt_fr, _dur_fr, _entry_fr = _cached_fr
+                # Describe the run from what the ENTRY recorded, never from
+                # this invocation's flags -- those describe the reader, and a
+                # --unit run's cache can be served here to --cpp. An entry
+                # written before the split existed still reports honestly as
+                # unrecorded (#3779).
+                _counts_fr, _notes_fr = _cpp_run_breakdown(_entry_fr, _np_fr, _nt_fr)
                 print(
                     f"✓ Fingerprint cache valid - skipping C++ unit tests "
-                    f"[{_np_fr}/{_nt_fr} passed in {_dur_fr:.2f}s, "
-                    f"unit/example split unrecorded]"
+                    f"[{_counts_fr} passed in {_dur_fr:.2f}s"
+                    f"{'; ' + _notes_fr if _notes_fr else ''}]"
                 )
                 print(f"Total: {time.time() - start_time:.2f}s")
                 sys.exit(0)

--- a/ci/meson/cache_utils.py
+++ b/ci/meson/cache_utils.py
@@ -637,6 +637,9 @@ def save_full_run_result(
     num_tests: int,
     duration: float,
     watermarks: "Optional[dict[str, float]]" = None,
+    num_examples_passed: "Optional[int]" = None,
+    num_examples_run: "Optional[int]" = None,
+    examples_included: "Optional[bool]" = None,
 ) -> None:
     """Save full test suite result for future fast-path.
 
@@ -654,6 +657,10 @@ def save_full_run_result(
             running", so it would cache a pass over files that were never
             tested. Callers that cannot supply a full set simply forgo the
             fast path for one run.
+        num_examples_passed / num_examples_run / examples_included: which
+            populations the counts above cover (#3779). Omit them when the
+            producing path cannot attribute its counts -- the replayed line
+            then says the split is unrecorded rather than inventing one.
     """
     cache_file = get_full_run_cache_file(build_dir)
     try:
@@ -679,6 +686,14 @@ def save_full_run_result(
             ),
             **marks,
         }
+        # Optional attribution -- absent keys mean "not recorded", which every
+        # reader already renders honestly.
+        if num_examples_passed is not None:
+            data["num_examples_passed"] = num_examples_passed
+        if num_examples_run is not None:
+            data["num_examples_run"] = num_examples_run
+        if examples_included is not None:
+            data["examples_included"] = examples_included
 
         with open(cache_file, "w", encoding="utf-8") as f:
             json.dump(data, f)

--- a/ci/tests/test_full_run_cache_watermarks.py
+++ b/ci/tests/test_full_run_cache_watermarks.py
@@ -1,0 +1,274 @@
+"""Regression tests for the full-run cache (issue #3783).
+
+`runner()` has two branches that run unit tests -- unit-only and mixed
+(`--cpp`, bare `bash test`). Only the mixed branch persists
+`.full_run_cache.json`, but `_watermarks` was captured inside the *unit-only*
+branch, which returns before the mixed one is reached. So the value was
+computed where nothing used it and unbound where it was needed, and every
+`bash test --cpp` raised
+
+    NameError: name '_watermarks' is not defined
+
+straight into a bare `except Exception: pass`. The cache file was never created
+on a fresh checkout and the ultra-early-exit fast path it gates could never
+fire -- silently, for as long as the bug existed.
+
+Fixing that makes the write live, which puts real weight on two guards that
+were previously unreachable and are tested here: a narrowed run must never be
+persisted as a full-suite pass, and a unit-only entry must never be replayed to
+a caller that asked for examples. Both would be stale greens.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ci.early_exit_cache import full_run_cache
+from ci.meson.cache_utils import (
+    _WATERMARK_KEYS,
+    capture_source_watermarks,
+    get_full_run_cache_file,
+    save_full_run_result,
+)
+from ci.util.paths import PROJECT_ROOT
+
+
+def _runner_ast() -> ast.FunctionDef:
+    """The `runner` function of ci/util/test_runner.py, parsed."""
+    source = (PROJECT_ROOT / "ci" / "util" / "test_runner.py").read_text(
+        encoding="utf-8"
+    )
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.FunctionDef) and node.name == "runner":
+            return node
+    raise AssertionError("runner() not found in ci/util/test_runner.py")
+
+
+def _has_save_call(node: ast.AST) -> bool:
+    return any(
+        isinstance(c, ast.Call)
+        and isinstance(c.func, ast.Name)
+        and c.func.id == "save_full_run_result"
+        for c in ast.walk(node)
+    )
+
+
+def _innermost_trys_containing_save(node: ast.AST) -> "list[ast.Try]":
+    """Every tightest `try` wrapping a save_full_run_result call.
+
+    There are two -- the writer and the cache refresh -- and both must report
+    rather than swallow. Deliberately not every Try in the walk: runner()'s
+    giant outer try also *contains* the calls, and auditing its handlers would
+    fail this test the day someone adds a legitimate top-level
+    `except Exception` there.
+    """
+    out: list[ast.Try] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Try) or not _has_save_call(child):
+            continue
+        nested = any(
+            isinstance(g, ast.Try) and g is not child and _has_save_call(g)
+            for g in ast.walk(child)
+        )
+        if not nested:
+            out.append(child)
+    return out
+
+
+class TestWatermarksAreBoundOnEveryPath(unittest.TestCase):
+    def test_watermarks_is_assigned_at_function_scope(self) -> None:
+        """The assignment must sit in `runner`'s top-level body.
+
+        Nested inside a branch it binds on some paths and not others -- exactly
+        how #3783 happened.
+        """
+        runner = _runner_ast()
+        top_level: set[str] = set()
+        for stmt in runner.body:
+            targets = []
+            if isinstance(stmt, ast.Assign):
+                targets = stmt.targets
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                targets = [stmt.target]
+            for t in targets:
+                if isinstance(t, ast.Name):
+                    top_level.add(t.id)
+
+        self.assertIn(
+            "_watermarks",
+            top_level,
+            "_watermarks must be assigned in runner()'s top-level body; a "
+            "branch-local assignment leaves it unbound on the --cpp path "
+            "(#3783)",
+        )
+
+    def test_the_name_is_actually_read(self) -> None:
+        """Guards the test above from passing vacuously against dead code."""
+        reads = [
+            n
+            for n in ast.walk(_runner_ast())
+            if isinstance(n, ast.Name)
+            and n.id == "_watermarks"
+            and isinstance(n.ctx, ast.Load)
+        ]
+        self.assertTrue(reads, "expected runner() to read _watermarks")
+
+
+class TestCacheWriteReportsFailures(unittest.TestCase):
+    def test_handler_does_not_silently_pass(self) -> None:
+        """The write may fail without failing the run -- but not in silence.
+
+        A bare `pass` here hid the #3783 NameError for the life of the bug. The
+        handler stays broad on purpose (a malformed cache file can raise almost
+        anything), so the safety comes from reporting, not from narrowing.
+        """
+        nodes = _innermost_trys_containing_save(_runner_ast())
+        self.assertEqual(
+            len(nodes), 2, "expected the writer and the refresh call sites"
+        )
+
+        for node in nodes:
+            for handler in node.handlers:
+                if handler.type is None:
+                    self.fail("bare `except:` around save_full_run_result (#3783)")
+                # KeyboardInterrupt re-raises; only the catch-all must report.
+                if (
+                    isinstance(handler.type, ast.Name)
+                    and handler.type.id == "Exception"
+                ):
+                    body_is_only_pass = all(
+                        isinstance(st, ast.Pass) for st in handler.body
+                    )
+                    self.assertFalse(
+                        body_is_only_pass,
+                        "`except Exception: pass` around save_full_run_result "
+                        "swallows programming errors -- it hid #3783 "
+                        "completely. Stay tolerant, but report.",
+                    )
+
+
+class TestNarrowedRunsAreNeverCachedAsFullPasses(unittest.TestCase):
+    """The entry replays as an unconditional green for the WHOLE suite."""
+
+    def test_save_is_gated_on_full_scope(self) -> None:
+        source = (PROJECT_ROOT / "ci" / "util" / "test_runner.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "_full_scope_save = not (test_name or test_file_filter)",
+            source,
+            "a name/file-filtered run must not persist .full_run_cache.json: "
+            "its counts are a subset but its watermarks cover the whole tree, "
+            "so the next `bash test --cpp` would exit 0 having run nothing",
+        )
+
+    def test_gate_actually_guards_the_save_call(self) -> None:
+        """An `if` testing the gate must contain a save call -- otherwise the
+        constant exists but guards nothing."""
+        gated = [
+            n
+            for n in ast.walk(_runner_ast())
+            if isinstance(n, ast.If)
+            and any(
+                isinstance(sub, ast.Name) and sub.id == "_full_scope_save"
+                for sub in ast.walk(n.test)
+            )
+            and any(_has_save_call(st) for st in n.body)
+        ]
+        self.assertTrue(
+            gated,
+            "no `if` testing _full_scope_save encloses a save_full_run_result "
+            "call, so a filtered run can still be cached as a full pass",
+        )
+
+
+class TestFullRunCacheRoundTrip(unittest.TestCase):
+    def _write(self, build_dir: Path, **kw: object) -> None:
+        marks = {k: 0.0 for k in _WATERMARK_KEYS}
+        (build_dir / "build.ninja").write_text("", encoding="utf-8")
+        save_full_run_result(build_dir, 357, 357, 12.5, watermarks=marks, **kw)
+
+    def test_attribution_is_persisted_and_read_back(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = Path(tmp)
+            self._write(
+                build_dir,
+                num_examples_passed=83,
+                num_examples_run=83,
+                examples_included=True,
+            )
+            entry = json.loads(get_full_run_cache_file(build_dir).read_text())
+            self.assertEqual(entry["num_examples_run"], 83)
+            self.assertIs(entry["examples_included"], True)
+
+    def test_omitted_attribution_stays_absent_rather_than_zero(self) -> None:
+        """Absent must not become "0 examples" -- that reads as an
+        authoritative "examples were cached" claim (#3779)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = Path(tmp)
+            self._write(build_dir)
+            entry = json.loads(get_full_run_cache_file(build_dir).read_text())
+            self.assertNotIn("num_examples_run", entry)
+            self.assertNotIn("examples_included", entry)
+
+    def test_capture_supplies_every_required_key(self) -> None:
+        """save_full_run_result fails closed on a partial watermark set and
+        returns WITHOUT persisting -- a capture producing the wrong keys would
+        reproduce #3783's symptom (no cache file) with no error at all."""
+        marks = capture_source_watermarks(PROJECT_ROOT)
+        self.assertTrue(
+            _WATERMARK_KEYS <= marks.keys(),
+            f"capture is missing {_WATERMARK_KEYS - marks.keys()}",
+        )
+
+    def test_none_watermarks_skip_persisting_rather_than_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = Path(tmp)
+            save_full_run_result(build_dir, 357, 357, 1.0, watermarks=None)
+            self.assertFalse(get_full_run_cache_file(build_dir).exists())
+
+
+class TestUnitOnlyEntryIsNotServedToExamples(unittest.TestCase):
+    def test_examples_run_rejects_a_unit_only_entry(self) -> None:
+        """Mtime gates alone would replay a unit-only pass as covering
+        examples. The reader must fail closed on recorded coverage."""
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = Path(tmp)
+            (build_dir / "build.ninja").write_text("", encoding="utf-8")
+            save_full_run_result(
+                build_dir,
+                274,
+                274,
+                10.0,
+                watermarks={k: 0.0 for k in _WATERMARK_KEYS},
+                examples_included=False,
+            )
+            entry = json.loads(get_full_run_cache_file(build_dir).read_text())
+            self.assertIs(entry["examples_included"], False)
+
+            source = (PROJECT_ROOT / "ci" / "early_exit_cache.py").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn(
+                'saved.get("examples_included") is False',
+                source,
+                "full_run_cache must reject a unit-only entry when the caller "
+                "asked for examples",
+            )
+
+    def test_full_run_cache_returns_the_raw_entry(self) -> None:
+        """CASE 2 describes the run from what the ENTRY recorded, so the entry
+        itself has to come back with the counts."""
+        self.assertIn(
+            "tuple[int, int, float, dict]",
+            (PROJECT_ROOT / "ci" / "early_exit_cache.py").read_text(encoding="utf-8"),
+        )
+        self.assertTrue(callable(full_run_cache))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -1546,25 +1546,40 @@ def runner(
     # Determine test categories first to check if we should use meson
     test_categories = determine_test_categories(args)
 
+    # Snapshot the tree BEFORE building/running, for whichever unit-test branch
+    # runs below. Capturing after the run would absorb any file added meanwhile
+    # into the watermark, caching a pass over code that was never compiled or
+    # executed.
+    #
+    # An unreadable build file must not take down the test run: fall back to
+    # None, which makes save_full_run_result skip persisting. Worst case is one
+    # lost fast path, never a stale green.
+    #
+    # Captured out here rather than inside a branch. Only the mixed branch
+    # feeds save_full_run_result, but the capture used to live in the
+    # unit-only branch -- which returns first and never consumed it. So the
+    # value was computed where it was useless and unbound where it was needed:
+    # every `bash test --cpp` raised NameError into a swallowing
+    # `except Exception: pass`, .full_run_cache.json was never written, and the
+    # fast path it gates could never fire (#3783). Binding at function scope
+    # means no branch can omit it again.
+    _watermarks: Optional[dict[str, float]] = None
+    if test_categories.unit and not test_categories.unit_only and cpp_test_change:
+        from ci.meson.cache_utils import capture_source_watermarks
+        from ci.util.paths import PROJECT_ROOT
+
+        try:
+            _watermarks = capture_source_watermarks(PROJECT_ROOT)
+        except OSError:
+            _watermarks = None
+
     # Always use Meson build system for unit tests (Python build system has been removed)
     # Only return early if unit tests are the ONLY thing running (unit_only mode)
     # Skip if fingerprint cache indicates no changes
     if test_categories.unit_only:
         if cpp_test_change:
-            from ci.meson.cache_utils import capture_source_watermarks
             from ci.meson.runner import run_meson_build_and_test
             from ci.util.paths import PROJECT_ROOT
-
-            # Snapshot the tree BEFORE building/running. Capturing after the run
-            # would absorb any file added meanwhile into the watermark, caching
-            # a pass over code that was never compiled or executed.
-            # An unreadable build file must not take down the test run: fall
-            # back to None, which makes save_full_run_result skip persisting.
-            # Worst case is one lost fast path, never a stale green.
-            try:
-                _watermarks = capture_source_watermarks(PROJECT_ROOT)
-            except OSError:
-                _watermarks = None
 
             build_dir = PROJECT_ROOT / ".build" / "meson"
             test_name = args.test if args.test else None
@@ -1728,9 +1743,22 @@ def runner(
                     print(summary)
                 sys.exit(1)
 
-            # Save full-run cache after successful complete test suite run
-            # so the CASE 2 ultra-early exit can fire on next invocation.
-            if result.num_tests_run and result.num_tests_run == result.num_tests_passed:
+            # Save full-run cache after a successful COMPLETE suite run so the
+            # CASE 2 ultra-early exit can fire on the next invocation.
+            #
+            # A narrowed run must never be persisted here. This entry is
+            # replayed as an unconditional green for the whole suite, and its
+            # watermarks cover the entire tree -- so caching `bash test Foo`
+            # would let the next `bash test --cpp` exit 0 having compiled and
+            # run nothing. That is the stale-green #3763 was filed over, in its
+            # most dangerous form. Same condition the fingerprint writer above
+            # uses to stamp scope="partial" (#3783).
+            _full_scope_save = not (test_name or test_file_filter)
+            if (
+                _full_scope_save
+                and result.num_tests_run
+                and result.num_tests_run == result.num_tests_passed
+            ):
                 try:
                     from ci.meson.cache_utils import save_full_run_result
                     from ci.util.paths import PROJECT_ROOT
@@ -1747,11 +1775,20 @@ def runner(
                         result.num_tests_run,
                         result.duration,
                         watermarks=_watermarks,
+                        num_examples_passed=result.num_examples_passed,
+                        num_examples_run=result.num_examples_run,
+                        examples_included=result.examples_included,
                     )
                 except KeyboardInterrupt as ki:
                     handle_keyboard_interrupt(ki)
-                except Exception:
-                    pass  # Non-critical
+                except Exception as e:  # noqa: BLE001 - best-effort, see below
+                    # Persisting the fast-path cache is best-effort: a failure
+                    # costs one slower run, never correctness, so it must not
+                    # fail the suite. But it must not be SILENT either -- a
+                    # NameError sat in this exact handler undetected for the
+                    # life of #3783, disabling the fast path entirely with no
+                    # signal. Stay tolerant, become loud.
+                    ts_print(f"[cache] full-run cache not saved: {e!r}")
         else:
             # Fingerprint cache hit - skip unit tests
             cache_msg = _format_cache_hit_message(
@@ -1962,11 +1999,29 @@ def runner(
                                         _saved_tr.get("num_tests", 0),
                                         _saved_tr.get("duration", 0.0),
                                         watermarks={_k: _saved_tr[_k] for _k in _keys},
+                                        # Carry the split with the counts it
+                                        # describes; dropping it here would
+                                        # relabel an attributed run as
+                                        # unattributable on every refresh.
+                                        num_examples_passed=_saved_tr.get(
+                                            "num_examples_passed"
+                                        ),
+                                        num_examples_run=_saved_tr.get(
+                                            "num_examples_run"
+                                        ),
+                                        examples_included=_saved_tr.get(
+                                            "examples_included"
+                                        ),
                                     )
                     except KeyboardInterrupt as ki:
                         handle_keyboard_interrupt(ki)
-                    except Exception:
-                        pass  # Non-critical optimization; fail silently
+                    except Exception as e:  # noqa: BLE001 - best-effort, see below
+                        # Same bargain as the writer above: never fail a green
+                        # run over a cache refresh, never fail silently either
+                        # (#3783). A malformed entry can be any shape here --
+                        # json.loads happily returns a non-dict -- so the catch
+                        # stays broad and reports instead.
+                        ts_print(f"[cache] full-run cache not refreshed: {e!r}")
             summary = _format_timing_summary(all_timings)
             # Use print() instead of ts_print() to avoid orphan timestamps
             # before multi-line content (the summary starts with \n)


### PR DESCRIPTION
Fixes #3783.

## The bug

`runner()` has two branches that run unit tests. Only the mixed branch (`--cpp`, bare `bash test`) persists `.full_run_cache.json`, but `_watermarks` was captured inside the **unit-only** branch — which returns before the mixed one is reached. The value was computed where nothing consumed it, and unbound where it was needed:

```
NameError: name '_watermarks' is not defined
```

…straight into a bare `except Exception: pass`. So `.full_run_cache.json` was **never created on a fresh checkout**, and the ultra-early-exit fast path it gates could never fire. Silently, for as long as the bug existed.

## Before / after

```bash
rm -f .build/meson-quick/.full_run_cache.json
bash test --cpp     # green
ls .build/meson-quick/.full_run_cache.json
# before: No such file or directory
# after:  exists
```

Second consecutive `bash test --cpp`:

```
before: ~3s   (fingerprint path; CASE 2 unreachable)
after:  0.11s (CASE 2 fast path, finally firing)
```

Binding at function scope means no branch can omit it again.

## What making the write live exposed

This is the part worth reviewing. The write had never executed, so three guards around it had never carried weight:

1. **A narrowed run must never be persisted.** The entry replays as an unconditional green for the *whole suite*, and its watermarks cover the *entire tree*. So caching `bash test Foo` (1/1 passed) would let the next `bash test --cpp` exit 0 having compiled and run nothing — a stale green of the exact kind #3763 was filed over, in its most dangerous form. Now gated on the same condition the fingerprint writer uses to stamp `scope="partial"`.

2. **A unit-only entry must never be served to a caller that asked for examples.** The mtime gates alone would replay it as covering examples. `full_run_cache` now fails closed on recorded coverage.

3. **The write must not fail silently.** I first narrowed the two handlers to `OSError` / `(OSError, ValueError)` — review showed that turned best-effort paths into crash paths (a `.full_run_cache.json` containing valid-but-non-dict JSON makes `_saved_tr.get(...)` raise `AttributeError`; the refresh path's first `ci.meson.cache_utils` import can raise `ImportError`). Both would fail an otherwise-green run. So the handlers stay **broad and become loud** — tolerant of failure, never silent about it. Silence is what let this bug live.

## Attribution

Also carries the unit/example split (#3779) into the cache entry. Not scope creep: this path is now live for the first time, and would otherwise print `unit/example split unrecorded` on the most common invocation forever. Absent keys still mean "not recorded" and render honestly:

```
✓ Fingerprint cache valid - skipping C++ unit tests [357/357 unit + examples passed in 80.79s]
```

## Verification

End-to-end: file **is** created by a full run, is **not** created by a filtered run, fast path replays with attribution. 11 regression tests covering both the binding invariant and the two stale-green guards. Full Python suite green (651 passed); `bash lint` clean.

Note the regression tests deliberately assert behaviour *and* structure — the original bug is invisible to any runtime test that doesn't reach the mixed branch, so the shape of the binding is pinned too.

## Pre-existing, not touched

`test_fbuild_deploy_streaming::test_deploy_output_is_visible_before_process_exits` flaked once under full-suite load; passes 3/3 in isolation. `test_fbuild_qemu` and `test_meson_include_paths` fail on clean master (see #3774 context and PR #3782's notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached test results for unit and example runs by preserving accurate coverage information.
  * Prevented incomplete or unit-only cache entries from being used for example-test runs.
  * Ensured cache updates report persistence failures instead of failing silently.
  * Restricted full-suite cache results to complete, unfiltered successful runs.

* **Tests**
  * Added regression coverage for cache validation, metadata preservation, watermark handling, and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->