### PR TITLE
feat(rp2350w): enable CYW43 WiFi

### DIFF
--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -16,6 +16,9 @@ MUTEX_DISPATCH = REPO_ROOT / "src" / "platforms" / "mutex.h"
 MUTEX_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "mutex_rp.cpp.hpp"
 SEMAPHORE_DISPATCH = REPO_ROOT / "src" / "platforms" / "semaphore.h"
 SEMAPHORE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "semaphore_rp.cpp.hpp"
+WIFI_API = REPO_ROOT / "src" / "fl" / "net" / "wifi.h"
+RP_WIFI_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "wifi_rp.cpp.hpp"
+RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
 
 
 def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
@@ -78,3 +81,16 @@ def test_rp_platform_dispatches_real_mutex_and_semaphore_backends() -> None:
         assert re.search(r"\bFL_IS_RP\b", source), (
             f"{source_path} does not guard on FL_IS_RP"
         )
+
+
+def test_rp2350w_selects_the_cyw43_wifi_backend() -> None:
+    """Pico 2 W must not silently fall through to the no-WiFi stubs."""
+    api_source = WIFI_API.read_text(encoding="utf-8")
+    implementation = RP_WIFI_IMPL.read_text(encoding="utf-8")
+    build_source = RP_BUILD.read_text(encoding="utf-8")
+
+    assert "FL_IS_RP2350" in api_source
+    assert "PICO_CYW43_SUPPORTED" in api_source
+    assert "FL_HAS_INCLUDE(<WiFi.h>)" in api_source
+    assert "WiFi.beginNoBlock" in implementation
+    assert '"platforms/arm/rp/wifi_rp.cpp.hpp"' in build_source

--- a/src/fl/net/wifi.h
+++ b/src/fl/net/wifi.h
@@ -34,8 +34,10 @@
 #endif
 
 /// 1 when a real WiFi implementation is compiled in; 0 → stubs.
-#if defined(FL_IS_ESP32) && defined(SOC_WIFI_SUPPORTED) && SOC_WIFI_SUPPORTED && \
-    FL_HAS_INCLUDE(<esp_wifi.h>)
+#if (defined(FL_IS_ESP32) && defined(SOC_WIFI_SUPPORTED) && SOC_WIFI_SUPPORTED && \
+     FL_HAS_INCLUDE(<esp_wifi.h>)) || \
+    (defined(FL_IS_RP2350) && defined(PICO_CYW43_SUPPORTED) && \
+     FL_HAS_INCLUDE(<WiFi.h>))
 #define FL_WIFI_AVAILABLE 1
 #else
 #define FL_WIFI_AVAILABLE 0
@@ -61,8 +63,8 @@ const char* toString(Status s) FL_NO_EXCEPT;
 /// @brief Start an asynchronous station-mode join.
 ///
 /// Returns immediately; poll status()/isConnected(). Calling again with
-/// different credentials restarts the join. Coexists with an active
-/// SoftAP (APSTA mode).
+/// different credentials restarts the join. On platforms with APSTA support,
+/// it can coexist with an active SoftAP.
 /// @return false if the WiFi driver could not be started at all.
 bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT;
 

--- a/src/platforms/arm/rp/_build.cpp.hpp
+++ b/src/platforms/arm/rp/_build.cpp.hpp
@@ -11,6 +11,7 @@
 #include "platforms/arm/rp/io_rp.cpp.hpp"
 #include "platforms/arm/rp/mutex_rp.cpp.hpp"
 #include "platforms/arm/rp/semaphore_rp.cpp.hpp"
+#include "platforms/arm/rp/wifi_rp.cpp.hpp"
 
 // begin sub directory includes
 #include "platforms/arm/rp/rp2040/_build.cpp.hpp"

--- a/src/platforms/arm/rp/wifi_rp.cpp.hpp
+++ b/src/platforms/arm/rp/wifi_rp.cpp.hpp
@@ -1,0 +1,130 @@
+// IWYU pragma: private
+
+/// @file wifi_rp.cpp.hpp
+/// @brief CYW43-backed RP2350W implementation of fl::net::wifi.
+///
+/// Arduino-Pico supplies the CYW43/lwIP peripheral through its WiFi library.
+/// beginNoBlock() starts an association without waiting for DHCP, which keeps
+/// the fl::net::wifi API non-blocking just as it is on ESP32.
+
+#include "fl/net/wifi.h"
+#include "platforms/arm/rp/is_rp.h"
+
+#if FL_WIFI_AVAILABLE && defined(FL_IS_RP2350)
+
+#include "fl/stl/cstdio.h"
+#include "fl/stl/noexcept.h"
+
+// IWYU pragma: begin_keep
+#include <WiFi.h>
+// IWYU pragma: end_keep
+
+namespace fl {
+namespace net {
+namespace wifi {
+
+namespace {
+
+struct WifiState {
+    bool sta_requested = false;
+    bool ap_active = false;
+};
+
+// FL_LINT_ALLOW_GLOBAL(platform WiFi state is a singleton supplied by Arduino-Pico)
+WifiState g_state;
+
+Status currentStatus() FL_NO_EXCEPT {
+    if (WiFi.isConnected()) {
+        return Status::CONNECTED;
+    }
+    if (g_state.sta_requested) {
+        const int link_status = WiFi.status();
+        if (link_status == WL_CONNECT_FAILED ||
+            link_status == WL_NO_SSID_AVAIL ||
+            link_status == WL_CONNECTION_LOST ||
+            link_status == WL_NO_MODULE) {
+            return Status::FAILED;
+        }
+        return Status::CONNECTING;
+    }
+    return g_state.ap_active ? Status::AP_ACTIVE : Status::IDLE;
+}
+
+fl::string ipToString(IPAddress ip) FL_NO_EXCEPT {
+    char buffer[16];
+    fl::snprintf(buffer, sizeof(buffer), "%u.%u.%u.%u",
+                 static_cast<unsigned>(ip[0]),
+                 static_cast<unsigned>(ip[1]),
+                 static_cast<unsigned>(ip[2]),
+                 static_cast<unsigned>(ip[3]));
+    return fl::string(buffer);
+}
+
+} // namespace
+
+bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT {
+    if (ssid == nullptr || *ssid == '\0') {
+        return false;
+    }
+
+    WiFi.mode(WIFI_STA);
+    if (password != nullptr && *password != '\0') {
+        WiFi.beginNoBlock(ssid, password);
+    } else {
+        WiFi.beginNoBlock(ssid);
+    }
+
+    // Arduino-Pico returns WL_IDLE_STATUS while the CYW43 link is still
+    // coming up, so beginNoBlock's return value cannot distinguish that
+    // healthy intermediate state from a startup failure. Report initiation
+    // success and let status() surface a driver/link failure asynchronously.
+    g_state.sta_requested = true;
+    g_state.ap_active = false;
+    return true;
+}
+
+bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT {
+    if (ssid == nullptr || *ssid == '\0') {
+        return false;
+    }
+
+    WiFi.mode(WIFI_AP);
+    const int result = (password != nullptr && *password != '\0')
+                           ? WiFi.beginAP(ssid, password, channel)
+                           : WiFi.beginAP(ssid, channel);
+    if (result != WL_CONNECTED) {
+        return false;
+    }
+
+    g_state.sta_requested = false;
+    g_state.ap_active = true;
+    return true;
+}
+
+void stop() FL_NO_EXCEPT {
+    WiFi.end();
+    g_state.sta_requested = false;
+    g_state.ap_active = false;
+}
+
+Status status() FL_NO_EXCEPT {
+    return currentStatus();
+}
+
+bool isConnected() FL_NO_EXCEPT {
+    return currentStatus() == Status::CONNECTED;
+}
+
+fl::string ipAddress() FL_NO_EXCEPT {
+    return isConnected() ? ipToString(WiFi.localIP()) : fl::string();
+}
+
+fl::string apIpAddress() FL_NO_EXCEPT {
+    return g_state.ap_active ? ipToString(WiFi.softAPIP()) : fl::string();
+}
+
+} // namespace wifi
+} // namespace net
+} // namespace fl
+
+#endif // FL_WIFI_AVAILABLE && FL_IS_RP2350


### PR DESCRIPTION
## Summary
- enable l::net::wifi for Pico 2 W CYW43 builds through Arduino-Pico's non-blocking WiFi.beginNoBlock API
- expose station state, SoftAP state, and IP reporting while retaining platform-neutral stubs elsewhere
- add RP2350W build-routing regression coverage

## Validation
- uv run pytest ci/tests/test_rp2350w_board_config.py -q (6 passed)
- ash lint --cpp (passed; pre-existing warn-only baseline findings)
- ash compile rp2350w --examples AutoResearch (passed, fbuild)

The hardware proof remains gated on COM17 becoming a healthy/selectable Windows device; no raw flasher or serial access was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WiFi support for RP2350 boards with CYW43 hardware.
  - Added station-mode connections with non-blocking status reporting.
  - Added access point setup and shutdown support.
  - Added connection status checks and station/access-point IP address retrieval.
  - Added handling for connection failures and invalid network names.

- **Documentation**
  - Clarified when simultaneous station and access-point operation is supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->