### PR TITLE
fix(autoresearch): prove RP watchdog reset

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -270,6 +270,20 @@ def start_autoresearch_watchdog(ctx: "RunContext") -> None:
     thread.start()
 
 
+def stop_autoresearch_watchdog(ctx: "RunContext") -> None:
+    """Cancel the host watchdog after the complete AutoResearch run returns.
+
+    Per-phase cleanup deliberately keeps the watchdog armed because a blocked
+    serial close is exactly the failure it protects against. Once every phase
+    has returned, however, the daemon must not outlive its caller.
+    """
+    cancel_event = ctx._watchdog_task
+    if cancel_event is None:
+        return
+    cancel_event.set()
+    ctx._watchdog_task = None
+
+
 def extend_autoresearch_watchdog_deadline(
     ctx: "RunContext", extra_seconds: float
 ) -> None:
@@ -2210,10 +2224,25 @@ async def _run_watchdog_soak(ctx: RunContext) -> int:
             print(f"RESULT: watchdog soak FAIL: post-reset ping {after.data!r}")
             return 1
         after_uptime = after.data.get("uptimeMs")
+        watchdog_reset = after.data.get("lastResetWasWatchdog") is True
+        uptime_reset = (
+            isinstance(before_uptime, int)
+            and not isinstance(before_uptime, bool)
+            and isinstance(after_uptime, int)
+            and not isinstance(after_uptime, bool)
+            and after_uptime < before_uptime
+        )
         print(
             f"WATCHDOG: post-reset ping uptimeMs={after_uptime} "
-            f"port={new_port} reset_evidence={after_uptime is not None and before_uptime is not None and after_uptime < before_uptime}"
+            f"port={new_port} resetCause={after.data.get('lastResetCause')!r} "
+            f"watchdog_reset={watchdog_reset} uptime_reset={uptime_reset}"
         )
+        if not watchdog_reset or not uptime_reset:
+            print(
+                "RESULT: watchdog soak FAIL: re-enumerated device did not prove "
+                "the deliberate hang caused a watchdog reset"
+            )
+            return 1
     finally:
         try:
             await recovery.close()

--- a/ci/autoresearch/runner.py
+++ b/ci/autoresearch/runner.py
@@ -30,6 +30,7 @@ from ci.autoresearch.phases import (
     _run_native_autoresearch,
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
+    stop_autoresearch_watchdog,
 )
 from ci.util.global_interrupt_handler import (
     handle_keyboard_interrupt,
@@ -92,6 +93,18 @@ async def run(args: Args | None = None) -> int:
     if isinstance(result, int):
         return result
     ctx = result
+
+    try:
+        return await _run_context(ctx, args)
+    finally:
+        # The watchdog remains armed through deploy, RPC work, and every
+        # phase-level cleanup path. It is safe to cancel only after this
+        # complete top-level run has returned.
+        stop_autoresearch_watchdog(ctx)
+
+
+async def _run_context(ctx: Any, args: Args) -> int:
+    """Run all post-parse phases while the caller owns watchdog cleanup."""
 
     # Early return: --decode mode
     if ctx.decode_mode:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -29,6 +29,7 @@ from ci.autoresearch.phases import (
     _run_tests_or_special_mode,
     _run_watchdog_soak,
     _validate_test_rpc_response,
+    stop_autoresearch_watchdog,
 )
 from ci.rpc_client import RpcError, RpcTimeoutError
 from ci.util.port_utils import ChipDetectionResult, auto_detect_upload_port
@@ -1900,6 +1901,12 @@ class TestAutoDetectUploadPort:
 class TestRunBuildDeploy:
     """Test _run_build_deploy (uses mock BuildDriver)."""
 
+    @pytest.fixture(autouse=True)
+    def disable_host_watchdog_for_unit_deploys(self):
+        """Direct phase tests do not own the runner watchdog lifecycle."""
+        with patch(f"{_PATCH_MOD}.start_autoresearch_watchdog"):
+            yield
+
     def test_build_deploy_success(self) -> None:
         mock_driver = _make_mock_driver()
         ctx = _make_ctx(build_driver=mock_driver)
@@ -1978,6 +1985,16 @@ class TestRunBuildDeploy:
         flash.assert_called_once()
         assert flash.call_args.kwargs["environment"] == "lpc845brk_ieee754"
         mock_driver.deploy.assert_not_called()
+
+    def test_stopping_host_watchdog_signals_and_clears_the_runner_handle(self) -> None:
+        ctx = _make_ctx()
+        cancel_event = MagicMock()
+        ctx._watchdog_task = cancel_event
+
+        stop_autoresearch_watchdog(ctx)
+
+        cancel_event.set.assert_called_once_with()
+        assert ctx._watchdog_task is None
 
 
 # ============================================================
@@ -2625,7 +2642,9 @@ class TestRunTestsOrSpecialMode:
             ]
         )
         recovery_client = AsyncMock()
-        recovery_client.send = AsyncMock(return_value=response({"uptimeMs": 1}))
+        recovery_client.send = AsyncMock(
+            return_value=response({"uptimeMs": 1, "lastResetWasWatchdog": True})
+        )
         detected = MagicMock(selected_port="COM18")
 
         with (
@@ -2658,6 +2677,59 @@ class TestRunTestsOrSpecialMode:
         auto_detect.assert_called_once_with(
             "rp2350w", expected_serial_number="2DCB876B587EA334"
         )
+
+    def test_rp2350_watchdog_rejects_reenumeration_without_watchdog_reset(self) -> None:
+        ctx = _make_ctx(
+            final_environment="rp2350w",
+            upload_port="COM17",
+            use_fbuild=True,
+            watchdog_soak_mode=True,
+        )
+
+        def response(data):
+            item = MagicMock()
+            item.success = True
+            item.data = data
+            return item
+
+        initial_client = AsyncMock()
+        initial_client.send = AsyncMock(
+            side_effect=[
+                response({"uptimeMs": 100}),
+                response({"success": True}),
+            ]
+        )
+        recovery_client = AsyncMock()
+        recovery_client.send = AsyncMock(
+            return_value=response({"uptimeMs": 1, "lastResetWasWatchdog": False})
+        )
+        detected = MagicMock(selected_port="COM18")
+
+        with (
+            patch(
+                "ci.util.serial_interface.create_serial_interface",
+                return_value=MagicMock(),
+            ),
+            patch(
+                f"{_PATCH_MOD}.RpcClient",
+                side_effect=[initial_client, recovery_client],
+            ),
+            patch(f"{_PATCH_MOD}.port_exists", return_value=False),
+            patch(
+                f"{_PATCH_MOD}.get_port_serial_number",
+                return_value="2DCB876B587EA334",
+            ),
+            patch(f"{_PATCH_MOD}.auto_detect_upload_port", return_value=detected),
+            patch(
+                f"{_PATCH_MOD}._run_rpc_smoke_tests",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as rpc_smoke,
+        ):
+            rc = asyncio.run(_run_watchdog_soak(ctx))
+
+        assert rc == 1
+        rpc_smoke.assert_not_awaited()
 
     def test_ble_mode_delegates(self) -> None:
         ctx = _make_ctx(ble_mode=True)

--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -741,6 +741,8 @@ class TestAutoResearchFilter:
                 "esp32p4",
                 "teensy41",
                 "teensy40",
+                "rp2350",
+                "rp2350w",
                 "lpc845",
                 "lpc845brk",
                 "lpcxpresso845max",

--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -86,7 +86,7 @@ static const HelpEntry kHelpEntries[] = {
     {"getResult", "Phase 3: Selective Execution", "[testCaseIndex]", "{driver, lanes, stripSize, ...}", "Return specific test case result"},
     {"reset", "Phase 4: Utility", "[]", "{success, message, testCasesCleared}", "Reset test state without device reboot"},
     {"halt", "Phase 4: Utility", "[]", "{success, message}", "Trigger sketch halt"},
-    {"ping", "Phase 4: Utility", "[]", "{success, message, timestamp, uptimeMs, frameCounter}", "Health check with timestamp"},
+    {"ping", "Phase 4: Utility", "[]", "{success, message, timestamp, uptimeMs, lastResetCause, lastResetWasWatchdog, frameCounter}", "Health check with timestamp and reset evidence"},
     {"debugTest", "Phase 4: Utility", "object", "{success, received}", "Echo an exact nested JSON payload"},
     {"testNoSerial", "Phase 4: Utility", "[]", "{success, message, serial_safe}", "Verify RPC execution without device-side serial logging"},
     {"testRpConcurrency", "Phase 4: Utility", "[]", "{success, supported, backend, core1Ready, core1Done, recursiveMutexReady, generation, expected, actual}", "Exercise mutex and semaphore synchronization across both RP physical cores"},

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -26,6 +26,7 @@
 #include "AutoResearchPlatform.h"
 #include "AutoResearchRpConcurrency.h"
 #include "AutoResearchEdgeProbe.h"
+#include "fl/wdt/watchdog.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
 #include "platforms/is_platform.h"
@@ -212,12 +213,15 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
     // Register "ping" function - health check with timestamp
     remote.bind("ping", [this](const fl::json& args) -> fl::json {
         uint32_t now = millis();
+        const fl::ResetCause reset_cause = FastLED.watchdog().lastResetCause();
 
         fl::json response = fl::json::object();
         response.set("success", true);
         response.set("message", "pong");
         response.set("timestamp", static_cast<int64_t>(now));
         response.set("uptimeMs", static_cast<int64_t>(now));
+        response.set("lastResetCause", fl::resetCauseName(reset_cause).data());
+        response.set("lastResetWasWatchdog", reset_cause == fl::ResetCause::WATCHDOG);
         return response;
     });
 


### PR DESCRIPTION
Require watchdog reset proof after AutoResearch deliberateHang; clean up host watchdog lifecycle; cover RP2350W filter and false-positive recovery. Validation: bash compile rp2350w --examples AutoResearch; bash lint; targeted pytest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The AutoResearch `ping` response now includes the device’s last reset cause and whether the reset was watchdog-triggered, alongside existing status information.

- **Bug Fixes**
  - Watchdog monitoring now shuts down reliably after AutoResearch runs complete.
  - Recovery validation more accurately detects unsuccessful watchdog resets before continuing diagnostics.

- **Tests**
  - Expanded coverage for watchdog shutdown, recovery validation, and RP2350/RP2350W board filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->