### PR TITLE
docs(esp8266): correct the stale FASTLED_USE_PROGMEM claim (#743)

### DIFF
--- a/src/platforms/esp/8266/README.md
+++ b/src/platforms/esp/8266/README.md
@@ -17,10 +17,17 @@ ESP8266 family support (Xtensa).
 
 Notes:
 - Typical settings: `FASTLED_USE_PROGMEM=0`, `FASTLED_ALLOW_INTERRUPTS=1`; long ISRs will impact signal quality.
+- `FASTLED_USE_PROGMEM=0` does **not** mean constants live in RAM here — see below.
 
 ## Optional feature defines
 
-- **`FASTLED_USE_PROGMEM`**: Control PROGMEM usage. Default `0` in `led_sysdefs_esp8266.h`.
+- **`FASTLED_USE_PROGMEM`**: Default `0` in `led_sysdefs_esp8266.h`, but **vestigial on this platform** — it does not control data placement.
+
+  `fastled_progmem.h` dispatches on platform before testing the flag: its `#elif defined(ESP8266)` arm includes `progmem_esp8266.h`, which maps `FL_PROGMEM` to real `PROGMEM` and `FL_PGM_READ_*` to real `pgm_read_*`. The `#if (FASTLED_USE_PROGMEM == 1)` branch lives in an `#else` that ESP8266 never reaches.
+
+  So FastLED tables — palettes, gamma/sine LUTs, noise permutation tables — are flash-resident regardless. A `DEFINE_GRADIENT_PALETTE` links into `.irom0.text` (`0x402xxxxx`), not DRAM.
+
+  Setting it to `1` is a compile error (`platforms/esp/compile_test.hpp`), and would change nothing if it weren't. See [#743](https://github.com/FastLED/FastLED/issues/743).
 - **`FASTLED_ALLOW_INTERRUPTS`**: Allow interrupts during show. Default `1` in `led_sysdefs_esp8266.h`.
 - **`FASTLED_INTERRUPT_RETRY_COUNT`**: Max retries when a frame aborts due to long ISRs/NMIs. Default `2` (see `fastled_config.h`). Used by both single-lane and block drivers.
 

--- a/src/platforms/esp/8266/led_sysdefs_esp8266.h
+++ b/src/platforms/esp/8266/led_sysdefs_esp8266.h
@@ -19,7 +19,21 @@ typedef volatile fl::u32 RwReg;
 typedef fl::u32 prog_uint32_t;
 
 
-// Default to NOT using PROGMEM here
+// Vestigial on ESP8266 -- this value does NOT control data placement here.
+//
+// fastled_progmem.h dispatches on platform before it ever tests this flag:
+// its `#elif defined(ESP8266)` arm pulls in progmem_esp8266.h, which maps
+// FL_PROGMEM to real PROGMEM and FL_PGM_READ_* to real pgm_read_*. The
+// `#if (FASTLED_USE_PROGMEM == 1)` branch sits further down, inside an
+// `#else` that ESP8266 never reaches. FastLED tables are therefore
+// flash-resident on this platform regardless of the 0 below -- verified by
+// symbol placement: a DEFINE_GRADIENT_PALETTE lands in .irom0.text
+// (0x402xxxxx), not DRAM.
+//
+// Kept at 0 because platforms/esp/compile_test.hpp asserts it and user code
+// may branch on it. Do not read it as "ESP8266 keeps constants in RAM" --
+// that was true before the platform dispatch was added, and is exactly what
+// issue #743 reported.
 #ifndef FASTLED_USE_PROGMEM
 # define FASTLED_USE_PROGMEM 0
 #endif

--- a/src/platforms/esp/compile_test.hpp
+++ b/src/platforms/esp/compile_test.hpp
@@ -9,8 +9,14 @@ namespace fl {
 
 #ifdef ESP8266
 void esp8266_compile_tests() {
+// Pinned to 0, but note the flag is inert on ESP8266: fastled_progmem.h
+// selects progmem_esp8266.h from its `#elif defined(ESP8266)` arm, before
+// the `#if (FASTLED_USE_PROGMEM == 1)` test is ever reached. Tables are
+// flash-resident either way. This assert exists so the declared value and
+// the platform's real behavior don't drift further apart -- setting it to 1
+// would not move data, only make the header claim something new. See #743.
 #if FASTLED_USE_PROGMEM != 0
-#error "FASTLED_USE_PROGMEM should be 0 for ESP8266"
+#error "FASTLED_USE_PROGMEM must stay 0 on ESP8266 (it is inert there; PROGMEM is selected by platform dispatch in fastled_progmem.h, not by this flag)"
 #endif
 
 #if !defined(SKETCH_HAS_LARGE_MEMORY_OVERRIDDEN)


### PR DESCRIPTION
Closes #743. Comment-only; no behavior change.

## The report was right about the code, wrong about today

#743 says gradient palettes land in RAM on ESP8266, citing:

```c
// Default to NOT using PROGMEM here
#define FASTLED_USE_PROGMEM 0
```

The reporter read that correctly. **The comment is what's stale.**

`fastled_progmem.h` dispatches on *platform* before it ever tests the flag:

```c
#if defined(__EMSCRIPTEN__) || defined(FASTLED_TESTING) || defined(FASTLED_STUB_IMPL)
#include "platforms/null_progmem.h"
#elif defined(ESP8266)
#include "platforms/esp/8266/progmem_esp8266.h"   // <-- ESP8266 exits here
...
#else
    ...
    #if (FASTLED_USE_PROGMEM == 1)                // <-- never reached
```

`progmem_esp8266.h` maps `FL_PROGMEM` → real `PROGMEM` and `FL_PGM_READ_*` → real `pgm_read_*`. ESP8266 tables are flash-resident **regardless of the 0**.

## Measured, not inferred

Symbols from a linked ESP8266 image:

```
4023ac68  T  hot_gp                    (DEFINE_GRADIENT_PALETTE, Fire2023)
40239ef0  T  myRedWhiteBluePalette_p   (TProgmemPalette16, ColorPalette)
```

against the section map:

| section | VMA | region |
|---|---|---|
| `.data` | `0x3ffe8000` | DRAM |
| `.rodata` | `0x3ffe8620` | DRAM — **940 B total** |
| `.irom0.text` | `0x40201010` (242 KB) | **flash** |

Both palettes are in flash. RAM-resident `.rodata` across the entire image is under 1 KB.

## Changes

Three files, comments and one `#error` string:

- **`led_sysdefs_esp8266.h`** — replace the misleading one-liner with the dispatch explanation and the symbol evidence.
- **`README.md`** — same, plus a pointer from the "Typical settings: `FASTLED_USE_PROGMEM=0`" line so it doesn't read as "constants in RAM".
- **`compile_test.hpp`** — the assert **stays** (it's a useful drift guard), but its message now says the flag is inert instead of implying it controls placement.

I kept the assert rather than deleting it: pinning the declared value has value even when the value is inert, and flipping it to 1 would make the header claim something untrue without moving any data.

## Verification

| check | result |
|---|---|
| `bash compile esp8266 --examples ColorPalette` | **269475 B flash / 28012 B RAM — byte-identical to baseline** |
| forced `--defines FASTLED_USE_PROGMEM=1` | still errors, with the new message |
| `bash test --cpp --clean` | 359/359 |
| `bash lint` | clean |

## Note on the protected file

`led_sysdefs_esp8266.h` is guarded by `ci/hooks/protect_platform_headers.py`. I used the documented `FL_AGENT_ALLOW_PROTECTED_WRITE` override, deliberately and only because this is a comment-only edit to that file — flagging it so the override isn't invisible in review.

## What this does *not* claim

The ISR flash-cache hazard, the 2019 alignment crash, and the origin of the `0` are all covered in the [research writeup on the issue](https://github.com/FastLED/FastLED/issues/743#issuecomment-5153061708). Short version: the clockless output path reads zero PROGMEM and is `FL_IRAM`-placed; gradient palettes are 4-byte aligned via `FL_ALIGN_PROGMEM`; and the `0` arrived unexplained in the 2016 "ESP8266 first light" commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ESP8266 flash-memory behavior and platform-specific PROGMEM handling.
  * Documented that `FASTLED_USE_PROGMEM` is retained for compatibility and must remain set to `0`.
  * Added details about flash-resident gradient palette placement.
  * Improved compile-time guidance when the setting is changed incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->