### PR TITLE
feat(rp2350w): add board and transport foundation

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -49,6 +49,7 @@ from ci.util.port_utils import (
     auto_detect_upload_port,
     detect_attached_chip,
     environment_has_wifi,
+    get_port_serial_number,
     kill_port_users,
     port_exists,
 )
@@ -69,6 +70,23 @@ if TYPE_CHECKING:
 # unwind cleanly before we kill the process. Per session 2026-06-22 spec.
 WATCHDOG_GRACE_SECONDS = 20.0
 FLEX_IO_TEENSY_DEFAULT_TX_PIN = 6
+RP2040_ENVIRONMENTS = frozenset({"rp2040", "rpipico", "rpipicow"})
+RP2350_ENVIRONMENTS = frozenset({"rp2350", "rpipico2", "rp2350w", "rpipico2w"})
+RP2XXX_ENVIRONMENTS = RP2040_ENVIRONMENTS | RP2350_ENVIRONMENTS
+
+
+def _active_rp2xxx_environment(environment: str | None) -> str | None:
+    normalized = (environment or "").strip().lower()
+    return normalized if normalized in RP2XXX_ENVIRONMENTS else None
+
+
+def _canonical_board_environment(environment: str | None) -> str | None:
+    """Resolve a real PlatformIO board alias to its registered CI environment."""
+    if not environment:
+        return None
+    from ci.boards import create_board
+
+    return create_board(environment.strip()).board_name
 
 
 def _is_teensy4_environment(final_environment: str | None) -> bool:
@@ -85,8 +103,7 @@ def _driver_name_for_environment(
         return "SPI_UNIFIED"
     if (
         driver == "FLEX_IO"
-        and final_environment is not None
-        and final_environment.lower() in ("rp2040", "rpipico", "rp2350", "rpipico2")
+        and _active_rp2xxx_environment(final_environment) is not None
     ):
         # RP exposes two independent PIO engines as PIO0 and PIO1.  Their
         # concrete names must remain distinct so a runtime-exclusive test can
@@ -388,7 +405,9 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         args.uart = True
         args.lpuart = False
 
-    final_environment = args.environment_positional or args.environment
+    final_environment = _canonical_board_environment(
+        args.environment_positional or args.environment
+    )
 
     if args.lcd and not final_environment:
         final_environment = "esp32s3"
@@ -486,12 +505,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.object_fled:
             drivers.append("OBJECT_FLED")
         if args.flex_io:
-            is_rp = final_environment is not None and final_environment.lower() in (
-                "rp2040",
-                "rpipico",
-                "rp2350",
-                "rpipico2",
-            )
+            is_rp = _active_rp2xxx_environment(final_environment) is not None
             if args.rp_pio_both and is_rp:
                 drivers.extend(("PIO0", "PIO1"))
             else:
@@ -1177,12 +1191,13 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
     is_teensy = (
         ctx.final_environment is not None and "teensy" in ctx.final_environment.lower()
     )
-    stock_rp2040_transport = (args.rpc_smoke or args.watchdog_soak) and (
-        (ctx.final_environment or "").lower() in {"rp2040", "rpipico"}
+    rp2xxx_environment = _active_rp2xxx_environment(ctx.final_environment)
+    stock_rp2xxx_transport = bool(rp2xxx_environment) and (
+        args.rpc_smoke or args.watchdog_soak
     )
 
     upload_port = args.upload_port
-    if not upload_port and not stock_rp2040_transport:
+    if not upload_port and not stock_rp2xxx_transport:
         expected_environment = None if is_teensy else ctx.final_environment
         max_wait_s = 60
         poll_interval_s = 1.0
@@ -1253,9 +1268,9 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
 
         upload_port = result.selected_port
 
-    if stock_rp2040_transport and not upload_port:
+    if stock_rp2xxx_transport and not upload_port:
         print(
-            "📦 Stock RP2040 transport: no pre-deploy serial port required; "
+            f"📦 Stock {rp2xxx_environment} transport: no pre-deploy serial port required; "
             "fbuild will discover RPI-RP2 and return the application CDC port."
         )
     else:
@@ -1311,6 +1326,8 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
                 )
                 return 1
         print()
+
+    ctx.final_environment = _canonical_board_environment(ctx.final_environment)
 
     if args.use_root_platformio_ini and _reject_teensy_root_platformio_ini(
         ctx.final_environment
@@ -1595,19 +1612,34 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     """
     args = ctx.args
     upload_port = ctx.upload_port
+    rp2xxx_environment = _active_rp2xxx_environment(ctx.final_environment)
     if (
         upload_port is None
         and (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode)
         and ctx.use_fbuild
+        and rp2xxx_environment is not None
     ):
-        # Stock RP2040 deployment starts from BOOTSEL mass-storage and may
+        # Stock RP2xxx deployment starts from BOOTSEL mass-storage and may
         # return before Windows has published the application CDC endpoint.
-        # Re-scan by USB identity instead of asserting on the pre-deploy port.
-        result = auto_detect_upload_port(expected_environment="rp2040")
-        if result.selected_port:
-            upload_port = result.selected_port
-            ctx.upload_port = upload_port
-            print(f"✅ Discovered RP2040 application port: {upload_port}")
+        # Poll by USB identity instead of asserting on the pre-deploy port.
+        wait_seconds = min(10.0, ctx.remaining_seconds())
+        deadline = time.monotonic() + max(0.0, wait_seconds)
+        while True:
+            result = await asyncio.to_thread(
+                auto_detect_upload_port,
+                expected_environment=rp2xxx_environment,
+            )
+            if result.selected_port:
+                upload_port = result.selected_port
+                ctx.upload_port = upload_port
+                print(
+                    f"✅ Discovered {rp2xxx_environment} application port: "
+                    f"{upload_port}"
+                )
+                break
+            if time.monotonic() >= deadline:
+                break
+            await asyncio.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
     if upload_port is None:
         print("❌ No application serial port was returned after fbuild deployment")
         return 1
@@ -1920,9 +1952,13 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
         ):
             raise RpcError("ping uptime did not advance monotonically")
 
+        active_environment = (
+            _active_rp2xxx_environment(ctx.final_environment) or "rp2040"
+        )
+        chip_number = 2350 if active_environment in RP2350_ENVIRONMENTS else 2040
         payload = {
-            "text": "rp2040-rpc-smoke",
-            "number": 2040,
+            "text": f"{active_environment}-rpc-smoke",
+            "number": chip_number,
             "nested": {"ok": True, "values": [1, 2, 3]},
         }
         echoed = await call("debugTest", payload)
@@ -1979,6 +2015,7 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
     if not old_port:
         print("RESULT: watchdog soak FAIL: no application port")
         return 1
+    original_serial_number = get_port_serial_number(old_port)
     from ci.util.serial_interface import create_serial_interface
 
     # Do not reuse a pre-deploy adapter after fbuild has re-enumerated CDC.
@@ -2021,9 +2058,17 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
     while time.monotonic() < deadline and port_exists(old_port):
         await asyncio.sleep(0.1)
     print(f"WATCHDOG: application port disconnected={not port_exists(old_port)}")
+    expected_environment = _active_rp2xxx_environment(ctx.final_environment)
+    if expected_environment is None:
+        print("RESULT: watchdog soak FAIL: active environment is not RP2xxx")
+        return 1
     new_port: str | None = None
     while time.monotonic() < deadline:
-        detected = await asyncio.to_thread(auto_detect_upload_port, "rp2040")
+        detected = await asyncio.to_thread(
+            auto_detect_upload_port,
+            expected_environment,
+            expected_serial_number=original_serial_number,
+        )
         candidate = detected.selected_port
         if candidate and (not port_exists(old_port) or candidate != old_port):
             new_port = candidate

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1196,6 +1196,17 @@ RPI_PICO2 = Board(
     board_build_filesystem_size="0.5m",
 )
 
+RPI_PICO2_W = Board(
+    board_name="rp2350w",
+    real_board_name="rpipico2w",
+    platform="https://github.com/maxgerhardt/platform-raspberrypi.git",
+    platform_needs_install=True,  # Install platform package to get the boards
+    platform_packages="framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/4.5.3/rp2040-4.5.3.zip",
+    framework="arduino",
+    board_build_core="earlephilhower",
+    board_build_filesystem_size="0.5m",
+)
+
 # NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc
 # platform, so use the FastLED fork (transferred from zackees/ in 2026-06-28) that
 # layers framework-arduino-lpc8xx on top of

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -26,6 +26,7 @@ from ci.autoresearch.phases import (
     _run_build_deploy,
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
+    _run_watchdog_soak,
     _validate_test_rpc_response,
 )
 from ci.rpc_client import RpcError
@@ -726,13 +727,25 @@ class TestParseArgsAndBuildCommands:
         assert command["params"]["driver"] == "FLEX_IO"
         assert "pinTx" not in command["params"]
 
-    def test_flex_io_driver_name_maps_to_pio1_on_rp2040(
-        self, fake_project_dir: Path
+    @pytest.mark.parametrize(
+        "environment",
+        (
+            "rp2040",
+            "rpipico",
+            "rpipicow",
+            "rp2350",
+            "rpipico2",
+            "rp2350w",
+            "rpipico2w",
+        ),
+    )
+    def test_flex_io_driver_name_maps_to_pio1_on_rp2xxx_aliases(
+        self, fake_project_dir: Path, environment: str
     ) -> None:
         args = _make_args(
             parlio=False,
             flex_io=True,
-            environment_positional="rp2040",
+            environment_positional=environment,
             project_dir=fake_project_dir,
             use_root_platformio_ini=False,
         )
@@ -762,16 +775,29 @@ class TestParseArgsAndBuildCommands:
         assert result.drivers == ["PIO0"]
         assert result.json_rpc_commands[0]["params"]["driver"] == "PIO0"
 
-    def test_rp_pio_both_generates_one_parallel_command(
-        self, fake_project_dir: Path
+    @pytest.mark.parametrize(
+        "environment",
+        (
+            "rp2040",
+            "rpipico",
+            "rpipicow",
+            "rp2350",
+            "rpipico2",
+            "rp2350w",
+            "rpipico2w",
+        ),
+    )
+    def test_rp_pio_both_generates_one_parallel_command_for_rp2xxx_aliases(
+        self, fake_project_dir: Path, environment: str
     ) -> None:
         args = _make_args(
             parlio=False,
             flex_io=True,
             rp_pio_both=True,
             parallel=True,
-            environment_positional="rp2040",
+            environment_positional=environment,
             project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
         )
         with patch(
             "ci.autoresearch.staging.synthesise_autoresearch_project",
@@ -1069,6 +1095,44 @@ class TestParseArgsAndBuildCommands:
         )
         assert result.build_dir == fake_build_dir
 
+    @pytest.mark.parametrize(
+        ("requested_environment", "canonical_environment"),
+        (
+            ("rpipico", "rp2040"),
+            ("rpipico2", "rp2350"),
+            ("rpipico2w", "rp2350w"),
+        ),
+    )
+    def test_rp_board_alias_stages_the_canonical_environment(
+        self,
+        tmp_path: Path,
+        requested_environment: str,
+        canonical_environment: str,
+    ) -> None:
+        (tmp_path / "examples" / "AutoResearch").mkdir(parents=True)
+        fake_build_dir = tmp_path / ".build" / "pio" / canonical_environment
+        fake_build_dir.mkdir(parents=True)
+        args = _make_args(
+            environment_positional=requested_environment,
+            project_dir=tmp_path,
+            use_root_platformio_ini=False,
+        )
+
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_build_dir,
+        ) as mock_synth:
+            result = _parse_args_and_build_commands(args)
+
+        assert isinstance(result, RunContext)
+        assert result.final_environment == canonical_environment
+        mock_synth.assert_called_once_with(
+            canonical_environment,
+            project_root=tmp_path.resolve(),
+            verbose=False,
+            extra_defines=[],
+        )
+
     def test_synthesised_path_defers_when_board_unknown(self, tmp_path: Path) -> None:
         """When the board is NOT known up-front (no positional, no --env,
         no --lcd*) and the legacy flag is OFF, parse-time synthesis must NOT
@@ -1200,6 +1264,38 @@ class TestResolvePortAndEnvironment:
         assert rc is None
         assert ctx.upload_port == "COM9"
         auto_detect.assert_called_once_with(expected_environment="esp32c6")
+
+    @pytest.mark.parametrize(
+        "environment", ("rp2350", "rpipico2", "rp2350w", "rpipico2w")
+    )
+    def test_rp2xxx_rpc_smoke_allows_fbuild_no_port_transport(
+        self, environment: str
+    ) -> None:
+        args = _make_args(
+            environment=environment,
+            upload_port=None,
+            parlio=False,
+            rpc_smoke=True,
+        )
+        ctx = _make_ctx(
+            args=args,
+            final_environment=environment,
+            upload_port=None,
+            rpc_smoke_mode=True,
+        )
+
+        with (
+            patch(f"{_PATCH_MOD}.auto_detect_upload_port") as auto_detect,
+            patch(
+                f"{_PATCH_MOD}.select_build_driver",
+                return_value=_make_mock_driver(),
+            ),
+        ):
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+
+        assert rc is None
+        assert ctx.upload_port is None
+        auto_detect.assert_not_called()
 
     def test_ws2814_deferred_synthesis_injects_rmt_binding(
         self, tmp_path: Path
@@ -1481,6 +1577,22 @@ class TestAutoDetectUploadPort:
         assert result.ok is True
         assert result.selected_port == "COM11"
 
+    def test_rp2040_rejects_rp2350_application_cdc_fingerprint(self) -> None:
+        rp2350 = ListPortInfo("COM12")
+        rp2350.description = "USB Serial Device"
+        rp2350.hwid = "USB VID:PID=2E8A:000F"
+        rp2350.vid = 0x2E8A
+        rp2350.pid = 0x000F
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[rp2350],
+        ):
+            result = auto_detect_upload_port("rp2040")
+
+        assert result.ok is False
+        assert result.selected_port is None
+
     def test_rpipico2_application_cdc_fingerprint_matches(self) -> None:
         port = ListPortInfo("COM12")
         port.description = "USB Serial Device"
@@ -1494,6 +1606,142 @@ class TestAutoDetectUploadPort:
             result = auto_detect_upload_port("rpipico2")
         assert result.ok is True
         assert result.selected_port == "COM12"
+
+    @pytest.mark.parametrize(
+        ("environment", "pid"),
+        (
+            ("rp2350", 0x000F),
+            ("rpipico2", 0x000F),
+            ("rp2350w", 0xF00F),
+            ("rpipico2w", 0xF00F),
+        ),
+    )
+    def test_rp2350_aliases_accept_board_exact_application_cdc_fingerprint(
+        self, environment: str, pid: int
+    ) -> None:
+        port = ListPortInfo("COM17")
+        port.description = "USB Serial Device"
+        port.hwid = f"USB VID:PID=2E8A:{pid:04X}"
+        port.vid = 0x2E8A
+        port.pid = pid
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[port],
+        ):
+            result = auto_detect_upload_port(environment)
+
+        assert result.ok is True
+        assert result.selected_port == "COM17"
+
+    @pytest.mark.parametrize(
+        ("environment", "wrong_pid"),
+        (("rp2350", 0xF00F), ("rp2350w", 0x000F)),
+    )
+    def test_rp2350_variants_reject_each_others_application_identity(
+        self, environment: str, wrong_pid: int
+    ) -> None:
+        other_variant = ListPortInfo("COM12")
+        other_variant.description = "USB Serial Device"
+        other_variant.hwid = f"USB VID:PID=2E8A:{wrong_pid:04X}"
+        other_variant.vid = 0x2E8A
+        other_variant.pid = wrong_pid
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[other_variant],
+        ):
+            result = auto_detect_upload_port(environment)
+
+        assert result.ok is False
+        assert result.selected_port is None
+
+    def test_rp2350w_strict_fingerprint_skips_unrelated_usb_serial(self) -> None:
+        unrelated = ListPortInfo("COM11")
+        unrelated.description = "Silicon Labs CP210x USB to UART Bridge"
+        unrelated.hwid = "USB VID:PID=10C4:EA60"
+        unrelated.vid = 0x10C4
+        unrelated.pid = 0xEA60
+
+        rp2350 = ListPortInfo("COM17")
+        rp2350.description = "USB Serial Device"
+        rp2350.hwid = "USB VID:PID=2E8A:F00F"
+        rp2350.vid = 0x2E8A
+        rp2350.pid = 0xF00F
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[unrelated, rp2350],
+        ):
+            result = auto_detect_upload_port("rp2350w")
+
+        assert result.ok is True
+        assert result.selected_port == "COM17"
+
+    def test_rp2350_strict_fingerprint_skips_attached_esp32c6(self) -> None:
+        esp32c6 = ListPortInfo("COM9")
+        esp32c6.description = "USB JTAG/serial debug unit"
+        esp32c6.hwid = "USB VID:PID=303A:1001"
+        esp32c6.vid = 0x303A
+        esp32c6.pid = 0x1001
+
+        rp2350 = ListPortInfo("COM17")
+        rp2350.description = "USB Serial Device"
+        rp2350.hwid = "USB VID:PID=2E8A:F00F"
+        rp2350.vid = 0x2E8A
+        rp2350.pid = 0xF00F
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[esp32c6, rp2350],
+        ):
+            result = auto_detect_upload_port("rp2350w")
+
+        assert result.ok is True
+        assert result.selected_port == "COM17"
+
+    def test_rp2350_strict_fingerprint_rejects_unrelated_usb_serial(self) -> None:
+        unrelated = ListPortInfo("COM11")
+        unrelated.description = "Silicon Labs CP210x USB to UART Bridge"
+        unrelated.hwid = "USB VID:PID=10C4:EA60"
+        unrelated.vid = 0x10C4
+        unrelated.pid = 0xEA60
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[unrelated],
+        ):
+            result = auto_detect_upload_port("rp2350")
+
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "2E8A:000F" in (result.error_message or "")
+
+    def test_rp2350w_serial_identity_selects_original_board(self) -> None:
+        replacement = ListPortInfo("COM18")
+        replacement.description = "USB Serial Device"
+        replacement.hwid = "USB VID:PID=2E8A:F00F"
+        replacement.vid = 0x2E8A
+        replacement.pid = 0xF00F
+        replacement.serial_number = "OTHER-RP2350W"
+
+        original = ListPortInfo("COM19")
+        original.description = "USB Serial Device"
+        original.hwid = "USB VID:PID=2E8A:F00F"
+        original.vid = 0x2E8A
+        original.pid = 0xF00F
+        original.serial_number = "2DCB876B587EA334"
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[replacement, original],
+        ):
+            result = auto_detect_upload_port(
+                "rp2350w", expected_serial_number="2DCB876B587EA334"
+            )
+
+        assert result.ok is True
+        assert result.selected_port == "COM19"
 
     def test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches(self) -> None:
         """LPC845-BRK with LPC-Link2 CMSIS-DAP firmware (1FC9:0132) is accepted.
@@ -1556,6 +1804,20 @@ class TestRunBuildDeploy:
         assert rc is None
         mock_driver.install_packages.assert_called_once()
         mock_driver.deploy.assert_called_once()
+
+    def test_canonical_rp2350w_environment_is_used_for_fbuild_deploy(self) -> None:
+        mock_driver = _make_mock_driver()
+        ctx = _make_ctx(
+            args=_make_args(skip_lint=True),
+            build_driver=mock_driver,
+            final_environment="rp2350w",
+        )
+        qctx = QuietContext(quiet=False)
+
+        rc = asyncio.run(_run_build_deploy(ctx, qctx))
+
+        assert rc is None
+        assert mock_driver.deploy.call_args.kwargs["environment"] == "rp2350w"
 
     def test_build_deploy_install_failure(self) -> None:
         mock_driver = _make_mock_driver(install_ok=False)
@@ -1621,6 +1883,34 @@ class TestRunBuildDeploy:
 
 class TestRunSchemaAndPinSetup:
     """Test _run_schema_and_pin_setup (mocks RPC client)."""
+
+    def test_rp2350_postdeploy_rescan_polls_until_cdc_appears(self) -> None:
+        ctx = _make_ctx(
+            final_environment="rp2350",
+            upload_port=None,
+            use_fbuild=True,
+            rpc_smoke_mode=True,
+        )
+        missed = MagicMock(selected_port=None)
+        discovered = MagicMock(selected_port="COM17")
+
+        with (
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port",
+                side_effect=[missed, missed, discovered],
+            ) as auto_detect,
+            patch(
+                "ci.util.serial_interface.create_serial_interface",
+                return_value=MagicMock(),
+            ),
+            patch(f"{_PATCH_MOD}.CrashTraceDecoder", return_value=MagicMock()),
+        ):
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+
+        assert rc is None
+        assert ctx.upload_port == "COM17"
+        assert auto_detect.call_count == 3
+        auto_detect.assert_called_with(expected_environment="rp2350")
 
     def test_cli_pin_override(self) -> None:
         args = _make_args(tx_pin=3, rx_pin=4, skip_schema=True)
@@ -1904,8 +2194,13 @@ class TestRunTestsOrSpecialMode:
         assert rc == 0
 
     def test_rpc_smoke_mode_validates_core_surface(self) -> None:
-        ctx = _make_ctx(rpc_smoke_mode=True)
+        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="rp2350")
         qctx = QuietContext(quiet=False)
+        expected_payload = {
+            "text": "rp2350-rpc-smoke",
+            "number": 2350,
+            "nested": {"ok": True, "values": [1, 2, 3]},
+        }
 
         def response(data):
             item = MagicMock()
@@ -1920,15 +2215,7 @@ class TestRunTestsOrSpecialMode:
                 response([{"name": "ping"}]),
                 response({"uptimeMs": 1}),
                 response({"uptimeMs": 2}),
-                response(
-                    {
-                        "received": {
-                            "text": "rp2040-rpc-smoke",
-                            "number": 2040,
-                            "nested": {"ok": True, "values": [1, 2, 3]},
-                        }
-                    }
-                ),
+                response({"received": expected_payload}),
                 response({"ready": True}),
                 response([]),
                 response({"success": True}),
@@ -1944,6 +2231,65 @@ class TestRunTestsOrSpecialMode:
 
         assert rc == 0
         assert mock_client.send.await_count == 9
+        debug_test_call = mock_client.send.await_args_list[4]
+        assert debug_test_call.args == ("debugTest",)
+        assert debug_test_call.kwargs["args"] == expected_payload
+
+    def test_rp2350_watchdog_reacquires_active_environment_and_device(self) -> None:
+        ctx = _make_ctx(
+            final_environment="rp2350w",
+            upload_port="COM17",
+            use_fbuild=True,
+            watchdog_soak_mode=True,
+        )
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        initial_client = AsyncMock()
+        initial_client.send = AsyncMock(
+            side_effect=[
+                response({"uptimeMs": 100}),
+                response({"success": True}),
+            ]
+        )
+        recovery_client = AsyncMock()
+        recovery_client.send = AsyncMock(return_value=response({"uptimeMs": 1}))
+        detected = MagicMock(selected_port="COM18")
+
+        with (
+            patch(
+                "ci.util.serial_interface.create_serial_interface",
+                return_value=MagicMock(),
+            ),
+            patch(
+                f"{_PATCH_MOD}.RpcClient",
+                side_effect=[initial_client, recovery_client],
+            ),
+            patch(f"{_PATCH_MOD}.port_exists", return_value=False),
+            patch(
+                f"{_PATCH_MOD}.get_port_serial_number",
+                return_value="2DCB876B587EA334",
+            ),
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port", return_value=detected
+            ) as auto_detect,
+            patch(
+                f"{_PATCH_MOD}._run_rpc_smoke_tests",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+        ):
+            rc = asyncio.run(_run_watchdog_soak(ctx))
+
+        assert rc == 0
+        assert ctx.upload_port == "COM18"
+        auto_detect.assert_called_once_with(
+            "rp2350w", expected_serial_number="2DCB876B587EA334"
+        )
 
     def test_ble_mode_delegates(self) -> None:
         ctx = _make_ctx(ble_mode=True)

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -1,0 +1,59 @@
+"""Board-definition contracts for Raspberry Pi Pico 2 and Pico 2 W."""
+
+from pathlib import Path
+
+from ci.boards import create_board
+from ci.compiler.sketch_filter import parse_filter_from_sketch, should_skip_sketch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUTORESEARCH_INO = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
+AUTORESEARCH_PLATFORM = (
+    REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchPlatform.h"
+)
+
+
+def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
+    board = create_board("rp2350w")
+
+    assert board.board_name == "rp2350w"
+    assert board.real_board_name == "rpipico2w"
+    assert board.framework == "arduino"
+    assert board.board_build_core == "earlephilhower"
+    assert board.platform_packages is not None
+    assert "arduino-pico/releases/download/4.5.3/rp2040-4.5.3.zip" in (
+        board.platform_packages
+    )
+
+    ini = board.to_platformio_ini()
+    assert "[env:rp2350w]" in ini
+    assert "board = rpipico2w" in ini
+    assert "board_build.core = earlephilhower" in ini
+
+
+def test_rp2350_and_rp2350w_keep_distinct_board_profiles() -> None:
+    pico_2 = create_board("rp2350")
+    pico_2_w = create_board("rp2350w")
+
+    assert pico_2.real_board_name == "rpipico2"
+    assert pico_2_w.real_board_name == "rpipico2w"
+    assert pico_2.get_real_board_name() != pico_2_w.get_real_board_name()
+
+
+def test_autoresearch_filter_admits_both_rp2350_profiles() -> None:
+    sketch_filter = parse_filter_from_sketch(AUTORESEARCH_INO)
+
+    assert sketch_filter is not None
+    for environment in ("rp2350", "rp2350w"):
+        skip, reason = should_skip_sketch(create_board(environment), sketch_filter)
+        assert skip is False, reason
+
+
+def test_autoresearch_identity_prioritizes_pico_2_w() -> None:
+    source = AUTORESEARCH_PLATFORM.read_text(encoding="utf-8")
+    pico_2_w_branch = source.index("defined(ARDUINO_RASPBERRY_PI_PICO_2W)")
+    generic_rp2350_branch = source.index("defined(FL_IS_RP2350)")
+
+    assert pico_2_w_branch < generic_rp2350_branch
+    assert 'return "Raspberry Pi Pico 2 W (RP2350)";' in source
+    assert 'return "RP2350";' in source

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -64,11 +64,16 @@ ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
     # and is intentionally not a serial port). Keep this fingerprint strict:
     # falling back to an arbitrary CP210x/CH340 port can run RPC against a
     # different attached board.
-    "rp2040": ((0x2E8A, 0x000A), (0x2E8A, 0x000F)),
+    "rp2040": ((0x2E8A, 0x000A),),
     "rpipico": ((0x2E8A, 0x000A),),
     "rpipicow": ((0x2E8A, 0x000A),),
+    # Arduino-Pico assigns distinct application CDC identities to Pico 2
+    # and Pico 2 W. Keep them board-exact so a non-W RP2350 cannot be
+    # selected for an rp2350w run when both variants are attached.
+    "rp2350": ((0x2E8A, 0x000F),),
     "rpipico2": ((0x2E8A, 0x000F),),
-    "rpipico2w": ((0x2E8A, 0x000F),),
+    "rp2350w": ((0x2E8A, 0xF00F),),
+    "rpipico2w": ((0x2E8A, 0xF00F),),
     # LPC8xx family: the on-board debug probe can be either
     #   * LPC11U35 running the LPCXpresso VCOM firmware — 16C0:0483
     #     (the community "V-USB" VID:PID; shared with PJRC Teensy).
@@ -140,7 +145,29 @@ def port_exists(port: str) -> bool:
     return port in names or stripped in names
 
 
-def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
+def get_port_serial_number(port: str) -> str | None:
+    """Return the USB serial identity for an enumerated application port."""
+    stripped = port.replace("\\\\.\\", "").replace("\\.\\", "")
+    try:
+        for candidate in serial.tools.list_ports.comports():
+            candidate_name = candidate.device.replace("\\\\.\\", "").replace(
+                "\\.\\", ""
+            )
+            if candidate_name == stripped:
+                return candidate.serial_number
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        return None
+    return None
+
+
+def auto_detect_upload_port(
+    expected_environment: str | None,
+    *,
+    expected_serial_number: str | None = None,
+) -> ComportResult:
     """Auto-detect the upload port from available serial ports.
 
     Only considers USB devices - filters out Bluetooth and other non-USB ports.
@@ -152,6 +179,11 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
         - CH340/CH341 (WCH)
         - FTDI chips
         - Generic USB-Serial converters
+
+    Args:
+        expected_environment: Board environment used for strict fingerprinting.
+        expected_serial_number: Optional stable USB identity that a matching
+            board must retain across re-enumeration.
 
     Returns:
         ComportResult with detection status and diagnostics
@@ -219,7 +251,11 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
     if expected_vid_pids:
         accepted = set(expected_vid_pids)
         for port in usb_ports:
-            if (port.vid, port.pid) in accepted:
+            serial_matches = (
+                expected_serial_number is None
+                or port.serial_number == expected_serial_number
+            )
+            if (port.vid, port.pid) in accepted and serial_matches:
                 return ComportResult(
                     ok=True,
                     selected_port=port.device,
@@ -237,7 +273,13 @@ def auto_detect_upload_port(expected_environment: str | None) -> ComportResult:
             selected_port=None,
             error_message=(
                 f"No USB serial port matched expected VCOM fingerprint for "
-                f"'{expected_environment}' (VID:PID {formatted_expected}). "
+                f"'{expected_environment}' (VID:PID {formatted_expected}"
+                + (
+                    f", serial {expected_serial_number}"
+                    if expected_serial_number
+                    else ""
+                )
+                + "). "
                 f"Detected USB ports: "
                 + ", ".join(
                     f"{p.device}={p.vid:04X}:{p.pid:04X}"

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -1,6 +1,6 @@
 // @filter
 // require:
-//   - board: esp32s3,esp32c6,esp32p4,teensy41,teensy40,lpc845,lpc845brk,lpcxpresso845max,lpcxpresso804
+//   - board: esp32s3,esp32c6,esp32p4,teensy41,teensy40,rp2350,rp2350w,lpc845,lpc845brk,lpcxpresso845max,lpcxpresso804
 // @end-filter
 //
 // Low-memory mode (FastLED #3030): on Low-tier targets (LPC8xx etc., per
@@ -67,6 +67,8 @@ void loop()  { autoResearchLowMemoryLoop(); }
 //   - ESP32-S3 (Xtensa)
 //   - ESP32-C3 (RISC-V)
 //   - ESP32-C6 (RISC-V)
+//   - Raspberry Pi Pico 2 (RP2350)
+//   - Raspberry Pi Pico 2 W (RP2350 + CYW43)
 //
 // Expected Output:
 //   Serial monitor will show:

--- a/examples/AutoResearch/AutoResearchPlatform.h
+++ b/examples/AutoResearch/AutoResearchPlatform.h
@@ -85,6 +85,10 @@ constexpr const char* chipName() {
     return "ESP32-P4 (dual-core RISC-V)";
 #elif defined(FL_IS_TEENSY_4X)
     return "Teensy 4.x (Cortex-M7)";
+#elif defined(ARDUINO_RASPBERRY_PI_PICO_2W) || defined(ARDUINO_RPIPICO2W)
+    return "Raspberry Pi Pico 2 W (RP2350)";
+#elif defined(FL_IS_RP2350)
+    return "RP2350";
 #else
     return "Unknown platform";
 #endif


### PR DESCRIPTION
## Summary

- add the canonical `rp2350w -> rpipico2w` Arduino-Pico board profile while preserving `rp2350 -> rpipico2`
- make RP2xxx staging/deploy aliases canonical, poll for post-flash CDC publication, and retain the DUT USB serial identity through watchdog re-enumeration
- use board-exact Pico/Pico 2/Pico 2 W application USB identities so COM17 cannot be confused with the attached ESP32-C6 or another RP generation
- admit RP2350/Pico 2 W to AutoResearch and report its live platform identity
- cover PIO alias routing, strict port selection, fbuild environment consistency, and transport behavior

## Validation

- `uv run --no-sync fbuild --version` -> `fbuild 2.5.6`
- `uv run pytest ci/tests/test_rp2350w_board_config.py ci/tests/test_autoresearch_phases.py -q` -> 143 passed
- `bash lint` -> passed
- `bash test --cpp` -> 279/279 unit tests passed; 83/83 examples passed in the required debug rerun
- `bash compile rp2350w --examples AutoResearch` -> `Raspberry Pi Pico 2 W / RP2350`, build succeeded
- `/clud-review` -> no critical/high findings

Refs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Raspberry Pi Pico 2 and Pico 2 W boards.
  - Added RP2350 and RP2350 W support to the AutoResearch example.
  - Improved automatic board and USB port detection, including serial-number matching.
  - Added support for port reacquisition after deployment and watchdog recovery.
  - Added clear platform names for Pico 2 and Pico 2 W builds.

- **Bug Fixes**
  - Prevented incorrect matching between RP2040 and RP2350 USB identities.
  - Improved handling of board aliases and environment-specific deployment flows.

- **Tests**
  - Expanded coverage for RP2xxx boards, detection, deployment, watchdog recovery, and platform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->