### PR TITLE
fix(chipsets): give GS1903 its own timing instead of WS2812's (#739)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -417,9 +417,13 @@ template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class WS2812BV5 : public WS2812BV5Controller<DATA_PIN, RGB_ORDER> {};
 
 /// @brief GS1903 controller class.
-/// @copydetails WS2812Controller800Khz
+/// @copydetails GS1903Controller
+/// @note Previously an alias for WS2812Controller800Khz. The GS1903 datasheet
+///       specifies TH0=300ns / TH1=900ns with a ±50ns tolerance, so WS2812's
+///       250ns / 875ns fell outside the window and worked only by margin.
+///       See https://github.com/FastLED/FastLED/issues/739
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
-class GS1903 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
+class GS1903 : public GS1903Controller<DATA_PIN, RGB_ORDER> {};
 
 /// @brief SK6812 controller class.
 /// @copydetails SK6812Controller

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -583,6 +583,11 @@ class SK6812Controller : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>
 class SM16703Controller : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_SM16703, RGB_ORDER> {};
 
+/// GS1903 controller - references centralized timing from fl::TIMING_GS1903
+/// @see fl::TIMING_GS1903 in chipsets::led_timing.h (300, 600, 300 ns)
+template <int DATA_PIN, EOrder RGB_ORDER = RGB>
+class GS1903Controller : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_GS1903, RGB_ORDER> {};
+
 /// PL9823 controller - references centralized timing from fl::TIMING_PL9823
 /// @see fl::TIMING_PL9823 in chipsets::led_timing.h (350, 1010, 350 ns)
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>

--- a/src/fl/chipsets/led_timing.h
+++ b/src/fl/chipsets/led_timing.h
@@ -327,6 +327,24 @@ struct TIMING_SM16703 {
     };
 };
 
+/// GS1903 RGB controller @ 800 kHz (12 V)
+/// Four-phase: TH0=300ns, TH1=900ns, TL0=900ns, TL1=300ns, TRST>40µs
+/// @note Same bit timing as the SM16703, but the GS1903 datasheet specifies a
+///       ±50ns tolerance -- a third of the WS2812's ±150ns. That is why this
+///       has its own entry rather than reusing WS2812 timing: at TH0=250ns /
+///       TH1=875ns the WS2812 numbers sit outside the GS1903's window, which
+///       produced the intermittent "sometimes works, sometimes doesn't"
+///       behavior reported in issue #739.
+/// @see https://github.com/FastLED/FastLED/issues/739
+struct TIMING_GS1903 {
+    enum : u32 {
+        T1 = 300,
+        T2 = 600,
+        T3 = 300,
+        RESET = 280
+    };
+};
+
 /// SM16824E RGBW controller @ 800 kHz
 /// Four-phase: TH0=300ns, TH1=900ns, TL0=900ns, TL1=300ns, TRST=200µs
 /// Datasheet typicals are identical to the SM16703 / WS2811-800kHz RZ family,


### PR DESCRIPTION
Closes #739.

## Bug

`GS1903` was a plain alias for `WS2812Controller800Khz`, so it transmitted WS2812 bit timing. The datasheets don't match:

| | TH0 | TH1 | bit period | tolerance |
|---|---|---|---|---|
| **GS1903** | 300 ns | 900 ns | 1200 ns | **±50 ns** |
| **WS2812_800KHZ** (what it used) | 250 ns | 875 ns | 1250 ns | ±150 ns |

WS2812's TH0 is **50 ns off** and TH1 **25 ns off** — at or outside the GS1903's window, which is a third as forgiving. That produces exactly the reported symptom: mostly working, intermittently corrupt, and very sensitive to wiring and drive level.

The thread had already worked this out. @focalintent found a datasheet and told @Pfannex to try `SM16703` — whose FastLED timing is `300/600/300`, i.e. TH0=300 / TH1=900, the GS1903's numbers exactly. @Pfannex corroborated against a Chinese-language datasheet, measured with a logic analyser, and closed with:

> imho adding a real GS1903 makes sense

Six years later, here it is.

## Fix

Adds `TIMING_GS1903` + `GS1903Controller`, and repoints the `GS1903` alias at it.

**Why not just alias to `SM16703Controller`,** given identical bit timing: `TIMING_SM16703` has `RESET = 0`, while the outgoing WS2812 timing had `RESET = 280` (µs). Aliasing would silently drop the explicit latch gap *at the same time* as changing bit timing — two behavior changes at once, with the second one invisible. `TIMING_GS1903` keeps `RESET = 280`, comfortably above the datasheet's >40 µs requirement.

## Behavior change

Existing `GS1903` users get different timing. It moves **toward** the datasheet, so strips that previously worked only by margin should become more stable, not less. Anyone who was relying on the old behavior can still write `WS2812` explicitly.

## Verification

- `bash test --cpp --clean` — 359/359
- `bash compile uno` — AVR cycle-counted clockless path, 5036 B flash
- `bash lint` — clean

**Not verified on GS1903 silicon.** This is datasheet-driven, corroborated independently by two people in the thread, one of them with a logic analyser. Flagging that explicitly rather than implying hardware validation.

## Credit

@Pfannex for the report, the persistence, the datasheet hunt and the scope traces; @focalintent for spotting the SM16703 timing equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated support for GS1903 LED controllers.
  * Improved GS1903 signal timing accuracy, including reset timing and tolerance details.
  * Preserved compatibility with existing GS1903 usage while providing controller-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->