### PR TITLE
fix(build): key the PCH cache on compiler flags, validate the PCH build command

### DIFF
--- a/ci/compile_pch.py
+++ b/ci/compile_pch.py
@@ -204,6 +204,31 @@ def hash_input_files(files: list[Path]) -> str:
     return h.hexdigest()
 
 
+def hash_compile_flags(args: list[str]) -> str:
+    """Hash the full compiler argument vector, byte for byte.
+
+    Deliberately NOT normalized. Two spellings of the same include root --
+    ``-IC:/x/src`` and ``-IC:\\x\\src`` -- must produce different digests,
+    because a PCH built under one spelling cannot be reused under the other:
+    clang canonicalizes header identity at PCH-build time, so the consuming
+    TU re-parses headers the PCH already contains, ``#pragma once`` fails to
+    dedupe, and the build dies with "redefinition of ...".
+
+    Normalizing here would collapse exactly the difference we need to catch
+    and reintroduce the stale-PCH bug this guards.
+
+    Kept separate from :func:`hash_input_files` on purpose: that hash is also
+    computed by :func:`invalidate_stale_pch`, which never sees the arguments.
+    Mixing args into it made the two disagree and deleted every freshly built
+    PCH.
+    """
+    h = hashlib.sha256()
+    for arg in args:
+        h.update(arg.encode("utf-8"))
+        h.update(b"\x00")  # unambiguous separator: args may contain spaces
+    return h.hexdigest()
+
+
 def invalidate_stale_pch(pch_file: Path) -> None:
     """Delete a PCH file if its input files have changed since it was built.
 
@@ -219,16 +244,22 @@ def invalidate_stale_pch(pch_file: Path) -> None:
 
     saved_depfile = pch_file.with_name(pch_file.name.replace(".pch", ".d.cache"))
     hash_file = Path(str(pch_file) + ".input_hash")
-    if not saved_depfile.exists() or not hash_file.exists():
+    flags_file = Path(str(pch_file) + ".flags_hash")
+    if not saved_depfile.exists() or not hash_file.exists() or not flags_file.exists():
         # Missing tracking files means we can't verify the PCH is fresh.
         # Delete it to force a safe rebuild rather than risking a stale-PCH
         # compiler error that would fail the entire build.
+        #
+        # flags_file is included so a PCH left behind by a build predating
+        # flag hashing -- which may have been built under a different include
+        # spelling -- is discarded rather than trusted.
         print(
             f"PCH tracking files missing — removing {pch_file.name} to force rebuild",
             file=sys.stderr,
         )
         pch_file.unlink(missing_ok=True)
         hash_file.unlink(missing_ok=True)
+        flags_file.unlink(missing_ok=True)
         return
 
     try:
@@ -277,14 +308,35 @@ def main() -> int:
     # saved copy (.d.cache) from the previous successful build.
     saved_depfile = Path(str(depfile) + ".cache") if depfile else None
     hash_file = Path(str(pch_output) + ".input_hash") if pch_output else None
-    if pch_output and saved_depfile and hash_file and pch_output.exists():
-        if saved_depfile.exists() and hash_file.exists():
+    flags_file = Path(str(pch_output) + ".flags_hash") if pch_output else None
+    current_flags_hash = hash_compile_flags(args)
+    if (
+        pch_output
+        and saved_depfile
+        and hash_file
+        and flags_file
+        and pch_output.exists()
+    ):
+        if saved_depfile.exists() and hash_file.exists() and flags_file.exists():
             try:
                 input_files = parse_depfile_inputs(saved_depfile)
                 if input_files:
                     current_hash = hash_input_files(input_files)
                     stored_hash = hash_file.read_text(encoding="utf-8").strip()
-                    if current_hash == stored_hash:
+                    stored_flags = flags_file.read_text(encoding="utf-8").strip()
+                    # Both must match. The input hash alone cannot see a
+                    # changed include spelling: the resolved dependency set is
+                    # identical, so its digest is identical, and the PCH built
+                    # under the old spelling gets reused and poisons the build.
+                    if (
+                        current_hash == stored_hash
+                        and current_flags_hash != stored_flags
+                    ):
+                        print(
+                            "PCH compiler flags changed - rebuilding",
+                            file=sys.stderr,
+                        )
+                    elif current_hash == stored_hash:
                         print(
                             "PCH inputs unchanged (hash match) - skipping compilation",
                             file=sys.stderr,
@@ -314,7 +366,12 @@ def main() -> int:
             traceback.print_exc(file=sys.stderr)
 
         # Save depfile copy and input hash for next build's cache check
-        if saved_depfile and hash_file and depfile.exists():
+        if saved_depfile and hash_file and flags_file and depfile.exists():
+            # Written before the input hash: if the process dies between the
+            # two, the next run sees a flags sidecar with no input hash and
+            # rebuilds. The reverse order would leave an input hash with no
+            # flags sidecar, which is the state we treat as untrustworthy.
+            flags_file.write_text(current_flags_hash, encoding="utf-8")
             try:
                 shutil.copy2(str(depfile), str(saved_depfile))
                 input_files = parse_depfile_inputs(saved_depfile)

--- a/ci/meson/path_normalization.py
+++ b/ci/meson/path_normalization.py
@@ -235,17 +235,57 @@ def find_strict_path_violations(build_dir: Path) -> list[str]:
         command = entry_dict.get("command")
         if not isinstance(command, str):
             continue
-        for match in _STRICT_PATH_FLAG_RE.finditer(command):
-            raw = match.group("path")
-            normalized = raw.replace("\\", "/")
-            if "\\" in raw:
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
-                continue
-            if not _is_forward_slash_absolute(normalized):
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
-                continue
-            if _has_dot_components(normalized):
-                violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+        violations.extend(scan_command_for_strict_path_violations(command))
+    violations.extend(find_ninja_strict_path_violations(build_dir))
+    return violations
+
+
+def scan_command_for_strict_path_violations(command: str) -> list[str]:
+    """Strict-path offenders in a single command line."""
+    violations: list[str] = []
+    for match in _STRICT_PATH_FLAG_RE.finditer(command):
+        raw = match.group("path")
+        normalized = raw.replace("\\", "/")
+        if "\\" in raw:
+            violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+            continue
+        if not _is_forward_slash_absolute(normalized):
+            violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+            continue
+        if _has_dot_components(normalized):
+            violations.append(f"{match.group('prefix').lstrip(chr(34))}{raw}")
+    return violations
+
+
+def find_ninja_strict_path_violations(build_dir: Path) -> list[str]:
+    """Strict-path offenders in ``build.ninja`` command lines.
+
+    ``compile_commands.json`` covers compile targets only. The PCH is built by
+    a Meson *custom target*, which never appears there -- ``compile_pch.py``
+    occurs zero times in a generated ``compile_commands.json`` while the
+    consuming ``-include-pch`` flags occur hundreds of times. So the include
+    flags a PCH is *consumed* with were validated and the ones it is *built*
+    with were not, even though a mismatch between the two is precisely what
+    makes clang re-parse headers the PCH already contains and fail with
+    "redefinition of ...".
+
+    Scanning ``build.ninja`` closes that gap: it is the only generated file
+    that contains the PCH build command.
+    """
+    ninja_file = build_dir / "build.ninja"
+    if not ninja_file.exists():
+        return []
+    try:
+        text = ninja_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    violations: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("COMMAND = "):
+            continue
+        violations.extend(scan_command_for_strict_path_violations(stripped))
     return violations
 
 

--- a/ci/tests/test_pch_staleness_guards.py
+++ b/ci/tests/test_pch_staleness_guards.py
@@ -1,0 +1,104 @@
+"""Regression tests for the two PCH-poisoning guards.
+
+Both cover the same failure: a PCH built under one include spelling is reused
+under another, clang re-parses headers the PCH already contains, ``#pragma
+once`` fails to dedupe, and the build dies with "redefinition of ...".
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.compile_pch import hash_compile_flags
+from ci.meson.path_normalization import find_ninja_strict_path_violations
+
+
+BASE_ARGS = [
+    "clang++.exe",
+    "-c",
+    "-x",
+    "c++-header",
+    "C:/x/tests/test_pch.h",
+    "-o",
+    "tests/test_pch.h.pch",
+    "-IC:/x/src",
+]
+
+
+class TestCompileFlagsHash(unittest.TestCase):
+    def test_identical_args_hash_identically(self) -> None:
+        self.assertEqual(hash_compile_flags(BASE_ARGS), hash_compile_flags(BASE_ARGS))
+
+    def test_include_separator_spelling_changes_the_hash(self) -> None:
+        """The whole point: the two spellings must NOT collapse together.
+
+        The resolved dependency set is identical either way, so the input-file
+        hash cannot tell these apart. If this hash also cannot, the stale PCH
+        is reused and poisons the build.
+        """
+        backslashed = [a.replace("-IC:/x/src", "-IC:\\x\\src") for a in BASE_ARGS]
+        self.assertNotEqual(
+            hash_compile_flags(BASE_ARGS), hash_compile_flags(backslashed)
+        )
+
+    def test_added_include_root_changes_the_hash(self) -> None:
+        self.assertNotEqual(
+            hash_compile_flags(BASE_ARGS),
+            hash_compile_flags([*BASE_ARGS, "-IC:/x/tests"]),
+        )
+
+    def test_arg_boundaries_are_unambiguous(self) -> None:
+        """['-IC:/a', '-IC:/b'] must not hash like ['-IC:/a-IC:/b']."""
+        self.assertNotEqual(
+            hash_compile_flags(["-IC:/a", "-IC:/b"]),
+            hash_compile_flags(["-IC:/a-IC:/b"]),
+        )
+
+
+class TestNinjaStrictPathViolations(unittest.TestCase):
+    def _ninja(self, tmp: str, command: str) -> Path:
+        build_dir = Path(tmp)
+        (build_dir / "build.ninja").write_text(
+            f"rule CUSTOM_COMMAND\n  COMMAND = {command}\n", encoding="utf-8"
+        )
+        return build_dir
+
+    def test_clean_pch_command_is_accepted(self) -> None:
+        with TemporaryDirectory() as tmp:
+            build_dir = self._ninja(
+                tmp, '"python" "C:/x/ci/compile_pch.py" "-IC:/x/src"'
+            )
+            self.assertEqual(find_ninja_strict_path_violations(build_dir), [])
+
+    def test_backslash_include_in_pch_command_is_caught(self) -> None:
+        """This is the case compile_commands.json structurally cannot see.
+
+        The PCH is a Meson custom target, so its build command exists only in
+        build.ninja -- the consuming -include-pch flags are validated but the
+        flags it was built with were not.
+        """
+        with TemporaryDirectory() as tmp:
+            build_dir = self._ninja(
+                tmp, '"python" "C:/x/ci/compile_pch.py" "-IC:\\x\\src"'
+            )
+            self.assertTrue(find_ninja_strict_path_violations(build_dir))
+
+    def test_relative_include_is_caught(self) -> None:
+        with TemporaryDirectory() as tmp:
+            build_dir = self._ninja(tmp, '"python" "compile_pch.py" "-Isrc"')
+            self.assertTrue(find_ninja_strict_path_violations(build_dir))
+
+    def test_dot_components_are_caught(self) -> None:
+        with TemporaryDirectory() as tmp:
+            build_dir = self._ninja(tmp, '"python" "x.py" "-IC:/x/tests/../src"')
+            self.assertTrue(find_ninja_strict_path_violations(build_dir))
+
+    def test_missing_build_ninja_is_not_a_violation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(find_ninja_strict_path_violations(Path(tmp)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the recurring `error: redefinition of 'hsv8'` PCH poisoning, which until now was only survivable by hand-deleting the PCH and its sidecars.

## What I found — one correction to the premise

The starting theory was un-normalized paths. The paths turn out to be **fine**: `ci/meson/path_normalization.py` post-processes both `build.ninja` and `compile_commands.json`, and a scan of the live build dirs finds **zero** strict-path violations. Every `-I` is already forward-slash absolute.

The path spelling was still the right thread, though — just one step removed. The poisoning does not come from a bad spelling; it comes from the PCH cache being **blind to the spelling changing**.

## 1. The cache key omitted the compiler flags

`ci/compile_pch.py` skipped compilation whenever the input-file hash matched:

```python
if current_hash == stored_hash:
    print("PCH inputs unchanged (hash match) - skipping compilation")
    return 0
```

That hash cannot see a changed include spelling. The *resolved dependency set* is byte-identical either way, so the digest is identical, and the PCH built under the old spelling is handed to a TU resolving headers under the new one. `#pragma once` fails to dedupe and the build dies.

Args were excluded deliberately, and the docstring gave the reason:

> Note: compiler args are NOT included in this hash. Meson/Ninja already tracks compiler flag changes via build.ninja regeneration.

That reasoning doesn't hold. The build tool *does* reschedule the target when the command line changes — and then `compile_pch.py` vetoes the rebuild. **The veto was the bug.**

The rest of the docstring records a real constraint I had to respect: `invalidate_stale_pch` computes the same hash and never sees the args, so folding args into it made the two disagree and deleted every freshly built PCH. Hence a **separate** `.flags_hash` sidecar rather than a changed input hash.

Two deliberate choices:

- **The flags hash is not normalized.** Normalizing would collapse exactly the difference that must invalidate. This is the one place in the build where `C:/x/src` and `C:\x\src` must *not* compare equal.
- **A PCH with no flags sidecar is discarded**, so trees already poisoned self-heal on the next build instead of needing manual deletion.

The sibling `ci/wasm_compile_pch.py` has hashed its flags all along (`compute_flags_hash`), so this brings the native path in line with a pattern already proven in-repo.

## 2. The strict-path validator could not see the PCH build command

`find_strict_path_violations` scanned only `compile_commands.json`. The PCH is a Meson **custom target**, so it isn't there:

| | occurrences in `compile_commands.json` |
|---|---|
| `compile_pch.py` (the build command) | **0** |
| `-include-pch` (the consume flags) | **365** |

So the flags a PCH is *consumed* with were validated, and the flags it is *built* with were not — even though a mismatch between those two is the entire failure mode. Now `build.ninja` is scanned as well, being the only generated file that contains that command.

Measured **0 pre-existing violations** in both `meson-quick` and `meson-debug` before wiring it in, so it enforces at zero tolerance with no baseline.

## Verification

Both guards are only worth having if they fire, so I proved each does.

**End-to-end, against the real generated PCH command:**

```
--- run 1: unchanged flags (expect SKIP) ---
PCH inputs unchanged (hash match) - skipping compilation
--- run 2: one -I respelled (expect REBUILD, not silent reuse) ---
PCH compiler flags changed - rebuilding
```

Run 2 is the bug: it previously printed *"inputs unchanged - skipping"* and handed the build a poisoned PCH. Run 1 confirms there's no cache regression — unchanged builds still skip.

**Self-heal**, on the actually-poisoned tree that prompted this:

```
PCH tracking files missing — removing test_pch.h.pch to force rebuild
PCH tracking files missing — removing FastLED.h.pch to force rebuild
```

**`ci/tests/test_pch_staleness_guards.py`** — 9 new tests, including that the two separator spellings hash differently, that arg boundaries are unambiguous (`['-IC:/a','-IC:/b']` must not hash like `['-IC:/a-IC:/b']`), and that a backslash / relative / dot-component `-I` in a `build.ninja` PCH command is caught.

| check | result |
|---|---|
| `bash test --clean --cpp` | 276/276 unit, 83/83 examples — no redefinition errors |
| `uv run python -m pytest ci/tests/test_pch_staleness_guards.py ci/tests/test_meson_private_include_normalization.py` | 16 passed |
| `bash lint` | no blocking violations (40 pre-existing warn-only, unchanged) |

## Left alone deliberately

`ci/lint_meson/` has two checkers, `BackslashPathChecker` and `PathNormJoinChecker`, that give **contradictory advice** about whether Meson's `/` operator is safe on Windows. The generated `build.ninja` supports `BackslashPathChecker`'s premise. That contradiction wants resolving, but it is not what caused this bug and folding it in here would muddy the diff — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precompiled-header cache validation so changes to compiler options correctly trigger rebuilding.
  * Added stricter detection of invalid include paths in generated build commands, including commands not listed in compilation databases.
  * Removed stale cached build artifacts when required validation metadata is missing.

* **Tests**
  * Added coverage for compiler-option changes, include-path variations, and Ninja command path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->