### PR TITLE
fix(teensy4): vendor the LPSPI bring-up so SPI drivers stop needing Arduino <SPI.h> (#3777)

### DIFF
--- a/src/platforms/arm/mxrt1062/fastspi_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/fastspi_arm_mxrt1062.h
@@ -6,9 +6,9 @@
 #include "platforms/arm/teensy/is_teensy.h"
 
 #if defined(FL_IS_TEENSY_4X)
-// IWYU pragma: begin_keep
-#include <SPI.h>
-// IWYU pragma: end_keep
+// Local LPSPI fork instead of the Arduino SPI library -- see
+// platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h (#3777).
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
 
@@ -17,7 +17,7 @@ FL_DISABLE_WARNING_DEPRECATED_REGISTER
 
 namespace fl {
 
-template <u8 _DATA_PIN, u8 _CLOCK_PIN, u32 _SPI_CLOCK_RATE, SPIClass & _SPIObject, int _SPI_INDEX>
+template <u8 _DATA_PIN, u8 _CLOCK_PIN, u32 _SPI_CLOCK_RATE, int _SPI_INDEX>
 class Teensy4HardwareSPIOutput {
 	Selectable *mPSelect = nullptr;
 	u32  mBitCount = 0;
@@ -41,19 +41,20 @@ public:
 	void setSelect(Selectable *pSelect) { /* TODO */ }
 
 	// initialize the SPI subssytem
-	void init() { _SPIObject.begin(); }
+	void init() { fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).begin(); }
 
 	// latch the CS select
 	void inline select() FL_NO_EXCEPT __attribute__((always_inline)) {
 		// begin the SPI transaction
-		_SPIObject.beginTransaction(SPISettings(_SPI_CLOCK_RATE, MSBFIRST, SPI_MODE0));
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).beginTransaction(
+			fl::platforms::teensy::LpspiSettings(_SPI_CLOCK_RATE, MSBFIRST, SPI_MODE0));
 		if(mPSelect != nullptr) { mPSelect->select(); }
 	}
 
 	// release the CS select
 	void inline release() FL_NO_EXCEPT __attribute__((always_inline)) {
 		if(mPSelect != nullptr) { mPSelect->release(); }
-		_SPIObject.endTransaction();
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).endTransaction();
 	}
 
 	void endTransaction() FL_NO_EXCEPT {
@@ -67,7 +68,7 @@ public:
 	// write a byte out via SPI (returns immediately on writing register) -
 	void inline writeByte(u8 b) FL_NO_EXCEPT __attribute__((always_inline)) {
 		if(mBitCount == 0) {
-			_SPIObject.transfer(b);
+			fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(b);
 		} else {
 			// There's been a bit of data written, add that to the output as well
 			u32 outData = (mBitData << 8) | b;
@@ -84,12 +85,12 @@ public:
 	// write a word out via SPI (returns immediately on writing register)
 	void inline writeWord(u16 w) FL_NO_EXCEPT __attribute__((always_inline)) {
 		writeByte(((w>>8) & 0xFF));
-		_SPIObject.transfer(w & 0xFF);
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(w & 0xFF);
 	}
 
 	// A raw set of writing byte values, assumes setup/init/waiting done elsewhere
 	static void writeBytesValueRaw(u8 value, int len) FL_NO_EXCEPT {
-		while(len--) { _SPIObject.transfer(value); }
+		while(len--) { fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(value); }
 	}
 
 	// A full cycle of writing a value for len bytes, including select, release, and waiting
@@ -121,7 +122,7 @@ public:
 		bc = (bc + 1) & 0x07;
 		if (!bc) {
 			mBitCount = 0;
-			_SPIObject.transfer(mBitData);
+			fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(mBitData);
 		}
 		mBitCount = bc;
 	}

--- a/src/platforms/arm/mxrt1062/spi_device_proxy.h
+++ b/src/platforms/arm/mxrt1062/spi_device_proxy.h
@@ -30,7 +30,8 @@
 #include "fl/stl/stddef.h"
 #include "fl/log/log.h"
 // IWYU pragma: begin_keep
-#include <SPI.h>
+// Local LPSPI fork instead of the Arduino SPI library (#3777).
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"
 #include "fl/stl/noexcept.h"
 // IWYU pragma: end_keep
 
@@ -47,14 +48,13 @@ namespace fl {
 /// @tparam DATA_PIN GPIO pin for SPI data (MOSI)
 /// @tparam CLOCK_PIN GPIO pin for SPI clock (SCK)
 /// @tparam SPI_CLOCK_RATE SPI clock speed in Hz
-/// @tparam SPIObject Reference to SPIClass object (SPI, SPI1, or SPI2)
 /// @tparam SPI_INDEX SPI peripheral index (0, 1, or 2)
-template<u8 DATA_PIN, u8 CLOCK_PIN, u32 SPI_CLOCK_RATE, SPIClass & SPIObject, int SPI_INDEX>
+template<u8 DATA_PIN, u8 CLOCK_PIN, u32 SPI_CLOCK_RATE, int SPI_INDEX>
 class SPIDeviceProxy {
 private:
     SPIBusHandle mHandle;                    // Handle from SPIBusManager
     SPIBusManager* mBusManager;              // Pointer to global bus manager
-    fl::unique_ptr<Teensy4HardwareSPIOutput<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, SPIObject, SPI_INDEX>> mSingleSPI;
+    fl::unique_ptr<Teensy4HardwareSPIOutput<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, SPI_INDEX>> mSingleSPI;
     fl::vector<u8> mWriteBuffer;        // Buffered writes (for Dual/Quad-SPI)
     bool mInitialized;                       // Whether init() was called
     bool mBusInitialized;                    // Whether bus manager has been initialized
@@ -127,7 +127,7 @@ public:
         const SPIBusInfo* bus = mBusManager->getBusInfo(mHandle.bus_id);
         if (bus && bus->bus_type == SPIBusType::SINGLE_SPI && !mSingleSPI) {
             // We're using single-SPI - create owned Teensy4HardwareSPIOutput instance
-            mSingleSPI = fl::make_unique<Teensy4HardwareSPIOutput<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, SPIObject, SPI_INDEX>>();
+            mSingleSPI = fl::make_unique<Teensy4HardwareSPIOutput<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, SPI_INDEX>>();
             mSingleSPI->init();
         }
         // For Dual/Quad-SPI, bus manager handles hardware - we just buffer writes

--- a/src/platforms/arm/teensy/teensy4_common/fastspi_arm_mxrt1062.h
+++ b/src/platforms/arm/teensy/teensy4_common/fastspi_arm_mxrt1062.h
@@ -6,9 +6,9 @@
 #include "platforms/arm/teensy/is_teensy.h"
 
 #if defined(FL_IS_TEENSY_4X)
-// IWYU pragma: begin_keep
-#include <SPI.h>
-// IWYU pragma: end_keep
+// Local LPSPI fork instead of the Arduino SPI library -- see
+// platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h (#3777).
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"
 #include "fastspi_types.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
@@ -18,7 +18,7 @@ FL_DISABLE_WARNING_DEPRECATED_REGISTER
 
 namespace fl {
 
-template <u8 _DATA_PIN, u8 _CLOCK_PIN, u32 _SPI_CLOCK_RATE, SPIClass & _SPIObject, int _SPI_INDEX>
+template <u8 _DATA_PIN, u8 _CLOCK_PIN, u32 _SPI_CLOCK_RATE, int _SPI_INDEX>
 class Teensy4HardwareSPIOutput {
 	Selectable *mPSelect = nullptr;
 	u32  mBitCount = 0;
@@ -42,19 +42,20 @@ public:
 	void setSelect(Selectable *pSelect) { /* TODO */ }
 
 	// initialize the SPI subssytem
-	void init() { _SPIObject.begin(); }
+	void init() { fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).begin(); }
 
 	// latch the CS select
 	void inline select() FL_NO_EXCEPT __attribute__((always_inline)) {
 		// begin the SPI transaction
-		_SPIObject.beginTransaction(SPISettings(_SPI_CLOCK_RATE, MSBFIRST, SPI_MODE0));
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).beginTransaction(
+			fl::platforms::teensy::LpspiSettings(_SPI_CLOCK_RATE, MSBFIRST, SPI_MODE0));
 		if(mPSelect != nullptr) { mPSelect->select(); }
 	}
 
 	// release the CS select
 	void inline release() FL_NO_EXCEPT __attribute__((always_inline)) {
 		if(mPSelect != nullptr) { mPSelect->release(); }
-		_SPIObject.endTransaction();
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).endTransaction();
 	}
 
 	void endTransaction() FL_NO_EXCEPT {
@@ -68,7 +69,7 @@ public:
 	// write a byte out via SPI (returns immediately on writing register) -
 	void inline writeByte(u8 b) FL_NO_EXCEPT __attribute__((always_inline)) {
 		if(mBitCount == 0) {
-			_SPIObject.transfer(b);
+			fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(b);
 		} else {
 			// There's been a bit of data written, add that to the output as well
 			u32 outData = (mBitData << 8) | b;
@@ -85,12 +86,12 @@ public:
 	// write a word out via SPI (returns immediately on writing register)
 	void inline writeWord(u16 w) FL_NO_EXCEPT __attribute__((always_inline)) {
 		writeByte(((w>>8) & 0xFF));
-		_SPIObject.transfer(w & 0xFF);
+		fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(w & 0xFF);
 	}
 
 	// A raw set of writing byte values, assumes setup/init/waiting done elsewhere
 	static void writeBytesValueRaw(u8 value, int len) FL_NO_EXCEPT {
-		while(len--) { _SPIObject.transfer(value); }
+		while(len--) { fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(value); }
 	}
 
 	// A full cycle of writing a value for len bytes, including select, release, and waiting
@@ -122,7 +123,7 @@ public:
 		bc = (bc + 1) & 0x07;
 		if (!bc) {
 			mBitCount = 0;
-			_SPIObject.transfer(mBitData);
+			fl::platforms::teensy::LpspiBus::get(_SPI_INDEX).transfer(mBitData);
 		}
 		mBitCount = bc;
 	}

--- a/src/platforms/arm/teensy/teensy4_common/lpspi/README.md
+++ b/src/platforms/arm/teensy/teensy4_common/lpspi/README.md
@@ -1,0 +1,88 @@
+# Teensy 4.x LPSPI — local fork
+
+Vendored from the Teensyduino `SPI` library so FastLED does not depend on the
+Arduino `SPI` library on Teensy 4.x.
+
+## Upstream
+
+| | |
+|---|---|
+| Source | `libraries/SPI/SPI.h`, `libraries/SPI/SPI.cpp` |
+| Version | Teensyduino 1.60 (`framework-arduinoteensy` 1.160.0) |
+| Author / licence | Paul Stoffregen, PJRC — MIT |
+
+Only the IMXRT1062 (Teensy 4.x) paths are taken. Every copied body carries an
+`// Upstream SPI.{h,cpp}:<lines>` comment next to it; keep those accurate if
+this is ever re-synced.
+
+Same precedent as `platforms/arm/teensy/audio/pjrc_*` and
+`platforms/arm/teensy/sdfat/`: fork locally, namespace it, and document
+provenance next to the code. Files are named `lpspi_*` rather than `SPI.*`
+deliberately — the sdfat fork kept upstream filenames and as a result its
+`SdSpiDriver.h` still resolves `#include "SPI.h"` to the *framework* header.
+
+## Why fork at all
+
+Two independent reasons, both from FastLED#3777:
+
+1. **It was not linking.** fbuild will not let a local library's header select
+   a framework library, so `<SPI.h>` never entered the link and every
+   `SpiHw2MXRT1062` / `SpiHw4MXRT1062` symbol came up undefined
+   (FastLED#3775). Every documented way to declare the dependency was tried
+   and none worked.
+2. **We do not want it even if it linked.** The framework defines three global
+   `SPIClass` objects (`SPI`, `SPI1`, `SPI2`). Each carries ~600 bytes of
+   `.bss`, and once anything names one the linker can never drop it. FastLED
+   named `SPI` as a template argument in `spi_output_template.h`, which is
+   reached from `chipsets.h` — i.e. from essentially every sketch. That
+   template parameter is now a plain bus index, so nothing references a
+   global.
+
+## What is here
+
+| file | contents |
+|---|---|
+| `lpspi_hardware.h` | `LpspiHardware` struct + the three per-bus pin/mux tables, copied verbatim |
+| `lpspi_bus.h` | `LpspiBus` (begin/end/setSCK/setMOSI/setMISO/beginTransaction/endTransaction/transfer) and `LpspiSettings` |
+
+Bus indices match the legacy Arduino names the drivers already used:
+`0 -> LPSPI4` (was `SPI`), `1 -> LPSPI3` (was `SPI1`), `2 -> LPSPI1` (was `SPI2`).
+
+## Deliberate deviations from upstream
+
+- **DMA triple dropped** from the hardware struct (`tx_dma_channel`,
+  `rx_dma_channel`, `dma_rxisr`). Nothing on the FastLED path reads it, and
+  keeping the `_spi_dma_rxISR*` pointers would anchor upstream's DMA and
+  `EventResponder` machinery into the link.
+- **NVIC mask save/restore dropped** from `beginTransaction` /
+  `endTransaction`. That path is gated on `interruptMasksUsed`, which upstream
+  only sets from `usingInterrupt()`. FastLED never calls it, so the masks are
+  always zero and the block is dead. `endTransaction` is therefore a no-op.
+- **Header-only.** Everything is `inline`; there is deliberately no
+  `.cpp.hpp` and no `_build.cpp.hpp` entry. An earlier revision put the
+  implementation in the unity build, which emitted `LpspiBus::get()`
+  unconditionally and dragged all three hardware tables into every firmware —
+  Teensy 4.1 `Blink` grew from 58,688 to 106,816 bytes of `.text`. Keeping it
+  header-only restores byte-identical output for sketches that do not use SPI.
+  **Do not move this into the unity build.**
+- **Types** are FastLED's `fl::` fixed-width aliases.
+- The `transfer*` family beyond single-byte, `setCS`, `setBitOrder`,
+  `setDataMode`, the deprecated setters and the whole async/DMA block are
+  simply absent — FastLED drives the data path itself with direct register
+  access.
+
+## Do not "tidy" the tables
+
+The pin numbers, mux values and select-input registers are load-bearing and
+board-specific (T4.0 and T4.1 differ in both arity and pin numbers). A wrong
+mux value links cleanly and silently drives nothing.
+
+## Validation status
+
+`bash compile teensy41 --examples Apa102` links (it did not before), and
+`--examples Blink` is byte-identical to the pre-change build, confirming the
+backend is still fully strippable.
+
+**Not yet validated on hardware.** Driving an APA102/SK9822 strip from a
+Teensy 4.x is still outstanding — see FastLED#3777. Compiling proves the
+symbols resolve, not that the pads are muxed correctly.

--- a/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
+++ b/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
@@ -1,0 +1,327 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
+/// Minimal LPSPI bus control for Teensy 4.x, forked from Teensyduino's
+/// `SPIClass` so FastLED does not depend on the Arduino `SPI` library.
+///
+/// See lpspi_hardware.h for provenance and the reasoning. This header carries
+/// only what FastLED's SPI drivers actually call:
+///
+///     setSCK / setMOSI / setMISO   pad mux + input-select routing
+///     begin / end                  clock gate + pad drive strength
+///     beginTransaction / endTransaction   CCR divisor + CR/CFGR1/TCR
+///
+/// Everything else in upstream SPIClass -- transfer*, DMA, async, setCS,
+/// usingInterrupt, the deprecated setters -- is deliberately absent. FastLED
+/// drives the data path itself via direct register access (see
+/// spi_hw_4_mxrt1062.cpp.hpp's transmit loop polling LPSPI_SR_TDF).
+///
+/// One behavioural simplification vs upstream: `beginTransaction` /
+/// `endTransaction` do NOT save and restore the NVIC interrupt masks. That
+/// path is gated on `interruptMasksUsed`, which upstream only ever sets from
+/// `usingInterrupt()`. FastLED never calls it, so the masks are always zero
+/// and the whole block is dead. Dropping it keeps `endTransaction` a no-op.
+
+#include "fl/stl/int.h"
+#include "fl/stl/singleton.h"
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h"
+
+// SPI mode constants, normally supplied by the Arduino <SPI.h> we no longer
+// include. Values are upstream's (SPI.h:51-54) and are load-bearing: the TCR
+// assembly below tests bit 3 for CPOL and bit 2 for CPHA. Guarded because the
+// SD-card path still pulls in the framework header, so both can be in scope
+// in one translation unit.
+#ifndef SPI_MODE0
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x04
+#define SPI_MODE2 0x08
+#define SPI_MODE3 0x0C
+#endif
+
+namespace fl {
+namespace platforms {
+namespace teensy {
+
+/// Transaction parameters. Replaces upstream `SPISettings`
+/// (SPI.h:1045-1075); the TCR assembly is copied from its
+/// `init_AlwaysInline`.
+class LpspiSettings {
+  public:
+    LpspiSettings() : mClock(4000000) { init(MSBFIRST, SPI_MODE0); }
+
+    LpspiSettings(fl::u32 clock, fl::u8 bit_order, fl::u8 data_mode)
+        : mClock(clock) {
+        init(bit_order, data_mode);
+    }
+
+    fl::u32 clock() const { return mClock; }
+    fl::u32 tcr() const { return mTcr; }
+
+  private:
+    void init(fl::u8 bit_order, fl::u8 data_mode) {
+        mTcr = LPSPI_TCR_FRAMESZ(7);  // TCR carries polarity and bit order too
+        if (bit_order == LSBFIRST) {
+            mTcr |= LPSPI_TCR_LSBF;
+        }
+        if (data_mode & 0x08) {
+            mTcr |= LPSPI_TCR_CPOL;
+        }
+        if (data_mode & 0x04) {
+            mTcr |= LPSPI_TCR_CPHA;
+        }
+    }
+
+    fl::u32 mClock;
+    fl::u32 mTcr = 0;
+};
+
+/// One LPSPI peripheral. Construct via `LpspiBus::get(index)`.
+///
+/// `index` matches the legacy Arduino naming the drivers already use:
+///   0 -> LPSPI4 (was `SPI`), 1 -> LPSPI3 (was `SPI1`), 2 -> LPSPI1 (was `SPI2`)
+class LpspiBus {
+  public:
+    /// Bus for a legacy Arduino SPI index. Returns bus 0 for out-of-range.
+    static LpspiBus &get(fl::u8 index);
+
+    void setSCK(fl::u8 pin);
+    void setMOSI(fl::u8 pin);
+    void setMISO(fl::u8 pin);
+
+    void begin();
+    void end();
+
+    void beginTransaction(const LpspiSettings &settings);
+    void endTransaction();
+
+    /// Blocking single-byte exchange. Upstream SPI.h:1246-1257.
+    fl::u8 transfer(fl::u8 data) {
+        mPort->TDR = data;
+        while (true) {
+            const fl::u32 fifo = (mPort->FSR >> 16) & 0x1F;
+            if (fifo > 0) {
+                return static_cast<fl::u8>(mPort->RDR);
+            }
+        }
+    }
+
+    /// The peripheral register block, for drivers that drive data directly.
+    IMXRT_LPSPI_t &port() { return *mPort; }
+
+  private:
+    LpspiBus() = default;
+
+    void configure(IMXRT_LPSPI_t *port, const LpspiHardware *hw) {
+        mPort = port;
+        mHw = hw;
+    }
+
+    const LpspiHardware &hardware() const { return *mHw; }
+
+    IMXRT_LPSPI_t *mPort = nullptr;
+    const LpspiHardware *mHw = nullptr;
+
+    fl::u8 mMisoPinIndex = 0;
+    fl::u8 mMosiPinIndex = 0;
+    fl::u8 mSckPinIndex = 0;
+
+    fl::u32 mClock = 0;
+    fl::u32 mCcr = 0;
+
+    friend struct LpspiBusStorage;
+};
+
+
+
+/// Storage for the three buses.
+///
+/// Held in a `fl::Singleton` rather than at namespace scope so an unused SPI
+/// backend is fully strippable -- the whole point of not linking the
+/// framework library, whose three global `SPIClass` objects the linker can
+/// never drop once anything names them (FastLED#3777, and the
+/// SingletonElisionChecker rule generally).
+struct LpspiBusStorage {
+    LpspiBus buses[3];
+    bool initialized = false;
+
+    void ensure() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+        buses[0].configure(&IMXRT_LPSPI4_S, &lpspi_hardware<4>());
+        buses[1].configure(&IMXRT_LPSPI3_S, &lpspi_hardware<3>());
+        buses[2].configure(&IMXRT_LPSPI1_S, &lpspi_hardware<1>());
+    }
+};
+
+inline LpspiBus &LpspiBus::get(fl::u8 index) {
+    LpspiBusStorage &storage = fl::Singleton<LpspiBusStorage>::instance();
+    storage.ensure();
+    if (index > 2) {
+        index = 0;
+    }
+    return storage.buses[index];
+}
+
+// Upstream SPI.cpp:1450-1467.
+inline void LpspiBus::setSCK(fl::u8 pin) {
+    if (pin == hardware().sck_pin[mSckPinIndex]) {
+        return;
+    }
+    for (fl::u8 i = 0; i < CNT_SCK_PINS; i++) {
+        if (pin != hardware().sck_pin[i]) {
+            continue;
+        }
+        if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+            // Upstream note: unlike t3.x there is no "unused" mux setting, so
+            // the previous pin is left as-is.
+            const fl::u32 fastio = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_SPEED(2);
+            *(portControlRegister(hardware().sck_pin[i])) = fastio;
+            *(portConfigRegister(hardware().sck_pin[i])) = hardware().sck_mux[i];
+            hardware().sck_select_input_register = hardware().sck_select_val[i];
+        }
+        mSckPinIndex = i;
+        return;
+    }
+}
+
+// Upstream SPI.cpp:1412-1429.
+inline void LpspiBus::setMOSI(fl::u8 pin) {
+    if (pin == hardware().mosi_pin[mMosiPinIndex]) {
+        return;
+    }
+    for (fl::u8 i = 0; i < CNT_MOSI_PINS; i++) {
+        if (pin != hardware().mosi_pin[i]) {
+            continue;
+        }
+        if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+            const fl::u32 fastio = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_SPEED(2);
+            *(portControlRegister(hardware().mosi_pin[i])) = fastio;
+            *(portConfigRegister(hardware().mosi_pin[i])) =
+                hardware().mosi_mux[i];
+            hardware().mosi_select_input_register =
+                hardware().mosi_select_val[i];
+        }
+        mMosiPinIndex = i;
+        return;
+    }
+}
+
+// Upstream SPI.cpp:1431-1448.
+inline void LpspiBus::setMISO(fl::u8 pin) {
+    if (pin == hardware().miso_pin[mMisoPinIndex]) {
+        return;
+    }
+    for (fl::u8 i = 0; i < CNT_MISO_PINS; i++) {
+        if (pin != hardware().miso_pin[i]) {
+            continue;
+        }
+        if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+            const fl::u32 fastio = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_SPEED(2);
+            *(portControlRegister(hardware().miso_pin[i])) = fastio;
+            *(portConfigRegister(hardware().miso_pin[i])) =
+                hardware().miso_mux[i];
+            hardware().miso_select_input_register =
+                hardware().miso_select_val[i];
+        }
+        mMisoPinIndex = i;
+        return;
+    }
+}
+
+// Upstream SPI.cpp:1271-1316.
+inline void LpspiBus::begin() {
+    // CBCMR[LPSPI_CLK_SEL] -> PLL2 = 528 MHz, CBCMR[LPSPI_PODF] -> div4.
+    hardware().clock_gate_register &= ~hardware().clock_gate_mask;
+
+    CCM_CBCMR = (CCM_CBCMR & ~(CCM_CBCMR_LPSPI_PODF_MASK |
+                               CCM_CBCMR_LPSPI_CLK_SEL_MASK)) |
+                CCM_CBCMR_LPSPI_PODF(2) | CCM_CBCMR_LPSPI_CLK_SEL(1);  // pg 714
+
+    const fl::u32 fastio = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_SPEED(2);
+    *(portControlRegister(hardware().miso_pin[mMisoPinIndex])) = fastio;
+    *(portControlRegister(hardware().mosi_pin[mMosiPinIndex])) = fastio;
+    *(portControlRegister(hardware().sck_pin[mSckPinIndex])) = fastio;
+
+    hardware().clock_gate_register |= hardware().clock_gate_mask;
+    *(portConfigRegister(hardware().miso_pin[mMisoPinIndex])) =
+        hardware().miso_mux[mMisoPinIndex];
+    *(portConfigRegister(hardware().mosi_pin[mMosiPinIndex])) =
+        hardware().mosi_mux[mMosiPinIndex];
+    *(portConfigRegister(hardware().sck_pin[mSckPinIndex])) =
+        hardware().sck_mux[mSckPinIndex];
+
+    hardware().sck_select_input_register = hardware().sck_select_val[mSckPinIndex];
+    hardware().miso_select_input_register =
+        hardware().miso_select_val[mMisoPinIndex];
+    hardware().mosi_select_input_register =
+        hardware().mosi_select_val[mMosiPinIndex];
+
+    port().CR = LPSPI_CR_RST;
+
+    // Transmit FIFO watermark = FIFO size - 1 (upstream assumes 16).
+    port().FCR = LPSPI_FCR_TXWATER(15);
+
+    // Leave the peripheral in a known state.
+    beginTransaction(LpspiSettings());
+    endTransaction();
+}
+
+// Upstream SPI.h:1176-1243, minus the NVIC mask save/restore (see header).
+inline void LpspiBus::beginTransaction(const LpspiSettings &settings) {
+    if (settings.clock() != mClock) {
+        static const fl::u32 clk_sel[4] = {664615384,   // PLL3 PFD1
+                                           720000000,   // PLL3 PFD0
+                                           528000000,   // PLL2
+                                           396000000};  // PLL2 PFD2
+
+        mClock = settings.clock();
+
+        const fl::u32 cbcmr = CCM_CBCMR;
+        // LPSPI peripheral clock
+        const fl::u32 clkhz =
+            clk_sel[(cbcmr >> 4) & 0x03] / (((cbcmr >> 26) & 0x07) + 1);
+
+        fl::u32 d = mClock ? clkhz / mClock : clkhz;
+        if (d && clkhz / d > mClock) {
+            d++;
+        }
+        if (d > 257) {
+            d = 257;  // max div
+        }
+        const fl::u32 div = (d > 2) ? (d - 2) : 0;
+
+        mCcr = LPSPI_CCR_SCKDIV(div) | LPSPI_CCR_DBT(div / 2) |
+               LPSPI_CCR_PCSSCK(div / 2);
+    }
+
+    port().CR = 0;
+    port().CFGR1 = LPSPI_CFGR1_MASTER | LPSPI_CFGR1_SAMPLE;
+    port().CCR = mCcr;
+    port().TCR = settings.tcr();
+    port().CR = LPSPI_CR_MEN;
+}
+
+// Upstream SPI.h:1308-1324. The body there only unwinds the NVIC masks that
+// `usingInterrupt()` would have set; FastLED never calls it, so this is a
+// no-op kept for call-site symmetry.
+inline void LpspiBus::endTransaction() {}
+
+// Upstream SPI.cpp:1805-1813.
+inline void LpspiBus::end() {
+    // Disable the peripheral and return the pads to a safe state.
+    port().CR = 0;
+    // `::pinMode` explicitly: we are inside namespace fl, where an unqualified
+    // call would bind FastLED's own typed fl::pinMode(PinMode) rather than the
+    // Teensy core's, and INPUT_DISABLE is a core constant.
+    ::pinMode(hardware().miso_pin[mMisoPinIndex], INPUT_DISABLE);
+    ::pinMode(hardware().mosi_pin[mMosiPinIndex], INPUT_DISABLE);
+    ::pinMode(hardware().sck_pin[mSckPinIndex], INPUT_DISABLE);
+}
+
+}  // namespace teensy
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h
+++ b/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h
@@ -1,0 +1,268 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file platforms/arm/teensy/teensy4_common/lpspi/lpspi_hardware.h
+/// Per-bus LPSPI pin/mux tables for Teensy 4.x (IMXRT1062).
+///
+/// VENDORED from the Teensyduino SPI library, `libraries/SPI/SPI.cpp`
+/// (Teensyduino 1.60 / framework-arduinoteensy 1.160.0), MIT licensed by
+/// Paul Stoffregen / PJRC. Same local-fork precedent as
+/// `platforms/arm/teensy/audio/pjrc_*` and `platforms/arm/teensy/sdfat/`.
+///
+/// Why fork rather than link the framework library: fbuild will not let a
+/// local library's headers select a framework library, so `<SPI.h>` simply
+/// never entered the link and every `SpiHw*MXRT1062` symbol came up undefined
+/// (FastLED#3775). Declaring the dependency is also not what we want -- the
+/// framework's three global `SPIClass` objects cost ~600 bytes of .bss each
+/// and cannot be stripped once anything names them, which is why the drivers
+/// now select a bus by integer index instead (FastLED#3777).
+///
+/// The tables below are copied VERBATIM so the register values stay the
+/// battle-tested ones. Two deliberate deviations, both marked inline:
+///   1. The DMA triple (`tx_dma_channel`, `rx_dma_channel`, `dma_rxisr`) is
+///      dropped. Nothing on the FastLED path reads it, and keeping the
+///      `_spi_dma_rxISR*` function pointers would anchor the upstream DMA and
+///      EventResponder machinery into the link for no benefit.
+///   2. Types are FastLED's `fl::` fixed-width aliases.
+/// Everything else -- pin numbers, mux values, select-input registers, the
+/// T4.0/T4.1 split -- is unchanged. Do not "tidy" these numbers; a wrong mux
+/// links fine and silently drives nothing.
+
+#include "fl/stl/int.h"
+#include "fl/stl/compiler_control.h"
+
+namespace fl {
+namespace platforms {
+namespace teensy {
+
+// Pin-count arities differ between T4.0 and T4.1: the T4.1 exposes a second
+// set of LPSPI pins on the memory connectors and the SD socket. Upstream
+// SPI.h:1079-1090.
+#if defined(ARDUINO_TEENSY41)
+static const fl::u8 CNT_MISO_PINS = 2;
+static const fl::u8 CNT_MOSI_PINS = 2;
+static const fl::u8 CNT_SCK_PINS = 2;
+static const fl::u8 CNT_CS_PINS = 3;
+#else
+static const fl::u8 CNT_MISO_PINS = 1;
+static const fl::u8 CNT_MOSI_PINS = 1;
+static const fl::u8 CNT_SCK_PINS = 1;
+static const fl::u8 CNT_CS_PINS = 1;
+#endif
+
+/// Upstream `SPIClass::SPI_Hardware_t` (SPI.h:1091-1122), minus the DMA
+/// triple. Field ORDER is preserved so the table initializers below stay a
+/// 1:1 copy of upstream.
+struct LpspiHardware {
+    volatile fl::u32 &clock_gate_register;
+    const fl::u32 clock_gate_mask;
+
+    // MISO pins
+    const fl::u8 miso_pin[CNT_MISO_PINS];
+    const fl::u32 miso_mux[CNT_MISO_PINS];
+    const fl::u8 miso_select_val[CNT_MISO_PINS];
+    volatile fl::u32 &miso_select_input_register;
+
+    // MOSI pins
+    const fl::u8 mosi_pin[CNT_MOSI_PINS];
+    const fl::u32 mosi_mux[CNT_MOSI_PINS];
+    const fl::u8 mosi_select_val[CNT_MOSI_PINS];
+    volatile fl::u32 &mosi_select_input_register;
+
+    // SCK pins
+    const fl::u8 sck_pin[CNT_SCK_PINS];
+    const fl::u32 sck_mux[CNT_SCK_PINS];
+    const fl::u8 sck_select_val[CNT_SCK_PINS];
+    volatile fl::u32 &sck_select_input_register;
+
+    // CS pins -- retained so the table layout matches upstream exactly, even
+    // though FastLED drives chip-select itself and never calls setCS().
+    const fl::u8 cs_pin[CNT_CS_PINS];
+    const fl::u32 cs_mux[CNT_CS_PINS];
+    const fl::u8 cs_mask[CNT_CS_PINS];
+    const fl::u8 pcs_select_val[CNT_CS_PINS];
+    volatile fl::u32 *pcs_select_input_register[CNT_CS_PINS];
+};
+
+// ============================================================================
+// Hardware tables -- VERBATIM from upstream SPI.cpp, DMA line removed.
+// LPSPI4 = SPI (index 0), LPSPI3 = SPI1 (index 1), LPSPI1 = SPI2 (index 2).
+// ============================================================================
+
+// Upstream SPI.cpp:1504-1548
+#if defined(ARDUINO_TEENSY41)
+/// Bus index -> hardware table. Deliberately a TEMPLATE with a function-local
+/// `static`: that is the only shape that stays strippable. A namespace-scope
+/// table (even `inline const`) is emitted and kept, which grew Teensy 4.1
+/// Blink from 58,688 to 106,816 bytes of .text. See README.md.
+template <int BUS>
+const LpspiHardware &lpspi_hardware();
+
+template <>
+inline const LpspiHardware &lpspi_hardware<4>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI4(CCM_CCGR_ON),
+        {12, 255},  // MISO
+        {3 | 0x10, 0},
+        {0, 0},
+        IOMUXC_LPSPI4_SDI_SELECT_INPUT,
+        {11, 255},  // MOSI
+        {3 | 0x10, 0},
+        {0, 0},
+        IOMUXC_LPSPI4_SDO_SELECT_INPUT,
+        {13, 255},  // SCK
+        {3 | 0x10, 0},
+        {0, 0},
+        IOMUXC_LPSPI4_SCK_SELECT_INPUT,
+        {10, 37, 36},  // CS
+        {3 | 0x10, 2 | 0x10, 2 | 0x10},
+        {1, 2, 3},
+        {0, 0, 0},
+        {&IOMUXC_LPSPI4_PCS0_SELECT_INPUT, 0, 0}};
+    return kHw;
+}
+#else
+/// Bus index -> hardware table. Deliberately a TEMPLATE with a function-local
+/// `static`: that is the only shape that stays strippable. A namespace-scope
+/// table (even `inline const`) is emitted and kept, which grew Teensy 4.1
+/// Blink from 58,688 to 106,816 bytes of .text. See README.md.
+template <int BUS>
+const LpspiHardware &lpspi_hardware();
+
+template <>
+inline const LpspiHardware &lpspi_hardware<4>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI4(CCM_CCGR_ON),
+        {12},
+        {3 | 0x10},
+        {0},
+        IOMUXC_LPSPI4_SDI_SELECT_INPUT,
+        {11},
+        {3 | 0x10},
+        {0},
+        IOMUXC_LPSPI4_SDO_SELECT_INPUT,
+        {13},
+        {3 | 0x10},
+        {0},
+        IOMUXC_LPSPI4_SCK_SELECT_INPUT,
+        {10},
+        {3 | 0x10},
+        {1},
+        {0},
+        {&IOMUXC_LPSPI4_PCS0_SELECT_INPUT}};
+    return kHw;
+}
+#endif
+
+// Upstream SPI.cpp:1559-1603
+#if defined(ARDUINO_TEENSY41)
+template <>
+inline const LpspiHardware &lpspi_hardware<3>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI3(CCM_CCGR_ON),
+        {1, 39},
+        {7 | 0x10, 2 | 0x10},
+        {0, 1},
+        IOMUXC_LPSPI3_SDI_SELECT_INPUT,
+        {26, 255},
+        {2 | 0x10, 0},
+        {1, 0},
+        IOMUXC_LPSPI3_SDO_SELECT_INPUT,
+        {27, 255},
+        {2 | 0x10, 0},
+        {1, 0},
+        IOMUXC_LPSPI3_SCK_SELECT_INPUT,
+        {0, 38, 255},
+        {7 | 0x10, 2 | 0x10, 0},
+        {1, 1, 0},
+        {0, 1, 0},
+        {&IOMUXC_LPSPI3_PCS0_SELECT_INPUT, &IOMUXC_LPSPI3_PCS0_SELECT_INPUT,
+         0}};
+    return kHw;
+}
+#else
+template <>
+inline const LpspiHardware &lpspi_hardware<3>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI3(CCM_CCGR_ON),
+        {1},
+        {7 | 0x10},
+        {0},
+        IOMUXC_LPSPI3_SDI_SELECT_INPUT,
+        {26},
+        {2 | 0x10},
+        {1},
+        IOMUXC_LPSPI3_SDO_SELECT_INPUT,
+        {27},
+        {2 | 0x10},
+        {1},
+        IOMUXC_LPSPI3_SCK_SELECT_INPUT,
+        {0},
+        {7 | 0x10},
+        {1},
+        {0},
+        {&IOMUXC_LPSPI3_PCS0_SELECT_INPUT}};
+    return kHw;
+}
+#endif
+
+// Upstream SPI.cpp:1609-1653.
+//
+// Note the T4.0 pin set (34/35/37) differs from T4.1 (42/43/45). The previous
+// FastLED code hardcoded the T4.1 numbers unconditionally in
+// spi_hw_2_mxrt1062.cpp.hpp, which was a latent T4.0 bug; going through this
+// table fixes it.
+#if defined(ARDUINO_TEENSY41)
+template <>
+inline const LpspiHardware &lpspi_hardware<1>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI1(CCM_CCGR_ON),
+        {42, 54},
+        {4 | 0x10, 3 | 0x10},
+        {1, 0},
+        IOMUXC_LPSPI1_SDI_SELECT_INPUT,
+        {43, 50},
+        {4 | 0x10, 3 | 0x10},
+        {1, 0},
+        IOMUXC_LPSPI1_SDO_SELECT_INPUT,
+        {45, 49},
+        {4 | 0x10, 3 | 0x10},
+        {1, 0},
+        IOMUXC_LPSPI1_SCK_SELECT_INPUT,
+        {44, 255, 255},
+        {4 | 0x10, 0, 0},
+        {1, 0, 0},
+        {0, 0, 0},
+        {&IOMUXC_LPSPI1_PCS0_SELECT_INPUT, 0, 0}};
+    return kHw;
+}
+#else
+template <>
+inline const LpspiHardware &lpspi_hardware<1>() {
+    static const LpspiHardware kHw = {
+        CCM_CCGR1, CCM_CCGR1_LPSPI1(CCM_CCGR_ON),
+        {34},
+        {4 | 0x10},
+        {1},
+        IOMUXC_LPSPI1_SDI_SELECT_INPUT,
+        {35},
+        {4 | 0x10},
+        {1},
+        IOMUXC_LPSPI1_SDO_SELECT_INPUT,
+        {37},
+        {4 | 0x10},
+        {1},
+        IOMUXC_LPSPI1_SCK_SELECT_INPUT,
+        {36},
+        {4 | 0x10},
+        {1},
+        {0},
+        {&IOMUXC_LPSPI1_PCS0_SELECT_INPUT}};
+    return kHw;
+}
+#endif
+
+}  // namespace teensy
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/spi_hw_2_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/spi_hw_2_mxrt1062.cpp.hpp
@@ -18,7 +18,10 @@
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 // IWYU pragma: begin_keep
-#include <SPI.h>
+// Local LPSPI fork -- see lpspi/lpspi_hardware.h. The Arduino SPI
+// library is deliberately NOT used: fbuild never linked it (#3775)
+// and its three global SPIClass objects are unstrippable (#3777).
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"
 #include <imxrt.h>
 // IWYU pragma: end_keep
 #include "platforms/shared/spi_manager.h"  // For DMABuffer, TransmitMode, SPIError
@@ -56,7 +59,7 @@ private:
 
     int mBusId;
     const char* mName;
-    SPIClass* mSPI;
+    fl::platforms::teensy::LpspiBus* mSPI;
     bool mTransactionActive;
     bool mInitialized;
     u32 mClockSpeed;
@@ -131,15 +134,15 @@ bool SpiHw2MXRT1062::begin(const SpiHw2::Config& config) {
     u8 bus_num = (mBusId != -1) ? static_cast<u8>(mBusId) : config.bus_num;
     switch (bus_num) {
         case 0:
-            mSPI = &SPI;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(0);
             mBusId = 0;
             break;
         case 1:
-            mSPI = &SPI1;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(1);
             mBusId = 1;
             break;
         case 2:
-            mSPI = &SPI2;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(2);
             mBusId = 2;
             break;
         default:
@@ -290,7 +293,7 @@ bool SpiHw2MXRT1062::transmit(TransmitMode mode) {
     FL_LOG_SPI_F("SpiHw2MXRT1062: Transmitting %s bytes via LPSPI bus %s", mCurrentTotalSize, mBusId);
 
     // Begin SPI transaction with configured clock speed
-    mSPI->beginTransaction(SPISettings(mClockSpeed, MSBFIRST, SPI_MODE0));
+    mSPI->beginTransaction(fl::platforms::teensy::LpspiSettings(mClockSpeed, MSBFIRST, SPI_MODE0));
 
     // Note: True dual-mode transmission requires direct LPSPI register access
     // The Teensy SPI library doesn't support this natively.

--- a/src/platforms/arm/teensy/teensy4_common/spi_hw_4_mxrt1062.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/spi_hw_4_mxrt1062.cpp.hpp
@@ -32,7 +32,10 @@
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 // IWYU pragma: begin_keep
-#include <SPI.h>
+// Local LPSPI fork -- see lpspi/lpspi_hardware.h. The Arduino SPI
+// library is deliberately NOT used: fbuild never linked it (#3775)
+// and its three global SPIClass objects are unstrippable (#3777).
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"
 #include <imxrt.h>
 // IWYU pragma: end_keep
 #include "platforms/shared/spi_manager.h"  // For DMABuffer, TransmitMode, SPIError
@@ -66,7 +69,7 @@ private:
 
     int mBusId;
     const char* mName;
-    SPIClass* mSPI;
+    fl::platforms::teensy::LpspiBus* mSPI;
     bool mTransactionActive;
     bool mInitialized;
     u32 mClockSpeed;
@@ -147,15 +150,15 @@ bool SpiHw4MXRT1062::begin(const SpiHw4::Config& config) {
     u8 bus_num = (mBusId != -1) ? static_cast<u8>(mBusId) : config.bus_num;
     switch (bus_num) {
         case 0:
-            mSPI = &SPI;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(0);
             mBusId = 0;
             break;
         case 1:
-            mSPI = &SPI1;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(1);
             mBusId = 1;
             break;
         case 2:
-            mSPI = &SPI2;
+            mSPI = &fl::platforms::teensy::LpspiBus::get(2);
             mBusId = 2;
             break;
         default:
@@ -266,7 +269,7 @@ bool SpiHw4MXRT1062::transmit(TransmitMode mode) {
     FL_LOG_SPI_F("SpiHw4MXRT1062: Transmitting %s bytes via LPSPI bus %s with %s lanes", mCurrentTotalSize, mBusId, static_cast<int>(mActiveLanes));
 
     // Begin SPI transaction with configured clock speed
-    mSPI->beginTransaction(SPISettings(mClockSpeed, MSBFIRST, SPI_MODE0));
+    mSPI->beginTransaction(fl::platforms::teensy::LpspiSettings(mClockSpeed, MSBFIRST, SPI_MODE0));
 
     IMXRT_LPSPI_t* port = getPort();
     if (!port) {

--- a/src/platforms/arm/teensy/teensy4_common/spi_output_template.h
+++ b/src/platforms/arm/teensy/teensy4_common/spi_output_template.h
@@ -12,6 +12,6 @@ namespace fl {
 
 /// Teensy 4 hardware SPI output for all pins
 template<fl::u8 _DATA_PIN, fl::u8 _CLOCK_PIN, fl::u32 _SPI_CLOCK_DIVIDER>
-class SPIOutput : public SPIDeviceProxy<_DATA_PIN, _CLOCK_PIN, _SPI_CLOCK_DIVIDER, SPI, 0> {};
+class SPIOutput : public SPIDeviceProxy<_DATA_PIN, _CLOCK_PIN, _SPI_CLOCK_DIVIDER, 0> {};
 
 }  // namespace fl


### PR DESCRIPTION
Fixes #3777. Removes the last red check on master (#3775).

## The problem

`teensy41` has been red since 2026-07-30: every symbol `fl::SpiHw2MXRT1062` / `SpiHw4MXRT1062` needs from the Arduino SPI library came up undefined at link. fbuild will not let a local library's headers select a framework library, so `<SPI.h>` never entered the link, and #3777 established that every documented way to *declare* the dependency fails.

Declaring it isn't what we want anyway: the framework defines three global `SPIClass` objects, each ~600 bytes of `.bss`, and the linker can never drop one once anything names it.

**The binding site #3777 doesn't mention:** `spi_output_template.h:15` named the global `SPI` as a template argument, and that header is reached from `chipsets.h` — i.e. from essentially every sketch. No amount of work inside the drivers would have removed the global while that line stood. `SPI_INDEX` already existed alongside it, so the reference was redundant; it's now a plain bus index.

## The fork

Per the `audio/pjrc_*` and `sdfat/` precedent the issue title names — **vendored, not rewritten**, so the register values stay the battle-tested ones:

```
src/platforms/arm/teensy/teensy4_common/lpspi/
  lpspi_hardware.h   LpspiHardware + three per-bus pin/mux tables, VERBATIM
  lpspi_bus.h        begin/end/setSCK/setMOSI/setMISO/beginTransaction/
                     endTransaction/transfer, each with its upstream
                     SPI.{h,cpp}:<lines> reference
  README.md          provenance, deviations, validation status
```

Two deliberate deviations, both documented: the DMA triple is dropped (keeping `_spi_dma_rxISR*` would anchor upstream's DMA/EventResponder into the link), and the NVIC mask save/restore is dropped from `beginTransaction`/`endTransaction` — it's gated on `interruptMasksUsed`, which only `usingInterrupt()` sets and FastLED never calls.

## The shape is load-bearing — I got it wrong twice before measuring

The issue asks for **no flash growth** on `Blink`, as the check that the backend is still strippable. That check earned its keep:

| attempt | Blink `.text` |
|---|---|
| implementation in a `.cpp.hpp` (unity build) | **106,816** |
| tables as namespace-scope `inline const` | **106,816** |
| template accessors + function-local statics | **58,688** — byte-identical to master |

The first two emitted `LpspiBus::get()` / the tables unconditionally, dragging all three tables into *every* Teensy sketch — a 48 KB regression on clockless-only builds. The template form is instantiated only when a bus is actually used, and it also satisfies `StaticInHeaderChecker`, which exempts statics inside template functions.

I would not have caught either without building `Blink` and comparing sizes.

## Bonus fix

`spi_hw_2_mxrt1062.cpp.hpp` hardcoded the T4.1 LPSPI1 pins `{2,45,43,42}` unconditionally — a latent T4.0 bug. Going through the table picks up the T4.0 set (34/35/37).

## Validation (local, per the issue's own criteria)

| check | result |
|---|---|
| `bash compile teensy41 --examples Apa102` | **links** — 0 undefined refs (was 64) |
| `bash compile teensy41 --examples Blink` | **byte-identical** to master |
| `bash lint` | no blocking violations; SingletonElision unchanged at 33 |
| `bash test --cpp` | 274 unit + 83 examples pass |

## Not yet validated on hardware — please read

Compiling proves the symbols resolve. It does **not** prove the pads are muxed correctly, and #3777 is explicit that a wrong mux links fine and silently drives nothing.

That risk is why this vendors the proven register code rather than reimplementing it: the pin numbers, mux values and select-input registers are byte-for-byte upstream, so the failure mode would have to be in the wiring-up, not the values.

**Driving an APA102/SK9822 strip from a Teensy 4.x is still outstanding.** The README records that status next to the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone SPI hardware implementation for Teensy 4.x boards.
  - Improved support for selecting and operating multiple SPI buses.

- **Bug Fixes**
  - Replaced framework SPI handling with board-specific bus management for more consistent initialization, transactions, and data transfers.

- **Documentation**
  - Added documentation covering supported bus mappings, implementation details, and validation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->