### PR TITLE
fix(rp2350w): build CYW43 AutoResearch peer

### DIFF
--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -19,6 +19,8 @@ SEMAPHORE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "semaphore_rp.
 WIFI_API = REPO_ROOT / "src" / "fl" / "net" / "wifi.h"
 RP_WIFI_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "wifi_rp.cpp.hpp"
 RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
+AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
+AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
 
 
 def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
@@ -94,3 +96,16 @@ def test_rp2350w_selects_the_cyw43_wifi_backend() -> None:
     assert "FL_HAS_INCLUDE(<WiFi.h>)" in api_source
     assert "WiFi.beginNoBlock" in implementation
     assert '"platforms/arm/rp/wifi_rp.cpp.hpp"' in build_source
+
+
+def test_rp2350w_autoresearch_exposes_the_cyw43_http_peer_surface() -> None:
+    """The C6 peer can drive RP2350W HTTP through the existing RPC plane."""
+    net_source = AUTORESEARCH_NET.read_text(encoding="utf-8")
+    sketch_source = AUTORESEARCH_SKETCH.read_text(encoding="utf-8")
+
+    assert "defined(FL_IS_RP2350)" in net_source
+    assert "WiFiClient" in net_source
+    assert "WiFiServer" in net_source
+    assert "fl::Singleton<RpPeerState>::instance()" in net_source
+    assert "void pollNetServer()" in net_source
+    assert "pollNetServer();" in sketch_source

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -18,6 +18,9 @@ SEMAPHORE_DISPATCH = REPO_ROOT / "src" / "platforms" / "semaphore.h"
 SEMAPHORE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "semaphore_rp.cpp.hpp"
 WIFI_API = REPO_ROOT / "src" / "fl" / "net" / "wifi.h"
 RP_WIFI_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "wifi_rp.cpp.hpp"
+ESP_WIFI_IMPL = (
+    REPO_ROOT / "src" / "platforms" / "esp" / "32" / "net" / "wifi_esp32.cpp.hpp"
+)
 RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
 AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
 AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
@@ -95,7 +98,20 @@ def test_rp2350w_selects_the_cyw43_wifi_backend() -> None:
     assert "PICO_CYW43_SUPPORTED" in api_source
     assert "FL_HAS_INCLUDE(<WiFi.h>)" in api_source
     assert "WiFi.beginNoBlock" in implementation
+    assert "fl::Singleton<WifiState>::instance()" in implementation
+    assert "#if defined(PICO_CYW43_SUPPORTED)" in AUTORESEARCH_NET.read_text(
+        encoding="utf-8"
+    )
     assert '"platforms/arm/rp/wifi_rp.cpp.hpp"' in build_source
+
+
+def test_wifi_backends_are_platform_scoped_singletons() -> None:
+    """The unity build must not compile ESP implementation code for RP targets."""
+    implementation = ESP_WIFI_IMPL.read_text(encoding="utf-8")
+
+    assert "#if FL_WIFI_AVAILABLE && defined(FL_IS_ESP32)" in implementation
+    assert "fl::Singleton<WifiState>::instance()" in implementation
+    assert "WifiState g_state" not in implementation
 
 
 def test_rp2350w_autoresearch_exposes_the_cyw43_http_peer_surface() -> None:

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -203,6 +203,11 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // ============================================================================
 
 #include <FastLED.h>
+#if defined(PICO_CYW43_SUPPORTED)
+// Keep Arduino-Pico's WiFi library visible to fbuild's sketch dependency
+// resolver. The RP2350W implementation itself remains in AutoResearchNet.cpp.
+#include <WiFi.h>
+#endif
 #include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
 #include "fl/wdt/watchdog.h"  // FL_WATCHDOG_AUTO() — unified cross-platform WDT guard
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)
@@ -577,6 +582,10 @@ void loop() {
     for (int i = 0; i < 100; i++) {
         fl::task::run();
     }
+
+    // Arduino-Pico's CYW43 HTTP endpoint runs cooperatively from loop().
+    // ESP32's native HTTP server has its own task, so this is a no-op there.
+    pollNetServer();
 
     // ========================================================================
     // Watchdog autoresearch trigger (FastLED#2731) — when the host RPC sends

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -203,11 +203,6 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // ============================================================================
 
 #include <FastLED.h>
-#if defined(PICO_CYW43_SUPPORTED)
-// Keep Arduino-Pico's WiFi library visible to fbuild's sketch dependency
-// resolver. The RP2350W implementation itself remains in AutoResearchNet.cpp.
-#include <WiFi.h>
-#endif
 #include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
 #include "fl/wdt/watchdog.h"  // FL_WATCHDOG_AUTO() — unified cross-platform WDT guard
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -486,7 +486,246 @@ fl::json stopNet() {
     return response;
 }
 
-#else  // !FL_IS_ESP32 || !SOC_WIFI_SUPPORTED
+void pollNetServer() {}
+
+#elif defined(FL_IS_RP2350) && defined(PICO_CYW43_SUPPORTED)
+
+// ============================================================================
+// RP2350W CYW43 peer implementation
+// ============================================================================
+//
+// Arduino-Pico exposes lwIP through WiFiClient/WiFiServer rather than the
+// ESP-IDF APIs used above. Keep this deliberately small: it provides the same
+// GET endpoints as the C6 fixture and the matching outbound GET checks, while
+// the sketch loop calls pollNetServer() to service one peer at a time.
+
+#include "fl/net/wifi.h"
+#include "fl/stl/cstdio.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/singleton.h"
+#include "fl/stl/unique_ptr.h"
+
+// IWYU pragma: begin_keep
+#include <WiFi.h>
+// IWYU pragma: end_keep
+
+namespace {
+
+struct RpPeerState {
+    fl::unique_ptr<WiFiServer> server;
+    fl::unique_ptr<WiFiClient> client;
+    char request[128] = {};
+    size_t request_length = 0;
+};
+
+RpPeerState& rpPeerState() {
+    return fl::Singleton<RpPeerState>::instance();
+}
+
+void writeHttpResponse(WiFiClient& client, const char* body,
+                       const char* content_type) {
+    client.print("HTTP/1.1 200 OK\r\nContent-Type: ");
+    client.print(content_type);
+    client.print("\r\nContent-Length: ");
+    client.print(fl::strlen(body));
+    client.print("\r\nConnection: close\r\n\r\n");
+    client.print(body);
+    client.stop();
+}
+
+fl::json runRpHttpGetTest(const char* host_ip, uint16_t port,
+                          const char* path, const char* test_name) {
+    fl::json result = fl::json::object();
+    result.set("test", test_name);
+
+    WiFiClient client;
+    if (!client.connect(host_ip, port)) {
+        result.set("passed", false);
+        result.set("error", "TCP connect failed");
+        return result;
+    }
+
+    client.print("GET ");
+    client.print(path);
+    client.print(" HTTP/1.1\r\nHost: ");
+    client.print(host_ip);
+    client.print("\r\nConnection: close\r\n\r\n");
+
+    const uint32_t deadline_ms = millis() + 2000;
+    while (!client.available() && client.connected() &&
+           static_cast<int32_t>(millis() - deadline_ms) < 0) {
+        FastLED.watchdog().feed();
+        delay(1);
+    }
+
+    char status_line[64];
+    size_t length = 0;
+    while (client.available() && length + 1 < sizeof(status_line)) {
+        const int ch = client.read();
+        if (ch < 0 || ch == '\n') {
+            break;
+        }
+        if (ch != '\r') {
+            status_line[length++] = static_cast<char>(ch);
+        }
+    }
+    status_line[length] = '\0';
+    client.stop();
+
+    const bool passed = fl::strncmp(status_line, "HTTP/1.1 200", 12) == 0 ||
+                        fl::strncmp(status_line, "HTTP/1.0 200", 12) == 0;
+    result.set("status_line", status_line);
+    result.set("passed", passed);
+    if (!passed) {
+        result.set("error", "Expected HTTP 200");
+    }
+    return result;
+}
+
+} // namespace
+
+fl::json startNetServer() {
+    fl::json response = fl::json::object();
+    if (!fl::net::wifi::isConnected()) {
+        response.set("success", false);
+        response.set("error", "WiFi station is not connected");
+        return response;
+    }
+
+    RpPeerState& state = rpPeerState();
+    if (!state.server) {
+        state.server = fl::make_unique<WiFiServer>(AUTORESEARCH_NET_SERVER_PORT);
+        state.server->begin();
+        state.server->setNoDelay(true);
+    }
+    s_net_state.http_server_active = true;
+    response.set("success", true);
+    response.set("ip", fl::net::wifi::ipAddress().c_str());
+    response.set("port", static_cast<int64_t>(AUTORESEARCH_NET_SERVER_PORT));
+    return response;
+}
+
+fl::json startNetClient() {
+    fl::json response = fl::json::object();
+    response.set("success", fl::net::wifi::isConnected());
+    response.set("ip", fl::net::wifi::ipAddress().c_str());
+    return response;
+}
+
+fl::json runNetClientTest(const char* host_ip, uint16_t port) {
+    fl::json response = fl::json::object();
+    if (host_ip == nullptr || *host_ip == '\0' ||
+        !fl::net::wifi::isConnected()) {
+        response.set("success", false);
+        response.set("error", "WiFi station is not connected");
+        return response;
+    }
+
+    fl::json results = fl::json::array();
+    const char* paths[] = {"/ping", "/status", "/leds"};
+    const char* names[] = {"GET /ping", "GET /status", "GET /leds"};
+    int passed = 0;
+    for (size_t i = 0; i < 3; ++i) {
+        fl::json result = runRpHttpGetTest(host_ip, port, paths[i], names[i]);
+        const auto result_passed = result[fl::string("passed")].as_bool();
+        if (result_passed.has_value() && result_passed.value()) {
+            ++passed;
+        }
+        results.push_back(result);
+        FastLED.watchdog().feed();
+    }
+
+    response.set("success", passed == 3);
+    response.set("tests_passed", static_cast<int64_t>(passed));
+    response.set("tests_failed", static_cast<int64_t>(3 - passed));
+    response.set("results", results);
+    return response;
+}
+
+fl::json runNetLoopback() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Loopback is not applicable to the CYW43 peer path");
+    return response;
+}
+
+fl::json stopNet() {
+    fl::json response = fl::json::object();
+    RpPeerState& state = rpPeerState();
+    if (state.client) {
+        state.client->stop();
+        state.client.reset();
+    }
+    state.request_length = 0;
+    if (state.server) {
+        state.server->stop();
+        state.server.reset();
+    }
+    s_net_state.http_server_active = false;
+    s_net_state.wifi_ap_active = false;
+    fl::net::wifi::stop();
+    response.set("success", true);
+    return response;
+}
+
+void pollNetServer() {
+    RpPeerState& state = rpPeerState();
+    if (!state.server) {
+        return;
+    }
+    if (!state.client && state.server->hasClient()) {
+        state.client = fl::make_unique<WiFiClient>(state.server->accept());
+        state.request_length = 0;
+    }
+    if (!state.client || !state.client->available()) {
+        return;
+    }
+
+    bool request_line_complete = false;
+    while (state.client->available() &&
+           state.request_length + 1 < sizeof(state.request)) {
+        const int ch = state.client->read();
+        if (ch < 0) {
+            break;
+        }
+        if (ch == '\n') {
+            request_line_complete = true;
+            break;
+        }
+        if (ch != '\r') {
+            state.request[state.request_length++] = static_cast<char>(ch);
+        }
+    }
+    if (!request_line_complete) {
+        if (state.request_length + 1 == sizeof(state.request)) {
+            state.client->print(
+                "HTTP/1.1 414 URI Too Long\r\nConnection: close\r\n\r\n");
+            state.client->stop();
+            state.client.reset();
+            state.request_length = 0;
+        }
+        return;
+    }
+    state.request[state.request_length] = '\0';
+
+    if (fl::strncmp(state.request, "GET /ping ", 10) == 0) {
+        writeHttpResponse(*state.client, "pong", "text/plain");
+    } else if (fl::strncmp(state.request, "GET /status ", 12) == 0) {
+        writeHttpResponse(*state.client,
+                          "{\"chip\":\"rp2350w\",\"network\":\"cyw43\"}",
+                          "application/json");
+    } else if (fl::strncmp(state.request, "GET /leds ", 10) == 0) {
+        writeHttpResponse(*state.client, "{\"num_leds\":10,\"brightness\":64}",
+                          "application/json");
+    } else {
+        state.client->print("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
+        state.client->stop();
+    }
+    state.client.reset();
+    state.request_length = 0;
+}
+
+#else  // !FL_IS_ESP32 && !FL_IS_RP2350
 
 // ============================================================================
 // Stub Implementation for Non-ESP32 Platforms
@@ -528,6 +767,8 @@ fl::json stopNet() {
     return response;
 }
 
-#endif  // FL_IS_ESP32
+void pollNetServer() {}
+
+#endif  // FL_IS_ESP32 || FL_IS_RP2350
 
 #endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -5,6 +5,15 @@
 // Uses ESP-IDF native APIs for WiFi Soft AP and HTTP client.
 // Guarded with FL_IS_ESP32 - no-op stubs on other platforms.
 
+// Keep the Arduino-Pico WiFi library visible to the LDF before the
+// header-derived low-memory guard below. The RP2350W peer owns
+// WiFiClient/WiFiServer, so this is its direct framework dependency.
+#if defined(PICO_CYW43_SUPPORTED)
+// IWYU pragma: begin_keep
+#include <WiFi.h>
+// IWYU pragma: end_keep
+#endif
+
 // Gate out under low-memory mode -- the LowMemory bring-up surface
 // (AutoResearchLowMemory.h) doesn't expose any network endpoints and the
 // fl::net HTTP / asio machinery is several KB that won't fit on the
@@ -504,10 +513,6 @@ void pollNetServer() {}
 #include "fl/stl/cstring.h"
 #include "fl/stl/singleton.h"
 #include "fl/stl/unique_ptr.h"
-
-// IWYU pragma: begin_keep
-#include <WiFi.h>
-// IWYU pragma: end_keep
 
 namespace {
 

--- a/examples/AutoResearch/AutoResearchNet.h
+++ b/examples/AutoResearch/AutoResearchNet.h
@@ -55,6 +55,10 @@ fl::json runNetLoopback();
 /// @return JSON with {success: true} on success
 fl::json stopNet();
 
+/// @brief Service pending peer HTTP requests from the sketch loop.
+/// ESP32 uses its native HTTP server task; Arduino-Pico uses this poll hook.
+void pollNetServer();
+
 /// @brief Get current network autoresearch state.
 /// @return Reference to the global net state
 AutoResearchNetState& getNetState();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,18 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.7. It carries library-dependency fixes for Teensy/STM32,
+    # Pin to fbuild 2.5.10. It carries library-dependency fixes for Teensy/STM32,
     # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment,
     # plus the monitor WebSocket and serial-health fixes required by
     # AutoResearch.
     #
     # Pin history:
+    #   2.5.10 -- restores Arduino-Pico framework header visibility and
+    #              applies its data-declared network flags, including
+    #              LWIP_CHECKSUM_CTRL_PER_NETIF (FastLED/fbuild#1252).
+    #   2.5.8 -- resolves bundled Arduino-Pico framework libraries for
+    #             RP2040/RP2350, including WiFi headers and sources required
+    #             by the RP2350W AutoResearch peer (FastLED/fbuild#1248).
     #   2.5.7 -- rolls up the 2.5.6 deployment fixes and preserves RP2350
     #             UF2 rejection diagnostics (FastLED/fbuild#1246).
     #   2.5.6 -- honors lib_deps on Teensy/STM32, reclaims dead-owner package
@@ -173,7 +179,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.7",
+    "fbuild==2.5.10",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",

--- a/src/platforms/arm/rp/wifi_rp.cpp.hpp
+++ b/src/platforms/arm/rp/wifi_rp.cpp.hpp
@@ -14,6 +14,7 @@
 
 #include "fl/stl/cstdio.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 
 // IWYU pragma: begin_keep
 #include <WiFi.h>
@@ -30,14 +31,16 @@ struct WifiState {
     bool ap_active = false;
 };
 
-// FL_LINT_ALLOW_GLOBAL(platform WiFi state is a singleton supplied by Arduino-Pico)
-WifiState g_state;
+WifiState& wifiState() {
+    return fl::Singleton<WifiState>::instance();
+}
 
 Status currentStatus() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (WiFi.isConnected()) {
         return Status::CONNECTED;
     }
-    if (g_state.sta_requested) {
+    if (state.sta_requested) {
         const int link_status = WiFi.status();
         if (link_status == WL_CONNECT_FAILED ||
             link_status == WL_NO_SSID_AVAIL ||
@@ -47,7 +50,7 @@ Status currentStatus() FL_NO_EXCEPT {
         }
         return Status::CONNECTING;
     }
-    return g_state.ap_active ? Status::AP_ACTIVE : Status::IDLE;
+    return state.ap_active ? Status::AP_ACTIVE : Status::IDLE;
 }
 
 fl::string ipToString(IPAddress ip) FL_NO_EXCEPT {
@@ -63,6 +66,7 @@ fl::string ipToString(IPAddress ip) FL_NO_EXCEPT {
 } // namespace
 
 bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
@@ -78,12 +82,13 @@ bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT {
     // coming up, so beginNoBlock's return value cannot distinguish that
     // healthy intermediate state from a startup failure. Report initiation
     // success and let status() surface a driver/link failure asynchronously.
-    g_state.sta_requested = true;
-    g_state.ap_active = false;
+    state.sta_requested = true;
+    state.ap_active = false;
     return true;
 }
 
 bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
@@ -96,15 +101,16 @@ bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT {
         return false;
     }
 
-    g_state.sta_requested = false;
-    g_state.ap_active = true;
+    state.sta_requested = false;
+    state.ap_active = true;
     return true;
 }
 
 void stop() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     WiFi.end();
-    g_state.sta_requested = false;
-    g_state.ap_active = false;
+    state.sta_requested = false;
+    state.ap_active = false;
 }
 
 Status status() FL_NO_EXCEPT {
@@ -120,7 +126,7 @@ fl::string ipAddress() FL_NO_EXCEPT {
 }
 
 fl::string apIpAddress() FL_NO_EXCEPT {
-    return g_state.ap_active ? ipToString(WiFi.softAPIP()) : fl::string();
+    return wifiState().ap_active ? ipToString(WiFi.softAPIP()) : fl::string();
 }
 
 } // namespace wifi

--- a/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
+++ b/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
@@ -11,12 +11,14 @@
 /// disconnect, then FAILED). SoftAP can coexist (APSTA).
 
 #include "fl/net/wifi.h"
+#include "platforms/esp/is_esp.h"
 
-#if FL_WIFI_AVAILABLE
+#if FL_WIFI_AVAILABLE && defined(FL_IS_ESP32)
 
 #include "fl/log/log.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 
 FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
@@ -47,30 +49,33 @@ struct WifiState {
     int retries = 0;
 };
 
-// FL_LINT_ALLOW_GLOBAL(referenced from a C event-handler callback registered with the IDF event loop; zero-init POD keeps status readable before begin)
-WifiState g_state;
+WifiState& wifiState() {
+    return fl::Singleton<WifiState>::instance();
+}
 
 void wifiEventHandler(void *, esp_event_base_t base, i32 id, void *) {
+    WifiState& state = wifiState();
     if (base == WIFI_EVENT) {
         if (id == WIFI_EVENT_STA_START) {
             esp_wifi_connect();
         } else if (id == WIFI_EVENT_STA_DISCONNECTED) {
-            if (g_state.sta_requested && g_state.retries < kMaxStaRetries) {
-                ++g_state.retries;
-                g_state.status = Status::CONNECTING;
+            if (state.sta_requested && state.retries < kMaxStaRetries) {
+                ++state.retries;
+                state.status = Status::CONNECTING;
                 esp_wifi_connect();
-            } else if (g_state.sta_requested) {
-                g_state.status = Status::FAILED;
+            } else if (state.sta_requested) {
+                state.status = Status::FAILED;
             }
         }
     } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
-        g_state.retries = 0;
-        g_state.status = Status::CONNECTED;
+        state.retries = 0;
+        state.status = Status::CONNECTED;
     }
 }
 
 /// One-time driver + netif + event plumbing. Idempotent.
 bool ensureDriver() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     esp_err_t err = esp_netif_init();
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         FL_WARN_F("wifi: esp_netif_init failed: %s", esp_err_to_name(err));
@@ -81,7 +86,7 @@ bool ensureDriver() FL_NO_EXCEPT {
         FL_WARN_F("wifi: event loop create failed: %s", esp_err_to_name(err));
         return false;
     }
-    if (!g_state.handlers_registered) {
+    if (!state.handlers_registered) {
         if (esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
                                                 &wifiEventHandler, nullptr,
                                                 nullptr) != ESP_OK ||
@@ -91,7 +96,7 @@ bool ensureDriver() FL_NO_EXCEPT {
             FL_WARN_F("wifi: event handler registration failed");
             return false;
         }
-        g_state.handlers_registered = true;
+        state.handlers_registered = true;
     }
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     err = esp_wifi_init(&cfg);
@@ -103,12 +108,13 @@ bool ensureDriver() FL_NO_EXCEPT {
 }
 
 bool applyMode() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     wifi_mode_t mode = WIFI_MODE_NULL;
-    if (g_state.sta_requested && g_state.ap_active) {
+    if (state.sta_requested && state.ap_active) {
         mode = WIFI_MODE_APSTA;
-    } else if (g_state.sta_requested) {
+    } else if (state.sta_requested) {
         mode = WIFI_MODE_STA;
-    } else if (g_state.ap_active) {
+    } else if (state.ap_active) {
         mode = WIFI_MODE_AP;
     }
     esp_err_t err = esp_wifi_set_mode(mode);
@@ -136,15 +142,16 @@ fl::string netifIp(esp_netif_t *netif) FL_NO_EXCEPT {
 } // anonymous namespace
 
 bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
     if (!ensureDriver()) {
         return false;
     }
-    if (g_state.sta_netif == nullptr) {
-        g_state.sta_netif = esp_netif_create_default_wifi_sta();
-        if (g_state.sta_netif == nullptr) {
+    if (state.sta_netif == nullptr) {
+        state.sta_netif = esp_netif_create_default_wifi_sta();
+        if (state.sta_netif == nullptr) {
             FL_WARN_F("wifi: STA netif creation failed");
             return false;
         }
@@ -159,9 +166,9 @@ bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
                     sizeof(cfg.sta.password) - 1);
     }
 
-    g_state.sta_requested = true;
-    g_state.retries = 0;
-    g_state.status = Status::CONNECTING;
+    state.sta_requested = true;
+    state.retries = 0;
+    state.status = Status::CONNECTING;
     if (!applyMode()) {
         return false;
     }
@@ -175,25 +182,26 @@ bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
         FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
         return false;
     }
-    if (g_state.driver_started) {
+    if (state.driver_started) {
         // Driver was already running (mode change) — STA_START will not
         // re-fire, so kick the join directly.
         esp_wifi_connect();
     }
-    g_state.driver_started = true;
+    state.driver_started = true;
     return true;
 }
 
 bool startAp(const char *ssid, const char *password, u8 channel) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
     if (!ensureDriver()) {
         return false;
     }
-    if (g_state.ap_netif == nullptr) {
-        g_state.ap_netif = esp_netif_create_default_wifi_ap();
-        if (g_state.ap_netif == nullptr) {
+    if (state.ap_netif == nullptr) {
+        state.ap_netif = esp_netif_create_default_wifi_ap();
+        if (state.ap_netif == nullptr) {
             FL_WARN_F("wifi: AP netif creation failed");
             return false;
         }
@@ -214,59 +222,60 @@ bool startAp(const char *ssid, const char *password, u8 channel) FL_NO_EXCEPT {
         cfg.ap.authmode = WIFI_AUTH_OPEN;
     }
 
-    g_state.ap_active = true;
+    state.ap_active = true;
     if (!applyMode()) {
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
     esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &cfg);
     if (err != ESP_OK) {
         FL_WARN_F("wifi: AP set_config failed: %s", esp_err_to_name(err));
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
     err = esp_wifi_start();
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
-    g_state.driver_started = true;
-    if (g_state.status == Status::IDLE ||
-        g_state.status == Status::UNSUPPORTED) {
-        g_state.status = Status::AP_ACTIVE;
+    state.driver_started = true;
+    if (state.status == Status::IDLE ||
+        state.status == Status::UNSUPPORTED) {
+        state.status = Status::AP_ACTIVE;
     }
     return true;
 }
 
 void stop() FL_NO_EXCEPT {
-    g_state.sta_requested = false;
-    g_state.ap_active = false;
-    if (g_state.driver_started) {
+    WifiState& state = wifiState();
+    state.sta_requested = false;
+    state.ap_active = false;
+    if (state.driver_started) {
         esp_wifi_stop();
-        g_state.driver_started = false;
+        state.driver_started = false;
     }
-    g_state.status = Status::IDLE;
+    state.status = Status::IDLE;
 }
 
 Status status() FL_NO_EXCEPT {
-    return g_state.status;
+    return wifiState().status;
 }
 
 bool isConnected() FL_NO_EXCEPT {
-    return g_state.status == Status::CONNECTED;
+    return wifiState().status == Status::CONNECTED;
 }
 
 fl::string ipAddress() FL_NO_EXCEPT {
-    return netifIp(g_state.sta_netif);
+    return netifIp(wifiState().sta_netif);
 }
 
 fl::string apIpAddress() FL_NO_EXCEPT {
-    return netifIp(g_state.ap_netif);
+    return netifIp(wifiState().ap_netif);
 }
 
 } // namespace wifi
 } // namespace net
 } // namespace fl
 
-#endif // FL_WIFI_AVAILABLE
+#endif // FL_WIFI_AVAILABLE && FL_IS_ESP32


### PR DESCRIPTION
## Summary

- scope ESP WiFi unity implementation to ESP32 builds and store both WiFi backend states in l::Singleton<T>
- place the RP2350W Arduino-Pico WiFi dependency ahead of AutoResearch's header-derived low-memory guard so fbuild selects its implementation sources
- update the fbuild pin to 2.5.10 and add singleton/platform-scope regression checks

## Verification

- uv run pytest ci/tests/test_rp2350w_board_config.py -q (8 passed)
- ash lint (passed)
- ash compile rp2350w --examples AutoResearch (fbuild, no temporary WiFi dependency override; passed: 1.12 MB flash, 124.26 KB RAM)

Follow-up to #3843.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RP2350W networking support for the AutoResearch example, including HTTP endpoints for peer requests.
  * Added cooperative network-server processing for compatible platforms.

* **Bug Fixes**
  * Improved Wi-Fi state consistency across RP2350W and ESP32 implementations.
  * Restricted ESP32 Wi-Fi code to supported platforms.

* **Chores**
  * Updated the pinned build tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->