### PR TITLE
fix(ci): read gh output from stdout, not the always-None stderr

### DIFF
--- a/ci/oldest_issue.py
+++ b/ci/oldest_issue.py
@@ -64,6 +64,18 @@ def _parse_created_at(raw: str) -> datetime:
     return datetime.fromisoformat(raw.replace("Z", "+00:00"))
 
 
+def _output(result: object) -> str:
+    """Combined stdout+stderr from a RunningProcess result.
+
+    RunningProcess merges the child's stderr into stdout and leaves .stderr as
+    None, so reading .stderr alone silently sees nothing -- which made every
+    error message here blank and, worse, made the "already exists" check below
+    never match.
+    """
+    parts = [getattr(result, "stdout", None), getattr(result, "stderr", None)]
+    return " ".join(p.strip() for p in parts if p).strip()
+
+
 def fetch_issues(repo: str) -> list[Issue]:
     """Fetch all open issues via gh, sorted oldest-first."""
     result = RunningProcess.run(
@@ -93,7 +105,7 @@ def fetch_issues(repo: str) -> list[Issue]:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"gh issue list failed ({result.returncode}): {result.stderr}"
+            f"gh issue list failed ({result.returncode}): {_output(result)}"
         )
 
     issues = [
@@ -141,12 +153,9 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
         capture_output=True,
         text=True,
     )
-    if label_result.returncode != 0 and "already exists" not in (
-        label_result.stderr or ""
-    ):
-        raise RuntimeError(
-            f"failed to create label {DEFERRED_LABEL!r}: {label_result.stderr}"
-        )
+    label_output = _output(label_result)
+    if label_result.returncode != 0 and "already exists" not in label_output:
+        raise RuntimeError(f"failed to create label {DEFERRED_LABEL!r}: {label_output}")
 
     result = RunningProcess.run(
         [
@@ -165,7 +174,7 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
         text=True,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"failed to label #{number}: {result.stderr}")
+        raise RuntimeError(f"failed to label #{number}: {_output(result)}")
 
     if reason:
         comment_result = RunningProcess.run(
@@ -190,7 +199,7 @@ def defer_issue(repo: str, number: int, reason: str | None) -> None:
         if comment_result.returncode != 0:
             raise RuntimeError(
                 f"labeled #{number} deferred, but posting the reason comment "
-                f"failed: {comment_result.stderr}"
+                f"failed: {_output(comment_result)}"
             )
     print(f"Deferred #{number}" + (f": {reason}" if reason else ""))
 


### PR DESCRIPTION
## Bug

`RunningProcess.run` merges the child's stderr into stdout and leaves `.stderr` as `None`. Verified directly:

```
rc     = 1
stdout = 'label with name "deferred" already exists; use `--force` to update its color and description'
stderr = None
```

`ci/oldest_issue.py` read `.stderr` in four places, so all four were blind.

The visible consequence — `--defer` failed outright once the label existed:

```
RuntimeError: failed to create label 'deferred': None
```

`gh label create` exits 1 with "already exists", the guard looked for that text in `stderr`, got `None`, and raised. So **deferring worked exactly once, then never again** — backwards, since re-deferring is the normal case for a loop that keeps re-scanning the backlog.

The other three sites failed the same way, just less visibly: each raised a `RuntimeError` whose message was the literal string `"None"`.

## Fix

Adds `_output()` to combine both streams, and routes all four call sites through it.

## Verification

Hit live: `--defer 481` now succeeds against an existing label, and the issue picks up the `deferred` label. Re-running the scanner confirms it's skipped:

```
268 actionable of 270 open; 2 deferred skipped
```

`bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for issue management tasks.
  * Error messages now include both standard output and error details, making failures easier to diagnose.
  * Added clearer handling when labels already exist or when label creation, application, or comment posting fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->