### PR TITLE
fix(rp): share Channels bus holders safely

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,14 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.13. It carries library-dependency fixes for Teensy/STM32,
-    # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment,
-    # plus the monitor WebSocket and serial-health fixes required by
-    # AutoResearch.
+    # Pin to fbuild 2.5.14. It carries library-dependency fixes for Teensy/STM32,
+    # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment
+    # that binds picotool to the selected board rather than a USB enumeration.
     #
     # Pin history:
+    #   2.5.14 -- binds RP2040/RP2350 picotool deployment to the selected
+    #              board and refuses Windows USB Code 43 devices
+    #              (FastLED/fbuild#1260).
     #   2.5.13 -- canonicalizes named local `symlink://` and `file://` roots
     #              before resolving manifest-relative paths (FastLED/fbuild#1258).
     #   2.5.12 -- resolves named local `symlink://` and `file://` library
@@ -184,7 +186,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.13",
+    "fbuild==2.5.14",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",

--- a/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h
@@ -1,0 +1,143 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file rp_pio_peripheral_mock.h
+/// @brief Host-testable RP PIO TX/SPI peripheral implementations.
+///
+/// These mocks implement the same peripheral seams used by
+/// `ChannelEngineRpPio`. They deliberately carry no global state: each test
+/// owns its peripheral, can inject a lifecycle failure, and can inspect the
+/// exact words submitted to DMA.
+
+#include "fl/stl/vector.h"
+#include "platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h"
+#include "platforms/arm/rp/rpcommon/irp_pio_tx_peripheral.h"
+
+namespace fl {
+
+class RpPioTxPeripheralMock final : public IRpPioTxPeripheral {
+  public:
+    bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override {
+        lastConfig = config;
+        ++configureCalls;
+        return configureOk;
+    }
+
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+        ++startCalls;
+        firstWord = word_count == 0 ? 0 : words[0];
+        wordCount = word_count;
+        capturedWords.clear();
+        for (size_t index = 0; index < word_count; ++index) {
+            capturedWords.push_back(words[index]);
+        }
+        dmaBusy = startOk;
+        return startOk;
+    }
+
+    bool isDmaBusy() const FL_NO_EXCEPT override { return dmaBusy; }
+    bool isTerminalComplete() const FL_NO_EXCEPT override { return terminal; }
+    bool hasError() const FL_NO_EXCEPT override { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
+
+    void abort() FL_NO_EXCEPT override {
+        ++abortCalls;
+        dmaBusy = false;
+    }
+
+    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
+
+    void reset() FL_NO_EXCEPT {
+        lastConfig = RpPioTxConfig();
+        configureOk = true;
+        startOk = true;
+        dmaBusy = false;
+        terminal = false;
+        error = false;
+        configureCalls = 0;
+        startCalls = 0;
+        abortCalls = 0;
+        deinitializeCalls = 0;
+        wordCount = 0;
+        firstWord = 0;
+        timeUs = 0;
+        capturedWords.clear();
+    }
+
+    RpPioTxConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool dmaBusy = false;
+    bool terminal = false;
+    bool error = false;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    size_t wordCount = 0;
+    u32 firstWord = 0;
+    u32 timeUs = 0;
+    fl::vector<u32> capturedWords;
+};
+
+class RpPioSpiPeripheralMock final : public IRpPioSpiPeripheral {
+  public:
+    bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override {
+        lastConfig = config;
+        ++configureCalls;
+        return configureOk;
+    }
+
+    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+        ++startCalls;
+        capturedWords.clear();
+        for (size_t index = 0; index < word_count; ++index) {
+            capturedWords.push_back(words[index]);
+        }
+        dmaBusy = startOk;
+        return startOk;
+    }
+
+    bool isDmaBusy() const FL_NO_EXCEPT override { return dmaBusy; }
+    bool isTerminalComplete() const FL_NO_EXCEPT override { return terminal; }
+    bool hasError() const FL_NO_EXCEPT override { return error; }
+    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
+
+    void abort() FL_NO_EXCEPT override {
+        ++abortCalls;
+        dmaBusy = false;
+    }
+
+    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
+
+    void reset() FL_NO_EXCEPT {
+        lastConfig = RpPioSpiConfig();
+        configureOk = true;
+        startOk = true;
+        dmaBusy = false;
+        terminal = false;
+        error = false;
+        configureCalls = 0;
+        startCalls = 0;
+        abortCalls = 0;
+        deinitializeCalls = 0;
+        timeUs = 0;
+        capturedWords.clear();
+    }
+
+    RpPioSpiConfig lastConfig;
+    bool configureOk = true;
+    bool startOk = true;
+    bool dmaBusy = false;
+    bool terminal = false;
+    bool error = false;
+    int configureCalls = 0;
+    int startCalls = 0;
+    int abortCalls = 0;
+    int deinitializeCalls = 0;
+    u32 timeUs = 0;
+    fl::vector<u32> capturedWords;
+};
+
+}  // namespace fl

--- a/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h
@@ -11,6 +11,7 @@
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/shared_ptr.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/type_traits.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
 #include "platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.h"
@@ -38,8 +39,7 @@ struct RpPioTxBusHolder {
 
 template<u8 Which>
 inline fl::shared_ptr<ChannelEngineRpPio> rpPioTxInstancePtr() FL_NO_EXCEPT {
-    static RpPioTxBusHolder<Which> holder;
-    return holder.driver;
+    return SingletonShared<RpPioTxBusHolder<Which>>::instance().driver;
 }
 
 }  // namespace detail

--- a/src/platforms/arm/rp/rpcommon/rp_spi_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_bus_traits.h
@@ -11,6 +11,7 @@
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/shared_ptr.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/type_traits.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_spi.h"
 #include "platforms/arm/rp/rpcommon/rp_spi_peripheral.h"
@@ -29,8 +30,7 @@ struct RpSpiBusHolder {
 
 template<u8 Which>
 inline fl::shared_ptr<ChannelEngineRpSpi> rpSpiInstancePtr() FL_NO_EXCEPT {
-    static RpSpiBusHolder<Which> holder;
-    return holder.driver;
+    return SingletonShared<RpSpiBusHolder<Which>>::instance().driver;
 }
 
 }  // namespace detail

--- a/src/platforms/arm/rp/rpcommon/rp_uart_bus_traits.h
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_bus_traits.h
@@ -11,6 +11,7 @@
 #include "fl/channels/bus_traits.h"
 #include "fl/channels/manager.h"
 #include "fl/stl/shared_ptr.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/type_traits.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.h"
 #include "platforms/arm/rp/rpcommon/rp_uart_peripheral.h"
@@ -18,18 +19,18 @@
 namespace fl {
 namespace detail {
 
+template<u8 UartIndex>
 struct RpUartBusHolder {
     fl::shared_ptr<RpUartPeripheral> peripheral;
     fl::shared_ptr<ChannelEngineRpUart> driver;
-    explicit RpUartBusHolder(u8 uart_index) FL_NO_EXCEPT
+    RpUartBusHolder() FL_NO_EXCEPT
         : peripheral(fl::make_shared<RpUartPeripheral>()),
-          driver(fl::make_shared<ChannelEngineRpUart>(peripheral, uart_index)) {}
+          driver(fl::make_shared<ChannelEngineRpUart>(peripheral, UartIndex)) {}
 };
 
 template<u8 UartIndex>
 inline fl::shared_ptr<ChannelEngineRpUart> rpUartInstancePtr() FL_NO_EXCEPT {
-    static RpUartBusHolder holder(UartIndex);
-    return holder.driver;
+    return SingletonShared<RpUartBusHolder<UartIndex>>::instance().driver;
 }
 
 }  // namespace detail

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -9,140 +9,14 @@
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/move.h"
 #include "fl/stl/shared_ptr.h"
-#include "fl/stl/singleton.h"
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_pio.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
 using namespace fl;
 
 namespace {
-
-class PioTxMock final : public IRpPioTxPeripheral {
-  public:
-    bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override {
-        lastConfig = config;
-        ++configureCalls;
-        return configureOk;
-    }
-    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
-        ++startCalls;
-        firstWord = word_count == 0 ? 0 : words[0];
-        wordCount = word_count;
-        capturedWords.clear();
-        for (size_t index = 0; index < word_count; ++index) {
-            capturedWords.push_back(words[index]);
-        }
-        dmaBusy = startOk;
-        return startOk;
-    }
-    bool isDmaBusy() const FL_NO_EXCEPT override { return dmaBusy; }
-    bool isTerminalComplete() const FL_NO_EXCEPT override { return terminal; }
-    bool hasError() const FL_NO_EXCEPT override { return error; }
-    u32 nowMicros() const FL_NO_EXCEPT override { return timeUs; }
-    void abort() FL_NO_EXCEPT override { ++abortCalls; dmaBusy = false; }
-    void deinitialize() FL_NO_EXCEPT override { ++deinitializeCalls; }
-
-    RpPioTxConfig lastConfig;
-    bool configureOk = true;
-    bool startOk = true;
-    bool dmaBusy = false;
-    bool terminal = false;
-    bool error = false;
-    int configureCalls = 0;
-    int startCalls = 0;
-    int abortCalls = 0;
-    int deinitializeCalls = 0;
-    size_t wordCount = 0;
-    u32 firstWord = 0;
-    u32 timeUs = 0;
-    fl::vector<u32> capturedWords;
-};
-
-class PioSpiMock final {
-  public:
-    static PioSpiMock& instance() FL_NO_EXCEPT {
-        return Singleton<PioSpiMock>::instance();
-    }
-
-    void reset() FL_NO_EXCEPT {
-        lastConfig = RpPioSpiConfig();
-        configureOk = true;
-        startOk = true;
-        dmaBusy = false;
-        terminal = false;
-        error = false;
-        configureCalls = 0;
-        startCalls = 0;
-        abortCalls = 0;
-        deinitializeCalls = 0;
-        capturedWords.clear();
-    }
-
-    bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT {
-        lastConfig = config;
-        ++configureCalls;
-        return configureOk;
-    }
-    bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT {
-        ++startCalls;
-        capturedWords.clear();
-        for (size_t index = 0; index < word_count; ++index) {
-            capturedWords.push_back(words[index]);
-        }
-        dmaBusy = startOk;
-        return startOk;
-    }
-    bool isDmaBusy() const FL_NO_EXCEPT { return dmaBusy; }
-    bool isTerminalComplete() const FL_NO_EXCEPT { return terminal; }
-    bool hasError() const FL_NO_EXCEPT { return error; }
-    u32 nowMicros() const FL_NO_EXCEPT { return 0; }
-    void abort() FL_NO_EXCEPT { ++abortCalls; dmaBusy = false; }
-    void deinitialize() FL_NO_EXCEPT { ++deinitializeCalls; }
-
-    RpPioSpiConfig lastConfig;
-    bool configureOk = true;
-    bool startOk = true;
-    bool dmaBusy = false;
-    bool terminal = false;
-    bool error = false;
-    int configureCalls = 0;
-    int startCalls = 0;
-    int abortCalls = 0;
-    int deinitializeCalls = 0;
-    fl::vector<u32> capturedWords;
-};
-
-fl::shared_ptr<IRpPioSpiPeripheral> createSpiMockPeripheral() {
-    class MockWrapper final : public IRpPioSpiPeripheral {
-      public:
-        bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override {
-            return PioSpiMock::instance().configure(config);
-        }
-        bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
-            return PioSpiMock::instance().startTxDma(words, word_count);
-        }
-        bool isDmaBusy() const FL_NO_EXCEPT override {
-            return PioSpiMock::instance().isDmaBusy();
-        }
-        bool isTerminalComplete() const FL_NO_EXCEPT override {
-            return PioSpiMock::instance().isTerminalComplete();
-        }
-        bool hasError() const FL_NO_EXCEPT override {
-            return PioSpiMock::instance().hasError();
-        }
-        u32 nowMicros() const FL_NO_EXCEPT override {
-            return PioSpiMock::instance().nowMicros();
-        }
-        void abort() FL_NO_EXCEPT override { PioSpiMock::instance().abort(); }
-        void deinitialize() FL_NO_EXCEPT override {
-            PioSpiMock::instance().deinitialize();
-        }
-    };
-
-    PioSpiMock::instance().reset();
-    return fl::make_shared<MockWrapper>();
-}
 
 ChannelDataPtr makeChannel(int pin, const fl::vector_psram<u8>& bytes) {
     fl::vector_psram<u8> copy = bytes;
@@ -161,7 +35,7 @@ ChannelDataPtr makeSpiChannel(int mosi_pin, int sck_pin, u32 clock_hz,
 }  // namespace
 
 FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
-    auto peripheral = fl::make_shared<PioTxMock>();
+    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
     ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x00);
@@ -199,7 +73,7 @@ FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
 }
 
 FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
-    auto peripheral = fl::make_shared<PioTxMock>();
+    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
     ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> firstBytes;
     firstBytes.push_back(0x12);
@@ -222,7 +96,7 @@ FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
 }
 
 FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
-    auto peripheral = fl::make_shared<PioTxMock>();
+    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
     ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x42);
@@ -242,7 +116,7 @@ FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
 }
 
 FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes") {
-    auto peripheral = fl::make_shared<PioTxMock>();
+    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
     ChannelEngineRpPio engine(peripheral);
     fl::vector_psram<u8> leftBytes;
     leftBytes.push_back(0x80);
@@ -272,7 +146,7 @@ FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes")
 
 FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs") {
     for (u8 lanes = 4; lanes <= 8; lanes = static_cast<u8>(lanes * 2)) {
-        auto peripheral = fl::make_shared<PioTxMock>();
+        auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
         ChannelEngineRpPio engine(peripheral);
         fl::vector_psram<u8> bytes;
         bytes.push_back(0xFF);
@@ -288,9 +162,8 @@ FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs")
 }
 
 FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
-    auto clockless = fl::make_shared<PioTxMock>();
-    auto spi = createSpiMockPeripheral();
-    PioSpiMock& spiMock = PioSpiMock::instance();
+    auto clockless = fl::make_shared<RpPioTxPeripheralMock>();
+    auto spi = fl::make_shared<RpPioSpiPeripheralMock>();
     ChannelEngineRpPio engine(clockless, spi);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0xA5);
@@ -303,29 +176,29 @@ FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
     engine.enqueue(channel);
     engine.show();
     FL_CHECK(channel->isInUse());
-    FL_CHECK_EQ(spiMock.lastConfig.mosi_pin, 5);
-    FL_CHECK_EQ(spiMock.lastConfig.sck_pin, 9);
-    FL_CHECK_EQ(spiMock.lastConfig.clock_hz, 4000000u);
-    FL_REQUIRE_EQ(spiMock.capturedWords.size(), static_cast<size_t>(2));
-    FL_CHECK_EQ(spiMock.capturedWords[0], 0xA5000000u);
-    FL_CHECK_EQ(spiMock.capturedWords[1], 0x5A000000u);
+    FL_CHECK_EQ(spi->lastConfig.mosi_pin, 5);
+    FL_CHECK_EQ(spi->lastConfig.sck_pin, 9);
+    FL_CHECK_EQ(spi->lastConfig.clock_hz, 4000000u);
+    FL_REQUIRE_EQ(spi->capturedWords.size(), static_cast<size_t>(2));
+    FL_CHECK_EQ(spi->capturedWords[0], 0xA5000000u);
+    FL_CHECK_EQ(spi->capturedWords[1], 0x5A000000u);
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
-    spiMock.dmaBusy = false;
+    spi->dmaBusy = false;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
-    spiMock.terminal = true;
+    spi->terminal = true;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
     FL_CHECK_FALSE(channel->isInUse());
-    FL_CHECK_EQ(spiMock.deinitializeCalls, 1);
+    FL_CHECK_EQ(spi->deinitializeCalls, 1);
 }
 
 FL_TEST_CASE("RP PIO instances preserve distinct concrete driver names") {
     const fl::shared_ptr<IRpPioSpiPeripheral> no_spi;
     auto pio0 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<PioTxMock>(), no_spi, "PIO0");
+        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO0");
     auto pio1 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<PioTxMock>(), no_spi, "PIO1");
+        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO1");
     auto pio2 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<PioTxMock>(), no_spi, "PIO2");
+        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO2");
 
     ChannelManager& manager = ChannelManager::instance();
     manager.clearAllDrivers();
@@ -341,8 +214,8 @@ FL_TEST_CASE("RP PIO instances preserve distinct concrete driver names") {
 }
 
 FL_TEST_CASE("RP FLEX_IO defers native SPI pin pairs to the hardware driver") {
-    auto clockless = fl::make_shared<PioTxMock>();
-    auto spi = createSpiMockPeripheral();
+    auto clockless = fl::make_shared<RpPioTxPeripheralMock>();
+    auto spi = fl::make_shared<RpPioSpiPeripheralMock>();
     ChannelEngineRpPio engine(clockless, spi);
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x01);


### PR DESCRIPTION
## Summary\n- replace RP PIO/SPI/UART function-local bus holder state with header-safe l::SingletonShared instances\n- provide reusable, isolated RP PIO TX/SPI peripheral mocks and use them in lifecycle tests\n- pin FastLED to fbuild 2.5.14, including selected-device RP deployment protection\n\n## Verification\n- ash test --unit channel_engine_rp_pio --no-interactive --no-fingerprint\n- ash lint --cpp --strict on all touched C++ files\n- ash compile rp2350w AutoResearch --no-interactive\n\nRefs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable host-test mocks for RP PIO transmit and SPI peripherals.
  * Expanded validation of DMA behavior, configuration, failure handling, timing, cleanup, and captured data.
  * Improved coverage for RP platform bus and driver interactions.

* **Refactor**
  * Standardized RP PIO, SPI, and UART driver instance management for more consistent behavior.

* **Chores**
  * Updated the `fbuild` build dependency to version 2.5.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->