### PR TITLE
chore(deps): bump zccache 1.12.17 -> 1.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,18 @@ dependencies = [
     # incremental builds produce stale .obj files after a git pull that
     # changes transitive headers (symptom: `undefined symbol: ...` link
     # errors hours after a header actually changed).
+    # 1.13.0 (released 2026-07-31): 163 commits since 1.12.17. Bumped for
+    # three fixes that map onto failures seen during long local sessions:
+    # the warm-cache deadlock and perf-watchdog fix (zackees/zccache#1151),
+    # which is the shape of the `embedded zccache compile timed out after
+    # 300s` wedge; shortened artifact locks with deferred metadata GC
+    # (#1180); and a daemon shutdown fix that drains the index-writer WAL
+    # instead of aborting it, alongside embedded-cache durability hardening
+    # (#1193). Also correctness-relevant: the C/C++ compiler binary identity
+    # is now part of the cache key (#1166), so a toolchain swap can no
+    # longer serve objects built by the previous compiler. Security: journal
+    # environments no longer persist secrets (#1179), and daemon-owned
+    # artifact retention is bounded (#1169).
     # 1.12.13 (released 2026-07-05): picks up running-process 4.5.8,
     # suppresses Windows console flashes during compiler identity probes,
     # and fixes daemon wedging on large-crate full-codegen misses
@@ -236,7 +248,7 @@ dependencies = [
     # `FileNotFoundError: meson_native.txt` / `ninja: error: rebuilding
     # 'build.ninja': subcommand failed` cascade we hit during long-session
     # `bash test --cpp` cycles.
-    "zccache>=1.12.15",
+    "zccache>=1.13.0",
     "ninja",
     "meson>=1.11.0",
     "download",


### PR DESCRIPTION
Closes #3819.

## What

Raise the `zccache` floor in `pyproject.toml` from `>=1.12.15` (resolving to **1.12.17**) to `>=1.13.0`, released upstream 2026-07-31 — **163 commits** further on.

`uv.lock` is gitignored in this repo, so the constraint in `pyproject.toml` is what actually moves resolution.

## Why

Three upstream fixes map onto build failures I hit repeatedly while compiling across boards in one session:

| upstream | fixes | symptom observed |
|---|---|---|
| [#1151](https://github.com/zackees/zccache/pull/1151) | warm-cache deadlock + perf watchdog | `embedded zccache compile timed out after 300s for .build/pio/uno/src/main.cpp` |
| [#1180](https://github.com/zackees/zccache/pull/1180) | shorter artifact locks, deferred metadata GC | stalls under concurrent compiles |
| [#1193](https://github.com/zackees/zccache/pull/1193) | embedded-cache durability; daemon drains the index-writer WAL instead of aborting it on shutdown | `daemon error: daemon did not become healthy after 3 spawn attempts (10s each)` |

Both symptoms were environmental rather than source-caused — I confirmed an unmodified-master control build failed identically — but they blocked verification work outright.

## The correctness item, which matters more than the perf ones

[#1166](https://github.com/zackees/zccache/pull/1166) — **the C/C++ compiler binary identity is now part of the cache key.**

Before this, swapping toolchains could serve cached objects built by the *previous* compiler. That's a silent-wrong-output bug, not a slow-build one, and it's especially relevant here because FastLED drives avr-gcc, arm-none-eabi-gcc, xtensa and host clang out of a single cache.

## Security

- [#1179](https://github.com/zackees/zccache/pull/1179) — journal environments no longer persist secrets.
- [#1169](https://github.com/zackees/zccache/pull/1169) — daemon-owned artifact retention is bounded.

## Out of scope

`fbuild` stays at **2.5.5**. It embeds its own zccache copy, and its pin-history comment records that zccache had "no tag past 1.12.17" when that pin was written — so realigning fbuild's embedded copy is a separate upstream concern.

## Verification

After `uv lock && uv sync` (`zccache` reports `1.13.0`):

| check | result |
|---|---|
| `bash test --cpp --clean` | ✅ 359/359 |
| `bash compile uno --examples Blink` | ✅ 5036 B — **this is the build that had been wedging** |
| `bash compile esp8266 --examples ColorPalette` | ✅ 269475 B |
| `bash lint` | ✅ clean |

One honesty note on that `uno` result: reinstalling also restarts the daemon, so I can't attribute the recovery to 1.13.0 alone from a single observation. The upstream fixes named above are the right shape for the failure, but treat it as consistent-with rather than proof-of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented release history to include version 1.13.0.
  * Clarified the minimum supported version requirement for compatibility.
* **Chores**
  * Refreshed project metadata to align with the latest supported release and ensure installations use the appropriate baseline version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->