### PR TITLE
fix(lint): register SRC006 in ruff's external list (re-land of a lost commit)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,7 +301,7 @@ external = [
     "DCT001", "DCT002", "KBI001", "KBI002", "KBI003",
     # ci/lint_python/subprocess_capture_checker.py. Without these,
     # ruff reads `# noqa: SRC00x` as an unused suppression.
-    "SRC001", "SRC002", "SRC003", "SRC004", "SRC005",
+    "SRC001", "SRC002", "SRC003", "SRC004", "SRC005", "SRC006",
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Re-lands the SRC006 registration that was lost in #3792's merge.

## What happened

CodeRabbit correctly flagged that `external` in `pyproject.toml` listed `SRC001`–`SRC005` but not **SRC006** — the code #3792 itself adds — while `ci/tests/test_subprocess_deadlock_rules.py:132` uses `# noqa: SRC006`. Without registration ruff reads that as an unused suppression.

I fixed it in `6cc913ad07`, pushed, and replied on the review thread saying it was fixed. But #3792's squash merge captured branch state that did not include that commit:

```
$ git merge-base --is-ancestor 6cc913ad07 master
NO
$ grep external -A 4 pyproject.toml
    "SRC001", "SRC002", "SRC003", "SRC004", "SRC005",     # no SRC006
```

So my reply was inaccurate the moment it was written.

This is the **second** time in this session a post-review commit was silently dropped by a merge — the first was #3787, re-landed as #3788. Both times `gh pr merge` reported success, and both times the branch survived `--delete-branch`. Worth knowing before trusting that command's own output; I now diff against master afterwards, which is how this was caught.

## Impact

Master is not actively broken: ruff's unused-noqa rule (RUF100) is not currently in the enabled set, so `bash lint` passes today. The registration still matters — it is what makes the suppression honoured if RUF100 is ever enabled, and it keeps the list truthful about which custom codes exist.

## Verification

One line changed. `bash lint` → `python_pipeline` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered the Ruff `SRC006` lint code for external checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->