### PR TITLE
test(spi): pin SPI chipset instantiation across the data-rate range

### DIFF
--- a/tests/fl/channels/bus_traits.cpp
+++ b/tests/fl/channels/bus_traits.cpp
@@ -122,4 +122,32 @@ FL_TEST_CASE("enableDrivers<Bus::BIT_BANG>() is idempotent") {
     FL_CHECK(registered2.get() == &fl::BusTraits<fl::Bus::BIT_BANG>::instance());
 }
 
+
+// Issues #974 and #976: `template instantiation depth exceeds maximum` when a
+// software-SPI chipset was given an explicit data rate. delaycycles<N> used to
+// recurse linearly (N -> N-1); it now splits binary, with <0>/<1>/<2> base
+// cases present in every translation unit.
+//
+// Scope note, so this is not mistaken for full coverage: FASTLED_STUB_IMPL is
+// in the *hardware* SPI branch of fastspi.h, so DATA_RATE_KHZ here expands to
+// a frequency, not to the cycles-per-bit divider that fed delaycycles. These
+// cases pin the template surface -- that every rate, including the
+// pathological ones from the reports, instantiates -- but the software-SPI
+// path that actually broke can only be exercised by compiling for a
+// software-SPI platform. Verified there by hand:
+// `bash compile uno --examples Apa102` with DATA_RATE_KHZ(1).
+
+FL_TEST_CASE("SPI chipsets instantiate across the data-rate range (#974, #976)") {
+    static CRGB slowest[8];
+    static CRGB slow[8];
+    static CRGB mid[8];
+    static CRGB fast[8];
+    // DATA_RATE_KHZ(1) is the exact rate from #976.
+    auto& a = FastLED.addLeds<SK9822, 23, 18, BGR, DATA_RATE_KHZ(1)>(slowest, 8);
+    auto& b = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_KHZ(500)>(slow, 8);
+    auto& c = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(1)>(mid, 8);
+    auto& d = FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(24)>(fast, 8);
+    (void)a; (void)b; (void)c; (void)d;
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
Addresses #974 and #976 — both `template instantiation depth exceeds maximum` when a software-SPI chipset is given an explicit data rate, on Teensy and ESP32 respectively.

## Both are fixed

`delaycycles<N>` used to recurse linearly (`N -> N-1`), which is exactly the chain in #974's log:

```
void delaycycles() [with int CYCLES = 2147482745]
  recursively required from 'void delaycycles() [with int CYCLES = 2147483640]'
```

It now splits binary — `delaycycles<N/2>() + delaycycles<N - N/2>()` — with `<0>`/`<1>`/`<2>` base cases present in **every** translation unit, so depth is logarithmic. `src/platforms/shared/delay_cycles_generic.h:40-52` carries a good comment on why those base cases must be per-TU.

**Verified on a software-SPI platform, not assumed.** I temporarily gave `examples/Apa102` the `DATA_RATE_KHZ(1)` from the reports and ran `bash compile uno --examples Apa102` — succeeds in 31s. Reverted after.

## Why they lasted six years

Not a hard bug — a coverage hole:

- **No example anywhere passes a data rate at all.** `grep -rn "DATA_RATE_KHZ\|DATA_RATE_MHZ" examples/` returns nothing.
- The only tests that did used a single *fast* rate (`DATA_RATE_MHZ(12)`).

So the 83-example compile matrix, across every board, never once instantiated the path that broke.

## What this adds

SK9822 and APA102 across `DATA_RATE_KHZ(1)` — the exact rate from #976 — through `DATA_RATE_MHZ(24)`.

## Scoped deliberately, and the test says so

This is the part I want reviewed rather than skimmed. `FASTLED_STUB_IMPL` is in the **hardware**-SPI branch of `fastspi.h:78`:

```c
#elif defined(FASTLED_TEENSY4) || defined(ESP32) || ... || defined(FASTLED_STUB_IMPL)
#define FL_DATA_RATE_KHZ(X) (1000 * (X))
```

so natively `DATA_RATE_KHZ` expands to a *frequency*, not to the cycles-per-bit divider that fed `delaycycles`. These cases pin the template surface — that every rate, including the pathological ones, instantiates — but they **cannot** reach the software-SPI path that actually broke.

I caught that after writing a native test and nearly reporting it as proof. It isn't. The genuine guard needs a platform compile, and the natural home for one (`examples/CompileTest/`) is itself dead — see #3816. The test comment states this so nobody later reads it as coverage it doesn't provide.

## Related finding, not fixed here

`delaycycles` is loop-based on AVR (`_delaycycles_avr<CYCLES/3, CYCLES%3>`) but the generic path force-inlines N NOPs via the binary split. On a non-AVR software-SPI platform a slow rate therefore emits tens of thousands of inlined NOPs — it compiles, but the code-size cost is large and silent. That's Teensy 3.x, exactly #974's board. Worth its own look; I haven't measured it on hardware-class flash so I'm not asserting a number.

| check | result |
|---|---|
| `bash test --cpp` | 277/277 unit, 83/83 examples |
| `bash lint` | no blocking violations |
| `bash compile uno --examples Apa102` with `DATA_RATE_KHZ(1)` | succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added compile-time coverage for SPI chipset configurations across data rates from 1 kHz to 24 MHz.
  * Included rates that help validate compatibility with deep template instantiations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->