### PR TITLE
fix(teensy): unbreak Teensy 3.x builds referencing F_CPU_ACTUAL

### DIFF
--- a/src/platforms/arm/teensy/audio/pjrc_audio_stream.h
+++ b/src/platforms/arm/teensy/audio/pjrc_audio_stream.h
@@ -113,7 +113,17 @@ protected:
 	AudioStream::initialize_memory(data, num); \
 })
 
-#define CYCLE_COUNTER_APPROX_PERCENT(n) (((float)((u32)(n) * 6400u) * (float)(AUDIO_SAMPLE_RATE_EXACT / AUDIO_BLOCK_SAMPLES)) / (float)(F_CPU_ACTUAL))
+// F_CPU_ACTUAL exists only on Teensy 4.x (IMXRT), where the core clock can be
+// changed at runtime and so differs from the compile-time F_CPU. On Teensy 3.x
+// the clock is fixed, F_CPU is exact, and F_CPU_ACTUAL is never defined --
+// referencing it there is a compile error rather than a wrong number.
+#if defined(F_CPU_ACTUAL)
+#define FASTLED_AUDIO_CPU_HZ F_CPU_ACTUAL
+#else
+#define FASTLED_AUDIO_CPU_HZ F_CPU
+#endif
+
+#define CYCLE_COUNTER_APPROX_PERCENT(n) (((float)((u32)(n) * 6400u) * (float)(AUDIO_SAMPLE_RATE_EXACT / AUDIO_BLOCK_SAMPLES)) / (float)(FASTLED_AUDIO_CPU_HZ))
 
 #define AudioProcessorUsage() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpuCyclesTotal()))
 #define AudioProcessorUsageMax() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpuCyclesTotalMax()))


### PR DESCRIPTION
## Bug

`bash compile teensy36` fails on current master:

```
lib/FastLED/platforms/arm/teensy/audio/pjrc_audio_stream.h:116:137:
error: 'F_CPU_ACTUAL' was not declared in this scope
```

`F_CPU_ACTUAL` exists only on **Teensy 4.x (IMXRT)**, where the core clock can be changed at runtime and so differs from the compile-time `F_CPU`. On Teensy 3.x the clock is fixed, only `F_CPU` is defined, and naming `F_CPU_ACTUAL` is a hard compile error rather than a wrong number.

`CYCLE_COUNTER_APPROX_PERCENT` referenced it unconditionally:

```c
#define CYCLE_COUNTER_APPROX_PERCENT(n) (... / (float)(F_CPU_ACTUAL))
```

so the whole audio header failed to compile on K20/K66 — **taking every Teensy 3.x build with it, including sketches that never touch audio.** Blink doesn't compile for a Teensy 3.6 today.

## Fix

Select `F_CPU` where `F_CPU_ACTUAL` doesn't exist, via a local `FASTLED_AUDIO_CPU_HZ`:

```c
#if defined(F_CPU_ACTUAL)
#define FASTLED_AUDIO_CPU_HZ F_CPU_ACTUAL
#else
#define FASTLED_AUDIO_CPU_HZ F_CPU
#endif
```

Deliberately a local macro rather than `#define F_CPU_ACTUAL F_CPU` — defining a PJRC symbol ourselves would shadow theirs and could surprise anything else that tests for it.

The substitution is also semantically right, not just a compile fix: on Teensy 3.x the clock genuinely is fixed, so `F_CPU` is the exact value this CPU-usage percentage wants. Teensy 4.x keeps using the real runtime clock.

## Verification

| board | before | after |
|---|---|---|
| `teensy36` (K66) | **fails to compile** | ✅ 17140 B flash / 4528 B RAM |
| `teensy41` (IMXRT) | ✅ | ✅ 72704 B flash / 81984 B RAM |

`bash lint` clean.

Found while verifying a fix for #703, which needs a working Teensy 3.x build to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio processing compatibility across platforms by supporting environments that provide either actual or standard CPU frequency definitions.
  * Prevented audio processor usage calculations from failing when the preferred CPU frequency value is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->