### PR TITLE
docs(esp8266): correct the Input-mode open-drain comment (#3735 follow-up)

### DIFF
--- a/src/platforms/esp/8266/pin_esp8266_native.hpp
+++ b/src/platforms/esp/8266/pin_esp8266_native.hpp
@@ -160,7 +160,10 @@ inline void pinMode(int pin, PinMode mode) FL_NO_EXCEPT {
                 GPF(pin) = GPFFS(GPFFS_GPIO(pin));
                 // Disable output (write 1 to bit position to disable)
                 GPEC = (1 << pin);
-                // Configure as input with open-drain disabled, no pull resistors
+                // Clear the interrupt-type field and set the driver bit.
+                // GPCD=1 is open-drain; the core does the same for a plain
+                // INPUT, so this matches wiring_digital.cpp rather than
+                // disabling open-drain as the previous comment claimed.
                 GPC(pin) = (GPC(pin) & ~(0xF << GPCI)) | (1 << GPCD);
                 break;
 


### PR DESCRIPTION
Follow-up to #3787.

CodeRabbit correctly flagged that the Input-mode comment claimed open-drain was *disabled*, while the code writes `| (1 << GPCD)` — which **enables** it. I pushed the fix as `ab65604f21` and replied on that thread saying it was fixed, but #3787 had already merged a few seconds earlier, so the commit never landed. Re-landing it here so the record matches reality.

Comment-only; the register write is unchanged and matches the core's `wiring_digital.cpp`, which sets the same bit for a plain `INPUT`. The comment now says so explicitly, to stop a future reader 'fixing' the code to match the old wrong comment.

Verified: the affected TU still compiles clean against the real 3.1.2 core headers with the xtensa toolchain, and the six #3735 static assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented behavior of ESP8266 input-mode configuration, including interrupt-field clearing and open-drain support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->