### PR TITLE
fix(ci): address CodeRabbit feedback on oldest-issue scanner

### DIFF
--- a/ci/oldest_issue.py
+++ b/ci/oldest_issue.py
@@ -9,7 +9,7 @@ Usage:
     uv run ci/oldest_issue.py                 # oldest actionable issue
     uv run ci/oldest_issue.py --list 20       # oldest 20, in age order
     uv run ci/oldest_issue.py --json          # machine-readable
-    uv run ci/oldest_issue.py --max-age-days 365
+    uv run ci/oldest_issue.py --min-age-days 365
     uv run ci/oldest_issue.py --defer 11 --reason "needs hardware"
 """
 
@@ -20,22 +20,26 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from running_process import RunningProcess
+from typeguard import typechecked
 
 
 DEFAULT_REPO = "FastLED/FastLED"
 DEFERRED_LABEL = "deferred"
 
-# gh caps --limit; issues are fetched in one page and sorted locally so that
-# "oldest" is a property of the whole open set, not of one page.
+# gh caps --limit. The fetch asks for oldest-first ordering server-side, so if a
+# repo ever exceeds this cap the issues dropped are the newest ones -- "oldest"
+# stays a property of the whole open set, not of one arbitrary page.
 FETCH_LIMIT = 1000
 
 
+@typechecked
 @dataclass
 class Issue:
     number: int
     title: str
     created_at: datetime
     labels: list[str] = field(default_factory=list)
+    repo: str = DEFAULT_REPO
 
     @property
     def age_days(self) -> int:
@@ -43,7 +47,7 @@ class Issue:
 
     @property
     def url(self) -> str:
-        return f"https://github.com/{DEFAULT_REPO}/issues/{self.number}"
+        return f"https://github.com/{self.repo}/issues/{self.number}"
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -73,6 +77,12 @@ def fetch_issues(repo: str) -> list[Issue]:
             "open",
             "--limit",
             str(FETCH_LIMIT),
+            # gh defaults to newest-first, so a repo with more than FETCH_LIMIT
+            # open issues would return the newest page and drop the very issues
+            # this tool exists to surface. Sort oldest-first server-side so the
+            # cap truncates the *newest* tail instead.
+            "--search",
+            "sort:created-asc",
             "--json",
             "number,title,createdAt,labels",
         ],
@@ -92,6 +102,7 @@ def fetch_issues(repo: str) -> list[Issue]:
             title=row["title"],
             created_at=_parse_created_at(row["createdAt"]),
             labels=[label["name"] for label in row.get("labels", [])],
+            repo=repo,
         )
         for row in json.loads(result.stdout)
     ]
@@ -99,17 +110,20 @@ def fetch_issues(repo: str) -> list[Issue]:
     return issues
 
 
-def filter_actionable(issues: list[Issue], max_age_days: int | None) -> list[Issue]:
+def filter_actionable(issues: list[Issue], min_age_days: int | None) -> list[Issue]:
     actionable = [i for i in issues if DEFERRED_LABEL not in i.labels]
-    if max_age_days is not None:
-        actionable = [i for i in actionable if i.age_days >= max_age_days]
+    if min_age_days is not None:
+        actionable = [i for i in actionable if i.age_days >= min_age_days]
     return actionable
 
 
 def defer_issue(repo: str, number: int, reason: str | None) -> None:
     """Label an issue ``deferred`` so later scans skip it."""
-    # Idempotent: gh creates the label only when it is missing.
-    RunningProcess.run(
+    # Idempotent: gh creates the label only when it is missing. "already exists"
+    # is the expected steady-state outcome; anything else (auth, permissions,
+    # network) must surface here rather than resurfacing as a confusing
+    # "label not found" from the --add-label call below.
+    label_result = RunningProcess.run(
         [
             "gh",
             "label",
@@ -127,6 +141,13 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
         capture_output=True,
         text=True,
     )
+    if label_result.returncode != 0 and "already exists" not in (
+        label_result.stderr or ""
+    ):
+        raise RuntimeError(
+            f"failed to create label {DEFERRED_LABEL!r}: {label_result.stderr}"
+        )
+
     result = RunningProcess.run(
         [
             "gh",
@@ -147,7 +168,7 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
         raise RuntimeError(f"failed to label #{number}: {result.stderr}")
 
     if reason:
-        RunningProcess.run(
+        comment_result = RunningProcess.run(
             [
                 "gh",
                 "issue",
@@ -163,10 +184,18 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
             capture_output=True,
             text=True,
         )
+        # The label is already applied at this point, so the defer itself stuck.
+        # Report the missing comment loudly instead of printing a success line
+        # that implies the reason was recorded on the issue.
+        if comment_result.returncode != 0:
+            raise RuntimeError(
+                f"labeled #{number} deferred, but posting the reason comment "
+                f"failed: {comment_result.stderr}"
+            )
     print(f"Deferred #{number}" + (f": {reason}" if reason else ""))
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -181,7 +210,7 @@ def main() -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit JSON")
     parser.add_argument(
-        "--max-age-days",
+        "--min-age-days",
         type=int,
         help="only consider issues at least this old (e.g. 365 for the >1y backlog)",
     )
@@ -194,7 +223,7 @@ def main() -> int:
         "--defer", type=int, metavar="NUMBER", help="label an issue deferred, then exit"
     )
     parser.add_argument("--reason", help="comment to leave alongside --defer")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.defer is not None:
         defer_issue(args.repo, args.defer, args.reason)
@@ -204,11 +233,11 @@ def main() -> int:
     if args.include_deferred:
         candidates = (
             issues
-            if args.max_age_days is None
-            else [i for i in issues if i.age_days >= args.max_age_days]
+            if args.min_age_days is None
+            else [i for i in issues if i.age_days >= args.min_age_days]
         )
     else:
-        candidates = filter_actionable(issues, args.max_age_days)
+        candidates = filter_actionable(issues, args.min_age_days)
 
     deferred_count = sum(1 for i in issues if DEFERRED_LABEL in i.labels)
 
@@ -222,7 +251,9 @@ def main() -> int:
         # Exit 1 so a driving loop can detect "backlog is done".
         return 1
 
-    selected = candidates[: args.list] if args.list else candidates[:1]
+    # `is not None` so an explicit `--list 0` selects nothing instead of
+    # falling through to the default single-issue slice.
+    selected = candidates[: args.list] if args.list is not None else candidates[:1]
 
     if args.json:
         print(

--- a/ci/tests/test_coderabbit_classification.py
+++ b/ci/tests/test_coderabbit_classification.py
@@ -1,0 +1,84 @@
+"""Classification tests for the CodeRabbit review addressor.
+
+The `security-flag` bucket is the one classification with teeth: the
+address-reviews skill refuses to auto-fix it, and `--check` counts it as
+unresolved, which blocks merge. So it has to be wrong in neither direction.
+
+Both directions have failed in practice:
+
+- Substring matching fired "rce" inside "Sou(rce)". Every guideline-sourced
+  CodeRabbit comment ends with "_Source: Coding guidelines_", so ordinary nits
+  became permanently-unresolved security flags and merge blocked forever.
+- The whole-word fix for that then stopped matching the plurals and inflections
+  real findings use -- "leaks secrets", "hardcoded credentials" -- silently
+  demoting genuine security comments to auto-fixable.
+"""
+
+import pytest
+
+from ci.tools.coderabbit_addressor import Comment
+
+
+def _classify(body: str) -> str:
+    return Comment(
+        id=1,
+        author="coderabbitai",
+        body=body,
+        path="ci/example.py",
+        line=1,
+        in_reply_to=None,
+    ).classification
+
+
+# Must reach a human. Inflected forms are the point: these are how findings are
+# actually phrased, not the dictionary-form keyword.
+SECURITY_BODIES = [
+    "This leaks secrets to the log",
+    "Hardcoded credentials in the diff",
+    "This breaks authentication",
+    "Missing authorization check",
+    "Possible RCE risk here",
+    "Critical data loss on this path",
+    "use-after-free here",
+    "An auth failure is unhandled",
+    "argv injection via unsanitized input",
+    "Potential buffer overflow",
+    "out-of-bounds read",
+]
+
+# Ordinary prose that merely contains a keyword *inside* another word, or uses
+# "author" in its everyday sense.
+NON_SECURITY_BODIES = [
+    "See the Source file for details",
+    "This enforces ordering",
+    "Frees resources properly",
+    "The author of this patch should note",
+    "_Source: Coding guidelines_",
+]
+
+
+@pytest.mark.parametrize("body", SECURITY_BODIES)
+def test_security_comments_are_flagged(body: str) -> None:
+    assert _classify(body) == "security-flag", f"should be security-flag: {body!r}"
+
+
+@pytest.mark.parametrize("body", NON_SECURITY_BODIES)
+def test_ordinary_prose_is_not_flagged(body: str) -> None:
+    assert _classify(body) != "security-flag", f"should not be security-flag: {body!r}"
+
+
+def test_boilerplate_does_not_drive_classification() -> None:
+    """CodeRabbit's footer is keyword-rich but describes nothing."""
+    body = (
+        "nit: rename this variable\n"
+        "<!-- fingerprinting:phantom -->\n"
+        "<details><summary>Prompt for AI Agents</summary>\n"
+        "Check the source for critical security issues.\n"
+        "</details>\n"
+        "_Source: Coding guidelines_"
+    )
+    assert _classify(body) == "style"
+
+
+def test_suggestion_block_classifies_as_valid_fix() -> None:
+    assert _classify("Consider:\n```suggestion\nx = 1\n```") == "valid-fix"

--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -34,7 +34,7 @@ CODERABBIT_LOGINS = {"coderabbitai", "coderabbitai[bot]"}
 SECURITY_KEYWORDS = [
     "security",
     "cve",
-    " auth",
+    "auth",
     "credential",
     "secret",
     "rce",
@@ -46,6 +46,31 @@ SECURITY_KEYWORDS = [
     "buffer overflow",
     "out-of-bounds",
 ]
+
+# Matched with word boundaries. Plain substring matching produced constant false
+# positives: "rce" fired on "Sou(rce)" -- and every guideline-sourced CodeRabbit
+# comment ends with "_Source: Coding guidelines_" -- as well as on "enfo(rce)s"
+# and "resou(rce)s". That routed ordinary maintainability nits into
+# security-flag, where the skill forbids auto-fixing and the --check hook counts
+# them as permanently unresolved, blocking merge forever.
+_SECURITY_RE = re.compile(
+    r"\b(" + "|".join(re.escape(kw) for kw in SECURITY_KEYWORDS) + r")\b"
+)
+
+# CodeRabbit appends boilerplate to every comment: HTML marker comments, a
+# collapsed "Prompt for AI Agents" / "Committable suggestion" <details> block,
+# and quoted coding-guideline text. None of it describes the finding, but it is
+# full of trigger words, so classification looks at the prose only.
+_BOILERPLATE_RE = re.compile(
+    r"<!--.*?-->|<details>.*?</details>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _classifiable_text(body: str) -> str:
+    """Strip CodeRabbit boilerplate so keywords match the finding, not the footer."""
+    return _BOILERPLATE_RE.sub(" ", body)
+
 
 STYLE_KEYWORDS = [
     "nit:",
@@ -70,17 +95,16 @@ class Comment:
 
     @property
     def classification(self) -> str:
-        body_lower = self.body.lower()
-        for kw in SECURITY_KEYWORDS:
-            if kw in body_lower:
-                return "security-flag"
+        prose_lower = _classifiable_text(self.body).lower()
+        if _SECURITY_RE.search(prose_lower):
+            return "security-flag"
         if re.search(r"```suggestion", self.body):
             return "valid-fix"
         for kw in STYLE_KEYWORDS:
-            if kw in body_lower:
+            if kw in prose_lower:
                 return "style"
         if any(
-            tok in body_lower
+            tok in prose_lower
             for tok in (
                 "should be",
                 "bug:",

--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -34,7 +34,12 @@ CODERABBIT_LOGINS = {"coderabbitai", "coderabbitai[bot]"}
 SECURITY_KEYWORDS = [
     "security",
     "cve",
-    "auth",
+    # Spelled out rather than a bare "auth" so that "author"/"authored" -- which
+    # CodeRabbit uses routinely in ordinary prose -- does not read as security.
+    "authentication",
+    "authorization",
+    "authn",
+    "authz",
     "credential",
     "secret",
     "rce",
@@ -47,15 +52,25 @@ SECURITY_KEYWORDS = [
     "out-of-bounds",
 ]
 
-# Matched with word boundaries. Plain substring matching produced constant false
-# positives: "rce" fired on "Sou(rce)" -- and every guideline-sourced CodeRabbit
-# comment ends with "_Source: Coding guidelines_" -- as well as on "enfo(rce)s"
-# and "resou(rce)s". That routed ordinary maintainability nits into
-# security-flag, where the skill forbids auto-fixing and the --check hook counts
-# them as permanently unresolved, blocking merge forever.
+# Anchored at the start of a word, open-ended at the end.
+#
+# The leading \b is the fix: plain substring matching made "rce" fire inside
+# "Sou(rce)" -- and every guideline-sourced CodeRabbit comment ends with
+# "_Source: Coding guidelines_" -- as well as inside "enfo(rce)s" and
+# "resou(rce)s". That routed ordinary maintainability nits into security-flag,
+# where the skill forbids auto-fixing and --check counts them as permanently
+# unresolved, blocking merge forever.
+#
+# The trailing \w* is equally load-bearing: a closing \b would drop the plurals
+# and inflections these findings actually use -- "leaks secrets", "hardcoded
+# credentials", "breaks authentication". Those must stay in security-flag, so
+# match the keyword as a word *prefix*, not as a whole word.
 _SECURITY_RE = re.compile(
-    r"\b(" + "|".join(re.escape(kw) for kw in SECURITY_KEYWORDS) + r")\b"
+    r"\b(?:" + "|".join(re.escape(kw) for kw in SECURITY_KEYWORDS) + r")\w*"
 )
+
+# A bare "auth" on its own is still worth flagging; "author" is not.
+_BARE_AUTH_RE = re.compile(r"\bauth\b")
 
 # CodeRabbit appends boilerplate to every comment: HTML marker comments, a
 # collapsed "Prompt for AI Agents" / "Committable suggestion" <details> block,
@@ -96,7 +111,7 @@ class Comment:
     @property
     def classification(self) -> str:
         prose_lower = _classifiable_text(self.body).lower()
-        if _SECURITY_RE.search(prose_lower):
+        if _SECURITY_RE.search(prose_lower) or _BARE_AUTH_RE.search(prose_lower):
             return "security-flag"
         if re.search(r"```suggestion", self.body):
             return "valid-fix"


### PR DESCRIPTION
Follow-up to #3798, which was merged before its seven CodeRabbit review threads were addressed. All seven are resolved here.

### `ci/oldest_issue.py`

| Finding | Fix |
|---|---|
| `Issue.url` ignored `--repo`, always linking at `FastLED/FastLED` | carry `repo` on `Issue`, build URL from it |
| `fetch_issues` relied on gh's newest-first default, so >`FETCH_LIMIT` open issues would drop the oldest ones the tool exists to surface | request `sort:created-asc` so the cap truncates the newest tail |
| `--list 0` was truthiness-checked and silently showed one issue | `is not None` |
| `--max-age-days` enforced a *minimum* age | rename to `--min-age-days` |
| `defer_issue` discarded `gh label create` / `gh issue comment` results, hiding auth failures and printing success when the reason comment never posted | check both, fail loudly |
| `Issue` lacked `@typechecked` | added per repo convention |
| `main()` couldn't take injected argv | `main(argv=None)` |

### `ci/tools/coderabbit_addressor.py`

Root-cause fix for a classifier bug found while running this workflow. The security-keyword scan used plain substring matching, so **`"rce"` matched `"Source"`** — and every guideline-sourced CodeRabbit comment ends with `_Source: Coding guidelines_`. Four ordinary maintainability nits on #3798 were routed into `security-flag`, where the skill forbids auto-fixing and `--check` counts them as unresolved — blocking merge indefinitely. `"enforces"` and `"resources"` tripped it too.

Now matches on word boundaries and strips CodeRabbit boilerplate (HTML markers, collapsed `<details>` blocks) before classifying.

### Verification

Driven against the live repo, not just linted:

- `--list 3` returns issues #52/#179/#186 (2014–2015), oldest-first
- `--repo FastLED/fbuild --list 2` emits `github.com/FastLED/fbuild/...` URLs (previously would have printed FastLED/FastLED)
- `--list 0` now selects nothing; previously printed one issue
- `--json` and `--help` intact
- classifier: `Source:` / `enforces` no longer fire; `injection` / `auth error` still do
- `bash lint` clean

One note: `@typechecked` on a `@dataclass` is decorative under typeguard 4.x — it instruments by recompiling source and the dataclass-generated `__init__` has none, so it does not actually validate construction. Added anyway for consistency with the documented convention and the repo's existing usages, which all behave the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering to select issues older than a specified age.
  * Added repository-aware issue links and oldest-first issue retrieval.
  * `--list 0` now correctly selects no issues.

* **Bug Fixes**
  * Improved error reporting for label creation and comment failures.
  * Refined security classification to avoid false matches from ordinary prose, boilerplate, and generated suggestions.
  * Improved command documentation and argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->