### PR TITLE
fix(rp2350w): build CYW43 AutoResearch peer

### DIFF
--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -18,6 +18,9 @@ SEMAPHORE_DISPATCH = REPO_ROOT / "src" / "platforms" / "semaphore.h"
 SEMAPHORE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "semaphore_rp.cpp.hpp"
 WIFI_API = REPO_ROOT / "src" / "fl" / "net" / "wifi.h"
 RP_WIFI_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "wifi_rp.cpp.hpp"
+ESP_WIFI_IMPL = (
+    REPO_ROOT / "src" / "platforms" / "esp" / "32" / "net" / "wifi_esp32.cpp.hpp"
+)
 RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
 AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
 AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
@@ -95,7 +98,20 @@ def test_rp2350w_selects_the_cyw43_wifi_backend() -> None:
     assert "PICO_CYW43_SUPPORTED" in api_source
     assert "FL_HAS_INCLUDE(<WiFi.h>)" in api_source
     assert "WiFi.beginNoBlock" in implementation
+    assert "fl::Singleton<WifiState>::instance()" in implementation
+    assert "#if defined(PICO_CYW43_SUPPORTED)" in AUTORESEARCH_NET.read_text(
+        encoding="utf-8"
+    )
     assert '"platforms/arm/rp/wifi_rp.cpp.hpp"' in build_source
+
+
+def test_wifi_backends_are_platform_scoped_singletons() -> None:
+    """The unity build must not compile ESP implementation code for RP targets."""
+    implementation = ESP_WIFI_IMPL.read_text(encoding="utf-8")
+
+    assert "#if FL_WIFI_AVAILABLE && defined(FL_IS_ESP32)" in implementation
+    assert "fl::Singleton<WifiState>::instance()" in implementation
+    assert "WifiState g_state" not in implementation
 
 
 def test_rp2350w_autoresearch_exposes_the_cyw43_http_peer_surface() -> None:

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -203,11 +203,6 @@ void loop()  { autoResearchLowMemoryLoop(); }
 // ============================================================================
 
 #include <FastLED.h>
-#if defined(PICO_CYW43_SUPPORTED)
-// Keep Arduino-Pico's WiFi library visible to fbuild's sketch dependency
-// resolver. The RP2350W implementation itself remains in AutoResearchNet.cpp.
-#include <WiFi.h>
-#endif
 #include "fl/channels/all_drivers.h"  // for FastLED.enableAllDrivers() post-#2428
 #include "fl/wdt/watchdog.h"  // FL_WATCHDOG_AUTO() — unified cross-platform WDT guard
 #include "fl/stl/undef.h"  // Undefine Arduino macros (DEFAULT, INPUT, OUTPUT)

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -5,6 +5,15 @@
 // Uses ESP-IDF native APIs for WiFi Soft AP and HTTP client.
 // Guarded with FL_IS_ESP32 - no-op stubs on other platforms.
 
+// Keep the Arduino-Pico WiFi library visible to the LDF before the
+// header-derived low-memory guard below. The RP2350W peer owns
+// WiFiClient/WiFiServer, so this is its direct framework dependency.
+#if defined(PICO_CYW43_SUPPORTED)
+// IWYU pragma: begin_keep
+#include <WiFi.h>
+// IWYU pragma: end_keep
+#endif
+
 // Gate out under low-memory mode -- the LowMemory bring-up surface
 // (AutoResearchLowMemory.h) doesn't expose any network endpoints and the
 // fl::net HTTP / asio machinery is several KB that won't fit on the
@@ -504,10 +513,6 @@ void pollNetServer() {}
 #include "fl/stl/cstring.h"
 #include "fl/stl/singleton.h"
 #include "fl/stl/unique_ptr.h"
-
-// IWYU pragma: begin_keep
-#include <WiFi.h>
-// IWYU pragma: end_keep
 
 namespace {
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,18 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.7. It carries library-dependency fixes for Teensy/STM32,
+    # Pin to fbuild 2.5.10. It carries library-dependency fixes for Teensy/STM32,
     # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment,
     # plus the monitor WebSocket and serial-health fixes required by
     # AutoResearch.
     #
     # Pin history:
+    #   2.5.10 -- restores Arduino-Pico framework header visibility and
+    #              applies its data-declared network flags, including
+    #              LWIP_CHECKSUM_CTRL_PER_NETIF (FastLED/fbuild#1252).
+    #   2.5.8 -- resolves bundled Arduino-Pico framework libraries for
+    #             RP2040/RP2350, including WiFi headers and sources required
+    #             by the RP2350W AutoResearch peer (FastLED/fbuild#1248).
     #   2.5.7 -- rolls up the 2.5.6 deployment fixes and preserves RP2350
     #             UF2 rejection diagnostics (FastLED/fbuild#1246).
     #   2.5.6 -- honors lib_deps on Teensy/STM32, reclaims dead-owner package
@@ -173,7 +179,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.7",
+    "fbuild==2.5.10",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",

--- a/src/platforms/arm/rp/wifi_rp.cpp.hpp
+++ b/src/platforms/arm/rp/wifi_rp.cpp.hpp
@@ -14,6 +14,7 @@
 
 #include "fl/stl/cstdio.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 
 // IWYU pragma: begin_keep
 #include <WiFi.h>
@@ -30,14 +31,16 @@ struct WifiState {
     bool ap_active = false;
 };
 
-// FL_LINT_ALLOW_GLOBAL(platform WiFi state is a singleton supplied by Arduino-Pico)
-WifiState g_state;
+WifiState& wifiState() {
+    return fl::Singleton<WifiState>::instance();
+}
 
 Status currentStatus() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (WiFi.isConnected()) {
         return Status::CONNECTED;
     }
-    if (g_state.sta_requested) {
+    if (state.sta_requested) {
         const int link_status = WiFi.status();
         if (link_status == WL_CONNECT_FAILED ||
             link_status == WL_NO_SSID_AVAIL ||
@@ -47,7 +50,7 @@ Status currentStatus() FL_NO_EXCEPT {
         }
         return Status::CONNECTING;
     }
-    return g_state.ap_active ? Status::AP_ACTIVE : Status::IDLE;
+    return state.ap_active ? Status::AP_ACTIVE : Status::IDLE;
 }
 
 fl::string ipToString(IPAddress ip) FL_NO_EXCEPT {
@@ -63,6 +66,7 @@ fl::string ipToString(IPAddress ip) FL_NO_EXCEPT {
 } // namespace
 
 bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
@@ -78,12 +82,13 @@ bool connectSta(const char* ssid, const char* password) FL_NO_EXCEPT {
     // coming up, so beginNoBlock's return value cannot distinguish that
     // healthy intermediate state from a startup failure. Report initiation
     // success and let status() surface a driver/link failure asynchronously.
-    g_state.sta_requested = true;
-    g_state.ap_active = false;
+    state.sta_requested = true;
+    state.ap_active = false;
     return true;
 }
 
 bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
@@ -96,15 +101,16 @@ bool startAp(const char* ssid, const char* password, u8 channel) FL_NO_EXCEPT {
         return false;
     }
 
-    g_state.sta_requested = false;
-    g_state.ap_active = true;
+    state.sta_requested = false;
+    state.ap_active = true;
     return true;
 }
 
 void stop() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     WiFi.end();
-    g_state.sta_requested = false;
-    g_state.ap_active = false;
+    state.sta_requested = false;
+    state.ap_active = false;
 }
 
 Status status() FL_NO_EXCEPT {
@@ -120,7 +126,7 @@ fl::string ipAddress() FL_NO_EXCEPT {
 }
 
 fl::string apIpAddress() FL_NO_EXCEPT {
-    return g_state.ap_active ? ipToString(WiFi.softAPIP()) : fl::string();
+    return wifiState().ap_active ? ipToString(WiFi.softAPIP()) : fl::string();
 }
 
 } // namespace wifi

--- a/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
+++ b/src/platforms/esp/32/net/wifi_esp32.cpp.hpp
@@ -11,12 +11,14 @@
 /// disconnect, then FAILED). SoftAP can coexist (APSTA).
 
 #include "fl/net/wifi.h"
+#include "platforms/esp/is_esp.h"
 
-#if FL_WIFI_AVAILABLE
+#if FL_WIFI_AVAILABLE && defined(FL_IS_ESP32)
 
 #include "fl/log/log.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 
 FL_EXTERN_C_BEGIN
 // IWYU pragma: begin_keep
@@ -47,30 +49,33 @@ struct WifiState {
     int retries = 0;
 };
 
-// FL_LINT_ALLOW_GLOBAL(referenced from a C event-handler callback registered with the IDF event loop; zero-init POD keeps status readable before begin)
-WifiState g_state;
+WifiState& wifiState() {
+    return fl::Singleton<WifiState>::instance();
+}
 
 void wifiEventHandler(void *, esp_event_base_t base, i32 id, void *) {
+    WifiState& state = wifiState();
     if (base == WIFI_EVENT) {
         if (id == WIFI_EVENT_STA_START) {
             esp_wifi_connect();
         } else if (id == WIFI_EVENT_STA_DISCONNECTED) {
-            if (g_state.sta_requested && g_state.retries < kMaxStaRetries) {
-                ++g_state.retries;
-                g_state.status = Status::CONNECTING;
+            if (state.sta_requested && state.retries < kMaxStaRetries) {
+                ++state.retries;
+                state.status = Status::CONNECTING;
                 esp_wifi_connect();
-            } else if (g_state.sta_requested) {
-                g_state.status = Status::FAILED;
+            } else if (state.sta_requested) {
+                state.status = Status::FAILED;
             }
         }
     } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
-        g_state.retries = 0;
-        g_state.status = Status::CONNECTED;
+        state.retries = 0;
+        state.status = Status::CONNECTED;
     }
 }
 
 /// One-time driver + netif + event plumbing. Idempotent.
 bool ensureDriver() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     esp_err_t err = esp_netif_init();
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         FL_WARN_F("wifi: esp_netif_init failed: %s", esp_err_to_name(err));
@@ -81,7 +86,7 @@ bool ensureDriver() FL_NO_EXCEPT {
         FL_WARN_F("wifi: event loop create failed: %s", esp_err_to_name(err));
         return false;
     }
-    if (!g_state.handlers_registered) {
+    if (!state.handlers_registered) {
         if (esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
                                                 &wifiEventHandler, nullptr,
                                                 nullptr) != ESP_OK ||
@@ -91,7 +96,7 @@ bool ensureDriver() FL_NO_EXCEPT {
             FL_WARN_F("wifi: event handler registration failed");
             return false;
         }
-        g_state.handlers_registered = true;
+        state.handlers_registered = true;
     }
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     err = esp_wifi_init(&cfg);
@@ -103,12 +108,13 @@ bool ensureDriver() FL_NO_EXCEPT {
 }
 
 bool applyMode() FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     wifi_mode_t mode = WIFI_MODE_NULL;
-    if (g_state.sta_requested && g_state.ap_active) {
+    if (state.sta_requested && state.ap_active) {
         mode = WIFI_MODE_APSTA;
-    } else if (g_state.sta_requested) {
+    } else if (state.sta_requested) {
         mode = WIFI_MODE_STA;
-    } else if (g_state.ap_active) {
+    } else if (state.ap_active) {
         mode = WIFI_MODE_AP;
     }
     esp_err_t err = esp_wifi_set_mode(mode);
@@ -136,15 +142,16 @@ fl::string netifIp(esp_netif_t *netif) FL_NO_EXCEPT {
 } // anonymous namespace
 
 bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
     if (!ensureDriver()) {
         return false;
     }
-    if (g_state.sta_netif == nullptr) {
-        g_state.sta_netif = esp_netif_create_default_wifi_sta();
-        if (g_state.sta_netif == nullptr) {
+    if (state.sta_netif == nullptr) {
+        state.sta_netif = esp_netif_create_default_wifi_sta();
+        if (state.sta_netif == nullptr) {
             FL_WARN_F("wifi: STA netif creation failed");
             return false;
         }
@@ -159,9 +166,9 @@ bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
                     sizeof(cfg.sta.password) - 1);
     }
 
-    g_state.sta_requested = true;
-    g_state.retries = 0;
-    g_state.status = Status::CONNECTING;
+    state.sta_requested = true;
+    state.retries = 0;
+    state.status = Status::CONNECTING;
     if (!applyMode()) {
         return false;
     }
@@ -175,25 +182,26 @@ bool connectSta(const char *ssid, const char *password) FL_NO_EXCEPT {
         FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
         return false;
     }
-    if (g_state.driver_started) {
+    if (state.driver_started) {
         // Driver was already running (mode change) — STA_START will not
         // re-fire, so kick the join directly.
         esp_wifi_connect();
     }
-    g_state.driver_started = true;
+    state.driver_started = true;
     return true;
 }
 
 bool startAp(const char *ssid, const char *password, u8 channel) FL_NO_EXCEPT {
+    WifiState& state = wifiState();
     if (ssid == nullptr || *ssid == '\0') {
         return false;
     }
     if (!ensureDriver()) {
         return false;
     }
-    if (g_state.ap_netif == nullptr) {
-        g_state.ap_netif = esp_netif_create_default_wifi_ap();
-        if (g_state.ap_netif == nullptr) {
+    if (state.ap_netif == nullptr) {
+        state.ap_netif = esp_netif_create_default_wifi_ap();
+        if (state.ap_netif == nullptr) {
             FL_WARN_F("wifi: AP netif creation failed");
             return false;
         }
@@ -214,59 +222,60 @@ bool startAp(const char *ssid, const char *password, u8 channel) FL_NO_EXCEPT {
         cfg.ap.authmode = WIFI_AUTH_OPEN;
     }
 
-    g_state.ap_active = true;
+    state.ap_active = true;
     if (!applyMode()) {
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
     esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &cfg);
     if (err != ESP_OK) {
         FL_WARN_F("wifi: AP set_config failed: %s", esp_err_to_name(err));
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
     err = esp_wifi_start();
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         FL_WARN_F("wifi: start failed: %s", esp_err_to_name(err));
-        g_state.ap_active = false;
+        state.ap_active = false;
         return false;
     }
-    g_state.driver_started = true;
-    if (g_state.status == Status::IDLE ||
-        g_state.status == Status::UNSUPPORTED) {
-        g_state.status = Status::AP_ACTIVE;
+    state.driver_started = true;
+    if (state.status == Status::IDLE ||
+        state.status == Status::UNSUPPORTED) {
+        state.status = Status::AP_ACTIVE;
     }
     return true;
 }
 
 void stop() FL_NO_EXCEPT {
-    g_state.sta_requested = false;
-    g_state.ap_active = false;
-    if (g_state.driver_started) {
+    WifiState& state = wifiState();
+    state.sta_requested = false;
+    state.ap_active = false;
+    if (state.driver_started) {
         esp_wifi_stop();
-        g_state.driver_started = false;
+        state.driver_started = false;
     }
-    g_state.status = Status::IDLE;
+    state.status = Status::IDLE;
 }
 
 Status status() FL_NO_EXCEPT {
-    return g_state.status;
+    return wifiState().status;
 }
 
 bool isConnected() FL_NO_EXCEPT {
-    return g_state.status == Status::CONNECTED;
+    return wifiState().status == Status::CONNECTED;
 }
 
 fl::string ipAddress() FL_NO_EXCEPT {
-    return netifIp(g_state.sta_netif);
+    return netifIp(wifiState().sta_netif);
 }
 
 fl::string apIpAddress() FL_NO_EXCEPT {
-    return netifIp(g_state.ap_netif);
+    return netifIp(wifiState().ap_netif);
 }
 
 } // namespace wifi
 } // namespace net
 } // namespace fl
 
-#endif // FL_WIFI_AVAILABLE
+#endif // FL_WIFI_AVAILABLE && FL_IS_ESP32


### PR DESCRIPTION
Rebased follow-up to #3843.\n\nVerified with uv run pytest ci/tests/test_rp2350w_board_config.py -q, ash lint, and ash compile rp2350w --examples AutoResearch (fbuild; 1.12 MB flash, 124.26 KB RAM).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wi‑Fi reliability across RP2350W and ESP32 platforms by ensuring networking operations share consistent connection state.
  - Added platform safeguards so Wi‑Fi functionality is enabled only where supported.
  - Improved handling of station and access-point modes, shutdown, status reporting, and IP address retrieval.

- **Tests**
  - Expanded automated coverage for platform-specific Wi‑Fi behavior and shared state management.

- **Chores**
  - Updated the build tooling version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->