### PR TITLE
fix(examples): make XYsafe return a signed type (#433)

### DIFF
--- a/examples/XYMatrix/XYMatrix.ino
+++ b/examples/XYMatrix/XYMatrix.ino
@@ -172,7 +172,14 @@ uint16_t XY( uint8_t x, uint8_t y)
 CRGB leds_plus_safety_pixel[ NUM_LEDS + 1];
 CRGB* const leds( leds_plus_safety_pixel + 1);
 
-uint16_t XYsafe( uint8_t x, uint8_t y)
+// NOTE: the return type must be SIGNED. Returning -1 from a uint16_t makes the
+// value 65535, which only behaves like -1 where int is 16 bits wide (AVR). On a
+// 32-bit board it promotes to the int 65535, so leds[XYsafe(...)] indexes far
+// past the array instead of landing on the safety pixel.
+//
+// `int` rather than `int16_t` so that on 32-bit boards the type stays wide
+// enough for any matrix a board that size can actually hold.
+int XYsafe( uint8_t x, uint8_t y)
 {
   if( x >= kMatrixWidth) return -1;
   if( y >= kMatrixHeight) return -1;


### PR DESCRIPTION
Closes #433.

## The bug

`XYsafe()` returns `-1` to steer out-of-bounds coordinates onto the safety pixel — but was declared `uint16_t`, so `-1` becomes `65535`:

```c
uint16_t XYsafe( uint8_t x, uint8_t y)
{
  if( x >= kMatrixWidth) return -1;   // actually returns 65535
  if( y >= kMatrixHeight) return -1;
  return XY(x,y);
}
```

That only *happens* to work where `int` is 16 bits wide:

- **AVR** (`int` = 16 bits): adding 65535 to a 16-bit index wraps, which is arithmetically identical to subtracting 1, so `leds[XYsafe(...)]` lands on `leds_plus_safety_pixel[0]` exactly as the surrounding comment describes.
- **Any 32-bit board** (ESP32, Teensy, SAMD, RP2040 — i.e. most of the install base now): `uint16_t` promotes to `int` `65535` with no wraparound. `leds[65535]` reads and writes ~65 KB past a matrix that is usually a few hundred bytes.

The whole point of `XYsafe` is to be the version you can hand arbitrary coordinates. On 32-bit it turns any out-of-bounds coordinate into an out-of-bounds *write* — the opposite of the guarantee.

## Fix

Declare the return type `int`.

`int` rather than `int16_t`: on 32-bit boards it stays wide enough for any matrix such a board can actually hold, and on AVR it's 16 bits, which is the width that already worked there. `int16_t` would cap at 32767 and could itself overflow on a large PSRAM-backed matrix.

Also fixes the debugging trap in the original report — printing the result showed `65535`, which reads as a garbage index rather than as the out-of-bounds sentinel it actually was. The reporter said they lost significant time stepping through the `XY` algorithm looking for a bug that wasn't there.

## Credit

Diagnosed by @eltang in 2017 ("no sign-extension is taking place... `0xFFFF` is most likely being interpreted as 65535 after being converted to an int"). @kriegsman reopened the issue agreeing 32-bit platforms likely had a real problem, and noted the net result "depends on the type (width) of the array index." It sat for 8 years.

## Verification

- `bash test --cpp --clean` — 357/357 pass on a full clean rebuild (274 unit, 83 examples; XYMatrix is in the example set)
- `bash lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected out-of-bounds handling in the XY matrix example.
  * Preserved the `-1` sentinel value while maintaining safe pixel indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->