### PR TITLE
fix(hsv): stop hsv2rgb_rainbow leaving AVR's R1 dirty on three paths (#668)

### DIFF
--- a/src/hsv2rgb.cpp.hpp
+++ b/src/hsv2rgb.cpp.hpp
@@ -422,7 +422,13 @@ void hsv2rgb_rainbow( const CHSV& hsv, CRGB& rgb)
     // This is one of the good places to scale the green down,
     // although the client can scale green down as well.
     if( G2 ) g = g >> 1;
-    if( Gscale ) g = scale8_video_LEAVING_R1_DIRTY( g, Gscale);
+    // Deliberately the cleaning variant. The _LEAVING_R1_DIRTY form only pays
+    // off when several calls are batched before one cleanup_R1(), and this is a
+    // lone call whose dirty R1 outlives it on three separate paths: sat == 255
+    // and val == 255 both skip their blocks entirely, and the sat == 0 branch
+    // below just assigns 255s. Any of those returns to the caller with AVR's
+    // __zero_reg__ non-zero. See issue #668.
+    if( Gscale ) g = scale8_video( g, Gscale);
 
     // Scale down colors if we're desaturated at all
     // and add the brightness_floor to r, g, and b.
@@ -463,6 +469,10 @@ void hsv2rgb_rainbow( const CHSV& hsv, CRGB& rgb)
         val = scale8_video_LEAVING_R1_DIRTY( val, val);
         if( val == 0 ) {
             r=0; g=0; b=0;
+            // The scale8_video_LEAVING_R1_DIRTY above dirtied R1 and this
+            // branch does no further scaling, so it has to clean up itself --
+            // only the else branch below batches into its own cleanup_R1().
+            cleanup_R1();
         } else {
             // nscale8x3_video( r, g, b, val);
 #if (FASTLED_SCALE8_FIXED==1)


### PR DESCRIPTION
Refs #668, #943.

## Background

#668 is the long-running "unexpected red pixel" in `fill_rainbow()` on AVR: one pixel mid-ramp comes out with a wrong channel, the affected pixel tracks the hue, and unrelated edits to the sketch make it appear and disappear. @kriegsman called it early — *"this looks like a compiler-level issue"* — and @ddesborough traced it to the `scale8_LEAVING_R1_DIRTY` inline asm, proposing three possible fixes, the third being to stop the compiler rearranging those calls.

#943 shipped that third fix, and the barriers are still in the source:

```c
r = scale8_LEAVING_R1_DIRTY( r, satscale);
asm volatile("");  // Fixes jumping red pixel: https://github.com/FastLED/FastLED/pull/943
g = scale8_LEAVING_R1_DIRTY( g, satscale);
```

**This PR fixes a second, independent half of the same hazard** that #943 didn't cover.

## The bug

`scale8*_LEAVING_R1_DIRTY` deliberately skips restoring AVR's `__zero_reg__` so several calls can share one `cleanup_R1()`. Its own docs (`scale8_avr.h:74`, `:133`) say:

> **@warning** You **MUST** call `cleanup_R1()` after using this function!

`hsv2rgb_rainbow()` has three paths that return without doing so:

| # | dirtied at | why nothing cleans up |
|---|---|---|
| 1 | `if (Gscale) g = scale8_video_LEAVING_R1_DIRTY(g, Gscale)` | `sat == 255` skips the saturation block **and** `val == 255` skips the value block |
| 2 | same call | the `sat == 0` branch only assigns `r = g = b = 255` |
| 3 | `val = scale8_video_LEAVING_R1_DIRTY(val, val)` | the `val == 0` branch assigns zeros; only the `else` batches into a `cleanup_R1()` |

Returning with `r1` non-zero **violates the AVR ABI** — the compiler treats `r1` as a hard zero and emits code assuming it. Whatever executes next can compute garbage.

That explains every reported symptom, including the confusing ones:

- **Which pixel is wrong depends on hue** — hue selects which branch runs, and only some branches leak.
- **It moves under recompilation** — the damage depends on what the compiler happens to schedule after the call, which unrelated edits change.
- **`-O1` made it go away** (@ddesborough) and **`delay()` vs `millis()` changed it** (@OneEyeRick) — both change surrounding codegen, not the conversion math.

This is also exactly what @kriegsman predicted: *"if we're having this issue here, we're probably having it other places too but we just haven't isolated those bugs yet."*

## The fix

**For the `Gscale` call — use the cleaning `scale8_video()`.** The `_LEAVING_R1_DIRTY` variant only pays off when calls are batched before one cleanup; this is a lone call, and covering it otherwise would mean duplicating `cleanup_R1()` onto three separate exit paths.

**For `val == 0` — add the missing `cleanup_R1()`.** Here the batching is real (the `else` branch chains three more scales), so the branch cleans up itself rather than giving up the optimization.

## Verification

- `bash test --cpp --clean` — 359/359 on a full clean rebuild
- `bash compile uno` — AVR, where this actually matters: builds clean, 4.92 KB flash / 538 B RAM

Host tests can't catch this class of bug (`cleanup_R1()` is a no-op off AVR), which is why the AVR build is the meaningful check.

## Credit

@Tim-AQ for the original report and the key observation that the glitch moves with hue; @kriegsman for the delta tables that showed it wasn't a math error; @ddesborough for the root-cause analysis and the three candidate fixes; @reyemxela and @OneEyeRick for independent reproductions that narrowed the trigger conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color conversion reliability on AVR-based devices.
  * Ensured internal processor state is properly restored after zero-value color scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->