### PR TITLE
chore: pin fbuild 2.5.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,17 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.10. It carries library-dependency fixes for Teensy/STM32,
+    # Pin to fbuild 2.5.13. It carries library-dependency fixes for Teensy/STM32,
     # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment,
     # plus the monitor WebSocket and serial-health fixes required by
     # AutoResearch.
     #
     # Pin history:
+    #   2.5.13 -- canonicalizes named local `symlink://` and `file://` roots
+    #              before resolving manifest-relative paths (FastLED/fbuild#1258).
+    #   2.5.12 -- resolves named local `symlink://` and `file://` library
+    #              dependencies without writing generated artifacts into the
+    #              source checkout (FastLED/fbuild#1256).
     #   2.5.10 -- restores Arduino-Pico framework header visibility and
     #              applies its data-declared network flags, including
     #              LWIP_CHECKSUM_CTRL_PER_NETIF (FastLED/fbuild#1252).
@@ -179,7 +184,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.10",
+    "fbuild==2.5.13",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
## Summary\n- update the FastLED fbuild pin from 2.5.10 to released 2.5.13\n- include the 2.5.12 local symlink/file dependency fix and the 2.5.13 manifest-relative path canonicalization\n\n## Validation\n- uv lock --upgrade-package fbuild\n- uv run fbuild --version → build 2.5.13\n\nRelated to #3832.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to a newer version.
  * Documented recent build tooling release changes in the version history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->