### PR TITLE
fix(rp2350): expose independent PIO channels

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -312,14 +312,17 @@ See Also:
         driver_group.add_argument(
             "--flex-io",
             action="store_true",
-            help="Test only FlexIO clockless driver (Teensy 4.x only; requires --tx-pin in {6-13,32})",
+            help=(
+                "Test FlexIO clockless (Teensy 4.x; requires --tx-pin in {6-13,32}) "
+                "or RP PIO clockless (RP2040/RP2350)"
+            ),
         )
         driver_group.add_argument(
             "--rp-pio-index",
             type=int,
-            choices=(0, 1),
+            choices=(0, 1, 2),
             default=1,
-            help="RP2040/RP2350 PIO engine for --flex-io (default: 1).",
+            help="RP PIO engine for --flex-io; PIO2 requires RP2350 (default: 1).",
         )
         driver_group.add_argument(
             "--rp-pio-both",

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -105,7 +105,7 @@ def _driver_name_for_environment(
         driver == "FLEX_IO"
         and _active_rp2xxx_environment(final_environment) is not None
     ):
-        # RP exposes two independent PIO engines as PIO0 and PIO1.  Their
+        # RP2040 exposes PIO0/PIO1; RP2350 adds PIO2. Their
         # concrete names must remain distinct so a runtime-exclusive test can
         # select one physical PIO block without replacing the other.
         return f"PIO{rp_pio_index}"
@@ -531,6 +531,15 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     if args.rp_pio_both and (not args.flex_io or not parallel_mode):
         print(
             f"{Fore.RED}❌ --rp-pio-both requires --flex-io --parallel{Style.RESET_ALL}"
+        )
+        return 1
+    if (
+        args.flex_io
+        and args.rp_pio_index == 2
+        and _active_rp2xxx_environment(final_environment) not in RP2350_ENVIRONMENTS
+    ):
+        print(
+            f"{Fore.RED}❌ --rp-pio-index 2 requires an RP2350 target{Style.RESET_ALL}"
         )
         return 1
     if parallel_mode:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -828,6 +828,33 @@ class TestParseArgsAndBuildCommands:
         assert result.drivers == ["PIO0"]
         assert result.json_rpc_commands[0]["params"]["driver"] == "PIO0"
 
+    def test_flex_io_selects_pio2_on_rp2350(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            parlio=False,
+            flex_io=True,
+            rp_pio_index=2,
+            environment_positional="rp2350w",
+            project_dir=fake_project_dir,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["PIO2"]
+        assert result.json_rpc_commands[0]["params"]["driver"] == "PIO2"
+
+    def test_flex_io_rejects_pio2_on_rp2040(self, fake_project_dir: Path) -> None:
+        args = _make_args(
+            parlio=False,
+            flex_io=True,
+            rp_pio_index=2,
+            environment_positional="rp2040",
+            project_dir=fake_project_dir,
+        )
+        assert _parse_args_and_build_commands(args) == 1
+
     @pytest.mark.parametrize(
         "environment",
         (

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -236,6 +236,7 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                 else if (n == "FLEX_IO")       { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }
                 else if (n == "PIO0")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 0; }
                 else if (n == "PIO1")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }
+                else if (n == "PIO2")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 2; }
                 else if (n == "OBJECT_FLED")   opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "LPUART")        opts.mBus = fl::Bus::UART;
                 else if (n == "BIT_BANG")      opts.mBus = fl::Bus::BIT_BANG;

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -1048,6 +1048,16 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         response.set("rpPioStartSucceeded", pio.lastStartSucceeded());
         response.set("rpPioWordCount", static_cast<int64_t>(pio.lastWordCount()));
     }
+    #if defined(FL_IS_RP2350)
+    if (driver_name == "PIO2") {
+        auto& pio = fl::BusTraits<fl::Bus::FLEX_IO, 2>::instance();
+        response.set("rpPioActive", pio.isActive());
+        response.set("rpPioLastError", pio.lastError().c_str());
+        response.set("rpPioStartAttempted", pio.lastStartAttempted());
+        response.set("rpPioStartSucceeded", pio.lastStartSucceeded());
+        response.set("rpPioWordCount", static_cast<int64_t>(pio.lastWordCount()));
+    }
+    #endif
 #endif
 
     fl::json sizes_response = fl::json::array();

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -88,6 +88,9 @@ fl::json autoResearchDeviceJson(const fl::string& name) {
         name == "LCD_CLOCKLESS" || name == "I2S" || name == "I2S_SPI") {
         return fl::deviceJson<fl::Bus::FLEX_IO, 0>();
     }
+    if (name == "PIO0") return fl::deviceJson<fl::Bus::FLEX_IO, 0>();
+    if (name == "PIO1") return fl::deviceJson<fl::Bus::FLEX_IO, 1>();
+    if (name == "PIO2") return fl::deviceJson<fl::Bus::FLEX_IO, 2>();
 
     fl::json info = fl::json::object();
     info.set("bus", static_cast<int64_t>(0));

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -462,7 +462,8 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     // an explicit PIO backend so the DMA capture is sized per frame.
     const bool is_rp_pio_capture =
         rx_channel->backend() == fl::RxBackend::PIO ||
-        fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0;
+        fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0 ||
+        fl::strcmp(driver_name, "PIO2") == 0;
     if (is_rp_pio_capture) {
         // The shared result buffer is intentionally sized for the largest
         // AutoResearch run, not this frame. PIO DMA stores one word for each
@@ -569,7 +570,8 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         fl::isr::handle edge_counter;
         bool edge_counter_attached = false;
         const bool measure_rp_pio =
-            (fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0) &&
+            (fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0 ||
+             fl::strcmp(driver_name, "PIO2") == 0) &&
             diagnostics != nullptr;
         if (measure_rp_pio) {
             // FastLED.show() drives the channel engine until it reaches its
@@ -595,7 +597,8 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         if (edge_counter_attached && edge_counter.is_valid()) {
             fl::isr::detach_handler(edge_counter);
         }
-        if ((fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0) &&
+        if ((fl::strcmp(driver_name, "PIO0") == 0 || fl::strcmp(driver_name, "PIO1") == 0 ||
+             fl::strcmp(driver_name, "PIO2") == 0) &&
             diagnostics != nullptr) {
             diagnostics->rpPioGpioTransitions = edge_counter_attached ? rising_edges.load() : -1;
         }

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -136,7 +136,11 @@ template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
 #elif defined(FL_IS_ARM_LPC_845)
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 1; };
-#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+#elif defined(FL_IS_RP2350)
+template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 3; };
+template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2; };
+template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
+#elif defined(FL_IS_RP2040)
 template<> struct BusInstanceCount<Bus::FLEX_IO> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::SPI> { static constexpr fl::u8 value = 2; };
 template<> struct BusInstanceCount<Bus::UART> { static constexpr fl::u8 value = 2; };
@@ -165,6 +169,14 @@ inline const char* busDriverName(Bus b, fl::u8 which = 0, bool spi = false) FL_N
 #if defined(FL_IS_TEENSY_4X)
             (void)spi;
             return which == 0 ? "OBJECT_FLED" : "FLEX_IO";
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+            (void)spi;
+            if (which == 0) return "PIO0";
+            if (which == 1) return "PIO1";
+            #if defined(FL_IS_RP2350)
+            if (which == 2) return "PIO2";
+            #endif
+            return "FLEX_IO_UNAVAILABLE";
 #elif defined(FL_IS_ESP32)
 #if FASTLED_HAS_PARLIO
             (void)which;

--- a/src/fl/channels/bus_info.h
+++ b/src/fl/channels/bus_info.h
@@ -156,6 +156,28 @@ template<> struct DeviceInfoResolver<Bus::UART, 0> {
     }
 };
 
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+template<> struct DeviceInfoResolver<Bus::FLEX_IO, 0> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::FLEX_IO, 0, "PIO", "RP PIO0");
+    }
+};
+
+template<> struct DeviceInfoResolver<Bus::FLEX_IO, 1> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::FLEX_IO, 1, "PIO", "RP PIO1");
+    }
+};
+
+#if defined(FL_IS_RP2350)
+template<> struct DeviceInfoResolver<Bus::FLEX_IO, 2> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::FLEX_IO, 2, "PIO", "RP2350 PIO2");
+    }
+};
+#endif
+
 #elif defined(FL_IS_ESP32)
 
 template<> struct DeviceInfoResolver<Bus::RMT, 0> {

--- a/src/fl/channels/bus_priorities.h
+++ b/src/fl/channels/bus_priorities.h
@@ -46,7 +46,7 @@ constexpr int default_bus_priority(Bus b, fl::u8 which) FL_NO_EXCEPT {
     // secondary (classic-ESP32 I2S0 second bank, ESP32-P4 LCD_RGB —
     // FastLED#3576 Phase 1).
     return
-        b == Bus::FLEX_IO   ? (which == 0 ? 4 : 3) :
+        b == Bus::FLEX_IO   ? (which == 0 ? 4 : which == 1 ? 3 : 2) :
         b == Bus::RMT       ? 2  :
         b == Bus::SPI       ? 1  :
         b == Bus::DUAL_SPI  ? 1  :

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp.hpp
@@ -25,8 +25,10 @@ bool isNativeSpiPinPair(const SpiChipsetConfig& config) FL_NO_EXCEPT {
 
 ChannelEngineRpPio::ChannelEngineRpPio(
     fl::shared_ptr<IRpPioTxPeripheral> peripheral,
-    fl::shared_ptr<IRpPioSpiPeripheral> spi_peripheral) FL_NO_EXCEPT
+    fl::shared_ptr<IRpPioSpiPeripheral> spi_peripheral,
+    const char* driver_name) FL_NO_EXCEPT
     : mPeripheral(fl::move(peripheral)), mSpiPeripheral(fl::move(spi_peripheral)),
+      mDriverName(driver_name != nullptr ? driver_name : "FLEX_IO"),
       mCurrentChannel(0), mLatchStartUs(0), mLatchDurationUs(0),
       mActiveLaneCount(1), mActiveMode(Mode::Clockless), mActive(false),
       mLatchPending(false), mFailed(false),

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_pio.h
@@ -19,7 +19,8 @@ class ChannelEngineRpPio final : public IChannelDriver {
   public:
     explicit ChannelEngineRpPio(fl::shared_ptr<IRpPioTxPeripheral> peripheral,
                                 fl::shared_ptr<IRpPioSpiPeripheral> spi_peripheral =
-                                    fl::shared_ptr<IRpPioSpiPeripheral>()) FL_NO_EXCEPT;
+                                    fl::shared_ptr<IRpPioSpiPeripheral>(),
+                                const char* driver_name = "FLEX_IO") FL_NO_EXCEPT;
     ~ChannelEngineRpPio() override;
 
     bool canHandle(const ChannelDataPtr& data) const FL_NO_EXCEPT override;
@@ -34,7 +35,7 @@ class ChannelEngineRpPio final : public IChannelDriver {
     size_t lastWordCount() const FL_NO_EXCEPT { return mLastWordCount; }
 
     fl::string getName() const FL_NO_EXCEPT override {
-        return fl::string::from_literal("FLEX_IO");
+        return fl::string::from_literal(mDriverName);
     }
     Capabilities getCapabilities() const FL_NO_EXCEPT override {
         return Capabilities(true, true);
@@ -50,6 +51,7 @@ class ChannelEngineRpPio final : public IChannelDriver {
 
     fl::shared_ptr<IRpPioTxPeripheral> mPeripheral;
     fl::shared_ptr<IRpPioSpiPeripheral> mSpiPeripheral;
+    const char* mDriverName;
     fl::vector<ChannelDataPtr> mPendingChannels;
     fl::vector<ChannelDataPtr> mInFlightChannels;
     fl::vector<u32> mPioWords;

--- a/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp
@@ -107,6 +107,9 @@ void initChannelDrivers() {
     BusTraits<Bus::SPI, 1>::registerWithManager();
     BusTraits<Bus::FLEX_IO, 0>::registerWithManager();
     BusTraits<Bus::FLEX_IO, 1>::registerWithManager();
+#if defined(FL_IS_RP2350)
+    BusTraits<Bus::FLEX_IO, 2>::registerWithManager();
+#endif
 
     FL_DBG_F("RP2040/RP2350: Channel drivers initialized");
 }

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
@@ -20,6 +20,11 @@ namespace fl {
 namespace detail {
 
 template<u8 Which>
+inline const char* rpPioDriverName() FL_NO_EXCEPT {
+    return Which == 0 ? "PIO0" : Which == 1 ? "PIO1" : "PIO2";
+}
+
+template<u8 Which>
 struct RpPioTxBusHolder {
     fl::shared_ptr<RpPioTxPeripheral> peripheral;
     fl::shared_ptr<RpPioSpiPeripheral> spiPeripheral;
@@ -27,7 +32,8 @@ struct RpPioTxBusHolder {
     RpPioTxBusHolder() FL_NO_EXCEPT
         : peripheral(fl::make_shared<RpPioTxPeripheral>(Which)),
           spiPeripheral(fl::make_shared<RpPioSpiPeripheral>(Which)),
-          driver(fl::make_shared<ChannelEngineRpPio>(peripheral, spiPeripheral)) {}
+          driver(fl::make_shared<ChannelEngineRpPio>(
+              peripheral, spiPeripheral, rpPioDriverName<Which>())) {}
 };
 
 template<u8 Which>
@@ -56,10 +62,25 @@ template<> struct BusTraits<Bus::FLEX_IO, 1> {
     }
 };
 
+#if defined(FL_IS_RP2350)
+template<> struct BusTraits<Bus::FLEX_IO, 2> {
+    using Driver = ChannelEngineRpPio;
+    static fl::shared_ptr<Driver> instancePtr() FL_NO_EXCEPT { return detail::rpPioTxInstancePtr<2>(); }
+    static Driver& instance() FL_NO_EXCEPT { return *instancePtr(); }
+    static void registerWithManager() FL_NO_EXCEPT {
+        ChannelManager::instance().addDriver(default_bus_priority(Bus::FLEX_IO, 2), instancePtr());
+    }
+};
+#endif
+
 template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 0> : fl::true_type {};
 template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 1> : fl::true_type {};
 template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 0> : fl::true_type {};
 template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 1> : fl::true_type {};
+#if defined(FL_IS_RP2350)
+template<> struct BusSupports<Bus::FLEX_IO, ClocklessChipset, 2> : fl::true_type {};
+template<> struct BusSupports<Bus::FLEX_IO, SpiChipsetConfig, 2> : fl::true_type {};
+#endif
 
 }  // namespace fl
 

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -4,6 +4,7 @@
 #include "test.h"
 
 #include "fl/channels/data.h"
+#include "fl/channels/manager.h"
 #include "fl/chipsets/spi.h"
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/move.h"
@@ -315,6 +316,28 @@ FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
     FL_CHECK_FALSE(channel->isInUse());
     FL_CHECK_EQ(spiMock.deinitializeCalls, 1);
+}
+
+FL_TEST_CASE("RP PIO instances preserve distinct concrete driver names") {
+    const fl::shared_ptr<IRpPioSpiPeripheral> no_spi;
+    auto pio0 = fl::make_shared<ChannelEngineRpPio>(
+        fl::make_shared<PioTxMock>(), no_spi, "PIO0");
+    auto pio1 = fl::make_shared<ChannelEngineRpPio>(
+        fl::make_shared<PioTxMock>(), no_spi, "PIO1");
+    auto pio2 = fl::make_shared<ChannelEngineRpPio>(
+        fl::make_shared<PioTxMock>(), no_spi, "PIO2");
+
+    ChannelManager& manager = ChannelManager::instance();
+    manager.clearAllDrivers();
+    manager.addDriver(4, pio0);
+    manager.addDriver(3, pio1);
+    manager.addDriver(2, pio2);
+
+    FL_CHECK_EQ(manager.getDriverCount(), static_cast<fl::size>(3));
+    FL_CHECK(manager.getDriverByName("PIO0") != nullptr);
+    FL_CHECK(manager.getDriverByName("PIO1") != nullptr);
+    FL_CHECK(manager.getDriverByName("PIO2") != nullptr);
+    manager.clearAllDrivers();
 }
 
 FL_TEST_CASE("RP FLEX_IO defers native SPI pin pairs to the hardware driver") {


### PR DESCRIPTION
## Summary

- Register each RP PIO block with concrete Channels driver names: PIO0, PIO1, and RP2350-only PIO2.
- Expose RP2350 PIO2 through bus traits, priorities, introspection, and AutoResearch.
- Retain Bus::FLEX_IO as the portable bus abstraction.

## Why

All RP PIO engines previously reported FLEX_IO, so manager registration replaced PIO0 with PIO1. That made runtime-exclusive PIO selection impossible and left RP2350 PIO2 inaccessible.

## Validation

- Focused RP PIO C++ mock and manager test
- Focused AutoResearch parser tests
- Full lint
- RP2350W AutoResearch firmware compile

Refs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RP2350 support for a third FLEX_IO channel, identified as PIO2.
  - Added PIO2 support for clockless and SPI communication, diagnostics, device detection, and channel configuration.
  - Improved driver identification for PIO0, PIO1, and PIO2.

- **Bug Fixes**
  - Prevented selecting PIO2 on targets that do not support it.
  - Updated channel priorities for multiple FLEX_IO instances.

- **Tests**
  - Added coverage for PIO2 selection, validation, registration, naming, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->