### PR TITLE
fix(gfx): make TProgmemHSVPalette a distinct type from TProgmemRGBPalette

### DIFF
--- a/src/fl/gfx/colorutils_misc.h
+++ b/src/fl/gfx/colorutils_misc.h
@@ -2,18 +2,38 @@
 
 #include "fl/stl/stdint.h"  // IWYU pragma: keep
 #include "fl/stl/int.h"  // IWYU pragma: keep
+#include "fl/stl/noexcept.h"  // IWYU pragma: keep
 
 // TODO: Figure out how to namespace these.
 typedef fl::u32 TProgmemRGBPalette16[16]; ///< CRGBPalette16 entries stored in
                                            ///< PROGMEM memory
-typedef fl::u32 TProgmemHSVPalette16[16]; ///< CHSVPalette16 entries stored in
-                                           ///< PROGMEM memory
+/// CHSVPalette16 entries stored in PROGMEM memory.
+///
+/// A distinct struct rather than another `fl::u32[16]` alias. When this was an
+/// array typedef it was *the same type* as TProgmemRGBPalette16 -- the names
+/// documented an intent the compiler could not enforce -- so an RGB progmem
+/// palette bound silently to every CHSV palette constructor and
+/// `loadProgmemPalette(CHSV*, ...)` copied red/green/blue straight into
+/// hue/sat/val. Reported as FastLED#807 in 2019.
+///
+/// The implicit conversion keeps every legitimate use working unchanged:
+/// brace initialisation, `pal[i]` indexing, and passing one where a
+/// `const fl::u32 *` is expected. Only the unsafe direction is now rejected,
+/// because a bare `fl::u32[16]` will no longer convert *to* this type.
+struct TProgmemHSVPalette16 {
+    fl::u32 entries[16];
+    operator const fl::u32 *() const FL_NO_EXCEPT { return entries; }
+};
 /// Alias for TProgmemRGBPalette16
 #define TProgmemPalette16 TProgmemRGBPalette16
 typedef fl::u32 TProgmemRGBPalette32[32]; ///< CRGBPalette32 entries stored in
                                            ///< PROGMEM memory
-typedef fl::u32 TProgmemHSVPalette32[32]; ///< CHSVPalette32 entries stored in
-                                           ///< PROGMEM memory
+/// CHSVPalette32 entries stored in PROGMEM memory.
+/// @copydetails TProgmemHSVPalette16
+struct TProgmemHSVPalette32 {
+    fl::u32 entries[32];
+    operator const fl::u32 *() const FL_NO_EXCEPT { return entries; }
+};
 /// Alias for TProgmemRGBPalette32
 #define TProgmemPalette32 TProgmemRGBPalette32
 

--- a/tests/fl/gfx/colorutils.cpp
+++ b/tests/fl/gfx/colorutils.cpp
@@ -253,3 +253,11 @@ FL_TEST_CASE("ColorFromPaletteHD supports existing RGB palette families") {
 }
 
 } // FL_TEST_FILE
+
+FL_TEST_CASE("RGB and HSV progmem palette types are distinct (issue #807)") {
+    // Both were `typedef fl::u32 X[16]`, i.e. THE SAME TYPE. So an RGB
+    // progmem palette bound silently to every CHSV palette constructor, and
+    // loadProgmemPalette(CHSV*, ...) reinterpreted red/green/blue as
+    // hue/sat/val -- garbage, with nothing to catch it.
+    FL_CHECK(!(fl::is_same<TProgmemRGBPalette16, TProgmemHSVPalette16>::value));
+}


### PR DESCRIPTION
Closes #807.

## The bug

```cpp
typedef fl::u32 TProgmemRGBPalette16[16];
typedef fl::u32 TProgmemHSVPalette16[16];
```

In C++ those are **one type with two names**. The distinction the names advertise was documentation the compiler could not enforce, so an RGB progmem palette bound silently to every `CHSVPalette` constructor and assignment operator. No overload could ever have separated them.

That is not a harmless alias, because the two loaders disagree about what the bits mean — `src/fl/gfx/colorutils.h:605-613`:

```cpp
inline void loadProgmemPalette(CHSV *entries, const fl::u32 *rhs, fl::u16 count) {
    for (fl::u16 i = 0; i < count; ++i) {
        CRGB xyz(FL_PGM_READ_DWORD_NEAR(rhs + i));
        entries[i].hue = xyz.red;
        entries[i].sat = xyz.green;
        entries[i].val = xyz.blue;
    }
}
```

So `CHSVPalette16 pal = CloudColors_p;` compiled cleanly and reinterpreted red/green/blue as hue/sat/val.

@ssilverman called this in 2019 without being able to name the cause:

> I'm aware that this may be automatically converting types, but I'm not convinced the results will be as expected. If `TProgmemRGBPalette16` is auto-converted to `TProgmemHSVPalette16` then the uint32_t values won't be correct.

There was no conversion at all — that was the problem. It was already the same type.

(The literal complaint in the issue title — `CHSVPalette256` taking a `TProgmemRGBPalette16` — was fixed at some point since; those signatures now read `TProgmemHSVPalette16`. It changed nothing, because the two spellings were interchangeable.)

## The fix

Make the **HSV** forms structs. The RGB typedefs are untouched: they are the widely used ones, and only one side of a pair has to differ for the pair to become distinguishable.

```cpp
struct TProgmemHSVPalette16 {
    fl::u32 entries[16];
    operator const fl::u32 *() const FL_NO_EXCEPT { return entries; }
};
```

The implicit conversion is what keeps this cheap. Every legitimate use works untouched — brace initialisation, `pal[i]` indexing, and passing one where a `const fl::u32 *` is expected. And it is deliberately **one-way**: a bare `fl::u32[16]` still will not convert *to* the struct, so only the unsafe direction is rejected.

**No call site needed changing.** Not one, in `src/` or `tests/` — the existing `kProgmemHsv16` / `kProgmemHsv32` fixtures and all six constructor/assignment sites compile as-is.

## Verified the test fails first

The new case asserts the two types differ. On the unfixed tree:

```
FAIL: RGB and HSV progmem palette types are distinct (issue #807)
      at ../../tests/fl/gfx/colorutils.cpp:257
```

so it exercises the real defect rather than restating the fix.

| check | result |
|---|---|
| `bash test --cpp` | 276/276 unit, 83/83 examples |
| `bash lint` | no blocking violations |

## Compatibility note

This is a deliberate, narrow source break: user code that declares its own `TProgmemHSVPalette16`/`32` **and** relies on it being literally `fl::u32[16]` in a context the conversion operator doesn't cover (e.g. `sizeof`, or binding to `fl::u32(&)[16]`) would need `.entries`. Brace init and indexing — the overwhelmingly common uses — are unaffected. The type has exactly one instance in this entire repo, so real-world exposure is minimal, and the break surfaces as a compile error at the misuse site rather than as wrong colours at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color palette type safety to prevent accidental interchange between RGB and HSV palettes.
  * Preserved existing palette indexing, initialization, and read-only access behavior.

* **Tests**
  * Added regression coverage confirming RGB and HSV palettes remain distinct and cannot be used interchangeably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->