### PR TITLE
fix(spi): clamp bit-bang clock-high delay instead of wrapping (#974)

### DIFF
--- a/src/platforms/shared/spi_bitbang/generic_software_spi.h
+++ b/src/platforms/shared/spi_bitbang/generic_software_spi.h
@@ -156,10 +156,28 @@ public:
 	/// We want to make sure that the clock pulse is held high for a minimum of 35 ns.
 	#define MIN_DELAY ((NS(35)>3) ? (NS(35) - 3) : 1)
 
+	/// Half the requested bit period, in cycles, for SPI_SPEED > 10.
+	#define FL_SPI_HALF_PERIOD ((SPI_SPEED - 6) / 2)
+
+	/// Extra cycles to add on top of MIN_DELAY to reach the requested half period.
+	///
+	/// SPI_SPEED is unsigned, so `FL_SPI_HALF_PERIOD - MIN_DELAY` wraps to ~4e9
+	/// whenever the requested half period is shorter than the 35ns minimum
+	/// pulse -- which then becomes the CYCLES template argument of
+	/// delaycycles<>. That is the #974 failure: on a Teensy 3.6 (180 MHz,
+	/// MIN_DELAY = 4) a plain DATA_RATE_MHZ(4) yields SPI_SPEED = 12, so
+	/// (12-6)/2 - 4 = -1 wraps to 4294967295 cycles of NOP. Clamp to zero
+	/// instead: MIN_DELAY has already been emitted and it is longer than the
+	/// half period being asked for, so no additional delay is owed.
+	#define FL_SPI_HI_EXTRA_DELAY \
+		((SPI_SPEED > 10) \
+			? ((FL_SPI_HALF_PERIOD > MIN_DELAY) ? (FL_SPI_HALF_PERIOD - MIN_DELAY) : 0) \
+			: (SPI_SPEED))
+
 	/// Delay for the clock signal 'high' period
-	#define CLOCK_HI_DELAY do { delaycycles<MIN_DELAY>(); delaycycles<((SPI_SPEED > 10) ? (((SPI_SPEED-6) / 2) - MIN_DELAY) : (SPI_SPEED))>(); } while(0);
+	#define CLOCK_HI_DELAY do { delaycycles<MIN_DELAY>(); delaycycles<FL_SPI_HI_EXTRA_DELAY>(); } while(0);
 	/// Delay for the clock signal 'low' period
-	#define CLOCK_LO_DELAY do { delaycycles<((SPI_SPEED > 10) ? ((SPI_SPEED-6) / 2) : (SPI_SPEED))>(); } while(0);
+	#define CLOCK_LO_DELAY do { delaycycles<((SPI_SPEED > 10) ? FL_SPI_HALF_PERIOD : (SPI_SPEED))>(); } while(0);
 #endif
 
 	/// Write the BIT'th bit out via SPI, setting the data pin then strobing the clock


### PR DESCRIPTION
Addresses the surviving tail of #974.

## What #974 reported

Software SPI (explicit DATA+CLOCK pins) on Teensy failed to compile with `template instantiation depth exceeds maximum`, recursing on `delaycycles<2147482745>`. The huge `CYCLES` came from an unsigned underflow in `CLOCK_HI_DELAY`.

## What is already fixed

Two independent changes since 2020 handle the reported case:

1. **The `SPI_SPEED > 10` guard** routes small values away from the subtraction, so the report's own `SPI_SPEED == 1` no longer underflows.
2. **`delaycycles<>` now binary-splits** (`N -> N/2 + N-N/2`) instead of recursing linearly by 1, so depth is logarithmic and the *depth* diagnostic can no longer occur.

## What is not fixed — and is reachable

The guard only covers the low end. A window survives where `SPI_SPEED` clears 10 but `(SPI_SPEED-6)/2` is still below `MIN_DELAY`:

```c
#define MIN_DELAY ((NS(35)>3) ? (NS(35) - 3) : 1)
delaycycles<((SPI_SPEED > 10) ? (((SPI_SPEED-6) / 2) - MIN_DELAY) : (SPI_SPEED))>();
```

`SPI_SPEED` is an unsigned template parameter, so that subtraction wraps. On a **Teensy 3.6 at 180 MHz** (`MIN_DELAY == 4`), a plain **`DATA_RATE_MHZ(4)`** gives `SPI_SPEED == 12`:

```
(12 - 6) / 2 - 4  ->  -1  ->  4294967295
```

Evaluated across the range with the real types:

| SPI_SPEED | before | after |
|---:|---:|---:|
| 1 | 1 | 1 |
| 8 | 8 | 8 |
| **11** | **4294967294** | 0 |
| **12** | **4294967295** | 0 |
| **13** | **4294967295** | 0 |
| 16 | 1 | 1 |
| 24 | 5 | 5 |
| 48 | 17 | 17 |

Note this no longer surfaces as the *depth* error from the original report. Because `cycle_t` is `i64` on non-AVR, the wrapped `u32` converts to a large **positive** value, so the `<=0` base-case specialisations never catch it — and with binary splitting the compiler now dutifully tries to emit ~4.29 billion inlined `NOP`s. The failure mode got quieter, not safer.

## The fix

Clamp to zero. `MIN_DELAY` has already been emitted at that point and is *longer* than the half period being requested, so no additional delay is owed. Clock-high becomes `max(MIN_DELAY, half_period)`, which is what the code intended.

Also hoists the twice-repeated `(SPI_SPEED-6)/2` into `FL_SPI_HALF_PERIOD` so the high and low delays cannot drift apart.

Behavior is unchanged for every `SPI_SPEED` outside the broken window (table above).

## Verification

- `bash test --cpp` — 279/279 unit, 83/83 examples
- `bash compile teensy31 --examples Blink` — success
- `bash lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI timing reliability for very short clock periods.
  * Prevented timing calculations from underflowing, helping maintain stable communication across supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->