### PR TITLE
feat(rp2350): harden pin-free RPC bring-up

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -610,6 +610,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         and not ieee754_test_mode
         and not rpc_smoke_mode
         and not watchdog_soak_mode
+        and perf_wave2d_grid is None
         and not net_server_mode
         and not net_client_mode
         and not net_loopback_mode
@@ -1752,6 +1753,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         )
     elif ctx.rpc_smoke_mode or ctx.watchdog_soak_mode:
         print("\n\U0001f4cc RPC smoke mode: skipping pin discovery and GPIO pre-test")
+    elif ctx.perf_wave2d_grid is not None:
+        print("\n\U0001f4cc Wave2D mode: skipping pin discovery and GPIO pre-test")
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         print("\n\U0001f4cc Network mode: skipping pin discovery and GPIO pre-test")
     elif ctx.ota_mode:
@@ -1820,7 +1823,9 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
             f"TX={ctx.effective_tx_pin}, RX={ctx.effective_rx_pin}"
         )
 
-    if not (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode):
+    if not (
+        ctx.rpc_smoke_mode or ctx.watchdog_soak_mode or ctx.perf_wave2d_grid is not None
+    ):
         _ensure_leading_set_pins_command(ctx)
 
     # GPIO connectivity pre-test
@@ -1835,6 +1840,8 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     elif ctx.ieee754_test_mode:
         pass
     elif ctx.rpc_smoke_mode or ctx.watchdog_soak_mode:
+        pass
+    elif ctx.perf_wave2d_grid is not None:
         pass
     elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
         pass
@@ -1891,6 +1898,27 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
 # ============================================================
 
 
+def _is_valid_rp_concurrency_result(result: Any) -> bool:
+    """Return whether an RP concurrency response proves the full gate."""
+    if not isinstance(result, dict):
+        return False
+    actual = result.get("actual")
+    expected = result.get("expected")
+    return (
+        result.get("success") is True
+        and result.get("supported") is True
+        and result.get("core1Ready") is True
+        and result.get("core1Done") is True
+        and result.get("recursiveMutexReady") is True
+        and isinstance(actual, int)
+        and not isinstance(actual, bool)
+        and isinstance(expected, int)
+        and not isinstance(expected, bool)
+        and expected > 0
+        and actual == expected
+    )
+
+
 async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
     """Validate the pin-free JSON-RPC transport and core system surface."""
     upload_port = ctx.upload_port
@@ -1916,16 +1944,37 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
         )
         if not response.success:
             raise RpcError(f"{name} returned unsuccessful response: {response.data!r}")
-        print(f"REMOTE: {name} -> {response.data!r}")
+        if name in {"rpc.discover", "help"}:
+            method_count = len(_rpc_manifest_method_names(response.data))
+            print(f"REMOTE: {name} -> {method_count} methods")
+        else:
+            print(f"REMOTE: {name} -> {response.data!r}")
         return response.data
 
     try:
         await client.connect()
         await client.drain_boot_output(verbose=False)
 
+        rp_environment = _active_rp2xxx_environment(ctx.final_environment)
+        required_methods = {
+            "help",
+            "ping",
+            "debugTest",
+            "status",
+            "drivers",
+            "testNoSerial",
+        }
+        if rp_environment is not None:
+            required_methods.add("testRpConcurrency")
+
         discovered = await call("rpc.discover")
-        if not isinstance(discovered, (dict, list)) or not discovered:
-            raise RpcError("rpc.discover returned an empty or invalid manifest")
+        discovered_methods = _rpc_manifest_method_names(discovered)
+        missing_discovered = sorted(required_methods - discovered_methods)
+        if missing_discovered:
+            raise RpcError(
+                "rpc.discover omitted required methods: "
+                + ", ".join(missing_discovered)
+            )
 
         help_manifest = await call("help")
         help_functions = (
@@ -1933,8 +1982,10 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
             if isinstance(help_manifest, dict)
             else help_manifest
         )
-        if not isinstance(help_functions, list) or not help_functions:
-            raise RpcError("help returned an empty or invalid manifest")
+        help_methods = _rpc_manifest_method_names(help_functions)
+        missing_help = sorted(({"rpc.discover"} | required_methods) - help_methods)
+        if missing_help:
+            raise RpcError("help omitted required methods: " + ", ".join(missing_help))
 
         first_ping = await call("ping")
         await asyncio.sleep(0.01)
@@ -1948,13 +1999,11 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
         if (
             not isinstance(first_uptime, (int, float))
             or not isinstance(second_uptime, (int, float))
-            or second_uptime < first_uptime
+            or second_uptime <= first_uptime
         ):
             raise RpcError("ping uptime did not advance monotonically")
 
-        active_environment = (
-            _active_rp2xxx_environment(ctx.final_environment) or "rp2040"
-        )
+        active_environment = rp_environment or "rp2040"
         chip_number = 2350 if active_environment in RP2350_ENVIRONMENTS else 2040
         payload = {
             "text": f"{active_environment}-rpc-smoke",
@@ -1966,35 +2015,71 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
             raise RpcError(f"debugTest payload mismatch: {echoed!r}")
 
         status = await call("status")
-        if not isinstance(status, dict) or status.get("ready") is not True:
-            raise RpcError(f"status did not report ready: {status!r}")
+        expected_platform = {
+            "rp2350": "RP2350",
+            "rpipico2": "RP2350",
+            "rp2350w": "Raspberry Pi Pico 2 W (RP2350)",
+            "rpipico2w": "Raspberry Pi Pico 2 W (RP2350)",
+        }.get(active_environment)
+        if (
+            not isinstance(status, dict)
+            or status.get("ready") is not True
+            or status.get("rpcReady") is not True
+            or not isinstance(status.get("ledRxAvailable"), bool)
+            or (
+                expected_platform is not None
+                and status.get("platform") != expected_platform
+            )
+        ):
+            raise RpcError(
+                "status did not prove the pin-free RPC/platform state: "
+                f"expected platform={expected_platform!r}, got {status!r}"
+            )
 
         drivers = await call("drivers")
         if not isinstance(drivers, list):
             raise RpcError(f"drivers returned a non-array result: {drivers!r}")
 
         no_serial = await call("testNoSerial")
-        if not isinstance(no_serial, dict) or no_serial.get("success") is not True:
+        if (
+            not isinstance(no_serial, dict)
+            or no_serial.get("success") is not True
+            or no_serial.get("serial_safe") is not False
+            or not isinstance(no_serial.get("message"), str)
+        ):
             raise RpcError(f"testNoSerial failed: {no_serial!r}")
 
+        if rp_environment is not None:
+            concurrency = await call("testRpConcurrency")
+            if not _is_valid_rp_concurrency_result(concurrency):
+                raise RpcError(
+                    f"RP mutex/semaphore dual-core validation failed: {concurrency!r}"
+                )
+
+        missing_method_returned = False
         try:
-            # Some firmware revisions reject an unknown method with an error;
-            # others intentionally emit no response. Bound this negative
-            # probe tightly so it cannot consume the whole smoke-test budget.
-            response = await client.send(
+            await client.send(
                 "__autoresearch_missing_method__",
                 timeout=min(2.0, max(1.0, ctx.remaining_seconds(minimum=1.0))),
             )
-            if response.success:
-                print("RESULT: RPC smoke FAIL: missing method unexpectedly succeeded")
-                return 1
-            print(f"REMOTE: missing-method error handled -> {response.data!r}")
-        except (RpcError, RpcTimeoutError) as exc:
-            print(f"REMOTE: missing-method error handled -> {exc}")
+            missing_method_returned = True
+        except RpcError as exc:
+            if exc.code != -32601:
+                raise RpcError(
+                    "missing method returned the wrong JSON-RPC error code: "
+                    f"{exc.code!r} ({exc})"
+                ) from exc
+            print(
+                "REMOTE: missing-method structured error -> "
+                f"code={exc.code}, message={exc.message!r}, data={exc.data!r}"
+            )
+        if missing_method_returned:
+            raise RpcError("missing method unexpectedly returned a result")
 
-        print(
-            "RESULT: RPC smoke PASS (discovery, help, ping, payload, status, drivers, testNoSerial, error handling)"
-        )
+        validated = "discovery, help, ping, payload, status, drivers, testNoSerial"
+        if rp_environment is not None:
+            validated += ", RP concurrency"
+        print(f"RESULT: RPC smoke PASS ({validated}, error handling)")
         return 0
     except (RpcCrashError, RpcTimeoutError, RpcError, OSError) as exc:
         print(f"RESULT: RPC smoke FAIL: {exc}")
@@ -2007,6 +2092,29 @@ async def _run_rpc_smoke_tests(ctx: RunContext) -> int:
             raise
         except Exception:
             pass
+
+
+def _rpc_manifest_method_names(manifest: Any) -> set[str]:
+    """Extract method names from rpc.discover or AutoResearch help payloads."""
+    if isinstance(manifest, dict):
+        for key in ("methods", "schema", "functions"):
+            if key in manifest:
+                return _rpc_manifest_method_names(manifest[key])
+        return set()
+    if not isinstance(manifest, list):
+        return set()
+
+    names: set[str] = set()
+    for entry in manifest:
+        if isinstance(entry, str):
+            names.add(entry)
+        elif isinstance(entry, dict):
+            name = entry.get("name")
+            if isinstance(name, str):
+                names.add(name)
+        elif isinstance(entry, list) and entry and isinstance(entry[0], str):
+            names.add(entry[0])
+    return names
 
 
 async def _run_watchdog_soak(ctx: RunContext) -> int:
@@ -3366,6 +3474,12 @@ async def _run_coroutine_tests(ctx: RunContext) -> int:
         )
         print(f" {Fore.GREEN}ok{Style.RESET_ALL}")
         print()
+
+        if response.get("supported", True) is False:
+            backend = response.get("backend", "unknown")
+            reason = response.get("reason", "no real coroutine backend")
+            print(f"RESULT: COROUTINE UNSUPPORTED (backend={backend}): {reason}")
+            return 0
 
         total = response.get("total", 0)
         passed_count = response.get("passed", 0)

--- a/ci/autoresearch/rpc_bench.py
+++ b/ci/autoresearch/rpc_bench.py
@@ -16,15 +16,28 @@ can call RPCs without each managing its own event loop.
 from __future__ import annotations
 
 import json
+import sys
+from argparse import ArgumentParser
 from typing import Any
 
 from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.serial_interface import create_serial_interface
 
 
 # Returned by RpcBench.call() when the device does not have the method
 # bound (e.g. a build without an optional feature's RPC).
 METHOD_NOT_FOUND = object()
+
+
+def _is_method_not_found(error: RpcError) -> bool:
+    """Classify structured errors, with text fallback for legacy firmware."""
+    if error.code == -32601:
+        return True
+    if error.code is not None:
+        return False
+    message = str(error).lower()
+    return "not found" in message or "unknown method" in message or "method" in message
 
 
 class RpcBench:
@@ -64,8 +77,7 @@ class RpcBench:
         except RpcTimeoutError:
             return None
         except RpcError as e:
-            msg = str(e).lower()
-            if "not found" in msg or "unknown method" in msg or "method" in msg:
+            if _is_method_not_found(e):
                 return METHOD_NOT_FOUND
             return None
         # Non-empty dict result — hand it straight back.
@@ -104,8 +116,7 @@ class RpcBench:
         except RpcTimeoutError:
             return None
         except RpcError as e:
-            msg = str(e).lower()
-            if "not found" in msg or "unknown method" in msg or "method" in msg:
+            if _is_method_not_found(e):
                 return METHOD_NOT_FOUND
             return None
         return self._extract_result(resp)
@@ -152,3 +163,52 @@ class RpcBench:
 
     def __exit__(self, *_exc: object) -> None:
         self.close()
+
+
+def _parse_cli_args_json(value: str) -> list[Any] | dict[str, Any] | None:
+    parsed = json.loads(value)
+    if parsed is None or isinstance(parsed, (list, dict)):
+        return parsed
+    raise ValueError("RPC args must decode to an array, object, or null")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Call one RPC method through the repository's fbuild-backed transport."""
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("port", help="Application serial port, for example COM17")
+    parser.add_argument("method", help="JSON-RPC method name")
+    parser.add_argument("--args", default="{}", help="JSON array/object arguments")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parsed = parser.parse_args(argv)
+
+    try:
+        rpc_args = _parse_cli_args_json(parsed.args)
+    except (json.JSONDecodeError, ValueError) as exc:
+        parser.error(str(exc))
+
+    try:
+        with RpcBench(parsed.port, timeout=parsed.timeout) as bench:
+            result = bench.call(parsed.method, args=rpc_args, timeout=parsed.timeout)
+    except KeyboardInterrupt as exc:
+        handle_keyboard_interrupt(exc)
+        return 130
+    except Exception as exc:  # noqa: BLE001 - CLI must report transport failures
+        print(f"RESULT: RPC call FAIL: {exc}")
+        return 1
+
+    if result is METHOD_NOT_FOUND:
+        print("RESULT: RPC call FAIL: method not found")
+        return 1
+    if result is None:
+        print("RESULT: RPC call FAIL: timeout or transport error")
+        return 1
+    print(f"REMOTE: {parsed.method} -> {result!r}")
+    if isinstance(result, dict) and result.get("success") is False:
+        print("RESULT: RPC call FAIL: method reported success=false")
+        return 1
+    print("RESULT: RPC call PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -83,7 +83,22 @@ class RpcTimeoutError(TimeoutError):
 class RpcError(Exception):
     """RPC operation failed."""
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: int | None = None,
+        data: Any = None,
+    ) -> None:
+        self.code = code
+        self.message = message
+        self.data = data
+        display_message = message
+        if code is not None:
+            display_message = f"RPC Error {code}: {message}"
+            if data is not None:
+                display_message += f" (data: {json.dumps(data)})"
+        super().__init__(display_message)
 
 
 class RpcCrashError(RpcError):
@@ -661,19 +676,18 @@ class RpcClient:
                         # Extract error details (code and message are standard fields)
                         if isinstance(error_obj, dict):
                             error_code = error_obj.get("code")  # type: ignore[assignment]
-                            error_message = error_obj.get(  # type: ignore[assignment]
-                                "message", "Unknown error"
+                            error_message = str(
+                                error_obj.get("message", "Unknown error")
                             )
                             error_data = error_obj.get("data")  # type: ignore[assignment]
 
-                            # Build detailed error message
-                            msg = f"RPC Error {error_code}: {error_message}"
-                            if error_data:
-                                import json as json_module
-
-                                msg += f" (data: {json_module.dumps(error_data)})"
-
-                            raise RpcError(msg)
+                            raise RpcError(
+                                error_message,
+                                code=(
+                                    error_code if isinstance(error_code, int) else None
+                                ),
+                                data=error_data,
+                            )
                         else:
                             # Malformed error object (should be dict)
                             raise RpcError(f"Malformed error object: {error_obj}")

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -21,6 +21,7 @@ from ci.autoresearch.build_driver import BuildDriver
 from ci.autoresearch.context import QuietContext, RunContext
 from ci.autoresearch.phases import (
     _build_environment_for_mode,
+    _is_valid_rp_concurrency_result,
     _parse_args_and_build_commands,
     _resolve_port_and_environment,
     _run_build_deploy,
@@ -29,12 +30,51 @@ from ci.autoresearch.phases import (
     _run_watchdog_soak,
     _validate_test_rpc_response,
 )
-from ci.rpc_client import RpcError
+from ci.rpc_client import RpcError, RpcTimeoutError
 from ci.util.port_utils import ChipDetectionResult, auto_detect_upload_port
 
 
 # Module path for patching symbols imported into phases.py
 _PATCH_MOD = "ci.autoresearch.phases"
+
+
+@pytest.mark.parametrize(
+    "counters",
+    [
+        {},
+        {"actual": None, "expected": None},
+        {"actual": True, "expected": True},
+        {"actual": 0, "expected": 0},
+        {"actual": -1, "expected": -1},
+        {"actual": 199, "expected": 200},
+    ],
+)
+def test_rp_concurrency_gate_requires_matching_integer_counters(
+    counters: dict[str, object],
+) -> None:
+    result: dict[str, object] = {
+        "success": True,
+        "supported": True,
+        "core1Ready": True,
+        "core1Done": True,
+        "recursiveMutexReady": True,
+        **counters,
+    }
+    assert _is_valid_rp_concurrency_result(result) is False
+
+
+def test_rp_concurrency_gate_accepts_matching_integer_counters() -> None:
+    assert _is_valid_rp_concurrency_result(
+        {
+            "success": True,
+            "supported": True,
+            "core1Ready": True,
+            "core1Done": True,
+            "recursiveMutexReady": True,
+            "actual": 200,
+            "expected": 200,
+        }
+    )
 
 
 # ============================================================
@@ -234,6 +274,19 @@ class TestParseArgsAndBuildCommands:
             "OBJECT_FLED",
             "FLEX_IO",
         }
+
+    def test_perf_wave2d_is_not_classified_as_gpio_only(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            perf_wave2d="32x32",
+            project_dir=fake_project_dir,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.perf_wave2d_grid == (32, 32)
+        assert result.gpio_only_mode is False
 
     def test_all_drivers_teensy4_only_real_teensy_drivers(
         self, fake_project_dir: Path
@@ -2091,6 +2144,25 @@ class TestRunSchemaAndPinSetup:
         assert ctx.effective_tx_pin is None
         assert ctx.effective_rx_pin is None
 
+    def test_perf_wave2d_skips_all_pin_setup(self) -> None:
+        args = _make_args(skip_schema=True, parlio=False, perf_wave2d="32x32")
+        ctx = _make_ctx(
+            args=args,
+            drivers=[],
+            json_rpc_commands=[],
+            perf_wave2d_grid=(32, 32),
+        )
+        with patch(
+            f"{_PATCH_MOD}.run_gpio_pretest",
+            new_callable=AsyncMock,
+        ) as pretest:
+            rc = asyncio.run(_run_schema_and_pin_setup(ctx))
+        assert rc is None
+        assert ctx.effective_tx_pin is None
+        assert ctx.effective_rx_pin is None
+        assert ctx.json_rpc_commands == []
+        pretest.assert_not_awaited()
+
     def test_lpc_fbuild_uses_pyserial_for_rpc(self) -> None:
         args = _make_args(skip_schema=True)
         ctx = _make_ctx(
@@ -2218,13 +2290,23 @@ class TestRunTestsOrSpecialMode:
         assert rc == 0
 
     def test_rpc_smoke_mode_validates_core_surface(self) -> None:
-        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="rp2350")
+        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="rp2350w")
         qctx = QuietContext(quiet=False)
         expected_payload = {
-            "text": "rp2350-rpc-smoke",
+            "text": "rp2350w-rpc-smoke",
             "number": 2350,
             "nested": {"ok": True, "values": [1, 2, 3]},
         }
+
+        required_methods = [
+            "help",
+            "ping",
+            "debugTest",
+            "status",
+            "drivers",
+            "testNoSerial",
+            "testRpConcurrency",
+        ]
 
         def response(data):
             item = MagicMock()
@@ -2235,15 +2317,145 @@ class TestRunTestsOrSpecialMode:
         mock_client = AsyncMock()
         mock_client.send = AsyncMock(
             side_effect=[
-                response({"methods": ["ping"]}),
-                response([{"name": "ping"}]),
+                response({"schema": [[name] for name in required_methods]}),
+                response(
+                    {
+                        "success": True,
+                        "functions": [
+                            {"name": name}
+                            for name in ["rpc.discover", *required_methods]
+                        ],
+                    }
+                ),
                 response({"uptimeMs": 1}),
                 response({"uptimeMs": 2}),
                 response({"received": expected_payload}),
-                response({"ready": True}),
+                response(
+                    {
+                        "ready": True,
+                        "platform": "Raspberry Pi Pico 2 W (RP2350)",
+                        "rpcReady": True,
+                        "ledRxAvailable": False,
+                    }
+                ),
                 response([]),
-                response({"success": True}),
-                RpcError("RPC Error -32601: Method not found"),
+                response(
+                    {
+                        "success": True,
+                        "message": "RPC works from task context",
+                        "serial_safe": False,
+                    }
+                ),
+                response(
+                    {
+                        "success": True,
+                        "supported": True,
+                        "backend": "pico-sdk-mutex+arduino-core1",
+                        "core1Ready": True,
+                        "core1Done": True,
+                        "recursiveMutexReady": True,
+                        "expected": 2000,
+                        "actual": 2000,
+                    }
+                ),
+                RpcError(
+                    "Method not found",
+                    code=-32601,
+                    data={"method": "__autoresearch_missing_method__"},
+                ),
+            ]
+        )
+        mock_client.connect = AsyncMock()
+        mock_client.drain_boot_output = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
+        assert mock_client.send.await_count == 10
+        debug_test_call = mock_client.send.await_args_list[4]
+        assert debug_test_call.args == ("debugTest",)
+        assert debug_test_call.kwargs["args"] == expected_payload
+
+    def test_rpc_smoke_rejects_missing_required_discovery_method(self) -> None:
+        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="rp2350w")
+        qctx = QuietContext(quiet=False)
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(
+            return_value=response({"schema": [["ping"], ["status"]]})
+        )
+        mock_client.connect = AsyncMock()
+        mock_client.drain_boot_output = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 1
+
+    def test_rpc_smoke_non_rp_target_skips_rp_concurrency(self) -> None:
+        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="esp32s3")
+        qctx = QuietContext(quiet=False)
+        required_methods = [
+            "help",
+            "ping",
+            "debugTest",
+            "status",
+            "drivers",
+            "testNoSerial",
+        ]
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        payload = {
+            "text": "rp2040-rpc-smoke",
+            "number": 2040,
+            "nested": {"ok": True, "values": [1, 2, 3]},
+        }
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(
+            side_effect=[
+                response({"schema": [[name] for name in required_methods]}),
+                response(
+                    {
+                        "functions": [
+                            {"name": name}
+                            for name in ["rpc.discover", *required_methods]
+                        ]
+                    }
+                ),
+                response({"uptimeMs": 1}),
+                response({"uptimeMs": 2}),
+                response({"received": payload}),
+                response(
+                    {
+                        "ready": True,
+                        "platform": "ESP32-S3",
+                        "rpcReady": True,
+                        "ledRxAvailable": False,
+                    }
+                ),
+                response([]),
+                response(
+                    {
+                        "success": True,
+                        "message": "RPC works from task context",
+                        "serial_safe": False,
+                    }
+                ),
+                RpcError("Method not found", code=-32601),
             ]
         )
         mock_client.connect = AsyncMock()
@@ -2255,9 +2467,114 @@ class TestRunTestsOrSpecialMode:
 
         assert rc == 0
         assert mock_client.send.await_count == 9
-        debug_test_call = mock_client.send.await_args_list[4]
-        assert debug_test_call.args == ("debugTest",)
-        assert debug_test_call.kwargs["args"] == expected_payload
+        assert all(
+            call.args[0] != "testRpConcurrency"
+            for call in mock_client.send.await_args_list
+        )
+
+    def test_rpc_smoke_rejects_timeout_for_unknown_method(self) -> None:
+        ctx = _make_ctx(rpc_smoke_mode=True, final_environment="rp2350w")
+        qctx = QuietContext(quiet=False)
+        methods = [
+            "help",
+            "ping",
+            "debugTest",
+            "status",
+            "drivers",
+            "testNoSerial",
+            "testRpConcurrency",
+        ]
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        payload = {
+            "text": "rp2350w-rpc-smoke",
+            "number": 2350,
+            "nested": {"ok": True, "values": [1, 2, 3]},
+        }
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(
+            side_effect=[
+                response({"schema": [[name] for name in methods]}),
+                response(
+                    {
+                        "functions": [
+                            {"name": name} for name in ["rpc.discover", *methods]
+                        ]
+                    }
+                ),
+                response({"uptimeMs": 1}),
+                response({"uptimeMs": 2}),
+                response({"received": payload}),
+                response(
+                    {
+                        "ready": True,
+                        "platform": "Raspberry Pi Pico 2 W (RP2350)",
+                        "rpcReady": True,
+                        "ledRxAvailable": False,
+                    }
+                ),
+                response([]),
+                response(
+                    {
+                        "success": True,
+                        "message": "RPC works from task context",
+                        "serial_safe": False,
+                    }
+                ),
+                response(
+                    {
+                        "success": True,
+                        "supported": True,
+                        "core1Ready": True,
+                        "core1Done": True,
+                        "recursiveMutexReady": True,
+                        "expected": 2000,
+                        "actual": 2000,
+                    }
+                ),
+                RpcTimeoutError("missing method timed out"),
+            ]
+        )
+        mock_client.connect = AsyncMock()
+        mock_client.drain_boot_output = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 1
+        assert mock_client.send.await_count == 10
+
+    def test_rp_coroutine_mode_reports_null_backend_as_unsupported(self) -> None:
+        ctx = _make_ctx(
+            coroutine_test_mode=True,
+            final_environment="rp2350w",
+        )
+        qctx = QuietContext(quiet=False)
+
+        response = MagicMock()
+        response.get = lambda key, default=None: {
+            "success": False,
+            "supported": False,
+            "backend": "null",
+            "reason": "RP2xxx currently selects the generic Arduino null coroutine backend",
+            "passed": 0,
+        }.get(key, default)
+
+        mock_client = AsyncMock()
+        mock_client.send_and_match = AsyncMock(return_value=response)
+        mock_client.connect = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
+            rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
+
+        assert rc == 0
 
     def test_rp2350_watchdog_reacquires_active_environment_and_device(self) -> None:
         ctx = _make_ctx(

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -1,5 +1,6 @@
 """Board-definition contracts for Raspberry Pi Pico 2 and Pico 2 W."""
 
+import re
 from pathlib import Path
 
 from ci.boards import create_board
@@ -11,6 +12,10 @@ AUTORESEARCH_INO = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
 AUTORESEARCH_PLATFORM = (
     REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchPlatform.h"
 )
+MUTEX_DISPATCH = REPO_ROOT / "src" / "platforms" / "mutex.h"
+MUTEX_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "mutex_rp.cpp.hpp"
+SEMAPHORE_DISPATCH = REPO_ROOT / "src" / "platforms" / "semaphore.h"
+SEMAPHORE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "semaphore_rp.cpp.hpp"
 
 
 def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
@@ -57,3 +62,19 @@ def test_autoresearch_identity_prioritizes_pico_2_w() -> None:
     assert pico_2_w_branch < generic_rp2350_branch
     assert 'return "Raspberry Pi Pico 2 W (RP2350)";' in source
     assert 'return "RP2350";' in source
+
+
+def test_rp_platform_dispatches_real_mutex_and_semaphore_backends() -> None:
+    for source_path in (
+        MUTEX_DISPATCH,
+        MUTEX_IMPL,
+        SEMAPHORE_DISPATCH,
+        SEMAPHORE_IMPL,
+    ):
+        source = source_path.read_text(encoding="utf-8")
+        assert not re.search(r"\bFL_IS_RP2040\b", source), (
+            f"{source_path} still guards on FL_IS_RP2040"
+        )
+        assert re.search(r"\bFL_IS_RP\b", source), (
+            f"{source_path} does not guard on FL_IS_RP"
+        )

--- a/ci/tests/test_rpc_bench_cli.py
+++ b/ci/tests/test_rpc_bench_cli.py
@@ -1,0 +1,94 @@
+"""Contracts for the fbuild-backed one-method RPC CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ci.autoresearch import rpc_bench
+from ci.autoresearch.rpc_bench import METHOD_NOT_FOUND, RpcBench, _parse_cli_args_json
+from ci.rpc_client import RpcError
+
+
+def test_parse_cli_args_accepts_rpc_containers_and_null() -> None:
+    assert _parse_cli_args_json('{"nested":{"ok":true}}') == {"nested": {"ok": True}}
+    assert _parse_cli_args_json("[1,2,3]") == [1, 2, 3]
+    assert _parse_cli_args_json("null") is None
+
+
+def test_parse_cli_args_rejects_scalar_json() -> None:
+    with pytest.raises(ValueError, match="array, object, or null"):
+        _parse_cli_args_json('"scalar"')
+
+
+def test_cli_rejects_method_reported_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    class FailedBench:
+        def __init__(self, _port: str, timeout: float) -> None:
+            assert timeout == 3.0
+
+        def __enter__(self) -> "FailedBench":
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def call(
+            self,
+            method: str,
+            args: dict[str, Any] | list[Any] | None,
+            timeout: float,
+        ) -> dict[str, Any]:
+            assert method == "testRpConcurrency"
+            assert args == {}
+            assert timeout == 3.0
+            return {"success": False, "actual": 100, "expected": 200}
+
+    monkeypatch.setattr(rpc_bench, "RpcBench", FailedBench)
+
+    assert rpc_bench.main(["COM17", "testRpConcurrency", "--timeout", "3"]) == 1
+    output = capsys.readouterr().out
+    assert "REMOTE: testRpConcurrency" in output
+    assert "method reported success=false" in output
+    assert "RESULT: RPC call PASS" not in output
+
+
+@pytest.mark.parametrize("caller", ["call", "call_flat"])
+def test_rpc_bench_uses_structured_method_not_found_code(caller: str) -> None:
+    bench = object.__new__(RpcBench)
+    bench._loop = MagicMock()
+    bench._client = MagicMock()
+    error = RpcError("Method not found", code=-32601)
+
+    def raise_error(awaitable: Any) -> None:
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise error
+
+    bench._loop.run_until_complete.side_effect = raise_error
+
+    assert getattr(bench, caller)("missing") is METHOD_NOT_FOUND
+
+
+@pytest.mark.parametrize("caller", ["call", "call_flat"])
+def test_rpc_bench_does_not_misclassify_other_structured_method_errors(
+    caller: str,
+) -> None:
+    bench = object.__new__(RpcBench)
+    bench._loop = MagicMock()
+    bench._client = MagicMock()
+    error = RpcError("Invalid params for method foo", code=-32602)
+
+    def raise_error(awaitable: Any) -> None:
+        close = getattr(awaitable, "close", None)
+        if close is not None:
+            close()
+        raise error
+
+    bench._loop.run_until_complete.side_effect = raise_error
+
+    assert getattr(bench, caller)("foo") is None

--- a/ci/tests/test_rpc_client_errors.py
+++ b/ci/tests/test_rpc_client_errors.py
@@ -34,8 +34,11 @@ def test_json_rpc_error_is_not_masked_as_timeout() -> None:
     async def _run() -> None:
         client = RpcClient("FAKE", serial_interface=_ErrorSerial())
         await client.connect(boot_wait=0, drain_boot=False)
-        with pytest.raises(RpcError, match=r"-32601.*Method not found"):
+        with pytest.raises(RpcError, match=r"-32601.*Method not found") as caught:
             await client.send("missing", timeout=0.1)
+        assert caught.value.code == -32601
+        assert caught.value.message == "Method not found: missing"
+        assert caught.value.data is None
         await client.close()
 
     asyncio.run(_run())

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -622,11 +622,15 @@ void loop() {
             // Test RX channel with manual GPIO toggle to confirm hardware path works
             // This isolates GPIO/hardware issues from PARLIO driver issues
             // Buffer size = 100 symbols, hz = 40MHz (same as LED autoresearch)
-            const bool gpio_ok = testRxChannel(g_autoresearch_state->rx_channel, PIN_TX, PIN_RX, 40000000, 100);
+            const int pin_tx = g_autoresearch_state->pin_tx;
+            const int pin_rx = g_autoresearch_state->pin_rx;
+            const bool gpio_ok = testRxChannel(
+                g_autoresearch_state->rx_channel, pin_tx, pin_rx, 40000000, 100);
+            g_autoresearch_state->led_rx_available = gpio_ok;
             fl::json gpioData = fl::json::object();
             gpioData.set("success", gpio_ok);
-            gpioData.set("pinTx", static_cast<int64_t>(PIN_TX));
-            gpioData.set("pinRx", static_cast<int64_t>(PIN_RX));
+            gpioData.set("pinTx", static_cast<int64_t>(pin_tx));
+            gpioData.set("pinRx", static_cast<int64_t>(pin_rx));
             gpioData.set("hz", static_cast<int64_t>(40000000));
             gpioData.set("symbols", static_cast<int64_t>(100));
             printStreamRaw("gpioBaseline", gpioData);

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -374,24 +374,32 @@ fl::json AutoResearchRemoteControl::findConnectedPinsImpl(const fl::json& args) 
         if (auto_apply) {
             int old_tx = mState->pin_tx;
             int old_rx = mState->pin_rx;
+            bool tx_changed = (found_tx != old_tx);
             bool rx_changed = (found_rx != old_rx);
 
-            mState->pin_tx = found_tx;
-            mState->pin_rx = found_rx;
-
-            // Recreate RX channel if pin changed
-            if (rx_changed && mState->rx_factory) {
-                mState->rx_channel.reset();
-                mState->rx_channel = mState->rx_factory(found_rx);
-                if (!mState->rx_channel) {
-                    // Restore old values
-                    mState->pin_tx = old_tx;
-                    mState->pin_rx = old_rx;
+            fl::shared_ptr<fl::RxChannel> replacement_rx;
+            if (rx_changed) {
+                if (mState->rx_factory) {
+                    replacement_rx = mState->rx_factory(found_rx);
+                }
+                if (!replacement_rx) {
+                    response.set("success", false);
                     response.set("error", "RxChannelCreationFailed");
                     response.set("message", "Failed to recreate RX channel on discovered pin");
                     response.set("autoApplied", false);
                     return response;
                 }
+            }
+
+            // Commit only after the replacement channel is ready, preserving
+            // the prior channel and validation state on factory failure.
+            if (tx_changed || rx_changed) {
+                mState->invalidateLedRxValidation();
+            }
+            mState->pin_tx = found_tx;
+            mState->pin_rx = found_rx;
+            if (rx_changed) {
+                mState->rx_channel = replacement_rx;
             }
 
             FL_DBG("[PIN PROBE] Auto-applied pins: TX=" << found_tx << ", RX=" << found_rx);

--- a/examples/AutoResearch/AutoResearchRemote.h
+++ b/examples/AutoResearch/AutoResearchRemote.h
@@ -42,11 +42,17 @@ struct AutoResearchState {
     int default_pin_rx;
     RxDeviceFactory rx_factory;
     bool gpio_baseline_test_done = false;  // Track whether GPIO baseline test has run in loop()
+    bool led_rx_available = false;  // True only after the configured RX path validates
     bool debug_enabled = false;  // Runtime debug logging toggle (default: off)
     bool net_server_active = false;  // Network server autoresearch active
     bool net_client_active = false;  // Network client autoresearch active
     bool ble_server_active = false;  // BLE GATT server autoresearch active
     bool deliberate_hang_requested = false;  // Watchdog autoresearch hang trigger (#2731)
+
+    void invalidateLedRxValidation() {
+        led_rx_available = false;
+        gpio_baseline_test_done = false;
+    }
 };
 
 /// @brief Print JSON directly to Serial, bypassing fl::println and ScopedLogDisable

--- a/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
@@ -452,6 +452,18 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
         (void)args;
         fl::json r = fl::json::object();
 
+#if defined(FL_IS_RP)
+        r.set("success", false);
+        r.set("supported", false);
+        r.set("backend", "null");
+        r.set("reason", "RP2xxx currently selects the generic Arduino null coroutine backend");
+        r.set("passed", static_cast<int64_t>(0));
+        r.set("failed", static_cast<int64_t>(0));
+        r.set("total", static_cast<int64_t>(0));
+        r.set("results", fl::json::object());
+        return r;
+#else
+
         const char* test_names[] = {
             "testCoroutineBasic",
             "testCoroutineStop",
@@ -499,6 +511,7 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
         r.set("total", static_cast<int64_t>(num_tests));
         r.set("results", results);
         return r;
+#endif
     });
 }
 

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -71,8 +71,9 @@ void streamHelpEntry(fl::JsonStreamWriter& writer, const HelpEntry& entry) {
 }
 
 static const HelpEntry kHelpEntries[] = {
+    {"rpc.discover", "JSON-RPC", "[]", "{schema:[[name, ...], ...]}", "Discover the registered JSON-RPC method schema"},
     {"start", "Phase 1: Basic Control", "[]", "void", "Trigger test matrix execution"},
-    {"status", "Phase 1: Basic Control", "[]", "{startReceived, testComplete, frameCounter, state}", "Query current test state"},
+    {"status", "Phase 1: Basic Control", "[]", "{ready, platform, rpcReady, ledRxAvailable, pinTx, pinRx}", "Query RPC, platform, and LED RX readiness"},
     {"drivers", "Phase 1: Basic Control", "[]", "[{name, priority, enabled}, ...]", "List available drivers"},
     {"getConfig", "Phase 2: Configuration", "[]", "{drivers, laneRange, stripSizes, totalTestCases}", "Query current test matrix configuration"},
     {"setDrivers", "Phase 2: Configuration", "[driver1, driver2, ...]", "{success, driversSet, testCases}", "Configure enabled drivers"},
@@ -86,6 +87,9 @@ static const HelpEntry kHelpEntries[] = {
     {"reset", "Phase 4: Utility", "[]", "{success, message, testCasesCleared}", "Reset test state without device reboot"},
     {"halt", "Phase 4: Utility", "[]", "{success, message}", "Trigger sketch halt"},
     {"ping", "Phase 4: Utility", "[]", "{success, message, timestamp, uptimeMs, frameCounter}", "Health check with timestamp"},
+    {"debugTest", "Phase 4: Utility", "object", "{success, received}", "Echo an exact nested JSON payload"},
+    {"testNoSerial", "Phase 4: Utility", "[]", "{success, message, serial_safe}", "Verify RPC execution without device-side serial logging"},
+    {"testRpConcurrency", "Phase 4: Utility", "[]", "{success, supported, backend, core1Ready, core1Done, recursiveMutexReady, generation, expected, actual}", "Exercise mutex and semaphore synchronization across both RP physical cores"},
     {"getPins", "Phase 5: Pin Configuration", "[]", "{txPin, rxPin, defaults: {txPin, rxPin}, platform}", "Query current and default pin configuration"},
     {"setTxPin", "Phase 5: Pin Configuration", "[pin]", "{success, txPin, previousTxPin, testCases}", "Set TX pin (regenerates test cases)"},
     {"setRxPin", "Phase 5: Pin Configuration", "[pin]", "{success, rxPin, previousRxPin, rxChannelRecreated}", "Set RX pin (recreates RX channel)"},
@@ -256,6 +260,9 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         }
 
         int old_pin = mState->pin_tx;
+        if (new_pin != old_pin) {
+            mState->invalidateLedRxValidation();
+        }
         mState->pin_tx = new_pin;
 
         response.set("success", true);
@@ -288,25 +295,21 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         bool rx_recreated = false;
 
         if (pin_changed) {
-            mState->pin_rx = new_pin;
-
-            // Recreate RX channel with new pin
-            // Destroy old RX channel
-            mState->rx_channel.reset();
-
-            // Create new RX channel on new pin using factory
-            mState->rx_channel = mState->rx_factory(new_pin);
-
-            if (mState->rx_channel) {
-                rx_recreated = true;
-            } else {
+            fl::shared_ptr<fl::RxChannel> replacement_rx;
+            if (mState->rx_factory) {
+                replacement_rx = mState->rx_factory(new_pin);
+            }
+            if (!replacement_rx) {
                 response.set("error", "RxChannelCreationFailed");
                 response.set("message", "Failed to create RX channel on new pin");
                 response.set("pinRx", static_cast<int64_t>(new_pin));
-                // Restore old pin value
-                mState->pin_rx = old_pin;
                 return response;
             }
+
+            mState->invalidateLedRxValidation();
+            mState->pin_rx = new_pin;
+            mState->rx_channel = replacement_rx;
+            rx_recreated = true;
         }
 
         response.set("success", true);
@@ -361,35 +364,33 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
 
         int old_tx_pin = mState->pin_tx;
         int old_rx_pin = mState->pin_rx;
+        bool tx_pin_changed = (new_tx_pin != old_tx_pin);
         bool rx_pin_changed = (new_rx_pin != old_rx_pin);
         bool rx_recreated = false;
 
-        // Update TX pin
-        mState->pin_tx = new_tx_pin;
-
-        // Update RX pin and recreate channel if changed
+        fl::shared_ptr<fl::RxChannel> replacement_rx;
         if (rx_pin_changed) {
-            mState->pin_rx = new_rx_pin;
-
-            // Destroy old RX channel
-            mState->rx_channel.reset();
-
-            // Create new RX channel using factory
-            mState->rx_channel = mState->rx_factory(new_rx_pin);
-
-            if (mState->rx_channel) {
-                rx_recreated = true;
-            } else {
-                // Rollback both pins
-                mState->pin_tx = old_tx_pin;
-                mState->pin_rx = old_rx_pin;
+            if (mState->rx_factory) {
+                replacement_rx = mState->rx_factory(new_rx_pin);
+            }
+            if (!replacement_rx) {
                 response.set("error", "RxChannelCreationFailed");
-                response.set("message", "Failed to create RX channel - pins restored to previous values");
+                response.set("message", "Failed to create RX channel - previous pins preserved");
                 response.set("pinRx", static_cast<int64_t>(new_rx_pin));
                 return response;
             }
-        } else {
-            mState->pin_rx = new_rx_pin;
+        }
+
+        // Commit pins, validation, and channel as one state transition only
+        // after any replacement channel has been created successfully.
+        if (tx_pin_changed || rx_pin_changed) {
+            mState->invalidateLedRxValidation();
+        }
+        mState->pin_tx = new_tx_pin;
+        mState->pin_rx = new_rx_pin;
+        if (rx_pin_changed) {
+            mState->rx_channel = replacement_rx;
+            rx_recreated = true;
         }
 
         response.set("success", true);

--- a/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
@@ -15,6 +15,7 @@
 #include "fl/chipsets/spi.h"
 #include "fl/remote/remote.h"
 #include "fl/stl/json.h"
+#include "fl/stl/limits.h"
 #include "fl/stl/move.h"
 #include "fl/stl/vector.h"
 #include "platforms/arm/rp/is_rp.h"
@@ -36,12 +37,18 @@ constexpr fl::u8 kLoopbackPattern[] = {
 
 bool parseInt(const fl::json& config, const char* key, int* value) {
     if (!config.contains(key) || !config[key].is_int()) return false;
-    *value = static_cast<int>(config[key].as_int().value());
+    const fl::i64 parsed = config[key].as_int().value();
+    if (parsed < static_cast<fl::i64>((fl::numeric_limits<int>::min)()) ||
+        parsed > static_cast<fl::i64>((fl::numeric_limits<int>::max)())) {
+        return false;
+    }
+    *value = static_cast<int>(parsed);
     return true;
 }
 
 template <fl::u8 Which>
-fl::json runLoopback(int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
+fl::json runLoopback(const fl::shared_ptr<AutoResearchState>& runtime_state,
+                     int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
     fl::json response = fl::json::object();
     const int expected_mosi = Which == 0 ? 3 : 11;
     const int expected_miso = Which == 0 ? 0 : 8;
@@ -58,6 +65,13 @@ fl::json runLoopback(int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
         response.set("error", "InvalidClock");
         response.set("message", "clock_hz must be in [100000, 62500000].");
         return response;
+    }
+
+    // The request is now fully validated. Release AutoResearch's diagnostic
+    // PIO reservation only when the fixed-SPI operation will actually run.
+    if (runtime_state) {
+        runtime_state->rx_channel.reset();
+        runtime_state->invalidateLedRxValidation();
     }
 
     fl::vector_psram<fl::u8> tx;
@@ -114,7 +128,9 @@ fl::json runLoopback(int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
 }
 
 template <bool Sk9822>
-fl::json runPublicApiLoopback(int pattern) {
+fl::json runPublicApiLoopback(
+    const fl::shared_ptr<AutoResearchState>& runtime_state,
+    int pattern) {
     constexpr fl::u8 kMosiPin = 11;
     constexpr fl::u8 kSckPin = 10;
     constexpr size_t kLedCount = 257;
@@ -122,6 +138,17 @@ fl::json runPublicApiLoopback(int pattern) {
     static CRGB leds[kLedCount];
     static bool initialized = false;
     fl::json response = fl::json::object();
+
+    if (pattern < 0 || pattern > 5) {
+        response.set("success", false);
+        response.set("error", "InvalidPattern");
+        return response;
+    }
+
+    if (runtime_state) {
+        runtime_state->rx_channel.reset();
+        runtime_state->invalidateLedRxValidation();
+    }
 
     if (!initialized) {
         if constexpr (Sk9822) {
@@ -143,12 +170,6 @@ fl::json runPublicApiLoopback(int pattern) {
         case 5: leds[16] = CRGB::Red; break;
         default: break;
     }
-    if (pattern < 0 || pattern > 5) {
-        response.set("success", false);
-        response.set("error", "InvalidPattern");
-        return response;
-    }
-
     fl::u8 captured[kFrameBytes] = {};
     auto& driver = fl::BusTraits<fl::Bus::SPI, 1>::instance();
     if (!driver.captureNextRxBytes(captured, sizeof(captured))) {
@@ -199,10 +220,6 @@ void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
         response.set("message", "rpSpiLoopback requires an RP2040 or RP2350 target.");
         return response;
 #else
-        // AutoResearch's GPIO pre-test owns its RX pin through a PIO receive
-        // channel. Release that diagnostic reservation before fixed SPI claims
-        // the same MISO pin through the RP resource manager.
-        if (mState) mState->rx_channel.reset();
         if (!args.is_object()) {
             fl::json response = fl::json::object();
             response.set("success", false);
@@ -227,8 +244,14 @@ void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
             response.set("message", "spi_index, mosi_pin, miso_pin, sck_pin, and clock_hz must be integers.");
             return response;
         }
-        if (spi_index == 0) return runLoopback<0>(mosi_pin, miso_pin, sck_pin, clock_hz);
-        if (spi_index == 1) return runLoopback<1>(mosi_pin, miso_pin, sck_pin, clock_hz);
+        if (spi_index == 0) {
+            return runLoopback<0>(mState, mosi_pin, miso_pin, sck_pin,
+                                  clock_hz);
+        }
+        if (spi_index == 1) {
+            return runLoopback<1>(mState, mosi_pin, miso_pin, sck_pin,
+                                  clock_hz);
+        }
         fl::json response = fl::json::object();
         response.set("success", false);
         response.set("error", "InvalidSpiIndex");
@@ -244,7 +267,6 @@ void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
         response.set("error", "PlatformNotSupported");
         return response;
 #else
-        if (mState) mState->rx_channel.reset();
         if (!args.is_object() || !args.contains("sk9822") ||
             !args["sk9822"].is_bool() || !args.contains("pattern") ||
             !args["pattern"].is_int()) {
@@ -253,10 +275,17 @@ void AutoResearchRemoteControl::bindRpSpiMethods(fl::Remote& remote) {
             response.set("error", "InvalidArgs");
             return response;
         }
+        const fl::i64 pattern_value = args["pattern"].as_int().value();
+        if (pattern_value < 0 || pattern_value > 5) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "InvalidPattern");
+            return response;
+        }
         const bool sk9822 = args["sk9822"].as_bool().value();
-        const int pattern = static_cast<int>(args["pattern"].as_int().value());
-        return sk9822 ? runPublicApiLoopback<true>(pattern)
-                      : runPublicApiLoopback<false>(pattern);
+        const int pattern = static_cast<int>(pattern_value);
+        return sk9822 ? runPublicApiLoopback<true>(mState, pattern)
+                      : runPublicApiLoopback<false>(mState, pattern);
 #endif
     });
 }

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -23,6 +23,8 @@
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
+#include "AutoResearchPlatform.h"
+#include "AutoResearchRpConcurrency.h"
 #include "AutoResearchEdgeProbe.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
@@ -114,6 +116,9 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     remote.bind("status", [this](const fl::json& args) -> fl::json {
         fl::json status = fl::json::object();
         status.set("ready", true);
+        status.set("platform", autoresearch::chipName());
+        status.set("rpcReady", true);
+        status.set("ledRxAvailable", mState->led_rx_available);
         status.set("pinTx", static_cast<int64_t>(mState->pin_tx));
         status.set("pinRx", static_cast<int64_t>(mState->pin_rx));
         return status;
@@ -221,6 +226,13 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         response.set("serial_safe", false);
         return response;
     });
+
+    remote.bind("testRpConcurrency", [this](const fl::json& args) -> fl::json {
+        (void)args;
+        mRemote->sendAsyncResponse("testRpConcurrency",
+                                   autoresearch::runRpConcurrencyTest());
+        return fl::json(nullptr);
+    }, fl::RpcMode::ASYNC);
 
     // "parlioMetrics" — PARLIO engine ISR/DMA counters (C6 bring-up,
     // FastLED#3576 Phase 7). Reads the engine's debug metrics AFTER a

--- a/examples/AutoResearch/AutoResearchRpConcurrency.cpp
+++ b/examples/AutoResearch/AutoResearchRpConcurrency.cpp
@@ -1,0 +1,184 @@
+#include "AutoResearchRpConcurrency.h"
+
+#include "platforms/is_platform.h"
+
+#if defined(FL_IS_RP)
+
+#include <Arduino.h>
+
+#include "fl/stl/atomic.h"
+#include "fl/stl/mutex.h"
+#include "fl/stl/semaphore.h"
+#include "fl/stl/static_assert.h"
+
+namespace {
+
+constexpr int kRpConcurrencyIterations = 100;
+constexpr uint32_t kRpConcurrencyDeadlineMs = 1500;
+constexpr uint32_t kRpCore1ReadyTimeoutMs = 500;
+constexpr uint32_t kRpCore1DoneTimeoutMs = 2000;
+// AutoResearch's loop watchdog is 5 seconds. Leave a full second for JSON
+// response construction and transport after every bounded diagnostic wait.
+constexpr uint32_t kRpConcurrencyWatchdogBudgetMs = 4000;
+FL_STATIC_ASSERT(kRpConcurrencyDeadlineMs + kRpCore1ReadyTimeoutMs +
+                         kRpCore1DoneTimeoutMs <=
+                     kRpConcurrencyWatchdogBudgetMs,
+                 "RP concurrency diagnostics exceed the watchdog-safe budget");
+
+fl::mutex gRpCounterMutex;
+fl::binary_semaphore gRpCore1Request(0);
+fl::counting_semaphore<1000> gRpCore1Done(0);
+fl::atomic<bool> gRpCore1Ready(false);
+fl::atomic<bool> gRpRequestInFlight(false);
+fl::atomic<uint32_t> gRpCore1LoopCount(0);
+fl::atomic<uint32_t> gRpRequestGeneration(0);
+fl::atomic<uint32_t> gRpCompletedGeneration(0);
+fl::atomic<int> gRpCore1Iterations(0);
+fl::atomic<int> gRpCore1Completed(0);
+int gRpSharedCounter = 0;
+
+int incrementRpSharedCounter(int iterations) {
+    int completed = 0;
+    const uint32_t deadline = millis() + kRpConcurrencyDeadlineMs;
+    while (completed < iterations &&
+           static_cast<int32_t>(millis() - deadline) < 0) {
+        if ((completed & 1) != 0) {
+            if (!gRpCounterMutex.try_lock()) {
+                continue;
+            }
+        } else {
+            gRpCounterMutex.lock();
+        }
+        ++gRpSharedCounter;
+        gRpCounterMutex.unlock();
+        ++completed;
+    }
+    return completed;
+}
+
+} // namespace
+
+// Arduino-Pico runs these entry points on the RP's second physical core.
+void setup1() { gRpCore1Ready.store(true); }
+
+void loop1() {
+    gRpCore1LoopCount.fetch_add(1);
+    if (!gRpCore1Request.try_acquire()) {
+        // Avoid a hot atomic/spinlock loop starving shared RP bus resources
+        // while retaining an observable core-1 heartbeat.
+        delay(1);
+        return;
+    }
+
+    const uint32_t generation = gRpRequestGeneration.load();
+    gRpCore1Completed.store(incrementRpSharedCounter(gRpCore1Iterations.load()));
+    gRpCompletedGeneration.store(generation);
+    gRpRequestInFlight.store(false);
+    gRpCore1Done.release();
+}
+
+namespace autoresearch {
+
+fl::json runRpConcurrencyTest() {
+    fl::json response = fl::json::object();
+    response.set("supported", true);
+    response.set("backend", "pico-sdk-mutex+arduino-core1");
+
+    const uint32_t readyDeadline = millis() + kRpCore1ReadyTimeoutMs;
+    while (!gRpCore1Ready.load() && static_cast<int32_t>(millis() - readyDeadline) < 0) {
+        delay(1);
+    }
+    if (!gRpCore1Ready.load()) {
+        response.set("success", false);
+        response.set("error", "RP core1 did not start");
+        return response;
+    }
+
+    while (gRpCore1Done.try_acquire()) {}
+    if (gRpRequestInFlight.exchange(true)) {
+        response.set("success", false);
+        response.set("error", "RP core1 still owns the prior concurrency request");
+        return response;
+    }
+    if (!gRpCounterMutex.try_lock()) {
+        gRpRequestInFlight.store(false);
+        response.set("success", false);
+        response.set("error", "RP mutex unavailable before contention test");
+        return response;
+    }
+    gRpSharedCounter = 0;
+    gRpCounterMutex.unlock();
+
+    gRpCore1Iterations.store(kRpConcurrencyIterations);
+    gRpCore1Completed.store(0);
+    const uint32_t generation = gRpRequestGeneration.fetch_add(1) + 1;
+    const uint32_t core1LoopCountBefore = gRpCore1LoopCount.load();
+    gRpCore1Request.release();
+    const int core0Completed =
+        incrementRpSharedCounter(kRpConcurrencyIterations);
+
+    bool core1Done = false;
+    const uint32_t doneDeadline = millis() + kRpCore1DoneTimeoutMs;
+    while (static_cast<int32_t>(millis() - doneDeadline) < 0) {
+        if (gRpCore1Done.try_acquire()) {
+            if (gRpCompletedGeneration.load() == generation) {
+                core1Done = true;
+                break;
+            }
+        }
+        delay(1);
+    }
+
+    if (!gRpCounterMutex.try_lock()) {
+        response.set("success", false);
+        response.set("error", "RP mutex unavailable after contention test");
+        return response;
+    }
+    const int actual = gRpSharedCounter;
+    gRpCounterMutex.unlock();
+    const int core1Completed = gRpCore1Completed.load();
+    const uint32_t core1LoopCountAfter = gRpCore1LoopCount.load();
+    fl::recursive_mutex recursiveMutex;
+    recursiveMutex.lock();
+    const bool recursiveMutexReady = recursiveMutex.try_lock();
+    if (recursiveMutexReady) {
+        recursiveMutex.unlock();
+    }
+    recursiveMutex.unlock();
+    const int expected = kRpConcurrencyIterations * 2;
+    response.set("success", core1Done &&
+                                core0Completed == kRpConcurrencyIterations &&
+                                core1Completed == kRpConcurrencyIterations &&
+                                actual == expected && recursiveMutexReady);
+    response.set("core1Ready", gRpCore1Ready.load());
+    response.set("core1Done", core1Done);
+    response.set("iterationsPerCore", static_cast<int64_t>(kRpConcurrencyIterations));
+    response.set("core0Completed", static_cast<int64_t>(core0Completed));
+    response.set("core1Completed", static_cast<int64_t>(core1Completed));
+    response.set("core1LoopCountBefore", static_cast<int64_t>(core1LoopCountBefore));
+    response.set("core1LoopCountAfter", static_cast<int64_t>(core1LoopCountAfter));
+    response.set("generation", static_cast<int64_t>(generation));
+    response.set("recursiveMutexReady", recursiveMutexReady);
+    response.set("expected", static_cast<int64_t>(expected));
+    response.set("actual", static_cast<int64_t>(actual));
+    return response;
+}
+
+} // namespace autoresearch
+
+#else
+
+namespace autoresearch {
+
+fl::json runRpConcurrencyTest() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("supported", false);
+    response.set("backend", "unsupported");
+    response.set("reason", "RP dual-core concurrency is available only on RP2xxx");
+    return response;
+}
+
+} // namespace autoresearch
+
+#endif

--- a/examples/AutoResearch/AutoResearchRpConcurrency.h
+++ b/examples/AutoResearch/AutoResearchRpConcurrency.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "fl/stl/json.h"
+
+namespace autoresearch {
+
+/// Exercise the RP dual-core mutex and semaphore backends from both cores.
+fl::json runRpConcurrencyTest();
+
+} // namespace autoresearch

--- a/src/platforms/arm/rp/mutex_rp.cpp.hpp
+++ b/src/platforms/arm/rp/mutex_rp.cpp.hpp
@@ -6,20 +6,9 @@
 // Include platform detection BEFORE the guard
 #include "platforms/arm/rp/is_rp.h"
 
-#ifdef FL_IS_RP2040
+#ifdef FL_IS_RP
 
 #include "platforms/arm/rp/mutex_rp.h"
-#include "fl/log/log.h"
-
-// Include Pico SDK headers ONLY in .cpp file
-FL_EXTERN_C_BEGIN
-// IWYU pragma: begin_keep
-#include "hardware/sync.h"
-// IWYU pragma: end_keep
-// IWYU pragma: begin_keep
-#include "pico/platform.h"
-// IWYU pragma: end_keep
-FL_EXTERN_C_END
 
 namespace fl {
 namespace platforms {
@@ -28,182 +17,43 @@ namespace platforms {
 // MutexRP Implementation
 //=============================================================================
 
-MutexRP::MutexRP() : mSpinlock(nullptr), mOwnerCore(0xFFFFFFFF), mLocked(false) {
-    // Claim a hardware spinlock from the pool
-    int spinlock_num = spin_lock_claim_unused(true);  // true = required (panic if none available)
+MutexRP::MutexRP() { mutex_init(&mMutex); }
 
-    if (spinlock_num < 0) {
-        FL_WARN_F("MutexRP: Failed to claim hardware spinlock");
-        return;
-    }
-
-    // Get the actual spinlock instance and store as opaque pointer
-    spin_lock_t* spinlock = spin_lock_instance(spinlock_num);
-    // spin_lock_t* may be volatile, so we need reinterpret_cast
-    mSpinlock = reinterpret_cast<void*>(const_cast<u32*>(reinterpret_cast<volatile u32*>(spinlock))); // ok reinterpret cast
-}
-
-MutexRP::~MutexRP() {
-    if (mSpinlock != nullptr) {
-        spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-        // Get the spinlock number and unclaim it
-        uint spinlock_num = spin_lock_get_num(spinlock);
-        spin_lock_unclaim(spinlock_num);
-
-        mSpinlock = nullptr;
-    }
-}
+MutexRP::~MutexRP() = default;
 
 void MutexRP::lock() {
-    FL_ASSERT(mSpinlock != nullptr, "MutexRP::lock() called on null mutex");
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-    // Block until we acquire the spinlock
-    u32 save = spin_lock_blocking(spinlock);
-
-    // Mark as locked and record owner
-    mLocked = true;
-    mOwnerCore = get_core_num();
-
-    // Keep the spinlock locked - it will be released in unlock()
-    // Note: We store the interrupt state to restore it later
-    // For now, we just use the spinlock directly as a mutex
-    (void)save;  // Suppress unused variable warning
+    mutex_enter_blocking(&mMutex);
 }
 
 void MutexRP::unlock() {
-    FL_ASSERT(mSpinlock != nullptr, "MutexRP::unlock() called on null mutex");
-    FL_ASSERT(mLocked, "MutexRP::unlock() called on unlocked mutex");
-    FL_ASSERT(mOwnerCore == get_core_num(), "MutexRP::unlock() called from different core than lock()");
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-    // Mark as unlocked
-    mLocked = false;
-    mOwnerCore = 0xFFFFFFFF;
-
-    // Release the spinlock with interrupt state restoration (0 means enable interrupts)
-    spin_unlock(spinlock, 0);
+    mutex_exit(&mMutex);
 }
 
 bool MutexRP::try_lock() {
-    if (mSpinlock == nullptr) {
-        return false;
-    }
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-    // Try to acquire the spinlock without blocking
-    // Use spin_try_lock_unsafe which returns true if lock acquired
-    bool acquired = spin_try_lock_unsafe(spinlock);
-
-    if (acquired) {
-        mLocked = true;
-        mOwnerCore = get_core_num();
-    }
-
-    return acquired;
+    return mutex_try_enter(&mMutex, nullptr);
 }
 
 //=============================================================================
 // RecursiveMutexRP Implementation
 //=============================================================================
 
-RecursiveMutexRP::RecursiveMutexRP() : mSpinlock(nullptr), mOwnerCore(0xFFFFFFFF), mLockCount(0) {
-    // Claim a hardware spinlock from the pool
-    int spinlock_num = spin_lock_claim_unused(true);  // true = required (panic if none available)
+RecursiveMutexRP::RecursiveMutexRP() { recursive_mutex_init(&mMutex); }
 
-    if (spinlock_num < 0) {
-        FL_WARN_F("RecursiveMutexRP: Failed to claim hardware spinlock");
-        return;
-    }
-
-    // Get the actual spinlock instance and store as opaque pointer
-    spin_lock_t* spinlock = spin_lock_instance(spinlock_num);
-    // spin_lock_t* may be volatile, so we need reinterpret_cast
-    mSpinlock = reinterpret_cast<void*>(const_cast<u32*>(reinterpret_cast<volatile u32*>(spinlock))); // ok reinterpret cast
-}
-
-RecursiveMutexRP::~RecursiveMutexRP() {
-    if (mSpinlock != nullptr) {
-        spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-        // Get the spinlock number and unclaim it
-        uint spinlock_num = spin_lock_get_num(spinlock);
-        spin_lock_unclaim(spinlock_num);
-
-        mSpinlock = nullptr;
-    }
-}
+RecursiveMutexRP::~RecursiveMutexRP() = default;
 
 void RecursiveMutexRP::lock() {
-    FL_ASSERT(mSpinlock != nullptr, "RecursiveMutexRP::lock() called on null mutex");
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-    u32 current_core = get_core_num();
-
-    // Check if we already own the lock (recursive case)
-    if (mLockCount > 0 && mOwnerCore == current_core) {
-        mLockCount++;
-        return;
-    }
-
-    // Block until we acquire the spinlock
-    u32 save = spin_lock_blocking(spinlock);
-
-    // Mark as locked and record owner
-    mLockCount = 1;
-    mOwnerCore = current_core;
-
-    (void)save;  // Suppress unused variable warning
+    recursive_mutex_enter_blocking(&mMutex);
 }
 
 void RecursiveMutexRP::unlock() {
-    FL_ASSERT(mSpinlock != nullptr, "RecursiveMutexRP::unlock() called on null mutex");
-    FL_ASSERT(mLockCount > 0, "RecursiveMutexRP::unlock() called on unlocked mutex");
-    FL_ASSERT(mOwnerCore == get_core_num(), "RecursiveMutexRP::unlock() called from different core than lock()");
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-
-    // Decrement lock count
-    mLockCount--;
-
-    if (mLockCount == 0) {
-        // No more recursive locks, release the spinlock
-        mOwnerCore = 0xFFFFFFFF;
-        spin_unlock(spinlock, 0);
-    }
+    recursive_mutex_exit(&mMutex);
 }
 
 bool RecursiveMutexRP::try_lock() {
-    if (mSpinlock == nullptr) {
-        return false;
-    }
-
-    spin_lock_t* spinlock = static_cast<spin_lock_t*>(mSpinlock);
-    u32 current_core = get_core_num();
-
-    // Check if we already own the lock (recursive case)
-    if (mLockCount > 0 && mOwnerCore == current_core) {
-        mLockCount++;
-        return true;
-    }
-
-    // Try to acquire the spinlock without blocking
-    // Use spin_try_lock_unsafe which returns true if lock acquired
-    bool acquired = spin_try_lock_unsafe(spinlock);
-
-    if (acquired) {
-        mLockCount = 1;
-        mOwnerCore = current_core;
-    }
-
-    return acquired;
+    return recursive_mutex_try_enter(&mMutex, nullptr);
 }
 
 } // namespace platforms
 } // namespace fl
 
-#endif // FL_IS_RP2040
+#endif // FL_IS_RP

--- a/src/platforms/arm/rp/mutex_rp.h
+++ b/src/platforms/arm/rp/mutex_rp.h
@@ -7,13 +7,14 @@
 /// @file platforms/arm/rp/mutex_rp.h
 /// @brief RP2040/RP2350 Pico SDK mutex implementation
 ///
-/// This header provides RP2040/RP2350-specific mutex implementations using Pico SDK spinlocks.
+/// This header provides RP2040/RP2350-specific mutex implementations using Pico SDK mutexes.
 /// For RP platforms, we use std::unique_lock for full compatibility with condition variables.
 
 #include "fl/stl/assert.h"
 // IWYU pragma: begin_keep
 #include <mutex>  // ok include - needed for std::unique_lock
 #include "fl/stl/noexcept.h"
+#include "pico/mutex.h"  // IWYU pragma: keep
 // IWYU pragma: end_keep
 
 namespace fl {
@@ -44,9 +45,7 @@ using std::adopt_lock;  // okay std namespace
 // RP2040/RP2350 Pico SDK mutex wrapper
 class MutexRP {
 private:
-    void* mSpinlock;      // spin_lock_t* (opaque pointer to avoid including Pico SDK headers)
-    u32 mOwnerCore;  // Core ID of the owner (for debug/assert purposes)
-    bool mLocked;         // Lock state
+    mutex_t mMutex;
 
 public:
     MutexRP() FL_NO_EXCEPT;
@@ -66,9 +65,7 @@ public:
 // RP2040/RP2350 Pico SDK recursive mutex wrapper
 class RecursiveMutexRP {
 private:
-    void* mSpinlock;      // spin_lock_t* (opaque pointer to avoid including Pico SDK headers)
-    u32 mOwnerCore;  // Core ID of the owner
-    u32 mLockCount;  // Recursion depth counter
+    recursive_mutex_t mMutex;
 
 public:
     RecursiveMutexRP() FL_NO_EXCEPT;

--- a/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
@@ -38,8 +38,8 @@ bool pinInList(u8 pin, const u8* pins, size_t count) FL_NO_EXCEPT {
 }  // namespace
 
 RpUartPeripheral::RpUartPeripheral() FL_NO_EXCEPT
-    : mDmaChannel(-1), mUartIndex(-1), mTxPin(-1), mInitialized(false),
-      mOwnsUart(false), mOwnsPin(false), mActualBaudRate(0) {}
+    : mDmaChannel(-1), mUartIndex(-1), mTxPin(-1), mActualBaudRate(0),
+      mInitialized(false), mOwnsUart(false), mOwnsPin(false) {}
 
 RpUartPeripheral::~RpUartPeripheral() { deinitialize(); }
 

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
@@ -92,8 +92,8 @@ RpPioRxDevice::RpPioRxDevice(int pin) FL_NO_EXCEPT
       mProgramOffset(-1), mPioClockHz(0), mTailLimitNs(1), mLastTransitionUs(0),
       mCapacity(0), mArmed(false), mFinished(false), mOverflow(false),
       mProgramLoaded(false), mIdleHigh(false), mSampleHigh(false), mHaveSample(false),
-      mLastBeginError(""), mDmaWordCount(0), mDmaWords(nullptr), mEdges(nullptr),
-      mDmaWordsProcessed(0), mSampleRunTicks(0) {}
+      mLastBeginError(""), mDmaWordCount(0), mDmaWordsProcessed(0),
+      mSampleRunTicks(0), mDmaWords(nullptr), mEdges(nullptr) {}
 
 RpPioRxDevice::~RpPioRxDevice() FL_NO_EXCEPT { stop(); }
 

--- a/src/platforms/arm/rp/semaphore_rp.cpp.hpp
+++ b/src/platforms/arm/rp/semaphore_rp.cpp.hpp
@@ -6,7 +6,7 @@
 // Include platform detection BEFORE the guard
 #include "platforms/arm/rp/is_rp.h"
 
-#ifdef FL_IS_RP2040
+#ifdef FL_IS_RP
 
 #include "platforms/arm/rp/semaphore_rp.h"
 #include "fl/log/log.h"
@@ -213,4 +213,4 @@ template bool CountingSemaphoreRP<1>::try_acquire_until(const std::chrono::time_
 } // namespace platforms
 } // namespace fl
 
-#endif // FL_IS_RP2040
+#endif // FL_IS_RP

--- a/src/platforms/mutex.h
+++ b/src/platforms/mutex.h
@@ -14,7 +14,7 @@
 ///
 /// Supported platforms:
 /// - ESP32: FreeRTOS mutex wrappers
-/// - RP2040/RP2350: Pico SDK spinlock-based mutexes
+/// - RP2040/RP2350: Pico SDK mutex_t / recursive_mutex_t wrappers
 /// - STM32: FreeRTOS mutex wrappers (when FreeRTOS is available)
 /// - SAMD21/SAMD51: CMSIS interrupt-based mutex
 /// - Teensy: Interrupt-based mutex using critical sections
@@ -32,7 +32,7 @@
 // Platform dispatch
 #ifdef FL_IS_ESP32
     #include "platforms/esp/32/mutex_esp32.h"  // IWYU pragma: keep
-#elif defined(FL_IS_RP2040)
+#elif defined(FL_IS_RP)
     #include "platforms/arm/rp/mutex_rp.h"  // IWYU pragma: keep
 #elif defined(FL_IS_STM32) && FL_HAS_INCLUDE("FreeRTOS.h")
     #include "platforms/arm/stm32/mutex_stm32.h"  // IWYU pragma: keep

--- a/src/platforms/semaphore.h
+++ b/src/platforms/semaphore.h
@@ -31,7 +31,7 @@
     #include "platforms/esp/32/semaphore_esp32.h"
 #elif defined(FL_IS_STM32) && FL_HAS_INCLUDE("FreeRTOS.h")
     #include "platforms/arm/stm32/semaphore_stm32.h"
-#elif defined(FL_IS_RP2040)
+#elif defined(FL_IS_RP)
     #include "platforms/arm/rp/semaphore_rp.h"
 #elif defined(FL_IS_TEENSY)
     #include "platforms/arm/teensy/semaphore_teensy.h"


### PR DESCRIPTION
## Summary
- make RP2350/RP2350W serial RPC smoke strict about discovery, help, monotonic uptime, exact payload echo, readiness, and JSON-RPC `-32601` errors
- dispatch RP2350 mutex/semaphore support through Pico SDK mutex primitives and add generation-safe dual-core hardware validation
- keep Wave2D pin-free, report the RP null coroutine backend as unsupported, and expose an fbuild-backed one-method RPC CLI
- distinguish serial RPC readiness from a validated LED RX path and invalidate RX proof after runtime pin changes

## Validation
- `bash lint`
- `uv run pytest ci/tests/test_autoresearch_phases.py ci/tests/test_rpc_client_errors.py ci/tests/test_rpc_bench_cli.py ci/tests/test_rp2350w_board_config.py -q` — 155 passed
- `bash test --cpp --clean` — 279/279 unit tests and 83/83 examples passed
- all transient Windows DLL-loader failures passed individually under `--debug`
- `bash compile rp2350w --examples AutoResearch` — 1,117,088 bytes flash, 106,920 bytes RAM
- clud-review Python and C++ buckets: clean

## Hardware status
Live execution is intentionally pending. fbuild identifies expected RP2350W serial `2DCB876B587EA334` at COM17 as phantom/non-selectable; attached ESP32-C6 COM9 remains healthy. This PR must not merge until COM17 is physically reconnected and the Phase 2 hardware gates pass.

Refs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RPC discovery, platform readiness, LED/RX availability, and RP dual-core concurrency diagnostics.
  - Added a command-line tool for invoking RPC methods with JSON arguments and clear status reporting.
  - Expanded support for RP platforms and coroutine capability reporting.

- **Bug Fixes**
  - Pin changes now preserve state if replacement setup fails and invalidate stale validation results.
  - Improved structured JSON-RPC error reporting and SPI input validation.
  - Performance-wave testing no longer performs unnecessary GPIO setup.

- **Tests**
  - Expanded coverage for RPC validation, timeouts, unsupported platforms, pin handling, and RP synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->