### PR TITLE
fix(teensy): silence unused 'clocks' in block controllers (#703)

### DIFF
--- a/src/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/src/platforms/arm/k20/clockless_block_arm_k20.h
@@ -70,6 +70,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}
@@ -266,6 +268,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}

--- a/src/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/src/platforms/arm/k66/clockless_block_arm_k66.h
@@ -76,6 +76,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}
@@ -283,6 +285,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 	#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}

--- a/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
+++ b/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
@@ -58,6 +58,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}
@@ -260,6 +262,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}

--- a/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
+++ b/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
@@ -62,6 +62,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 		#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}
@@ -275,6 +277,8 @@ public:
 		long microsTaken = CLKS_TO_MICROS(clocks);
 		MS_COUNTER += (1 + (microsTaken / 1000));
 	#endif
+		// Only read when interrupts are disabled; keep the call, drop the warning.
+		FASTLED_UNUSED(clocks);
 
 		mWait.mark();
 	}


### PR DESCRIPTION
Closes #703.

## Bug

`showPixels()` in the K20/K66 block controllers:

```c
u32 clocks = showRGBInternal(pixels);
#if FASTLED_ALLOW_INTERRUPTS == 0
long microsTaken = CLKS_TO_MICROS(clocks);
MS_COUNTER += (1 + (microsTaken / 1000));
#endif
```

`FASTLED_ALLOW_INTERRUPTS` defaults to **1** on Teensy, so in the default configuration `clocks` is assigned and never read — a `-Wunused-but-set-variable` per instantiation. Block mode instantiates the template once per lane configuration, which is why @sonoclick reported *"a lot of"* warnings rather than one.

## Fix

`FASTLED_UNUSED(clocks)` after the block — **8 sites across 4 files** (`k20`, `k66`, and the `teensy31_32` / `teensy36` copies).

I used `FASTLED_UNUSED` rather than the reporter's suggested `#if/#else` duplication:

```c
// suggested in the issue
#if FASTLED_ALLOW_INTERRUPTS == 1
    showRGBInternal(pixels);
#endif
#if FASTLED_ALLOW_INTERRUPTS == 0
    u32 clocks = showRGBInternal(pixels);
    ...
#endif
```

That works, but `showRGBInternal()` is the call that actually drives the LEDs and must run in both configurations — duplicating it into both arms creates two copies that can drift. `FASTLED_UNUSED` keeps one call site.

**Left alone deliberately:**
- `kl26` — `clocks` is genuinely read on both paths (`if(!clocks)` retry). Not affected.
- `mxrt1062` — already uses the `#if/#else` shape correctly, i.e. the reporter's pattern is already applied where it fits.

## Verification — and one honest caveat

**The repo's Teensy builds don't enable `-Wall`/`-Wextra`** (only `-Wdeprecated-copy`), so this warning does not surface through `bash compile`. It appears in Arduino IDE / Teensyduino builds, which is exactly where #703 reported it. I could not reproduce the warning locally, so what's verified here is the defect's presence by inspection plus no regression:

| check | result |
|---|---|
| `bash compile teensy36 --examples BlinkParallel` | ✅ 23472 B flash |
| `bash compile teensy31 --examples Blink` | ✅ 11076 B flash |
| `bash test --cpp --clean` | ✅ 359/359 |
| `bash lint` | ✅ clean |

That the project's own Teensy builds run without `-Wall` is arguably the more interesting finding here — it's why this sat for 7 years — but turning those on is a separate change with its own fallout.

## Credit

@sonoclick for the report and a working patch; @marcmerlin for the triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compiler warnings related to unused timing values on supported ARM and Teensy platforms.
  * Preserved existing LED timing and display behavior while improving build cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->