### PR TITLE
fix(rp2040): use Pico W USB identity

### DIFF
--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1593,7 +1593,9 @@ class TestAutoDetectUploadPort:
         assert result.ok is False
         assert result.selected_port is None
 
-    def test_rpipicow_uses_its_board_exact_application_identity(self) -> None:
+    def test_rpipicow_uses_its_board_exact_application_identity(
+        self: "TestAutoDetectUploadPort",
+    ) -> None:
         pico = ListPortInfo("COM11")
         pico.description = "USB Serial Device"
         pico.hwid = "USB VID:PID=2E8A:000A"

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1593,6 +1593,28 @@ class TestAutoDetectUploadPort:
         assert result.ok is False
         assert result.selected_port is None
 
+    def test_rpipicow_uses_its_board_exact_application_identity(self) -> None:
+        pico = ListPortInfo("COM11")
+        pico.description = "USB Serial Device"
+        pico.hwid = "USB VID:PID=2E8A:000A"
+        pico.vid = 0x2E8A
+        pico.pid = 0x000A
+
+        pico_w = ListPortInfo("COM12")
+        pico_w.description = "USB Serial Device"
+        pico_w.hwid = "USB VID:PID=2E8A:F00A"
+        pico_w.vid = 0x2E8A
+        pico_w.pid = 0xF00A
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=[pico, pico_w],
+        ):
+            result = auto_detect_upload_port("rpipicow")
+
+        assert result.ok is True
+        assert result.selected_port == "COM12"
+
     def test_rpipico2_application_cdc_fingerprint_matches(self) -> None:
         port = ListPortInfo("COM12")
         port.description = "USB Serial Device"

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -66,7 +66,7 @@ ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
     # different attached board.
     "rp2040": ((0x2E8A, 0x000A),),
     "rpipico": ((0x2E8A, 0x000A),),
-    "rpipicow": ((0x2E8A, 0x000A),),
+    "rpipicow": ((0x2E8A, 0xF00A),),
     # Arduino-Pico assigns distinct application CDC identities to Pico 2
     # and Pico 2 W. Keep them board-exact so a non-W RP2350 cannot be
     # selected for an rp2350w run when both variants are attached.


### PR DESCRIPTION
﻿## Summary

- use Arduino-Pico 4.5.3's board-exact `2E8A:F00A` application CDC identity for `rpipicow`
- prove a Pico W is selected when a non-W Pico is attached first
- address the actionable review thread from merged PR #3834

## Validation

- focused RP2040/Pico W port tests: 11 passed
- `bash lint`: passed
- `git diff --check`: passed
- `/clud-review`: no critical/high findings (mapping verified against Arduino-Pico 4.5.3)

Refs #3832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic upload-port detection for the `rpipicow` board by identifying its board-specific USB connection.
  * Prevented selection of the standard RP2040 port when both board types are connected.

* **Tests**
  * Added coverage to verify correct port selection when multiple compatible devices are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->