### PR TITLE
chore(deps): bump fbuild 2.5.4 -> 2.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,20 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.4. Its monitor WebSocket streaming and Windows
-    # serial-health fixes are required for AutoResearch to keep the daemon
-    # alive through the first RPC on attached boards. It also includes the
-    # RP2040 UF2 deploy-path handling added in 2.5.2.
+    # Pin to fbuild 2.5.5. It carries the 2.5.4 monitor WebSocket streaming and
+    # Windows serial-health fixes required for AutoResearch to keep the daemon
+    # alive through the first RPC on attached boards, plus the RP2040 UF2
+    # deploy-path handling added in 2.5.2.
     #
     # Pin history:
+    #   2.5.5 -- refreshes the embedded zccache (pin moved to upstream main
+    #             `5ee292f`; zccache published no tag past 1.12.17, so the
+    #             version string is unchanged across ~150 commits of cache
+    #             durability and security hardening). Also realigns
+    #             `running-process` onto the same git rev zccache uses --
+    #             a registry pin plus zccache's git pin put two copies of its
+    #             unmangled `rp_*_public` C symbols in the link
+    #             (FastLED/fbuild#1215). No fbuild API change.
     #   2.5.4 -- monitor WebSocket streaming and Windows serial-health fixes;
     #             2.5.2 repeatedly lost the daemon at the first serial
     #             WebSocket during attached ESP32-C6 AutoResearch runs.
@@ -159,7 +167,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.4",
+    "fbuild==2.5.5",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
Bumps the pinned fbuild from 2.5.4 to 2.5.5 (published to PyPI with wheels for macOS arm64/x86_64, manylinux x86_64/aarch64, and win_amd64).

## What's in 2.5.5

It refreshes fbuild's embedded zccache: the pin moved to upstream main `5ee292f`, roughly 150 commits of cache-durability and security hardening. zccache published no release tag past 1.12.17, so its version string is unchanged across that whole range — the pin moved by rev only.

The release also realigns `running-process` onto the same git rev zccache uses. fbuild had it pinned from crates.io while zccache pinned it from git; Cargo treats those as two distinct packages, so both copies entered the link and every one of its unmangled `rp_*_public` C symbols collided (FastLED/fbuild#1215).

**No fbuild API change**, so nothing on this side needs to adapt.

## Verification

Against the published wheels, not a local build:

- `uv sync` installs `fbuild==2.5.5`
- `from fbuild.api import SerialMonitor` imports — the consumer contract this repo depends on
- `fbuild --version` reports `2.5.5`

Only `pyproject.toml` changes; `uv.lock` is gitignored here.

## Worth knowing

2.5.5 is a patch bump carrying a large behavioral delta in the embedded cache — corrupt artifact-index recovery, Windows deploy-directory ACLs, and https-only download defaults all changed upstream. Nothing in that surface is part of fbuild's public API, and the serial/monitor paths this repo uses are untouched, but it is more than a typical patch release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the embedded build tooling to a newer patch release.
  * Revised related version documentation and dependency notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->