### PR TITLE
docs(color): cross-reference lerp8 and blend for CRGB/CHSV (#333)

### DIFF
--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -140,12 +140,30 @@ inline void fadeUsingColor(fl::span<CRGB> leds, const CRGB &colormask) FL_NO_EXC
 
 /// Computes a new color blended some fraction of the way between two other
 /// colors.
+///
+/// This is the linear-interpolation entry point for both pixel types, and is
+/// what to reach for when looking for a "CHSV lerp" — see the CHSV overload
+/// below. For CRGB it is equivalent to the CRGB::lerp8() member function; both
+/// spellings exist for historical reasons.
+///
 /// @param p1 the first color to blend
 /// @param p2 the second color to blend
 /// @param amountOfP2 the fraction of p2 to blend into p1
+/// @see CRGB::lerp8()
 CRGB blend(const CRGB &p1, const CRGB &p2, fract8 amountOfP2) FL_NO_EXCEPT;
 
 /// @copydoc blend(const CRGB&, const CRGB&, fract8)
+///
+/// Interpolating in HSV space preserves saturation and value far better than
+/// interpolating the equivalent RGB colors, so prefer this over converting to
+/// CRGB and blending there.
+///
+/// Hue is circular, so unlike the CRGB overload this one has to be told which
+/// way around the color wheel to travel — hence @p directionCode, and hence
+/// there being no `CHSV::lerp8()` member to mirror CRGB::lerp8(). The default
+/// ::SHORTEST_HUES takes whichever arc is shorter; use ::LONGEST_HUES,
+/// ::FORWARD_HUES, or ::BACKWARD_HUES to force a particular sweep.
+///
 /// @param directionCode the direction to travel around the color wheel
 CHSV blend(const CHSV &p1, const CHSV &p2, fract8 amountOfP2,
            TGradientDirectionCode directionCode = SHORTEST_HUES) FL_NO_EXCEPT;

--- a/src/fl/gfx/crgb.h
+++ b/src/fl/gfx/crgb.h
@@ -417,6 +417,13 @@ struct CRGB {
     static CRGB computeAdjustment(u8 scale, const CRGB & colorCorrection, const CRGB & colorTemperature) FL_NO_EXCEPT;
 
     /// Return a new CRGB object after performing a linear interpolation between this object and the passed in object
+    /// @note Equivalent to the free function `blend(*this, other, amountOf2)`.
+    ///       There is deliberately no `CHSV::lerp8` — interpolating hue requires
+    ///       choosing which way around the color wheel to travel, so the CHSV
+    ///       equivalent is `blend(const CHSV&, const CHSV&, fract8, TGradientDirectionCode)`,
+    ///       which takes that direction as a parameter.
+    /// @see blend(const CRGB&, const CRGB&, fract8)
+    /// @see blend(const CHSV&, const CHSV&, fract8, TGradientDirectionCode)
     CRGB lerp8( const CRGB& other, fract8 amountOf2) const FL_NO_EXCEPT;
 
     /// @copydoc lerp8


### PR DESCRIPTION
Closes #333.

## The actual problem

#333 opened as "there is no function that can successfully linearly interpolate `CHSV`", then the reporter self-corrected one comment later — `blend()` already does it. What they left behind is the real issue:

> Having both `CRGB.lerp` and the free function `blend` (which do the same thing) is confusing, especially when `CHSV.lerp` doesn't exist, but `blend` does exist for `CHSV`, and especially when there isn't much documentation to point you to the right place.

That asymmetry is still exactly true today:

| | member | free function |
|---|---|---|
| `CRGB` | `lerp8()` / `lerp16()` (`crgb.h:420`) | `blend()` (`colorutils.h:146`) |
| `CHSV` | — | `blend()` (`colorutils.h:150`) |

Someone reasoning by symmetry looks for `CHSV::lerp8`, doesn't find it, and concludes the feature is missing. The reporter enumerated four workarounds — including allocating a 768 KB temporary `CRGBSet` — before finding `blend()`.

## Change

Docs only, at both ends of the confusion:

- **`CRGB::lerp8`** — states it's equivalent to `blend()`, and that CHSV interpolation goes through the `blend()` overload rather than a `lerp8` member. `@see` links to both.
- **`blend()`** — described as the interpolation entry point for *both* pixel types, so a search for "blend" or "lerp" lands somewhere useful. The CHSV overload now explains **why** there's no `CHSV::lerp8`: hue is circular, so a direction around the wheel must be chosen, which is what `TGradientDirectionCode` is for (`SHORTEST_HUES` default, plus `LONGEST_HUES` / `FORWARD_HUES` / `BACKWARD_HUES`).

Also records the original motivation: HSV-space interpolation preserves saturation and value better than converting to CRGB and blending there.

## Deliberately not done

Adding real `CHSV::lerp8`/`lerp16` members. That would mean baking in a default hue direction at a call site whose whole point is that the direction is a choice, and it would add public API surface to resolve what the reporter concluded was a documentation problem. Documenting the asymmetry is the smaller and more honest fix.

## Verification

- `bash test --cpp` — 357/357 pass (274 unit, 83 examples)
- `bash lint` — clean

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for blending CRGB and CHSV colors, including interpolation behavior and hue-direction options.
  * Documented `CRGB::lerp8()` and clarified its relationship to color blending.
  * Added clarification about HSV hue interpolation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->