### PR TITLE
chore(deps): bump fbuild to 2.5.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,14 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.6. It carries library-dependency fixes for Teensy/STM32,
+    # Pin to fbuild 2.5.7. It carries library-dependency fixes for Teensy/STM32,
     # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment,
     # plus the monitor WebSocket and serial-health fixes required by
     # AutoResearch.
     #
     # Pin history:
+    #   2.5.7 -- rolls up the 2.5.6 deployment fixes and preserves RP2350
+    #             UF2 rejection diagnostics (FastLED/fbuild#1246).
     #   2.5.6 -- honors lib_deps on Teensy/STM32, reclaims dead-owner package
     #             install locks and stale daemon endpoints, hardens RP2350 UF2
     #             deployment, and improves ESP32 esptool provisioning errors
@@ -171,7 +173,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.6",
+    "fbuild==2.5.7",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary\n- pin FastLED's fbuild dependency to the released 2.5.7\n- retain the RP2350 UF2 diagnostic rationale from FastLED/fbuild#1246\n\n## Validation\n- uv lock --check\n- uv run fbuild --version (2.5.7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled build tooling to version 2.5.7.
  * Refreshed the associated version history notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->