### PR TITLE
fix(lint): stop the PlatformIO checker gating on git-ignored files

### DIFF
--- a/ci/lint_platformio/run_all_checkers.py
+++ b/ci/lint_platformio/run_all_checkers.py
@@ -79,8 +79,75 @@ _INTEREST_SUFFIXES: tuple[str, ...] = (
 )
 
 
+def _git_ignored(root: Path, paths: list[str]) -> set[str]:
+    """Subset of `paths` that git ignores.
+
+    Returns an empty set when git is unavailable or errors, so the checker
+    still works outside a checkout -- failing open here only means scanning a
+    few extra files, never missing a real one.
+    """
+    if not paths:
+        return set()
+
+    # Feed repo-relative POSIX paths: git echoes back exactly the spelling it
+    # was given, so anything else makes the returned names impossible to map
+    # onto the absolute paths the walk produced.
+    rel_to_abs: dict[str, str] = {}
+    for absolute in paths:
+        try:
+            rel = os.path.relpath(absolute, root).replace("\\", "/")
+        except ValueError:
+            continue  # different drive on Windows; cannot be repo-relative
+        rel_to_abs[rel] = absolute
+    if not rel_to_abs:
+        return set()
+
+    try:
+        from running_process import RunningProcess  # noqa: PLC0415 - lazy
+
+        # `git check-ignore --stdin` echoes back only the ignored paths and
+        # exits 1 when none match, so check=False.
+        result = RunningProcess.run(
+            ["git", "check-ignore", "--stdin"],
+            input="\n".join(rel_to_abs) + "\n",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(root),
+            check=False,
+            timeout=60,
+        )
+    except KeyboardInterrupt as ki:
+        from ci.util.global_interrupt_handler import (  # noqa: PLC0415 - lazy
+            handle_keyboard_interrupt,
+        )
+
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        # Fail open: git missing, not a checkout, or check-ignore erroring just
+        # means we scan a few extra files. Never a missed violation.
+        return set()
+
+    out = result.stdout or ""
+    ignored: set[str] = set()
+    for line in out.splitlines():
+        rel = line.strip().replace("\\", "/")
+        if rel in rel_to_abs:
+            ignored.add(rel_to_abs[rel])
+    return ignored
+
+
 def _collect_files(root: Path) -> list[str]:
-    """Walk the repo and collect files of interest, pruning skip dirs."""
+    """Walk the repo and collect files of interest, pruning skip dirs.
+
+    Git-ignored files are excluded. They cannot reach CI -- a developer's
+    local scratch script is not repository content -- so gating on them just
+    fails `bash lint` for something the reviewer will never see. This bit
+    people with a root `tmp.sh` containing `pio run -v`: ignored by
+    .gitignore, invisible to CI, and yet a hard lint failure locally.
+    """
     files: list[str] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # In-place prune
@@ -91,6 +158,10 @@ def _collect_files(root: Path) -> list[str]:
             if name.endswith(_INTEREST_SUFFIXES):
                 files.append(os.path.join(dirpath, name))
     files.sort()
+
+    ignored = _git_ignored(root, files)
+    if ignored:
+        files = [f for f in files if f not in ignored]
     return files
 
 


### PR DESCRIPTION
`bash lint` fails on a root `tmp.sh` — a local debugging scratch script containing `pio run -v`:

```
tmp.sh:
  Line 14: [pio_run] Forbidden: `pio run` as build invocation.
❌ PlatformIO-internal-usage: 1 violation(s) (gating).
```

That file is matched by `.gitignore:87` (`tmp.*`). **It cannot be committed and CI never sees it** — so the lint fails for something no reviewer will ever look at, and the only way to make it pass is to delete a file belonging to whoever is mid-debug.

## Fix

`_collect_files()` walked the tree pruning only `_SKIP_DIRS`, with no notion of gitignore. It now asks `git check-ignore --stdin` once for the whole candidate list and drops what git ignores.

Three details worth keeping:

- **Repo-relative POSIX paths** are fed in. `check-ignore` echoes back exactly the spelling it was given, so feeding the walk's absolute Windows paths made the results unmappable — my first cut silently filtered nothing, and I only caught it because the violation persisted.
- **Fails open.** No git, not a checkout, or `check-ignore` erroring just means a few extra files get scanned — never a missed violation.
- Uses `RunningProcess`, not stdlib subprocess, per the ban added in #3792.

## Verified both directions

| case | result |
|---|---|
| gitignored `tmp.sh` with `pio run -v` | skipped — no failure |
| tracked `ci/tmp_probe_tracked.sh` with `pio run -v` | **still caught**, exit 1 |

The second matters more than the first: it would be easy to "fix" this by filtering too aggressively and quietly disabling the checker.

`bash lint` fully green (all 7 stages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated linting checks to skip files ignored by Git.
  * Improved resilience when Git is unavailable or encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->