### PR TITLE
test(rp): model PIO peripherals as singleton hardware

### DIFF
--- a/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/_build.cpp.hpp
@@ -9,6 +9,7 @@
 #include "platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/clockless_rp_pio_auto.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/init_channel_driver_rp.cpp.hpp"
+#include "platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_pio_spi_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_peripheral.cpp.hpp"
 #include "platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp"

--- a/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.cpp.hpp
@@ -1,0 +1,25 @@
+// IWYU pragma: private
+
+/// @file rp_pio_peripheral_mock.cpp.hpp
+/// @brief Test-only singleton storage for RP PIO peripheral mocks.
+
+#include "platforms/is_platform.h"
+
+#if defined(FASTLED_STUB_IMPL)
+
+#include "fl/stl/singleton.h"
+#include "platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h"
+
+namespace fl {
+
+RpPioTxPeripheralMock& RpPioTxPeripheralMock::instance() FL_NO_EXCEPT {
+    return Singleton<RpPioTxPeripheralMock>::instance();
+}
+
+RpPioSpiPeripheralMock& RpPioSpiPeripheralMock::instance() FL_NO_EXCEPT {
+    return Singleton<RpPioSpiPeripheralMock>::instance();
+}
+
+}  // namespace fl
+
+#endif  // defined(FASTLED_STUB_IMPL)

--- a/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h
+++ b/src/platforms/arm/rp/rpcommon/rp_pio_peripheral_mock.h
@@ -6,9 +6,9 @@
 /// @brief Host-testable RP PIO TX/SPI peripheral implementations.
 ///
 /// These mocks implement the same peripheral seams used by
-/// `ChannelEngineRpPio`. They deliberately carry no global state: each test
-/// owns its peripheral, can inject a lifecycle failure, and can inspect the
-/// exact words submitted to DMA.
+/// `ChannelEngineRpPio`. Each represents one hardware peripheral, so tests
+/// access it through `instance()` and reset it before use. The backing storage
+/// lives in a test-only `.cpp.hpp` behind `fl::Singleton<T>`.
 
 #include "fl/stl/vector.h"
 #include "platforms/arm/rp/rpcommon/irp_pio_spi_peripheral.h"
@@ -18,6 +18,8 @@ namespace fl {
 
 class RpPioTxPeripheralMock final : public IRpPioTxPeripheral {
   public:
+    static RpPioTxPeripheralMock& instance() FL_NO_EXCEPT;
+
     bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override {
         lastConfig = config;
         ++configureCalls;
@@ -83,6 +85,8 @@ class RpPioTxPeripheralMock final : public IRpPioTxPeripheral {
 
 class RpPioSpiPeripheralMock final : public IRpPioSpiPeripheral {
   public:
+    static RpPioSpiPeripheralMock& instance() FL_NO_EXCEPT;
+
     bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override {
         lastConfig = config;
         ++configureCalls;

--- a/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
+++ b/tests/platforms/arm/rp/rpcommon/channel_engine_rp_pio.cpp
@@ -18,6 +18,76 @@ using namespace fl;
 
 namespace {
 
+fl::shared_ptr<IRpPioTxPeripheral> createTxMockPeripheral() {
+    class MockWrapper final : public IRpPioTxPeripheral {
+      public:
+        bool configure(const RpPioTxConfig& config) FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().configure(config);
+        }
+        bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().startTxDma(words, word_count);
+        }
+        bool isDmaBusy() const FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().isDmaBusy();
+        }
+        bool isTerminalComplete() const FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().isTerminalComplete();
+        }
+        bool hasError() const FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().hasError();
+        }
+        u32 nowMicros() const FL_NO_EXCEPT override {
+            return RpPioTxPeripheralMock::instance().nowMicros();
+        }
+        void abort() FL_NO_EXCEPT override { RpPioTxPeripheralMock::instance().abort(); }
+        void deinitialize() FL_NO_EXCEPT override {
+            RpPioTxPeripheralMock::instance().deinitialize();
+        }
+    };
+    return fl::make_shared<MockWrapper>();
+}
+
+fl::shared_ptr<IRpPioSpiPeripheral> createSpiMockPeripheral() {
+    class MockWrapper final : public IRpPioSpiPeripheral {
+      public:
+        bool configure(const RpPioSpiConfig& config) FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().configure(config);
+        }
+        bool startTxDma(const u32* words, size_t word_count) FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().startTxDma(words, word_count);
+        }
+        bool isDmaBusy() const FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().isDmaBusy();
+        }
+        bool isTerminalComplete() const FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().isTerminalComplete();
+        }
+        bool hasError() const FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().hasError();
+        }
+        u32 nowMicros() const FL_NO_EXCEPT override {
+            return RpPioSpiPeripheralMock::instance().nowMicros();
+        }
+        void abort() FL_NO_EXCEPT override { RpPioSpiPeripheralMock::instance().abort(); }
+        void deinitialize() FL_NO_EXCEPT override {
+            RpPioSpiPeripheralMock::instance().deinitialize();
+        }
+    };
+    return fl::make_shared<MockWrapper>();
+}
+
+RpPioTxPeripheralMock& resetTxMock() {
+    RpPioTxPeripheralMock& mock = RpPioTxPeripheralMock::instance();
+    mock.reset();
+    return mock;
+}
+
+RpPioSpiPeripheralMock& resetSpiMock() {
+    RpPioSpiPeripheralMock& mock = RpPioSpiPeripheralMock::instance();
+    mock.reset();
+    return mock;
+}
+
 ChannelDataPtr makeChannel(int pin, const fl::vector_psram<u8>& bytes) {
     fl::vector_psram<u8> copy = bytes;
     return ChannelData::create(pin, makeTimingConfig<TIMING_WS2812_800KHZ>(),
@@ -35,8 +105,8 @@ ChannelDataPtr makeSpiChannel(int mosi_pin, int sck_pin, u32 clock_hz,
 }  // namespace
 
 FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
-    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
-    ChannelEngineRpPio engine(peripheral);
+    RpPioTxPeripheralMock& peripheral = resetTxMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral());
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x00);
     bytes.push_back(0xFF);
@@ -46,35 +116,35 @@ FL_TEST_CASE("RP PIO TX waits for terminal state after DMA") {
     engine.enqueue(channel);
     engine.show();
     FL_REQUIRE(channel->isInUse());
-    FL_CHECK_EQ(peripheral->wordCount, static_cast<size_t>(32));
-    FL_CHECK_EQ(peripheral->firstWord, 0x00000000u);
-    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(32));
-    FL_CHECK_EQ(peripheral->capturedWords[0], 0x00000000u);
+    FL_CHECK_EQ(peripheral.wordCount, static_cast<size_t>(32));
+    FL_CHECK_EQ(peripheral.firstWord, 0x00000000u);
+    FL_REQUIRE_EQ(peripheral.capturedWords.size(), static_cast<size_t>(32));
+    FL_CHECK_EQ(peripheral.capturedWords[0], 0x00000000u);
     for (size_t index = 0; index < 8; ++index) {
-        FL_CHECK_EQ(peripheral->capturedWords[index], 0u); // 0x00
-        FL_CHECK_EQ(peripheral->capturedWords[8 + index], 0x80000000u); // 0xFF
+        FL_CHECK_EQ(peripheral.capturedWords[index], 0u); // 0x00
+        FL_CHECK_EQ(peripheral.capturedWords[8 + index], 0x80000000u); // 0xFF
     }
-    FL_CHECK_EQ(peripheral->capturedWords[16], 0x80000000u); // 0xAA MSB
-    FL_CHECK_EQ(peripheral->capturedWords[17], 0u);
-    FL_CHECK_EQ(peripheral->capturedWords[18], 0x80000000u);
-    FL_CHECK_EQ(peripheral->capturedWords[19], 0u);
-    FL_CHECK_EQ(peripheral->capturedWords[24], 0u); // 0x55 MSB
-    FL_CHECK_EQ(peripheral->capturedWords[25], 0x80000000u);
+    FL_CHECK_EQ(peripheral.capturedWords[16], 0x80000000u); // 0xAA MSB
+    FL_CHECK_EQ(peripheral.capturedWords[17], 0u);
+    FL_CHECK_EQ(peripheral.capturedWords[18], 0x80000000u);
+    FL_CHECK_EQ(peripheral.capturedWords[19], 0u);
+    FL_CHECK_EQ(peripheral.capturedWords[24], 0u); // 0x55 MSB
+    FL_CHECK_EQ(peripheral.capturedWords[25], 0x80000000u);
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
-    peripheral->dmaBusy = false;
+    peripheral.dmaBusy = false;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
     FL_CHECK(channel->isInUse());
-    peripheral->terminal = true;
+    peripheral.terminal = true;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
-    peripheral->timeUs += 1000;
+    peripheral.timeUs += 1000;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
     FL_CHECK_FALSE(channel->isInUse());
-    FL_CHECK_EQ(peripheral->deinitializeCalls, 1);
+    FL_CHECK_EQ(peripheral.deinitializeCalls, 1);
 }
 
 FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
-    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
-    ChannelEngineRpPio engine(peripheral);
+    RpPioTxPeripheralMock& peripheral = resetTxMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral());
     fl::vector_psram<u8> firstBytes;
     firstBytes.push_back(0x12);
     fl::vector_psram<u8> secondBytes;
@@ -85,19 +155,19 @@ FL_TEST_CASE("RP PIO TX preserves pending work and cleans up errors") {
     engine.show();
     engine.enqueue(second);
     FL_CHECK_FALSE(second->isInUse());
-    peripheral->error = true;
+    peripheral.error = true;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
     FL_CHECK_FALSE(first->isInUse());
     FL_CHECK_FALSE(second->isInUse());
     FL_CHECK_EQ(engine.lastError(), fl::string("RP PIO: peripheral error"));
     FL_CHECK_FALSE(engine.isActive());
-    FL_CHECK(peripheral->abortCalls > 0);
-    FL_CHECK(peripheral->deinitializeCalls > 0);
+    FL_CHECK(peripheral.abortCalls > 0);
+    FL_CHECK(peripheral.deinitializeCalls > 0);
 }
 
 FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
-    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
-    ChannelEngineRpPio engine(peripheral);
+    RpPioTxPeripheralMock& peripheral = resetTxMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral());
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x42);
     auto first = makeChannel(5, bytes);
@@ -105,19 +175,19 @@ FL_TEST_CASE("RP PIO TX rejects a failed second queued start") {
     engine.enqueue(first);
     engine.enqueue(second);
     engine.show();
-    peripheral->dmaBusy = false;
-    peripheral->terminal = true;
+    peripheral.dmaBusy = false;
+    peripheral.terminal = true;
     FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
-    peripheral->timeUs += 1000;
-    peripheral->configureOk = false;
+    peripheral.timeUs += 1000;
+    peripheral.configureOk = false;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::ERROR);
     FL_CHECK_FALSE(first->isInUse());
     FL_CHECK_FALSE(second->isInUse());
 }
 
 FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes") {
-    auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
-    ChannelEngineRpPio engine(peripheral);
+    RpPioTxPeripheralMock& peripheral = resetTxMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral());
     fl::vector_psram<u8> leftBytes;
     leftBytes.push_back(0x80);
     fl::vector_psram<u8> rightBytes;
@@ -127,18 +197,18 @@ FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes")
     engine.enqueue(left);
     engine.enqueue(right);
     engine.show();
-    FL_REQUIRE_EQ(peripheral->lastConfig.tx_pin, 10);
-    FL_REQUIRE_EQ(peripheral->lastConfig.lane_count, 2);
-    FL_REQUIRE_EQ(peripheral->capturedWords.size(), static_cast<size_t>(8));
+    FL_REQUIRE_EQ(peripheral.lastConfig.tx_pin, 10);
+    FL_REQUIRE_EQ(peripheral.lastConfig.lane_count, 2);
+    FL_REQUIRE_EQ(peripheral.capturedWords.size(), static_cast<size_t>(8));
     // Lane 0 occupies the most-significant emitted bit and lane 1 the next.
-    FL_CHECK_EQ(peripheral->capturedWords[0], 0x80000000u);
-    for (size_t index = 1; index < peripheral->capturedWords.size(); ++index) {
-        FL_CHECK_EQ(peripheral->capturedWords[index], 0u);
+    FL_CHECK_EQ(peripheral.capturedWords[0], 0x80000000u);
+    for (size_t index = 1; index < peripheral.capturedWords.size(); ++index) {
+        FL_CHECK_EQ(peripheral.capturedWords[index], 0u);
     }
-    peripheral->dmaBusy = false;
-    peripheral->terminal = true;
+    peripheral.dmaBusy = false;
+    peripheral.terminal = true;
     FL_REQUIRE_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
-    peripheral->timeUs += 1000;
+    peripheral.timeUs += 1000;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
     FL_CHECK_FALSE(left->isInUse());
     FL_CHECK_FALSE(right->isInUse());
@@ -146,25 +216,25 @@ FL_TEST_CASE("RP PIO TX batches only equal-length consecutive compatible lanes")
 
 FL_TEST_CASE("RP PIO TX selects four and eight lane batches only for full runs") {
     for (u8 lanes = 4; lanes <= 8; lanes = static_cast<u8>(lanes * 2)) {
-        auto peripheral = fl::make_shared<RpPioTxPeripheralMock>();
-        ChannelEngineRpPio engine(peripheral);
+        RpPioTxPeripheralMock& peripheral = resetTxMock();
+        ChannelEngineRpPio engine(createTxMockPeripheral());
         fl::vector_psram<u8> bytes;
         bytes.push_back(0xFF);
         for (u8 lane = 0; lane < lanes; ++lane) {
             engine.enqueue(makeChannel(12 + lane, bytes));
         }
         engine.show();
-        FL_CHECK_EQ(peripheral->lastConfig.lane_count, lanes);
-        FL_CHECK_EQ(peripheral->capturedWords.size(), static_cast<size_t>(8));
-        FL_CHECK_EQ(peripheral->capturedWords[0],
+        FL_CHECK_EQ(peripheral.lastConfig.lane_count, lanes);
+        FL_CHECK_EQ(peripheral.capturedWords.size(), static_cast<size_t>(8));
+        FL_CHECK_EQ(peripheral.capturedWords[0],
                     ((1u << lanes) - 1u) << (32u - lanes));
     }
 }
 
 FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
-    auto clockless = fl::make_shared<RpPioTxPeripheralMock>();
-    auto spi = fl::make_shared<RpPioSpiPeripheralMock>();
-    ChannelEngineRpPio engine(clockless, spi);
+    resetTxMock();
+    RpPioSpiPeripheralMock& spi = resetSpiMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral(), createSpiMockPeripheral());
     fl::vector_psram<u8> bytes;
     bytes.push_back(0xA5);
     bytes.push_back(0x5A);
@@ -176,29 +246,30 @@ FL_TEST_CASE("RP FLEX_IO PIO SPI sends arbitrary pin pairs") {
     engine.enqueue(channel);
     engine.show();
     FL_CHECK(channel->isInUse());
-    FL_CHECK_EQ(spi->lastConfig.mosi_pin, 5);
-    FL_CHECK_EQ(spi->lastConfig.sck_pin, 9);
-    FL_CHECK_EQ(spi->lastConfig.clock_hz, 4000000u);
-    FL_REQUIRE_EQ(spi->capturedWords.size(), static_cast<size_t>(2));
-    FL_CHECK_EQ(spi->capturedWords[0], 0xA5000000u);
-    FL_CHECK_EQ(spi->capturedWords[1], 0x5A000000u);
+    FL_CHECK_EQ(spi.lastConfig.mosi_pin, 5);
+    FL_CHECK_EQ(spi.lastConfig.sck_pin, 9);
+    FL_CHECK_EQ(spi.lastConfig.clock_hz, 4000000u);
+    FL_REQUIRE_EQ(spi.capturedWords.size(), static_cast<size_t>(2));
+    FL_CHECK_EQ(spi.capturedWords[0], 0xA5000000u);
+    FL_CHECK_EQ(spi.capturedWords[1], 0x5A000000u);
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::BUSY);
-    spi->dmaBusy = false;
+    spi.dmaBusy = false;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::DRAINING);
-    spi->terminal = true;
+    spi.terminal = true;
     FL_CHECK_EQ(engine.poll(), IChannelDriver::DriverState::READY);
     FL_CHECK_FALSE(channel->isInUse());
-    FL_CHECK_EQ(spi->deinitializeCalls, 1);
+    FL_CHECK_EQ(spi.deinitializeCalls, 1);
 }
 
 FL_TEST_CASE("RP PIO instances preserve distinct concrete driver names") {
+    resetTxMock();
     const fl::shared_ptr<IRpPioSpiPeripheral> no_spi;
     auto pio0 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO0");
+        createTxMockPeripheral(), no_spi, "PIO0");
     auto pio1 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO1");
+        createTxMockPeripheral(), no_spi, "PIO1");
     auto pio2 = fl::make_shared<ChannelEngineRpPio>(
-        fl::make_shared<RpPioTxPeripheralMock>(), no_spi, "PIO2");
+        createTxMockPeripheral(), no_spi, "PIO2");
 
     ChannelManager& manager = ChannelManager::instance();
     manager.clearAllDrivers();
@@ -214,9 +285,9 @@ FL_TEST_CASE("RP PIO instances preserve distinct concrete driver names") {
 }
 
 FL_TEST_CASE("RP FLEX_IO defers native SPI pin pairs to the hardware driver") {
-    auto clockless = fl::make_shared<RpPioTxPeripheralMock>();
-    auto spi = fl::make_shared<RpPioSpiPeripheralMock>();
-    ChannelEngineRpPio engine(clockless, spi);
+    resetTxMock();
+    resetSpiMock();
+    ChannelEngineRpPio engine(createTxMockPeripheral(), createSpiMockPeripheral());
     fl::vector_psram<u8> bytes;
     bytes.push_back(0x01);
     FL_CHECK_FALSE(engine.canHandle(makeSpiChannel(3, 2, 4000000, bytes)));


### PR DESCRIPTION
## Summary\n- make RP PIO TX/SPI peripheral mocks singleton-backed, consistent with hardware-resource mock policy\n- pass mocks to the Channels engine through non-owning forwarding wrappers\n- reset singleton state at every test boundary\n\n## Verification\n- ash lint --cpp --strict on touched files\n- ash test --unit channel_engine_rp_pio --clean --no-interactive\n- ash compile rp2350w --examples AutoResearch --no-interactive\n\nRefs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved host-based testing for RP-series PIO and SPI peripheral behavior.
  * Added more consistent mock peripheral setup and reset handling between tests.
  * Expanded coverage for transmission, batching, configuration, error handling, lifecycle behavior, and native SPI pin selection.
  * Consolidated test-only peripheral access to improve reliability and consistency across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->