### PR TITLE
fix(esp8266): probe <SPI.h> in the guard that admits the Arduino SD backend

### DIFF
--- a/src/fl/system/sd/fs_sdcard_arduino.cpp.hpp
+++ b/src/fl/system/sd/fs_sdcard_arduino.cpp.hpp
@@ -6,7 +6,14 @@
 #include "fl/system/sd/fs_sdcard_arduino.h"
 #include "platforms/is_platform.h"
 
-#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)
+// <SPI.h> is probed alongside the others because this block includes it
+// unconditionally below. ESP8266 satisfied the SD.h/fs.h half of this guard --
+// its core ships an unrelated <fs.h> for the flash filesystem -- while SPI was
+// not on the include path, so the platform failed to build at all with
+// "fatal error: SPI.h: No such file or directory". Every header this block
+// needs has to be in the condition that admits it.
+#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>) &&      \
+    FL_HAS_INCLUDE(<SPI.h>)
 
 // IWYU pragma: begin_keep
 #include <SPI.h>


### PR DESCRIPTION
ESP8266 does not build at all on master. Found while trying to compile an example to investigate #743.

```
fs_sdcard_arduino.cpp.hpp:12:10: fatal error: SPI.h: No such file or directory
```

## Cause

`src/fl/system/sd/fs_sdcard_arduino.cpp.hpp:9` guarded the Arduino SD backend on two headers, then included a third unconditionally:

```cpp
#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)

// IWYU pragma: begin_keep
#include <SPI.h>
```

ESP8266 satisfies both probed terms — and `<fs.h>` for a reason that has nothing to do with SD cards, since the ESP8266 core ships its own unrelated `<fs.h>` for the flash filesystem. So the block was admitted, and then failed on the one header the guard never checked.

Adding `<SPI.h>` to the condition is the whole fix. Every header a block includes has to be in the condition that admits it.

**Blast radius is one-directional.** This only adds a term that is already true on platforms that have `SPI.h`, so they are unaffected. Platforms that lack it lose a block that could not compile there anyway.

## Validation (local, per the skip-GHA-for-src workflow)

| check | result |
|---|---|
| `bash compile esp8266 --examples ColorPalette` on master | **fails** — `fatal error: SPI.h` |
| `bash compile esp8266 --examples ColorPalette` here | **succeeds** (4m50s) |
| `bash test --cpp` | 359/359 unit + examples |
| `bash lint` | no blocking violations |

## Context: this was found investigating #743

#743 (2019) reports gradient palettes landing in RAM on ESP8266 because `FASTLED_USE_PROGMEM` defaults to `0`. While set up to check that, I confirmed the platform simply didn't compile.

For the record, since it settles #743 — objdump on the linked ESP8266 image from this branch:

```
40239f70 g  O .irom0.text  00000040 PartyColors_p
4023a030 g  O .irom0.text  00000040 CloudColors_p
```

`.irom0.text` is flash. The palettes are **not** in RAM.

The reason the setting says otherwise is that **it is not consulted on ESP8266 at all**. `src/fastled_progmem.h:8` dispatches on `defined(ESP8266)` *before* it ever tests `FASTLED_USE_PROGMEM`, so `progmem_esp8266.h` is included unconditionally and maps `FL_PROGMEM` / `FL_PGM_READ_*` onto the real `pgm_read_*` accessors regardless of the value. Setting it to `0` or `1` does not move a byte. The reporter read `# define FASTLED_USE_PROGMEM 0` and drew the only reasonable conclusion from it.

I did **not** correct that value here: `led_sysdefs_esp8266.h` is behind the `protect_platform_headers` hook, and overriding a deliberate guardrail for a documentation-grade change wants explicit sign-off rather than my judgement. Left as a note on #743 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented compilation issues when the required SPI header is unavailable in Arduino SD-card builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->