### PR TITLE
test(pixelset): pin CPixelView reverse-direction behavior (#481)

### DIFF
--- a/tests/pixelset.cpp
+++ b/tests/pixelset.cpp
@@ -1,0 +1,167 @@
+/// CPixelView reverse-direction tests -- see issue #481.
+///
+/// The scenario from the report: one physical strip folded in half, exposed as
+/// two logical views -- one forward over the first half, one reversed over the
+/// second. Filling both with the same call must paint them identically, so the
+/// two halves line up side by side along the fold.
+///
+///     CPixelView<CRGB> forward (leds,  0, 49);
+///     CPixelView<CRGB> reversed(leds, 99, 50);
+///
+/// After the same fill, forward[i] must equal reversed[i] for every i.
+
+#include "test.h"
+
+#include "FastLED.h"
+#include "pixelset.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+using namespace fl;
+
+namespace {
+
+constexpr int kHalf = 50;
+constexpr int kTotal = kHalf * 2;
+
+/// Largest per-channel difference between the forward and reversed halves.
+/// 0 means the two views painted identically.
+int maxChannelDelta(const CRGB *leds, const char *what) {
+    CPixelView<CRGB> forward(const_cast<CRGB *>(leds), 0, kHalf - 1);
+    CPixelView<CRGB> reversed(const_cast<CRGB *>(leds), kTotal - 1, kHalf);
+    int worst = 0;
+    int worst_idx = -1;
+    for (int i = 0; i < kHalf; ++i) {
+        const CRGB &f = forward[i];
+        const CRGB &r = reversed[i];
+        int dr = (int)f.r - (int)r.r;
+        int dg = (int)f.g - (int)r.g;
+        int db = (int)f.b - (int)r.b;
+        if (dr < 0) dr = -dr;
+        if (dg < 0) dg = -dg;
+        if (db < 0) db = -db;
+        int local = dr;
+        if (dg > local) local = dg;
+        if (db > local) local = db;
+        if (local > worst) {
+            worst = local;
+            worst_idx = i;
+        }
+    }
+    if (worst > 0) {
+        CPixelView<CRGB> f2(const_cast<CRGB *>(leds), 0, kHalf - 1);
+        CPixelView<CRGB> r2(const_cast<CRGB *>(leds), kTotal - 1, kHalf);
+        FL_WARN(what << " max delta " << worst << " at index " << worst_idx
+                     << ": forward=(" << (int)f2[worst_idx].r << ","
+                     << (int)f2[worst_idx].g << "," << (int)f2[worst_idx].b
+                     << ") reversed=(" << (int)r2[worst_idx].r << ","
+                     << (int)r2[worst_idx].g << "," << (int)r2[worst_idx].b
+                     << ")");
+    }
+    return worst;
+}
+
+// The rainbow path is exact after the #1756 fix. The gradient paths still show
+// a sub-step rounding asymmetry: fill_gradient interpolates by accumulating a
+// fixed-point delta, and accumulating start->end is not bit-identical to
+// accumulating end->start. Over a 50-pixel red->blue ramp one step is ~5/255,
+// and the observed divergence stays under half of that. It is a rounding
+// artifact, not the mapping error #481 was about, and tightening it means
+// changing fill_gradient's interpolation for every caller -- so it is pinned
+// here rather than silently tolerated.
+constexpr int kGradientRoundingSlack = 3;
+
+// FIXME(#481): the 3- and 4-color gradients are worse than rounding -- they
+// place the middle color one pixel off under reversal.
+//
+// fl/gfx/fill.h pivots at `half = numLeds / 2` and fills [0,half] then
+// [half,last]. For an even count that splits 50 pixels as 26 + 25, putting c2
+// at index 25. CPixelView's reversed branch fills the same physical range with
+// the colors swapped, so the pivot lands at physical 25 again -- which is
+// logical index 24 in a reversed view. Hence a one-pixel shift of the middle
+// color, and a visible ~22/255 divergence mid-ramp.
+//
+// A tolerance is not a fix; it pins current behavior so the defect is visible
+// instead of silent. Correcting it means either making the pivot
+// reversal-symmetric in fill.h (affects every caller) or having CPixelView
+// fill forward and reverse the range in place -- a real design call, tracked
+// on #481.
+constexpr int kMidColorPivotDefect = 24;
+
+}  // namespace
+
+FL_TEST_CASE("CPixelView reversed - fill_rainbow matches forward (issue #481)") {
+    CRGB leds[kTotal];
+    CPixelView<CRGB> forward(leds, 0, kHalf - 1);
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+
+    forward.fill_rainbow(0, 5);
+    reversed.fill_rainbow(0, 5);
+
+    // Exact: this is the case #481 reported and #1756 fixed.
+    FL_CHECK_EQ(maxChannelDelta(leds, "fill_rainbow"), 0);
+}
+
+FL_TEST_CASE("CPixelView reversed - fill_gradient two-color matches forward") {
+    CRGB leds[kTotal];
+    CPixelView<CRGB> forward(leds, 0, kHalf - 1);
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+
+    const CHSV a(0, 255, 255);
+    const CHSV b(160, 255, 255);
+    forward.fill_gradient(a, b);
+    reversed.fill_gradient(a, b);
+
+    FL_CHECK_LE(maxChannelDelta(leds, "fill_gradient(2)"), kGradientRoundingSlack);
+}
+
+FL_TEST_CASE("CPixelView reversed - fill_gradient three-color matches forward") {
+    CRGB leds[kTotal];
+    CPixelView<CRGB> forward(leds, 0, kHalf - 1);
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+
+    const CHSV a(0, 255, 255);
+    const CHSV b(96, 255, 255);
+    const CHSV c(160, 255, 255);
+    forward.fill_gradient(a, b, c);
+    reversed.fill_gradient(a, b, c);
+
+    // Known defect, not a passing grade -- see kMidColorPivotDefect above.
+    FL_CHECK_LE(maxChannelDelta(leds, "fill_gradient(3)"), kMidColorPivotDefect);
+}
+
+FL_TEST_CASE("CPixelView reversed - fill_gradient_RGB matches forward") {
+    CRGB leds[kTotal];
+    CPixelView<CRGB> forward(leds, 0, kHalf - 1);
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+
+    forward.fill_gradient_RGB(CRGB::Red, CRGB::Blue);
+    reversed.fill_gradient_RGB(CRGB::Red, CRGB::Blue);
+
+    FL_CHECK_LE(maxChannelDelta(leds, "fill_gradient_RGB(2)"), kGradientRoundingSlack);
+}
+
+FL_TEST_CASE("CPixelView reversed - fill_solid matches forward") {
+    CRGB leds[kTotal];
+    CPixelView<CRGB> forward(leds, 0, kHalf - 1);
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+
+    forward.fill_solid(CRGB::Green);
+    reversed.fill_solid(CRGB::Green);
+
+    // Exact: no interpolation involved.
+    FL_CHECK_EQ(maxChannelDelta(leds, "fill_solid"), 0);
+}
+
+FL_TEST_CASE("CPixelView reversed - indexing walks the strip backwards") {
+    CRGB leds[kTotal];
+    for (int i = 0; i < kTotal; ++i) {
+        leds[i] = CRGB(i, 0, 0);
+    }
+    CPixelView<CRGB> reversed(leds, kTotal - 1, kHalf);
+    // reversed[0] is the highest physical index, reversed[n] walks down.
+    FL_CHECK_EQ((int)reversed[0].r, kTotal - 1);
+    FL_CHECK_EQ((int)reversed[1].r, kTotal - 2);
+    FL_CHECK_EQ((int)reversed[kHalf - 1].r, kHalf);
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
Refs #481 (does **not** close it — see below).

## What this establishes

#481 reported that a strip folded in half and driven as two logical `CPixelView`s didn't line up along the fold. @MFornander fixed the rainbow case locally in 2018 and noted he wanted "to look at the sibling gradient methods to make sure they are not flawed as well." That check never happened.

The rainbow half **was** fixed upstream in #1756 (Nicholas Asch, 2024) — and more correctly than the patch proposed in the thread. MFornander's `initialhue - deltahue*len` was off by one; the shipped `initialhue - deltahue*(len+1)` works out to `+deltahue*(N-1)`, which is right.

This adds the report's own scenario as a test — forward view over the first half, reversed view over the second, same fill call, compared index by index:

| method | divergence | verdict |
|---|---|---|
| `fill_rainbow` | **exact** | #1756 fix confirmed |
| `fill_solid` | **exact** | — |
| `fill_gradient(2)` | ≤ 3/255 | sub-step rounding |
| `fill_gradient_RGB(2)` | ≤ 1/255 | sub-step rounding |
| `fill_gradient(3)` | **~22/255** | **real defect** |

So MFornander's suspicion was correct, and it splits into two very different things.

## The 2-color paths: rounding, not a bug

`fill_gradient` accumulates a fixed-point delta, and accumulating `start→end` isn't bit-identical to accumulating `end→start`. One step of a 50-pixel red→blue ramp is ~5/255; divergence stays under half a step.

## The 3-color path: a genuine one-pixel misplacement

`fl/gfx/fill.h:235`:

```c
u16 half = (numLeds / 2);                              // 25 for N=50
fill_gradient(targetArray, 0,    c1, half, c2, ...);   // 0..25  -> 26 px
fill_gradient(targetArray, half, c2, last, c3, ...);   // 25..49 -> 25 px
```

The pivot sits at `floor(N/2)` = index 25. CPixelView's reversed branch fills the same physical range with the colors swapped, so the pivot lands at physical 25 again — which is **logical index 24** in a reversed view. The middle color is one pixel off, giving ~22/255 mid-ramp. The 4-color path splits on thirds and has the same shape of bug.

## Why this PR doesn't fix it

Two options, both with real blast radius:

1. **Make the pivot reversal-symmetric in `fill.h`** — changes output for *every* caller, forward views included, not just reversed ones.
2. **Have CPixelView fill forward then reverse the range in place** — exact by construction and needs no extra memory, but changes the cost model of every reversed gradient fill.

That's a design call, not a one-expression fix, so it stays on #481.

Meanwhile the tolerance for the 3-color case is named `kMidColorPivotDefect` and carries a FIXME rather than being folded into the rounding slack — the defect is **pinned and visible**, not silently passing.

Also still open on #481: @MFornander's request for perlin-noise methods on CPixelView, and @focalintent's 2018 plan to replace range selectors wholesale (forward/backward ranges, repeat patterns, skip lists).

## Verification

- `bash test --cpp --clean` — 358/358 on a full clean rebuild (275 unit, 83 examples)
- `bash lint` — clean

No behavior change; tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for reversed views of folded physical strips.
  * Verified rainbow, solid-color, two-color, three-color, and RGB gradients in both directions.
  * Added checks for reversed indexing and acceptable color-rendering differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->