### PR TITLE
fix(hsv): compare CHSV by field instead of by its RGB rendering (#691)

### DIFF
--- a/src/fl/gfx/hsv.h
+++ b/src/fl/gfx/hsv.h
@@ -60,6 +60,32 @@ struct hsv8 {
         return raw[x];
     }
 
+    /// Compare two HSV colors field by field.
+    ///
+    /// Without these, `a == b` on two CHSV values found no operator on the
+    /// type and instead converted BOTH operands to RGB, comparing the
+    /// rendering rather than the colors. Anything that renders alike then
+    /// compared equal: `CHSV(0,0,0) == CHSV(128,0,0)` was true (both black),
+    /// and so was `CHSV(10,20,30) == CHSV(10,20,31)` (both round to the same
+    /// RGB). Reported in 2018 as FastLED#691.
+    ///
+    /// Hidden friends rather than members: C++20 synthesizes a reversed
+    /// candidate for a member `operator==`, which trips
+    /// -Wambiguous-reversed-operator at every call site. Same reasoning and
+    /// same shape as the palette comparisons in colorutils.h (#2724).
+    friend FASTLED_FORCE_INLINE bool operator==(const hsv8& lhs,
+                                                const hsv8& rhs) FL_NO_EXCEPT
+    {
+        return lhs.h == rhs.h && lhs.s == rhs.s && lhs.v == rhs.v;
+    }
+
+    /// @copydoc operator==
+    friend FASTLED_FORCE_INLINE bool operator!=(const hsv8& lhs,
+                                                const hsv8& rhs) FL_NO_EXCEPT
+    {
+        return !(lhs == rhs);
+    }
+
     /// Default constructor
     /// @warning Default values are UNITIALIZED!
     constexpr hsv8() FL_NO_EXCEPT : h(0), s(0), v(0) { }

--- a/tests/fl/gfx/hsv.cpp
+++ b/tests/fl/gfx/hsv.cpp
@@ -1,0 +1,52 @@
+/// Regression test for FastLED#691 -- comparing two CHSV values.
+///
+/// Reported in 2018: `CHSV(0,0,0) == CHSV(128,0,0)` returned true, because
+/// CHSV had no operator== and the operands were implicitly converted to CRGB
+/// first. Both convert to black, so any two CHSV values with value==0 (or any
+/// pair that happens to render to the same RGB) compared equal.
+///
+/// A comparison that silently changes colour space is the same failure shape
+/// as a check that reports success it has not earned: it answers a question
+/// the caller did not ask.
+
+#include "test.h"
+
+#include "fl/gfx/hsv.h"
+
+FL_TEST_CASE("CHSV equality compares HSV fields, not the RGB rendering") {
+    // The exact case from the issue. Both render to black in RGB.
+    const CHSV a(0, 0, 0);
+    const CHSV b(128, 0, 0);
+
+    FL_CHECK_FALSE(a == b);
+    FL_CHECK(a != b);
+}
+
+FL_TEST_CASE("CHSV equality is true only for identical fields") {
+    const CHSV a(10, 20, 30);
+    const CHSV same(10, 20, 30);
+    const CHSV diff_hue(11, 20, 30);
+    const CHSV diff_sat(10, 21, 30);
+    const CHSV diff_val(10, 20, 31);
+
+    FL_CHECK(a == same);
+    FL_CHECK_FALSE(a != same);
+
+    FL_CHECK_FALSE(a == diff_hue);
+    FL_CHECK_FALSE(a == diff_sat);
+    FL_CHECK_FALSE(a == diff_val);
+
+    FL_CHECK(a != diff_hue);
+    FL_CHECK(a != diff_sat);
+    FL_CHECK(a != diff_val);
+}
+
+FL_TEST_CASE("CHSV hues that render alike still differ") {
+    // Saturation 0 makes hue irrelevant to the RGB rendering, so these are
+    // the pairs the old CRGB-conversion path collapsed together.
+    const CHSV red_ish(0, 0, 200);
+    const CHSV blue_ish(160, 0, 200);
+
+    FL_CHECK_FALSE(red_ish == blue_ish);
+    FL_CHECK(red_ish != blue_ish);
+}


### PR DESCRIPTION
Fixes #691 — open since 2018, and still live.

## The bug

`CHSV` had no `operator==`, so `a == b` on two CHSV values found no operator on the type and instead converted **both operands to RGB**, comparing the rendering rather than the colors. Anything that rendered alike compared equal.

The reporter's case:

```cpp
CHSV(0, 0, 0) == CHSV(128, 0, 0)   // true — both render to black
```

Writing the test showed it is **broader than the report suggests**. Every field collapses, not just hue at zero saturation:

```cpp
CHSV(10,20,30) == CHSV(11,20,30)   // true  (hue differs)
CHSV(10,20,30) == CHSV(10,21,30)   // true  (saturation differs)
CHSV(10,20,30) == CHSV(10,20,31)   // true  (value differs — same RGB)
```

A comparison that silently changes color space answers a question the caller did not ask.

## The fix

`operator==` / `operator!=` on `fl::hsv8`, comparing h/s/v directly.

**Hidden friends, not members** — C++20 synthesizes a reversed candidate for a member `operator==`, which trips `-Wambiguous-reversed-operator` at every call site. Same reasoning and same shape as the palette comparisons in `colorutils.h` (#2724), so this follows the precedent already set in this codebase rather than inventing a new one.

## Verification

`tests/fl/gfx/hsv.cpp` covers the reporter's exact case, each field in isolation, and the zero-saturation pair the RGB path collapsed. **It fails on master and passes here** — I wrote and ran it against the unfixed tree first.

Full suite: **275 unit + 83 examples pass**, so nothing depended on the old compare-as-RGB behaviour. That was the main risk with changing a seven-year-old default. `bash lint` clean.

Validated locally per the standing instruction to skip GHA for `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct equality and inequality comparisons for HSV color values.

* **Bug Fixes**
  * Comparisons now correctly evaluate hue, saturation, and value fields, including colors that render identically.

* **Tests**
  * Added coverage for matching values, individual field differences, and black colors with different hues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->