### PR TITLE
fix(color): stop rgb2hsv_approximate wrapping orange into green (#436)

### DIFF
--- a/src/hsv2rgb.cpp.hpp
+++ b/src/hsv2rgb.cpp.hpp
@@ -678,9 +678,23 @@ CHSV rgb2hsv_approximate( const CRGB& rgb)
             h = HUE_RED;
             h += scale8( g, FIXFRAC8(32,85));
         } else {
-            // R-G < G, we're in Orange-Yellow
+            // R-G < G, we're in Orange-Yellow.
+            //
+            // This used to read `(g - 85) + (171 - r)`. Reaching this branch
+            // requires g >= r/2, and r is the largest channel, so r > 171 is
+            // the normal case here -- making (171 - r) negative. The sum was
+            // then truncated to u8 by qsub8() and wrapped to a large value,
+            // sending orange out into the greens: rgb(255,153,0) returned hue
+            // 122 instead of ~26. See issue #436.
+            //
+            // (255 - r) is the same measure of "how far r has fallen" but
+            // cannot go negative, and the sum (g - 85) + (255 - r) has a
+            // minimum of ~42 over this branch's own entry condition, so the
+            // wrap is structurally impossible rather than merely unlikely.
+            // Spans ~42..170, hence FIXFRAC8(32,170) to land the top of the
+            // range on HUE_YELLOW.
             h = HUE_ORANGE;
-            h += scale8( qsub8((g - 85) + (171 - r), 4), FIXFRAC8(32,85)); //221
+            h += scale8( qsub8((g - 85) + (255 - r), 4), FIXFRAC8(32,170));
         }
 
     } else if ( highest == g) {

--- a/tests/fl/hsv2rgb_accuracy.cpp
+++ b/tests/fl/hsv2rgb_accuracy.cpp
@@ -189,6 +189,77 @@ FL_TEST_CASE("HSV to RGB Conversion Accuracy Comparison") {
     FL_CHECK_LT(rainbow_stats.average, fullspectrum_stats.average);
 }
 
+FL_TEST_CASE("rgb2hsv_approximate - orange is not reported as green (issue #436)") {
+    // The Orange->Yellow branch computed (g - 85) + (171 - r), which goes
+    // negative for every r > 171 and then wrapped when truncated to u8 inside
+    // qsub8(). Orange came back green: rgb(255,153,0) reported hue 122.
+    struct Case {
+        u8 r, g, b;
+        u8 expected_hue;
+        const char *source;
+    };
+    const Case cases[] = {
+        {255, 153, 0, 26, "issue body"},
+        {255, 128, 0, 21, "cad435 #ff8000"},
+        {255, 166, 0, 24, "DrJaymz"},
+        {255, 143, 0, 25, "5chmidti precise impl"},
+    };
+
+    for (const auto &c : cases) {
+        CRGB original(c.r, c.g, c.b);
+        CHSV hsv = rgb2hsv_approximate(original);
+        CRGB roundtrip;
+        hsv2rgb_rainbow(hsv, roundtrip);
+        FL_WARN("rgb(" << (int)c.r << "," << (int)c.g << "," << (int)c.b
+                       << ") -> hue " << (int)hsv.hue << " -> rgb("
+                       << (int)roundtrip.r << "," << (int)roundtrip.g << ","
+                       << (int)roundtrip.b << ")   [" << c.source
+                       << ", standard-HSV hue would be " << (int)c.expected_hue
+                       << "]");
+        // Orange must land in the red..yellow arc, never in the greens. This
+        // is the actual regression: these all returned 110-130 before.
+        FL_CHECK_LE((int)hsv.hue, (int)HUE_YELLOW);
+        // rgb2hsv_approximate inverts hsv2rgb_rainbow, not a textbook HSV
+        // hexagon, so correctness is round-trip fidelity rather than agreement
+        // with a standard-HSV hue. Green must stay the middle channel and blue
+        // must stay dark -- i.e. it still looks orange.
+        FL_CHECK_GT((int)roundtrip.r, (int)roundtrip.g);
+        FL_CHECK_GT((int)roundtrip.g, (int)roundtrip.b);
+    }
+}
+
+FL_TEST_CASE("rgb2hsv_approximate - hue stays in the red..yellow arc red -> yellow") {
+    // Sweeping green up at full red walks hue from red toward yellow. The
+    // underflow made this jump out into the greens partway through (46 -> 115
+    // -> 121 -> 126 -> 35), which is what made the bug so visible in fades.
+    //
+    // KNOWN LIMITATION: there is still a small backwards step of about 5 at
+    // g=128, where the Red-Orange and Orange-Yellow branches meet. The branch
+    // boundary sits at g = r/2, which does not correspond to HUE_ORANGE, so
+    // the two branches are calibrated against different endpoints. Closing
+    // that gap means recalibrating both branches together rather than fixing
+    // one expression, so it is left for follow-up -- a 5-unit seam is not
+    // visible where a 70-unit jump into green very much was.
+    const int kKnownSeam = 8;
+    int previous = -1;
+    for (int g = 0; g <= 255; g += 15) {
+        CHSV hsv = rgb2hsv_approximate(CRGB(255, g, 0));
+        FL_WARN("rgb(255," << g << ",0) -> hue " << (int)hsv.hue);
+        // The real regression check: never leave the red..yellow arc.
+        FL_CHECK_LE((int)hsv.hue, (int)HUE_YELLOW + 4);
+        FL_CHECK_GE((int)hsv.hue, previous - kKnownSeam);
+        previous = static_cast<int>(hsv.hue);
+    }
+}
+
+FL_TEST_CASE("rgb2hsv_approximate - greys report zero saturation") {
+    for (int level = 0; level <= 255; level += 51) {
+        CHSV hsv = rgb2hsv_approximate(CRGB(level, level, level));
+        FL_WARN("grey " << level << " -> sat " << (int)hsv.sat);
+        FL_CHECK_EQ((int)hsv.sat, 0);
+    }
+}
+
 FL_TEST_CASE("HSV to RGB Conversion - Specific Color Tests") {
     FL_WARN("=== Specific Color Conversion Tests ===");
     


### PR DESCRIPTION
Closes #436. Open 8 years, reported independently by 6 people.

## Root cause

The Orange→Yellow branch of `rgb2hsv_approximate()`:

```c
h += scale8( qsub8((g - 85) + (171 - r), 4), FIXFRAC8(32,85));
```

Reaching this branch requires `g >= r/2`, and `r` is the largest channel — so `r > 171` is the *ordinary* case here, making `(171 - r)` **negative**. The negative sum is then truncated to `u8` by `qsub8()` and wraps to a large value, pushing hue past yellow and into the greens.

For `rgb(255,153,0)`: `68 + (−84) = −16` → wraps to `236` → hue **122**.

Sweeping green up at full red shows the window exactly:

| g | 105 | 120 | **135** | **150** | **165** | 180 | 195 |
|---|---|---|---|---|---|---|---|
| hue | 40 | 46 | **115** | **121** | **126** | 35 | 41 |

## Fix

`(255 - r)` measures the same "how far has r fallen" quantity but cannot go negative. Over this branch's own entry condition, `(g - 85) + (255 - r)` has a minimum near **42** — the wrap becomes *structurally impossible* rather than merely unlikely. The span widens from ~85 to ~170, hence `FIXFRAC8(32,170)` to keep the top of the range on `HUE_YELLOW`.

Sweep now reads `46, 41, 44, 47, 50, 53, 56, 59, 61, 64`.

## The expected value in the thread is wrong (worth reading)

Everyone compared against ~26, from paint.net reporting `hsv(36°,100,100)`. But **`rgb2hsv_approximate` inverts `hsv2rgb_rainbow`, not a textbook HSV hexagon** — FastLED's rainbow hue is a perceptual mapping where `HUE_ORANGE = 32` and `HUE_YELLOW = 64`. The standard-HSV hue that paint.net and @5chmidti's `rgb2hsv_precise` report is simply a different scale.

So correctness is round-trip fidelity, which confirms **45 is right**:

```
rgb(255,153,0) -> hue 45 -> rgb(171,119,0)
```

`r > g > b` preserved, g/r ratio 0.60 in and 0.60 out. That's orange. (The absolute value drop is rainbow mode's own r-channel ceiling in this band, not part of this bug.)

Whole-cube round-trip deviation: **78.05 → 77.48** average, **62.01 → 61.93** median. The aggregate barely moves because the broken window is a narrow slice of the 4096-sample cube — but colors inside it go from unusable to correct.

## Tests

Added to `tests/fl/hsv2rgb_accuracy.cpp` (which already exercised this function): all four colors reported in the thread, the red→yellow sweep, and grey handling. Verified failing before the fix and passing after.

## Known limitation, documented in the test

A **~5 unit backwards step remains at g=128**, where the Red-Orange and Orange-Yellow branches meet. The boundary sits at `g = r/2`, which does not correspond to `HUE_ORANGE`, so the two branches are calibrated against different endpoints. Closing that seam means recalibrating both branches together rather than fixing one expression — deliberately left for follow-up. A 5-unit seam is not visible where a 70-unit jump into green very much was.

The `// Examples that need work:` list at the bottom of `hsv2rgb.cpp.hpp` is also still unaddressed.

## Verification

- `bash test --cpp --clean` — 357/357 on a full clean rebuild
- `bash lint` — clean

## Credit

@srwi for the original report with a reproducer; @PhotonicVelocity for the palette table that showed it was a band rather than a one-off; @5chmidti for the independent analysis and benchmarks; @cad435, @DrJaymz, @fabianoriccardi, @mike2003, @Modifikator for confirmations over the years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color conversion for orange and yellow tones.
  * Prevented certain orange colors from being incorrectly classified as green.
  * Improved hue progression and grayscale handling for more accurate results.

* **Tests**
  * Added coverage for orange-to-yellow conversion, hue progression, round-trip accuracy, and grayscale colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->