### PR TITLE
feat(ci): promote PlatformIO-internal-usage lint from warn-only to error (#2701)

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -104,15 +104,6 @@ jobs:
             rm -rf "$purge_root"
           fi
 
-      - name: Install Platform
-        if: inputs.platform != ''
-        run: |
-          uv run pio pkg -g install ${{ inputs.platform }}
-
-      - name: PlatformIO Versions
-        run: |
-          uv run platformio --version
-
       - name: Build FastLED examples with "./compile --no-interactive  ${{ inputs.args }}"
         id: build_examples
         # The ``FASTLED_FAIL_ON_ROOT_MERGE`` tripwire from #3278 was

--- a/ci/lint_platformio/check_no_internal_platformio.py
+++ b/ci/lint_platformio/check_no_internal_platformio.py
@@ -14,16 +14,24 @@ User-facing references stay allowed via the ALLOWED_PATH_FRAGMENTS
 allowlist (README/install docs, ``examples/`` comments, ``library.json``
 / ``library.properties``, issue templates, etc.).
 
-The checker is in WARN MODE — it reports violations but ``run_platformio_lint``
-returns ``True`` by default so the linter does not gate CI red while the
-follow-up sweep PR removes existing call sites. To promote the checker
-to error-on-violation, pass ``warn_only=False`` (or set the
-``FASTLED_LINT_PLATFORMIO_ERROR`` env var to ``1``).
+The checker is in ERROR MODE — any violation fails the lint. PlatformIO may
+be invoked only from the modules enumerated in
+``SANCTIONED_PLATFORMIO_SURFACE`` (the deliberate #3279 comparison-only
+backend and the user-facing PIO consumer surface) plus the shrinking
+``MIGRATION_DEBT`` list. A new call site anywhere else is a hard failure.
+
+To downgrade to warn-only, pass ``warn_only=True`` to ``run_platformio_lint``
+(or set ``FASTLED_LINT_PLATFORMIO_WARN_ONLY=1``).
+
+Matching is invocation-shaped, not mention-shaped: comment tails, backtick
+spans, and prose inside string literals and docstrings are masked out before
+patterns are applied, while argv lists like ``["pio", "run"]`` ARE caught.
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 from ci.util.check_files import FileContent, FileContentChecker
 
@@ -38,18 +46,18 @@ from ci.util.check_files import FileContent, FileContentChecker
 #   * The PlatformIO library manifest (library.json / library.properties)
 #   * Issue templates (.github/ISSUE_TEMPLATE/)
 #   * The linter itself (this file documents the patterns it forbids)
-#   * Backend comparison harness (ci/check_backend_flag_drift.py — when
-#     it lands; intentionally calls both backends side-by-side)
 #   * .git internal data
 #
-# NOTE: This is intentionally permissive. The point of the warn-mode first
-# pass is to surface the current state of internal PlatformIO usage so the
-# follow-up sweep PR has a punchlist.
+# NOTE: This list is about *documentation and user-facing surface* — places
+# where merely naming PlatformIO is fine. Code that genuinely invokes
+# PlatformIO belongs in SANCTIONED_PLATFORMIO_SURFACE below instead, so the
+# two reasons for exemption stay distinguishable.
 ALLOWED_PATH_FRAGMENTS: tuple[str, ...] = (
     # Linter itself
     "ci/lint_platformio/",
-    # The backend-comparison harness (planned, may not exist yet on master)
-    "ci/check_backend_flag_drift.py",
+    # The linter's own test fixtures — they must contain the literal
+    # forbidden patterns in order to assert that the checker catches them.
+    "ci/tests/test_no_internal_platformio_checker.py",
     # User-facing docs
     "/README.md",
     "/docs/",
@@ -100,10 +108,68 @@ ALLOWED_PATH_FRAGMENTS: tuple[str, ...] = (
 )
 
 
+# --- Sanctioned PlatformIO surface ----------------------------------------
+#
+# These are NOT debt. Each entry is a module whose *purpose* is to drive
+# PlatformIO, kept deliberately per #3279 Phase 3, which retained the PIO
+# backend as a comparison-only escape hatch rather than deleting it. Gating
+# them would mean deleting the #3279 drift harness, and that is a policy
+# decision for #3279 — not something a lint sweep gets to make.
+#
+# The checker's job after this list exists is to be a RATCHET: PlatformIO may
+# be invoked from these files and nowhere else. Any new call site elsewhere
+# fails CI.
+SANCTIONED_PLATFORMIO_SURFACE: tuple[str, ...] = (
+    # The PioCompiler backend itself — #3279 comparison-only, reachable only
+    # behind _assert_explicit_platformio_backend()/FASTLED_BACKEND_PLATFORMIO_EXPLICIT.
+    "ci/compiler/pio.py",
+    # Declares the --platformio/--pio/--backend=platformio opt-in flags that
+    # gate the above. Hard dependents: ci/check_backend_flag_drift.py,
+    # ci/tests/test_check_backend_flag_drift.py, both drift workflows.
+    "ci/compiler/argument_parser.py",
+    # #3279-mandated nightly fbuild-vs-PIO parity monitor. Its whole function
+    # is running both backends and diffing them.
+    ".github/workflows/nightly_fbuild_pio_parity.yml",
+    ".github/workflows/backend_flag_drift_teensy40.yml",
+    "ci/check_backend_flag_drift.py",
+    # Regression test for the *user-facing* PIO consumer surface: a fresh
+    # clone must still build via `pio run` against the frozen root
+    # platformio.ini (#3274/#3279/#3281). Deleting this removes the only
+    # coverage that downstream PlatformIO users still work.
+    ".github/workflows/build_clone_and_compile.yml",
+    # `bash debug` and per-symbol size measurement read the root
+    # platformio.ini, which fbuild deliberately does not parse.
+    "ci/debug_attached.py",
+    "ci/compiled_size.py",
+    # Documented manual bloat-audit tools (#2905/#2886). They measure flags
+    # injected through root platformio.ini, so they must use the PIO backend.
+    "ci/bloat.py",
+    "tests/measure_esp32s3_opt_ins.py",
+)
+
+
+# --- Migration debt -------------------------------------------------------
+#
+# Unlike the list above, these ARE debt and are expected to shrink to empty.
+# Each entry needs a tracking issue and a concrete migration path.
+MIGRATION_DEBT: tuple[tuple[str, str], ...] = (
+    (
+        ".github/workflows/build_esp_extra_libs.yml",
+        "Builds ci/kitchensink via `pio run` to exercise PlatformIO's LDF "
+        "dependency resolution, which fbuild does not yet reproduce. Port "
+        "kitchensink to fbuild, then drop this entry. See #2701.",
+    ),
+)
+
+
 def _is_path_allowed(file_path: str) -> bool:
-    """Return True if file_path is in the allowlist (substring match)."""
+    """Return True if file_path is exempt (allowlist / sanctioned / debt)."""
     normalized = file_path.replace("\\", "/")
-    return any(fragment in normalized for fragment in ALLOWED_PATH_FRAGMENTS)
+    if any(fragment in normalized for fragment in ALLOWED_PATH_FRAGMENTS):
+        return True
+    if any(fragment in normalized for fragment in SANCTIONED_PLATFORMIO_SURFACE):
+        return True
+    return any(fragment in normalized for fragment, _reason in MIGRATION_DEBT)
 
 
 # --- Forbidden patterns ----------------------------------------------------
@@ -163,16 +229,144 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
 )
 
 
+_HINT_BY_CATEGORY: dict[str, str] = {
+    category: hint for _pattern, category, hint in _PATTERNS
+}
+
+
 # Lines that look like in-file comments quoting the forbidden patterns
 # (e.g. doc strings inside this checker itself). We skip those rather than
 # blanket-allowlisting the file — keeps the checker honest about its own
 # source.
-_COMMENT_PREFIXES: tuple[str, ...] = ("#", "//", "*", "<!--", "/*")
+_COMMENT_PREFIXES: tuple[str, ...] = ("#", "//", "*", "<!--", "/*", ";")
 
 
 def _line_is_comment(line: str) -> bool:
     stripped = line.lstrip()
     return any(stripped.startswith(prefix) for prefix in _COMMENT_PREFIXES)
+
+
+# --- Prose vs. invocation -------------------------------------------------
+#
+# The rule is "don't SHELL OUT to PlatformIO", not "don't MENTION PlatformIO".
+# A docstring that explains why `pio run` is forbidden is not an invocation,
+# and flagging it pushes authors to mangle their own prose to appease a
+# linter. So before matching we mask out every region that is documentation
+# rather than code:
+#
+#   * comment tails (``#``, ``;``, ``//``, ``::`` — per file type)
+#   * backtick spans — the universal markdown/rST convention for quoting a
+#     command *as text* (`` `pio run` ``)
+#   * string literals, including multi-line triple-quoted docstrings
+#
+# String literals get a second, narrower look: a literal whose ENTIRE content
+# is the forbidden token (``"--platformio"``) is an argparse flag definition
+# or a subprocess argument — a real violation. A literal that merely contains
+# the token amid other words (``help="... --platformio ..."``) is prose.
+#
+# Adjacent literals on one line are also joined and re-tested so that
+# split-token argv lists like ``["pio", "run"]`` are still caught.
+
+_TRIPLE_DELIMS: tuple[str, ...] = ('"""', "'''")
+
+# Comment introducers per file extension. Order matters only for display.
+_COMMENT_CHARS_BY_SUFFIX: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
+    ((".py", ".sh", ".bash", ".ps1", ".toml", ".yml", ".yaml"), ("#",)),
+    ((".ini", ".cfg"), ("#", ";")),
+    ((".cmd", ".bat"), ("::", "rem ", "REM ")),
+    ((".md",), ()),
+)
+
+# Patterns that describe a *command* (as opposed to a flag). Only these are
+# re-tested against joined string literals, where a false positive from
+# accidental adjacency would be most likely.
+_COMMAND_CATEGORIES: frozenset[str] = frozenset(
+    {"pio_run", "platformio_run", "platformio_version_probe"}
+)
+
+
+def _comment_chars(file_path: str) -> tuple[str, ...]:
+    normalized = file_path.replace("\\", "/").lower()
+    for suffixes, chars in _COMMENT_CHARS_BY_SUFFIX:
+        if normalized.endswith(suffixes):
+            return chars
+    return ("#",)
+
+
+@dataclass(slots=True)
+class MaskedLine:
+    """One line split into the part that executes and the part that documents.
+
+    Attributes:
+        residue: The line with every prose region blanked out — what's left
+            is bare code, e.g. a shell command in a YAML ``run:`` step.
+        literals: Contents of string literals that opened and closed on this
+            line. Checked separately, since ``"--platformio"`` is a real flag
+            definition while ``"see --platformio for details"`` is prose.
+        in_string: The triple-quote delimiter still open at end-of-line, or
+            ``None``. Threaded into the next line so multi-line docstrings
+            stay masked.
+    """
+
+    residue: str
+    literals: list[str]
+    in_string: str | None
+
+
+def _mask_prose(
+    line: str, comment_chars: tuple[str, ...], in_string: str | None
+) -> MaskedLine:
+    """Split a line into executable residue and documentation."""
+    residue: list[str] = []
+    literals: list[str] = []
+    n = len(line)
+    i = 0
+
+    # Resume a docstring left open by a previous line.
+    if in_string is not None:
+        idx = line.find(in_string)
+        if idx == -1:
+            return MaskedLine("", [], in_string)
+        literals.append(line[:idx])
+        i = idx + len(in_string)
+        in_string = None
+
+    while i < n:
+        ch = line[i]
+
+        if any(line.startswith(cc, i) for cc in comment_chars):
+            break  # comment tail — everything after is prose
+
+        if ch == "`":
+            close = line.find("`", i + 1)
+            if close == -1:
+                break  # unterminated quote span; treat remainder as prose
+            i = close + 1
+            continue
+
+        if ch in "\"'":
+            triple = next((d for d in _TRIPLE_DELIMS if line.startswith(d, i)), None)
+            if triple is not None:
+                close = line.find(triple, i + len(triple))
+                if close == -1:
+                    literals.append(line[i + len(triple) :])
+                    return MaskedLine("".join(residue), literals, triple)
+                literals.append(line[i + len(triple) : close])
+                i = close + len(triple)
+                continue
+            j = i + 1
+            while j < n and line[j] != ch:
+                j += 2 if line[j] == "\\" else 1
+            if j >= n:
+                break  # unterminated literal; remainder is prose
+            literals.append(line[i + 1 : j])
+            i = j + 1
+            continue
+
+        residue.append(ch)
+        i += 1
+
+    return MaskedLine("".join(residue), literals, in_string)
 
 
 # File extensions considered "build/CI code" where internal PIO usage is
@@ -210,14 +404,44 @@ class NoInternalPlatformIOChecker(FileContentChecker):
         return True
 
     def check_file_content(self, file_content: FileContent) -> list[str]:
+        comment_chars = _comment_chars(file_content.path)
+        in_string: str | None = None
+
         for line_number, line in enumerate(file_content.lines, 1):
+            masked = _mask_prose(line, comment_chars, in_string)
+            in_string = masked.in_string
+
             if _line_is_comment(line):
                 continue
-            for pattern, category, hint in _PATTERNS:
-                if pattern.search(line):
-                    self.violations.setdefault(file_content.path, []).append(
-                        (line_number, f"[{category}] {hint}  >> {line.strip()}")
-                    )
-                    # one violation per line is enough
-                    break
+
+            category = self._first_match(masked.residue, masked.literals)
+            if category is None:
+                continue
+
+            hint = _HINT_BY_CATEGORY[category]
+            self.violations.setdefault(file_content.path, []).append(
+                (line_number, f"[{category}] {hint}  >> {line.strip()}")
+            )
         return []
+
+    @staticmethod
+    def _first_match(residue: str, literals: list[str]) -> str | None:
+        """Return the category of the first real violation on a line, if any."""
+        # Only argv-shaped tokens take part in the join. A literal containing
+        # whitespace is a sentence, not a command word, and joining it would
+        # resurrect exactly the prose false positives this pass removes.
+        joined = " ".join(
+            tok for tok in (lit.strip() for lit in literals) if tok and " " not in tok
+        )
+
+        for pattern, category, _hint in _PATTERNS:
+            # Bare code — an actual shell command or YAML `run:` step.
+            if pattern.search(residue):
+                return category
+            # A string literal that IS the token, e.g. argparse("--platformio").
+            if any(pattern.fullmatch(lit.strip()) for lit in literals):
+                return category
+            # Split argv lists, e.g. ["pio", "run"].
+            if category in _COMMAND_CATEGORIES and pattern.search(joined):
+                return category
+        return None

--- a/ci/lint_platformio/check_no_internal_platformio.py
+++ b/ci/lint_platformio/check_no_internal_platformio.py
@@ -26,6 +26,11 @@ To downgrade to warn-only, pass ``warn_only=True`` to ``run_platformio_lint``
 Matching is invocation-shaped, not mention-shaped: comment tails, backtick
 spans, and prose inside string literals and docstrings are masked out before
 patterns are applied, while argv lists like ``["pio", "run"]`` ARE caught.
+
+Known limitation: matching is line-oriented, so an argv list broken across
+physical lines is not detected. Closing that needs cross-line expression
+tracking; ``test_known_limitation_argv_split_across_lines`` pins the gap so
+it stays explicit rather than assumed-covered.
 """
 
 from __future__ import annotations
@@ -294,14 +299,28 @@ def _comment_chars(file_path: str) -> tuple[str, ...]:
 
 
 @dataclass(slots=True)
+class Literal:
+    """A string literal, with the span it occupied in the source line.
+
+    Positions matter: two literals may only be joined into a candidate
+    command if nothing but list punctuation separates them. Joining every
+    literal on a line would flag ``if mode == "pio": step = "run"``.
+    """
+
+    text: str
+    start: int
+    end: int
+
+
+@dataclass(slots=True)
 class MaskedLine:
     """One line split into the part that executes and the part that documents.
 
     Attributes:
         residue: The line with every prose region blanked out — what's left
             is bare code, e.g. a shell command in a YAML ``run:`` step.
-        literals: Contents of string literals that opened and closed on this
-            line. Checked separately, since ``"--platformio"`` is a real flag
+        literals: String literals that opened and closed on this line.
+            Checked separately, since ``"--platformio"`` is a real flag
             definition while ``"see --platformio for details"`` is prose.
         in_string: The triple-quote delimiter still open at end-of-line, or
             ``None``. Threaded into the next line so multi-line docstrings
@@ -309,8 +328,50 @@ class MaskedLine:
     """
 
     residue: str
-    literals: list[str]
+    literals: list[Literal]
     in_string: str | None
+
+
+# Characters that may sit between two literals of the same argv construct:
+# list/call punctuation and the quote marks themselves. Anything else (an
+# operator, a keyword, a bare identifier) means the literals belong to
+# different expressions and must not be joined.
+_ARGV_SEPARATORS = re.compile(r"^[\s,\[\]()'\"]*$")
+
+
+def _argv_groups(literals: list[Literal], line: str) -> list[str]:
+    """Join only literals that are genuinely adjacent in one argv construct.
+
+    ``["pio", "run"]`` is one command spelled across two tokens and must be
+    caught. ``if mode == "pio": step = "run"`` is two unrelated statements
+    that happen to share a line; joining those would fail the build for code
+    that never shells out to PlatformIO.
+    """
+    groups: list[str] = []
+    current: list[str] = []
+    previous: Literal | None = None
+
+    for lit in literals:
+        token = lit.text.strip()
+        # A literal containing whitespace is a sentence, not a command word.
+        if not token or " " in token:
+            previous = None
+            if current:
+                groups.append(" ".join(current))
+                current = []
+            continue
+
+        gap = line[previous.end : lit.start] if previous is not None else ""
+        if previous is not None and not _ARGV_SEPARATORS.match(gap):
+            groups.append(" ".join(current))
+            current = []
+
+        current.append(token)
+        previous = lit
+
+    if current:
+        groups.append(" ".join(current))
+    return groups
 
 
 def _is_contraction(line: str, i: int) -> bool:
@@ -325,7 +386,7 @@ def _mask_prose(
 ) -> MaskedLine:
     """Split a line into executable residue and documentation."""
     residue: list[str] = []
-    literals: list[str] = []
+    literals: list[Literal] = []
     n = len(line)
     i = 0
 
@@ -334,7 +395,7 @@ def _mask_prose(
         idx = line.find(in_string)
         if idx == -1:
             return MaskedLine("", [], in_string)
-        literals.append(line[:idx])
+        literals.append(Literal(line[:idx], 0, idx))
         i = idx + len(in_string)
         in_string = None
 
@@ -364,9 +425,13 @@ def _mask_prose(
             if triple is not None:
                 close = line.find(triple, i + len(triple))
                 if close == -1:
-                    literals.append(line[i + len(triple) :])
+                    literals.append(
+                        Literal(line[i + len(triple) :], i + len(triple), len(line))
+                    )
                     return MaskedLine("".join(residue), literals, triple)
-                literals.append(line[i + len(triple) : close])
+                literals.append(
+                    Literal(line[i + len(triple) : close], i + len(triple), close)
+                )
                 i = close + len(triple)
                 continue
             j = i + 1
@@ -374,7 +439,7 @@ def _mask_prose(
                 j += 2 if line[j] == "\\" else 1
             if j >= n:
                 break  # unterminated literal; remainder is prose
-            literals.append(line[i + 1 : j])
+            literals.append(Literal(line[i + 1 : j], i + 1, j))
             i = j + 1
             continue
 
@@ -429,7 +494,7 @@ class NoInternalPlatformIOChecker(FileContentChecker):
             if _line_is_comment(line):
                 continue
 
-            category = self._first_match(masked.residue, masked.literals)
+            category = self._first_match(masked.residue, masked.literals, line)
             if category is None:
                 continue
 
@@ -440,23 +505,20 @@ class NoInternalPlatformIOChecker(FileContentChecker):
         return []
 
     @staticmethod
-    def _first_match(residue: str, literals: list[str]) -> str | None:
+    def _first_match(residue: str, literals: list[Literal], line: str) -> str | None:
         """Return the category of the first real violation on a line, if any."""
-        # Only argv-shaped tokens take part in the join. A literal containing
-        # whitespace is a sentence, not a command word, and joining it would
-        # resurrect exactly the prose false positives this pass removes.
-        joined = " ".join(
-            tok for tok in (lit.strip() for lit in literals) if tok and " " not in tok
-        )
+        groups = _argv_groups(literals, line)
 
         for pattern, category, _hint in _PATTERNS:
             # Bare code — an actual shell command or YAML `run:` step.
             if pattern.search(residue):
                 return category
             # A string literal that IS the token, e.g. argparse("--platformio").
-            if any(pattern.fullmatch(lit.strip()) for lit in literals):
+            if any(pattern.fullmatch(lit.text.strip()) for lit in literals):
                 return category
             # Split argv lists, e.g. ["pio", "run"].
-            if category in _COMMAND_CATEGORIES and pattern.search(joined):
+            if category in _COMMAND_CATEGORIES and any(
+                pattern.search(group) for group in groups
+            ):
                 return category
         return None

--- a/ci/lint_platformio/check_no_internal_platformio.py
+++ b/ci/lint_platformio/check_no_internal_platformio.py
@@ -313,6 +313,13 @@ class MaskedLine:
     in_string: str | None
 
 
+def _is_contraction(line: str, i: int) -> bool:
+    """True if ``line[i]`` is an apostrophe inside a word, e.g. ``don't``."""
+    return (
+        i > 0 and i + 1 < len(line) and line[i - 1].isalnum() and line[i + 1].isalnum()
+    )
+
+
 def _mask_prose(
     line: str, comment_chars: tuple[str, ...], in_string: str | None
 ) -> MaskedLine:
@@ -342,6 +349,14 @@ def _mask_prose(
             if close == -1:
                 break  # unterminated quote span; treat remainder as prose
             i = close + 1
+            continue
+
+        if ch == "'" and _is_contraction(line, i):
+            # An apostrophe inside a word ("don't") is not a quote. Treating
+            # it as one opens a phantom literal that swallows the rest of the
+            # line — which would let `echo don't && pio run` slip the gate.
+            residue.append(ch)
+            i += 1
             continue
 
         if ch in "\"'":

--- a/ci/lint_platformio/run_all_checkers.py
+++ b/ci/lint_platformio/run_all_checkers.py
@@ -4,13 +4,14 @@
 Walks the repo, applies ``NoInternalPlatformIOChecker``, and prints any
 violations.
 
-WARN MODE (default): exits 0 even if violations are found. The companion
-sweep PR will remove the violating call sites; until then we don't want
-the linter to gate CI red.
+ERROR MODE (default since the #2701 sweep): any violation fails the lint.
+PlatformIO may be invoked only from the explicitly enumerated surface in
+``check_no_internal_platformio.SANCTIONED_PLATFORMIO_SURFACE``; a new call
+site anywhere else is a hard failure.
 
-To run as an error gate (CI green = no violations):
-  - Pass ``--error`` on the CLI, OR
-  - Set ``FASTLED_LINT_PLATFORMIO_ERROR=1`` in the env
+To downgrade to warn-only (escape hatch for bisecting a bad sweep):
+  - Pass ``--warn-only`` on the CLI, OR
+  - Set ``FASTLED_LINT_PLATFORMIO_WARN_ONLY=1`` in the env
 
 To dump the current punchlist:
   uv run python ci/lint_platformio/run_all_checkers.py --list-violations
@@ -128,13 +129,13 @@ def run_platformio_lint(warn_only: bool | None = None) -> bool:
     Args:
         warn_only: If True, always return True (warn mode). If False,
             return False when violations exist (error mode). If None,
-            consult ``FASTLED_LINT_PLATFORMIO_ERROR`` (defaults to warn).
+            consult ``FASTLED_LINT_PLATFORMIO_WARN_ONLY`` (defaults to error).
 
     Returns:
         True if clean OR warn-only mode is active.
     """
     if warn_only is None:
-        warn_only = os.environ.get("FASTLED_LINT_PLATFORMIO_ERROR", "") != "1"
+        warn_only = os.environ.get("FASTLED_LINT_PLATFORMIO_WARN_ONLY", "") == "1"
 
     files = _collect_files(PROJECT_ROOT)
     if not files:
@@ -180,17 +181,21 @@ def main() -> int:
     parser.add_argument(
         "--error",
         action="store_true",
-        help="Fail (exit 1) if any violation is found. Default is warn-only.",
+        help="Deprecated no-op: error mode is now the default.",
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Report violations but exit 0. Escape hatch; default is to fail.",
     )
     parser.add_argument(
         "--list-violations",
         action="store_true",
-        help="Alias for the default behavior: print the current violation punchlist.",
+        help="Print the current violation punchlist without failing.",
     )
     args = parser.parse_args()
 
-    # --list-violations is the default warn-mode behavior; alias for clarity.
-    warn_only = not args.error
+    warn_only = args.warn_only or args.list_violations
     ok = run_platformio_lint(warn_only=warn_only)
     return 0 if ok else 1
 

--- a/ci/lint_platformio/run_all_checkers.py
+++ b/ci/lint_platformio/run_all_checkers.py
@@ -174,7 +174,7 @@ def run_platformio_lint(warn_only: bool | None = None) -> bool:
     return False
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Lint for forbidden internal PlatformIO build usage (issue #2701).",
     )
@@ -193,10 +193,22 @@ def main() -> int:
         action="store_true",
         help="Print the current violation punchlist without failing.",
     )
-    args = parser.parse_args()
+    return parser
 
-    warn_only = args.warn_only or args.list_violations
-    ok = run_platformio_lint(warn_only=warn_only)
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse ``argv`` (defaults to ``sys.argv[1:]``). Split out for testing."""
+    return build_parser().parse_args(argv)
+
+
+def resolve_warn_only(args: argparse.Namespace) -> bool:
+    """Map parsed flags to warn-only mode. ``--error`` is a deprecated no-op."""
+    return bool(args.warn_only or args.list_violations)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ok = run_platformio_lint(warn_only=resolve_warn_only(args))
     return 0 if ok else 1
 
 

--- a/ci/tests/test_no_internal_platformio_checker.py
+++ b/ci/tests/test_no_internal_platformio_checker.py
@@ -73,6 +73,23 @@ class TestRealInvocationsAreCaught(unittest.TestCase):
         src = 'args = ["esp32s3", "--examples", example, "--platformio"]\n'
         self.assertEqual(len(_violations("ci/x.py", src)), 1)
 
+    def test_contraction_does_not_hide_a_later_invocation(self) -> None:
+        """Regression: an apostrophe must not open a phantom string literal.
+
+        Treating ``'`` in ``don't`` as a quote swallowed the rest of the
+        line, so a real invocation after a contraction slipped the gate.
+        """
+        for src in (
+            "  - run: echo don't bother && pio run\n",
+            "  - run: echo it's fine; platformio run\n",
+        ):
+            with self.subTest(src=src.strip()):
+                self.assertEqual(len(_violations("ci/x.yml", src)), 1)
+
+    def test_single_quoted_argv_list_is_caught(self) -> None:
+        src = "subprocess.run(['pio', 'run', '-d', d])\n"
+        self.assertEqual(len(_violations("ci/x.py", src)), 1)
+
 
 class TestProseIsNotCaught(unittest.TestCase):
     """Documentation describing the rule must not trip it."""

--- a/ci/tests/test_no_internal_platformio_checker.py
+++ b/ci/tests/test_no_internal_platformio_checker.py
@@ -24,6 +24,7 @@ from ci.lint_platformio.check_no_internal_platformio import (
     SANCTIONED_PLATFORMIO_SURFACE,
     NoInternalPlatformIOChecker,
 )
+from ci.lint_platformio.run_all_checkers import parse_args, resolve_warn_only
 from ci.util.check_files import FileContent
 
 
@@ -91,6 +92,44 @@ class TestRealInvocationsAreCaught(unittest.TestCase):
         self.assertEqual(len(_violations("ci/x.py", src)), 1)
 
 
+class TestUnrelatedAdjacentLiteralsAreNotJoined(unittest.TestCase):
+    """Regression: joining every literal on a line invented violations.
+
+    Two single-word literals in unrelated expressions would concatenate into
+    ``pio run`` and fail the build for code that never touches PlatformIO.
+    Only literals separated purely by list punctuation may be joined.
+    """
+
+    def test_unrelated_literals_are_not_joined(self) -> None:
+        for src in (
+            'if mode == "pio": step = "run"\n',
+            'd = {"pio": 1, "run": 2}\n',
+            'x = "pio" if flag else None; y = "run"\n',
+            'assert a == "pio" and b == "run"\n',
+        ):
+            with self.subTest(src=src.strip()):
+                self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_genuine_argv_lists_still_join(self) -> None:
+        for src in (
+            'cmd = ["pio", "run", "-d", str(d)]\n',
+            "subprocess.run(['pio', 'run'])\n",
+            'run(["platformio", "run"])\n',
+        ):
+            with self.subTest(src=src.strip()):
+                self.assertEqual(len(_violations("ci/x.py", src)), 1)
+
+    def test_known_limitation_argv_split_across_lines(self) -> None:
+        """Documents a gap rather than leaving it silently assumed-covered.
+
+        The checker is line-oriented, so an argv list broken across physical
+        lines is not detected. Closing this needs cross-line expression
+        tracking; until then the gap is explicit, not accidental.
+        """
+        src = 'cmd = [\n    "pio",\n    "run",\n]\n'
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+
 class TestProseIsNotCaught(unittest.TestCase):
     """Documentation describing the rule must not trip it."""
 
@@ -152,6 +191,23 @@ class TestAllowlisting(unittest.TestCase):
     def test_sanctioned_and_debt_lists_are_disjoint(self) -> None:
         debt_paths = {path for path, _reason in MIGRATION_DEBT}
         self.assertEqual(debt_paths & set(SANCTIONED_PLATFORMIO_SURFACE), set())
+
+
+class TestCliFlags(unittest.TestCase):
+    """Error mode is the default; warn-only must be opted into explicitly."""
+
+    def test_default_is_error_mode(self) -> None:
+        self.assertFalse(resolve_warn_only(parse_args([])))
+
+    def test_warn_only_flag(self) -> None:
+        self.assertTrue(resolve_warn_only(parse_args(["--warn-only"])))
+
+    def test_list_violations_does_not_fail(self) -> None:
+        self.assertTrue(resolve_warn_only(parse_args(["--list-violations"])))
+
+    def test_error_flag_is_a_no_op(self) -> None:
+        """--error used to enable the gate; it is now the default."""
+        self.assertFalse(resolve_warn_only(parse_args(["--error"])))
 
 
 class TestFileSelection(unittest.TestCase):

--- a/ci/tests/test_no_internal_platformio_checker.py
+++ b/ci/tests/test_no_internal_platformio_checker.py
@@ -1,0 +1,147 @@
+"""Tests for the PlatformIO-internal-usage checker (#2701).
+
+The checker gates internal PlatformIO shell-outs. It was promoted from
+warn-only to error mode, which makes two properties load-bearing:
+
+  1. It must still CATCH real invocations — otherwise the green gate is
+     vacuous. Notably it must catch argv-list forms like ``["pio", "run"]``,
+     which the original line-regex missed entirely.
+  2. It must NOT catch prose. Docstrings, ``help=`` text, trailing comments
+     and backtick-quoted commands describe the rule rather than violating
+     it, and flagging them pushes authors to mangle documentation to appease
+     a linter.
+
+These tests drive ``NoInternalPlatformIOChecker`` directly so no repo walk
+or real PlatformIO install is involved.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ci.lint_platformio.check_no_internal_platformio import (
+    MIGRATION_DEBT,
+    SANCTIONED_PLATFORMIO_SURFACE,
+    NoInternalPlatformIOChecker,
+)
+from ci.util.check_files import FileContent
+
+
+def _violations(path: str, src: str) -> list[tuple[int, str]]:
+    """Run the checker over in-memory source; return its violation list."""
+    checker = NoInternalPlatformIOChecker()
+    if not checker.should_process_file(path):
+        return []
+    content = FileContent(path=path, content=src, lines=src.splitlines())
+    checker.check_file_content(content)
+    return checker.violations.get(path, [])
+
+
+class TestRealInvocationsAreCaught(unittest.TestCase):
+    """The gate must actually bite."""
+
+    def test_yaml_run_step(self) -> None:
+        src = "steps:\n  - run: uv run platformio run\n"
+        self.assertEqual(len(_violations("ci/x.yml", src)), 1)
+
+    def test_yaml_chained_shell_command(self) -> None:
+        src = "steps:\n  - run: cd ci/kitchensink && pio run\n"
+        self.assertEqual(len(_violations("ci/x.yml", src)), 1)
+
+    def test_version_probe(self) -> None:
+        src = "steps:\n  - run: uv run platformio --version\n"
+        self.assertEqual(len(_violations("ci/x.yml", src)), 1)
+
+    def test_backend_flag_in_shell(self) -> None:
+        src = "steps:\n  - run: ci-compile.py --backend platformio\n"
+        self.assertEqual(len(_violations("ci/x.yml", src)), 1)
+
+    def test_argv_list_is_caught(self) -> None:
+        """Regression: the original line-regex missed every argv form."""
+        src = 'cmd = ["pio", "run", "-d", str(build_dir), "-t", "size"]\n'
+        violations = _violations("ci/x.py", src)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("pio_run", violations[0][1])
+
+    def test_flag_as_exact_string_literal(self) -> None:
+        """An argparse flag definition is a real acceptance point."""
+        for literal in ('"--platformio",', '"--pio",'):
+            with self.subTest(literal=literal):
+                self.assertEqual(len(_violations("ci/x.py", literal + "\n")), 1)
+
+    def test_flag_passed_in_arg_list(self) -> None:
+        src = 'args = ["esp32s3", "--examples", example, "--platformio"]\n'
+        self.assertEqual(len(_violations("ci/x.py", src)), 1)
+
+
+class TestProseIsNotCaught(unittest.TestCase):
+    """Documentation describing the rule must not trip it."""
+
+    def test_single_line_docstring(self) -> None:
+        src = '"""Backend selection (fbuild vs PlatformIO\'s `pio run`)."""\n'
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_multi_line_docstring(self) -> None:
+        src = (
+            '"""Measure opt-ins.\n'
+            "\n"
+            "On Linux/macOS run `bash compile esp32s3 --examples X\n"
+            "--platformio` to reproduce. The PlatformIO `pio run` backend\n"
+            "is comparison-only.\n"
+            '"""\n'
+        )
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_trailing_comment(self) -> None:
+        src = "ok = False  # some boards only work with pio run\n"
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_ini_semicolon_comment(self) -> None:
+        src = "; This file is consumed by `bash debug` (and raw `pio run`).\n"
+        self.assertEqual(_violations("ci/x.ini", src), [])
+
+    def test_help_text_mentioning_flag(self) -> None:
+        src = 'p.add_argument("--backend", help="Use --platformio to compare.")\n'
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_prose_string_containing_command(self) -> None:
+        src = 'label = "fbuild" if use_fbuild else "platformio (pio run)"\n'
+        self.assertEqual(_violations("ci/x.py", src), [])
+
+    def test_backtick_quoted_command_in_yaml_prose(self) -> None:
+        src = "# note\ndescription: reference for raw `pio run` invocations.\n"
+        self.assertEqual(_violations("ci/x.yml", src), [])
+
+
+class TestAllowlisting(unittest.TestCase):
+    def test_sanctioned_surface_is_skipped(self) -> None:
+        src = 'cmd = ["pio", "run", "--project-dir", str(d)]\n'
+        # Same source, sanctioned path vs. an arbitrary one.
+        self.assertEqual(_violations("ci/compiler/pio.py", src), [])
+        self.assertEqual(len(_violations("ci/compiler/other.py", src)), 1)
+
+    def test_migration_debt_is_skipped(self) -> None:
+        src = "steps:\n  - run: cd ci/kitchensink && pio run\n"
+        path = ".github/workflows/build_esp_extra_libs.yml"
+        self.assertEqual(_violations(path, src), [])
+
+    def test_every_debt_entry_carries_a_reason(self) -> None:
+        """Debt must be justified and tracked, not silently parked."""
+        for path, reason in MIGRATION_DEBT:
+            with self.subTest(path=path):
+                self.assertTrue(reason.strip(), f"{path} has no stated reason")
+                self.assertIn("#", reason, f"{path} cites no tracking issue")
+
+    def test_sanctioned_and_debt_lists_are_disjoint(self) -> None:
+        debt_paths = {path for path, _reason in MIGRATION_DEBT}
+        self.assertEqual(debt_paths & set(SANCTIONED_PLATFORMIO_SURFACE), set())
+
+
+class TestFileSelection(unittest.TestCase):
+    def test_cpp_sources_are_not_scanned(self) -> None:
+        """Board source never drives PlatformIO; scanning it only adds noise."""
+        self.assertEqual(_violations("src/platforms/esp/pio_run.cpp", "pio run\n"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Promotes the `PlatformIO-internal-usage` checker from warn-only to a hard CI gate, and fixes every violation.

The checker has been warn-only since it landed, printing **35 violations that nobody acted on**. Turning that into a gate needed two things: making the violations real, and making the exemptions honest.

## Precision: invocations, not mentions

The rule is *don't shell out to PlatformIO*, not *don't mention PlatformIO*. The old line-regex flagged docstrings, `help=` text, trailing comments and `;` ini comments that merely **described** the forbidden pattern — which pressures authors to mangle their own prose to appease a linter.

Matching is now invocation-shaped. Comment tails, backtick spans, and prose inside string literals and docstrings are masked before patterns apply. A literal is still flagged when it *is* the token (`"--platformio"`), and adjacent argv tokens are joined so split forms are caught.

**That last part found 7 real invocations the old checker missed entirely:**

| File | Missed invocation |
|---|---|
| `ci/compiled_size.py` (×3) | `["pio", "run", "-d", ...]` |
| `ci/compiler/pio.py` | `["pio", "run", "--project-dir", ...]` |
| `ci/debug_attached.py` (×2) | `["pio", "run", "--target", "clean", ...]` |

No line-oriented regex could see these. The checker was simultaneously **noisy about prose and blind to actual shell-outs**.

Violation count: 35 → 19 (prose removed, argv forms added) → 0 (exemptions applied).

## Exemptions split by reason

Rather than one undifferentiated allowlist:

- **`ALLOWED_PATH_FRAGMENTS`** — docs and user-facing surface, where naming PlatformIO is fine.
- **`SANCTIONED_PLATFORMIO_SURFACE`** — modules whose *purpose* is driving PlatformIO, kept deliberately by #3279 Phase 3 as a comparison-only escape hatch. Gating these would mean deleting the #3279 drift harness — a policy decision for #3279, not for a lint sweep.
- **`MIGRATION_DEBT`** — actual debt, expected to reach empty. One entry (`build_esp_extra_libs.yml`, needs `ci/kitchensink` ported off PIO's LDF). A test asserts every entry carries a reason and a tracking issue.

Net effect is a **ratchet**: PlatformIO may be invoked from an enumerated set of files and nowhere else. Any new call site fails CI.

## Dead code removed

Two steps deleted from `build_template.yml`:
- `platformio --version` — a probe whose output nothing consumed.
- `pio pkg -g install` — gated on `inputs.platform`, which **no caller of this `workflow_call` ever passes** (the `platform:` inputs elsewhere belong to the avr8js/qemu templates).

The now-unused `platform` input is left declared **on purpose** — removing it changes a `workflow_call` signature consumed by ~60 workflows for no functional gain.

## Validation

- `bash lint` — all 7 stages green, exit 0
- 19 new tests, **verified non-vacuous by mutation**: disabling the residue match kills 4 of them
- `build_template.yml` re-parsed and step list confirmed; no test or workflow references the deleted steps

⚠️ One pre-existing failure, **not from this PR**: `ci/tests/test_fbuild_qemu.py::test_fbuild_test_emu_esp32dev` fails identically on pristine `upstream/master` (verified by stashing) — the local toolchain can't resolve `FastLED.h`. Parts of `ci/tests/` are toolchain/QEMU integration tests that hard-exit locally; CI covers them properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PlatformIO policy checks to detect prohibited commands and flags more reliably.
  * Reduced false positives in comments, documentation, help text, prose, and quoted examples.
  * Added support for sanctioned exceptions and tracked migration-debt handling.

* **Chores**
  * Build validation now fails by default, with an optional warning-only mode.
  * Removed redundant platform installation and version-reporting steps.

* **Tests**
  * Added comprehensive coverage for command detection, exclusions, and allowlists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->