### PR TITLE
fix(esp8266): unbreak all ESP8266 builds by guarding on SPI.h

### DIFF
--- a/src/fl/system/sd/fs_sdcard_arduino.cpp.hpp
+++ b/src/fl/system/sd/fs_sdcard_arduino.cpp.hpp
@@ -6,7 +6,11 @@
 #include "fl/system/sd/fs_sdcard_arduino.h"
 #include "platforms/is_platform.h"
 
-#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)
+// SPI.h is checked alongside SD.h/fs.h because the body below includes it
+// unconditionally. On ESP8266 both <SD.h> and <fs.h> resolve (fs.h is the
+// core's own filesystem header), so the guard passed while <SPI.h> was not on
+// the include path -- breaking every ESP8266 build, SD-card sketch or not.
+#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>) && FL_HAS_INCLUDE(<SPI.h>)
 
 // IWYU pragma: begin_keep
 #include <SPI.h>


### PR DESCRIPTION
## Bug

`bash compile esp8266` fails on current master, for **any** sketch:

```
lib/FastLED/fl/system/sd/fs_sdcard_arduino.cpp.hpp:12:10:
fatal error: SPI.h: No such file or directory
```

The Arduino SD backend is gated on:

```c
#if !defined(FL_IS_TEENSY) && FL_HAS_INCLUDE(<SD.h>) && FL_HAS_INCLUDE(<fs.h>)
```

Both resolve on ESP8266 — `fs.h` is the core's *own* filesystem header, and the core ships an SD library — so the guard opens. But the body then includes `<SPI.h>` unconditionally, and SPI isn't on the include path unless a sketch pulls it in.

Net effect: the SD translation unit failed to compile on **every ESP8266 build**, whether or not the sketch has anything to do with SD cards.

## Fix

Add `FL_HAS_INCLUDE(<SPI.h>)` to the guard, so it tests what the body actually requires.

This can only make the block compile in *fewer* configurations, never more — any platform newly excluded is one where `<SPI.h>` is absent, and there the body could not have compiled anyway.

## Verification

| check | result |
|---|---|
| `bash compile esp8266 --examples ColorPalette` | **hard failure → 269475 B flash / 28012 B RAM** |
| `bash compile teensy41 --examples Blink` | ✅ 72704 B, unchanged |
| `bash test --cpp --clean` | ✅ 359/359 |
| `bash lint` | ✅ clean |

**Not re-verified locally: esp32dev and uno.** The fbuild daemon wedged partway through this session (`daemon did not become healthy after 3 spawn attempts`). I confirmed those same commands fail identically on **unmodified master**, so the failures are environmental, not caused by this change — flagging it rather than implying coverage I don't have. CI will cover both.

Found while investigating #743, which needs a working ESP8266 build to assess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD-card compatibility checks to prevent builds when the required SPI support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->