### PR TITLE
fix(attiny): drop unreachable pin-map listings for 4KB parts (#973)

### DIFF
--- a/src/platforms/avr/attiny/pins/fastpin_attiny.h
+++ b/src/platforms/avr/attiny/pins/fastpin_attiny.h
@@ -212,10 +212,21 @@ _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19,
 #define SPI_UART0_CLOCK 12
 #endif
 
+// The tinyAVR 2K and 4K parts (ATtiny2YZ / ATtiny4YZ) are deliberately caught
+// here, BEFORE the pin-map arms below, and are left with no pin definitions.
+// A minimal FastLED Blink links to ~4.8KB on this family, so a 4KB part cannot
+// hold the library at all -- see #973. FastPin<> is intentionally left
+// unspecialized so the failure is a compile error rather than a link-time
+// overflow.
+//
+// Do NOT list any part from this arm in the pin-map arms below: the #elif chain
+// reaches this one first, so a duplicate listing there is unreachable and only
+// creates the false impression that the part is supported (which is exactly the
+// confusion #973 ran into).
 #elif defined(__AVR_ATtiny202__) || defined(__AVR_ATtiny204__) || defined(__AVR_ATtiny212__) || defined(__AVR_ATtiny214__)  || defined(__AVR_ATtiny402__) || defined(__AVR_ATtiny404__) || defined(__AVR_ATtiny406__) || defined(__AVR_ATtiny407__) || defined(__AVR_ATtiny412__) || defined(__AVR_ATtiny414__) || defined(__AVR_ATtiny416__) || defined(__AVR_ATtiny417__)
 #pragma message "ATtiny2YZ or ATtiny4YZ have very limited storage. This library could use up to more than 100% of its flash size"
 
-#elif defined(__AVR_ATtinyxy4__) || defined(__AVR_ATtiny1604__) || defined(__AVR_ATtiny804__) || defined(__AVR_ATtiny404__)
+#elif defined(__AVR_ATtinyxy4__) || defined(__AVR_ATtiny1604__) || defined(__AVR_ATtiny804__)
 #define MAX_PIN 12
 _FL_DEFPIN( 0, 4, A); _FL_DEFPIN( 1, 5, A); _FL_DEFPIN( 2, 6, A); _FL_DEFPIN( 3, 7, A);
 _FL_DEFPIN( 4, 3, B); _FL_DEFPIN( 5, 2, B); _FL_DEFPIN( 6, 1, B); _FL_DEFPIN( 7, 0, B);
@@ -228,7 +239,7 @@ _FL_DEFPIN( 8, 1, A); _FL_DEFPIN( 9, 2, A); _FL_DEFPIN(10, 3, A); _FL_DEFPIN(11,
 #define AVR_HARDWARE_SPI 1
 #define HAS_HARDWARE_PIN_SUPPORT 1
 
-#elif defined(__AVR_ATtinyxy6__) || defined(__AVR_ATtiny1616__) || defined(__AVR_ATtiny816__) || defined(__AVR_ATtiny416__) || defined(__AVR_ATtiny3216__)
+#elif defined(__AVR_ATtinyxy6__) || defined(__AVR_ATtiny1616__) || defined(__AVR_ATtiny816__) || defined(__AVR_ATtiny3216__)
 
 #define MAX_PIN 18
 _FL_DEFPIN( 0, 4, A); _FL_DEFPIN( 1, 5, A); _FL_DEFPIN( 2, 6, A); _FL_DEFPIN( 3, 7, A);


### PR DESCRIPTION
Found while investigating #973.

`ATtiny404` and `ATtiny416` are each listed **twice** in the `#elif` chain in `fastpin_attiny.h`: once in the *"ATtiny2YZ or ATtiny4YZ have very limited storage"* arm (line 215), and again in the `xy4` / `xy6` pin-map arms below it (lines 218 / 231). The chain reaches the limited-storage arm first, so **the later listings are unreachable** — those parts never got a pin map and never could.

Harmless at compile time, but actively misleading when reading the file: it scans as though 404/416 are supported. That misreading has already happened once — #973 was answered with *"FastLED has pin maps for the full megaTinyCore family (ATtiny412/414/416/417/...)"*, when in fact **every one of those four lands in the no-pin-definitions arm**.

### The limited-storage arm is correct — this is not a bug to fix the other way

A minimal `Blink` links to **4885 bytes** of flash on this family (measured, `attiny1616`). A 4KB part cannot hold the library at all. Leaving `FastPin<>` unspecialised turns that into a compile error rather than a link-time overflow, which is the better failure. Same reasoning that closed #581 for the ATtiny13.

So the fix is to delete the two dead listings and document the ordering constraint at the arm itself, so nobody re-adds them.

### Verification — provably inert

Rebuilt `Blink` for both supported boards in this family and compared `firmware.elf` against the same build from unmodified master:

| Board | master | this branch | |
|---|---|---|---|
| ATtiny1616 | `8feac31b8d6ab5e9…` | `8feac31b8d6ab5e9…` | identical |
| ATtiny1604 | `17e30b0db565f98f…` | `17e30b0db565f98f…` | identical |

Flash/RAM unchanged: 1616 = 4885 B / 257 B, 1604 = 4839 B / 225 B.

> One note on method: my *first* ATtiny1604 baseline hashed `4a3c5b1…`, which looked like a real difference. It was a cold-cache first-build artifact — rebuilding on **unmodified** master also yields `17e30b0…`. Recording that because a single-shot before/after hash on a cold cache would have produced a false positive here.

`bash lint` clean (only pre-existing warn-only violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported TinyAVR 2YZ/4YZ devices from compiling with invalid pin mappings.
  * Corrected device-specific pin-map assignments for ATtiny404 and ATtiny416.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->