### PR TITLE
fix(controller): clear every lane of a parallel controller, not just the first

### DIFF
--- a/src/cled_controller.cpp.hpp
+++ b/src/cled_controller.cpp.hpp
@@ -58,7 +58,19 @@ bool CLEDController::isInList() const {
 
 void CLEDController::clearLedDataInternal(int nLeds) {
     // On common code that runs on avr, every byte counts.
-    fl::u16 n = nLeds >= 0 ? static_cast<fl::u16>(nLeds) : static_cast<fl::u16>(mLeds.size());
+    //
+    // mLeds spans one lane, not the whole buffer. A parallel controller is
+    // registered with the PER-LANE count -- addLeds<NUM_LANES, ...>(data,
+    // nLeds) forwards nLeds -- while the caller's array is NUM_LANES * nLeds.
+    // Clearing mLeds.size() therefore blanked only the first strip and left
+    // the rest lit, which is FastLED#1017.
+    //
+    // lanes() is 1 for every ordinary controller, so this is a no-op there. It
+    // reports the template lane count on parallel controllers, which is what
+    // the caller allocated, so this cannot run past the end of their array
+    // even when fewer lanes were actually claimed.
+    fl::u16 n = nLeds >= 0 ? static_cast<fl::u16>(nLeds)
+                           : static_cast<fl::u16>(mLeds.size() * lanes());
     if (mLeds.data()) {
         fl::memset((void*)mLeds.data(), 0, sizeof(CRGB) * n);
     }

--- a/tests/cled_controller.cpp
+++ b/tests/cled_controller.cpp
@@ -1,0 +1,68 @@
+/// Regression test for FastLED#1017: FastLED.clear() / clearData() blanked
+/// only the first strip when a parallel (multi-lane) controller was in use.
+///
+/// A parallel controller is registered with the PER-LANE led count --
+/// addLeds<NUM_LANES, CHIPSET, PIN, ORDER>(data, nLeds) forwards nLeds -- while
+/// the caller's array is NUM_LANES * nLeds. clearLedDataInternal() cleared
+/// mLeds.size(), i.e. one lane, and left the rest lit.
+///
+/// The real multi-lane path is Teensy-only (__FASTLED_HAS_FIBCC is defined
+/// only for mxrt1062), so it cannot be instantiated here. What IS portable is
+/// the mechanism: a controller reporting lanes() > 1 must have its whole
+/// buffer cleared. That is what these exercise.
+
+#include "FastLED.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+namespace {
+
+/// Stands in for a parallel controller: registered with the per-lane count,
+/// backed by an array LANES times larger, exactly as the Teensy block
+/// controllers are.
+class FakeParallelController : public CLEDController {
+  public:
+    explicit FakeParallelController(int lanes) : mLanes(lanes) {}
+    int lanes() FL_NO_EXCEPT override { return mLanes; }
+    void showColor(const CRGB &, int, fl::u8) FL_NO_EXCEPT override {}
+    void show(const CRGB *, int, fl::u8) FL_NO_EXCEPT override {}
+    void init() FL_NO_EXCEPT override {}
+
+  private:
+    int mLanes;
+};
+
+}  // namespace
+
+FL_TEST_CASE("clearLedData clears every lane of a parallel controller (#1017)") {
+    constexpr int kLanes = 4;
+    constexpr int kPerLane = 8;
+    static CRGB buffer[kLanes * kPerLane];
+    for (auto &px : buffer) { px = CRGB::White; }
+
+    FakeParallelController ctrl(kLanes);
+    ctrl.setLeds(buffer, kPerLane);  // per-lane count, as addLeds does
+    ctrl.clearLedDataInternal();  // what CFastLED::clearData() calls
+
+    int still_lit = 0;
+    for (const auto &px : buffer) {
+        if (px != CRGB(0, 0, 0)) { ++still_lit; }
+    }
+    // Before the fix this was 24: lanes 1..3 were untouched.
+    FL_CHECK_EQ(still_lit, 0);
+}
+
+FL_TEST_CASE("clearLedData on a single-lane controller is unchanged (#1017)") {
+    constexpr int kLeds = 8;
+    static CRGB buffer[kLeds];
+    for (auto &px : buffer) { px = CRGB::White; }
+
+    FakeParallelController ctrl(1);
+    ctrl.setLeds(buffer, kLeds);
+    ctrl.clearLedDataInternal();  // what CFastLED::clearData() calls
+
+    for (const auto &px : buffer) { FL_CHECK_EQ(px, CRGB(0, 0, 0)); }
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
Closes #1017.

## The bug

`clearData()` walks the controller list correctly. The **controller** was under-reporting its extent.

A parallel controller is registered with the **per-lane** count — `FastLED.h:1201` forwards `nLeds` straight through:

```cpp
static ::CLEDController &addLeds(CRGB *data, int nLeds) {
    static fl::__FIBCC<CHIPSET, DATA_PIN, NUM_LANES, RGB_ORDER> c;
    return addLeds(&c, data, nLeds);        // per-lane, not NUM_LANES * nLeds
}
```

while the caller's array is `NUM_LANES * nLeds`. So `mLeds` spans one lane, and `clearLedDataInternal` zeroing `mLeds.size()` blanked lane 0 and left the rest lit — exactly what @NiekLambert reported with four strips, and what @MartyMacGyver traced to `m_nLeds` in 2020.

## The fix

Multiply by `lanes()`. It's `1` for every ordinary controller, so nothing changes there. On a parallel controller it reports the template lane count — which is what the caller allocated — so it cannot run past the end of their buffer even when fewer lanes were claimed at runtime.

## Why `lanes()` and not `size()`

The parallel controllers already have a `size()` that returns the total, e.g. `block_clockless_arm_mxrt1062.h:38`:

```cpp
virtual int size() { return CLEDController::size() * mNActualLanes; }
```

**That is not an override.** The base is `virtual int size() const` (`cled_controller.h:298`) — the derived one is non-`const`, so it's a different signature. It *hides* the base rather than overriding it, and a call through a `CLEDController*` still gets the per-lane count.

This is not isolated. **All eight** parallel/block controllers do it:

```
arm/k20/clockless_block_arm_k20.h:63
arm/k20/octows2811_controller.h:36
arm/k66/clockless_block_arm_k66.h:69
arm/mxrt1062/block_clockless_arm_mxrt1062.h:39
arm/mxrt1062/octows2811_controller.h:35
arm/sam/clockless_block_arm_sam.h:59
arm/teensy/teensy31_32/clockless_block_arm_k20.h:51
arm/teensy/teensy31_32/octows2811_controller.h:36
```

`lanes()` by contrast is declared `int lanes() override` in `cpixel_ledcontroller.h:68`, so it genuinely dispatches. Hence this fix routes through the one that works.

**I have deliberately not fixed the `size()` hiding here**, because it isn't only cosmetic — `power_mgt.cpp.hpp:216` calls it through a base pointer:

```cpp
total_mW += calculate_unscaled_power_mW( pCur->leds(), pCur->size());
```

so power limiting currently under-counts by a factor of NUM_LANES on every parallel setup. Adding `const` would correct that *and* start engaging power limiting where it previously didn't — strips could visibly dim. That is a behaviour change on hardware I can't test, and it wants a maintainer's call rather than being smuggled into a clear() fix. Filing separately.

## Testing

The real multi-lane path is Teensy-only (`__FASTLED_HAS_FIBCC` is defined only for mxrt1062), so it cannot be instantiated natively. The test covers the portable mechanism instead: a controller reporting `lanes() > 1` must have its whole buffer cleared.

Verified it fails on the unfixed code rather than assuming:

```
FAIL: clearLedData clears every lane of a parallel controller (#1017)
[doctest] test cases: 2 | 1 passed | 1 failed
```

The 4-lane case fails, the 1-lane case passes — so it's detecting the defect, not just exercising the code.

| check | result |
|---|---|
| `bash test --clean --cpp` | 279/279 unit, 83/83 examples |
| `bash lint` | no blocking violations |
| `bash compile teensy41 --examples Blink` | succeeds (2m12s) |

Teensy 4.1 built locally since this touches the platform the report came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LED buffer clearing for parallel controllers so all lanes are cleared when no specific LED count is provided.
  * Preserved existing behavior when an explicit LED count is specified.

* **Tests**
  * Added regression coverage for multi-lane and single-lane controller buffer clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->