### PR TITLE
fix(chipsets): restore TM1829 FLIP + WAIT_TIME dropped in refactor (#8)

### DIFF
--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -544,13 +544,18 @@ class TM1803Controller400Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::
 
 /// TM1829 controller @ 800 kHz - references centralized timing from fl::TIMING_TM1829_800KHZ
 /// @see fl::TIMING_TM1829_800KHZ in chipsets::led_timing.h (340, 340, 550 ns)
+/// @note The TM1829 drives an *inverted* line (LOW-then-HIGH per bit, idling HIGH),
+///       hence FLIP=true, and needs a 500us latch gap, hence WAIT_TIME=500.
+///       FLIP is currently only honored by the nRF52 backend; see
+///       https://github.com/FastLED/FastLED/issues/8
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>
-class TM1829Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1829_800KHZ, RGB_ORDER> {};
+class TM1829Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1829_800KHZ, RGB_ORDER, 0, true, 500> {};
 
 /// TM1829 controller @ 1600 kHz - references centralized timing from fl::TIMING_TM1829_1600KHZ
 /// @see fl::TIMING_TM1829_1600KHZ in chipsets::led_timing.h (100, 300, 200 ns)
+/// @copydetails TM1829Controller800Khz
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>
-class TM1829Controller1600Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1829_1600KHZ, RGB_ORDER> {};
+class TM1829Controller1600Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1829_1600KHZ, RGB_ORDER, 0, true, 500> {};
 
 /// LPD1886 controller @ 1250 kHz - references centralized timing from fl::TIMING_LPD1886_1250KHZ
 /// @see fl::TIMING_LPD1886_1250KHZ in chipsets::led_timing.h (200, 400, 200 ns)


### PR DESCRIPTION
## Problem

Commit `fc0c3d5` ("refactor(chipsets): use platform-specific `ClocklessControllerImpl`") swept `src/chipsets.h` stripping trailing `0, false` template defaults. Harmless for every other chipset — but **TM1829 was the only chipset passing non-default values**, `0, true, 500`, and those were stripped along with the rest:

```diff
-class TM1829Controller800Khz  : public FASTLED_CLOCKLESS_CONTROLLER<..., RGB_ORDER, 0, true, 500> {};
+class TM1829Controller800Khz  : public ClocklessControllerImpl<..., RGB_ORDER> {};
-class TM1829Controller1600Khz : public FASTLED_CLOCKLESS_CONTROLLER<..., RGB_ORDER, 0, true, 500> {};
+class TM1829Controller1600Khz : public ClocklessControllerImpl<..., RGB_ORDER> {};
```

The TM1829 drives an **inverted** line (LOW-then-HIGH per bit, idling HIGH) and needs a **500 µs latch gap** — that is exactly what `FLIP=true, WAIT_TIME=500` encoded. `TX1813N1` (#1362) derives from the 800 kHz controller and regressed with it.

## Fix

Restore `0, true, 500` on both controllers, plus a `@note` recording the current backend limitation.

## Impact

| Parameter | Consumed by | Effect of restore |
|---|---|---|
| `WAIT_TIME=500` | `CMinWait<WAIT_TIME>` on ~20 backends (AVR, ATtiny, ARM bit-bang paths) | Latch gap restored broadly |
| `FLIP=true` | **only** nRF52 PWM (`clockless_arm_nrf52.h:53-54`) | True signal inversion restored on nRF52 |

ESP32 driver paths derive latch timing from `TIMING::RESET` and are unaffected either way.

## Scope note — #8 stays open

This restores prior behavior; it does not complete TM1829 support. Every backend except nRF52 still accepts `FLIP` and ignores it, and the newer `fl::channels` path has no polarity concept at all (`ChipsetTimingConfig` carries only `t1/t2/t3/reset`).

Worth recording for whoever finishes this: the hardware inversion flags already exist and sit unused —
- `irmt5_peripheral.h:94` — `bool invert_out`, always `false`
- `irmt4_peripheral.h:177` — `setGpio(..., bool invert)`, callers pass `false`
- `ii2s_peripheral_esp32dev.h:107` — `u16 mInvertMask`, always `0`

The missing plumbing is a polarity bool on `ChipsetTimingConfig`/`ClocklessChipset` (plus `operator==` and `makeTimingConfig`) bridged from `FLIP`, then wired into those three flags.

## Verification

- `bash test --cpp` — 357/357 pass (274 unit, 83 examples)
- `bash lint` — clean

Refs #8, #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TM1829 LED controller support at 800 kHz and 1600 kHz.
  * Corrected output signal inversion for compatible hardware.
  * Added the required 500 µs latch wait to improve data transmission reliability.

* **Documentation**
  * Clarified TM1829 inversion behavior and documented the backend limitation.
  * Added a reference for 1600 kHz configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->