### PR TITLE
fix(fastpin): make NO_PIN a constant instead of a macro

### DIFF
--- a/src/fl/system/fastpin.h
+++ b/src/fl/system/fastpin.h
@@ -14,11 +14,28 @@
 #pragma once
 
 #include "fl/stl/compiler_control.h"  // IWYU pragma: keep
+#include "fl/stl/int.h"  // IWYU pragma: keep
 #include "led_sysdefs.h"  // IWYU pragma: keep
 
-/// Constant for "not a pin"
-/// @todo Unused, remove?
-#define NO_PIN 255
+/// Constant for "not a pin".
+///
+/// Deliberately a constant and not a macro. As `#define NO_PIN 255` this
+/// replaced the token everywhere the preprocessor saw it, so any other
+/// library that used `NO_PIN` as an identifier -- an enumerator, a class
+/// member, a local -- failed to compile purely because FastLED.h had been
+/// included first. Reported as FastLED#893.
+///
+/// A constant obeys normal scoping instead. A colliding declaration inside
+/// another namespace, a class, or a function simply shadows this one, which
+/// is what the authors of that code expected. (A second declaration at
+/// global scope still conflicts -- unqualified lookup finds both and reports
+/// an ambiguity -- but that is an ordinary, diagnosable name clash rather
+/// than the preprocessor rewriting a token it had no business touching.)
+///
+/// Kept at namespace scope under the original spelling rather than deleted,
+/// so sketches that already reference NO_PIN continue to build. Nothing
+/// inside FastLED uses it.
+constexpr fl::u8 NO_PIN = 255;
 
 // Include base class definitions (Selectable, FastPin<>, FastPinBB, __FL_PORT_INFO, etc.)
 #include "fl/system/fastpin_base.h"  // IWYU pragma: keep

--- a/tests/fl/system/fastpin.cpp
+++ b/tests/fl/system/fastpin.cpp
@@ -1,0 +1,42 @@
+#include "FastLED.h"
+#include "test.h"
+
+// Issue #893: NO_PIN was `#define NO_PIN 255`, so the preprocessor replaced
+// that token everywhere and any other library using NO_PIN as an identifier
+// failed to compile merely because FastLED.h had been included first.
+//
+// Everything below is a compile-time assertion first and a runtime one
+// second: as a macro, none of these declarations parse at all -- each reads
+// as `255` where a name belongs.
+
+#ifdef NO_PIN
+#error "NO_PIN must be a constant, not a macro -- see FastLED#893"
+#endif
+
+namespace other_library {
+// The shape from the report: an enumerator named NO_PIN.
+enum PinSentinel { NO_PIN = 7 };
+}  // namespace other_library
+
+namespace another_library {
+// A class member, the other common shape.
+struct Config {
+    int NO_PIN = 3;
+};
+}  // namespace another_library
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+FL_TEST_CASE("NO_PIN is a constant, so other libraries can reuse the name (#893)") {
+    FL_CHECK_EQ(int(::NO_PIN), 255);
+    FL_CHECK_EQ(int(other_library::NO_PIN), 7);
+    FL_CHECK_EQ(another_library::Config().NO_PIN, 3);
+}
+
+FL_TEST_CASE("a local named NO_PIN shadows the global (#893)") {
+    const int NO_PIN = 42;  // impossible while it was a macro
+    FL_CHECK_EQ(NO_PIN, 42);
+    FL_CHECK_EQ(int(::NO_PIN), 255);
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
Closes #893.

## The bug

`src/fl/system/fastpin.h:21`, unchanged since the report:

```cpp
/// Constant for "not a pin"
/// @todo Unused, remove?
#define NO_PIN 255
```

As a macro this replaces the token everywhere the preprocessor sees it. Any other library using `NO_PIN` as an identifier fails to compile purely because `FastLED.h` was included first — `enum { NO_PIN = 7 }` reads as `enum { 255 = 7 }`.

@tttapa reported this in 2019 and @kriegsman agreed to change it. Six years later it's still a macro, still unused, and the `@todo` sitting next to it already says so.

**Confirmed unused:** `grep -rnw NO_PIN src/ examples/ tests/` returns exactly one line — the definition itself. Nothing in FastLED has ever referenced it.

## The fix

`constexpr fl::u8 NO_PIN = 255;` — the reporter's own suggestion, kept at the original spelling and global scope rather than deleted, so sketches that already reference `NO_PIN` keep building.

## One caveat, stated rather than glossed

A constant obeys normal scoping, so a colliding declaration in a **namespace, class, or function** shadows it cleanly. But a second declaration at **global** scope still conflicts — unqualified lookup finds both and reports an ambiguity.

That's still a real improvement: an ordinary, diagnosable name clash instead of the preprocessor rewriting a token it had no business touching. But it isn't "all collisions fixed", and the header comment now says exactly that.

I found this out the honest way — my first version of the test put the colliding enum in an anonymous namespace, which injects into global scope, and the compiler said:

```
error: reference to 'NO_PIN' is ambiguous
```

Rather than quietly reword the test, that behaviour is now what the test and the comment describe.

## The test asserts at compile time first

```cpp
#ifdef NO_PIN
#error "NO_PIN must be a constant, not a macro -- see FastLED#893"
#endif

namespace other_library { enum PinSentinel { NO_PIN = 7 }; }
namespace another_library { struct Config { int NO_PIN = 3; }; }
```

Each of those collision shapes — enumerator, class member, and a local in the test body — fails to *parse* if this is ever reverted to a macro. The runtime `FL_CHECK_EQ`s are secondary.

| check | result |
|---|---|
| `bash test --cpp` | 278/278 unit, 83/83 examples |
| `bash lint` | no blocking violations |
| `bash compile uno --examples Blink` | succeeds |

`fastpin.h` reaches every platform, so this was checked on the most constrained one rather than natively only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced the global `NO_PIN` macro with a scoped constant to prevent naming conflicts with other libraries.
  * Preserved existing pin-handling behavior while allowing enums, members, and identifiers named `NO_PIN`.

* **Tests**
  * Added regression coverage confirming the constant works globally, within namespaces, and in shadowing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->