### PR TITLE
feat(autoresearch): validate RP2350W and C6 peer networking

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -84,6 +84,9 @@ class Args:
     net_server: bool
     net_client: bool
     net: bool
+    net_peer: bool
+    peer_environment: str
+    peer_upload_port: str | None
 
     # OTA autoresearch mode
     ota: bool
@@ -410,6 +413,23 @@ See Also:
             "--net",
             action="store_true",
             help="Self-contained loopback test: ESP32 starts HTTP server, then GETs localhost (no WiFi needed)",
+        )
+        net_group.add_argument(
+            "--net-peer",
+            action="store_true",
+            help=(
+                "Deploy RP2350W and ESP32-C6 to explicit ports, then validate "
+                "device-to-device WiFi and HTTP without changing host WiFi"
+            ),
+        )
+        net_group.add_argument(
+            "--peer-environment",
+            default="esp32c6",
+            help="Companion board for --net-peer (currently esp32c6 only)",
+        )
+        net_group.add_argument(
+            "--peer-upload-port",
+            help="Explicit serial port for the --net-peer companion board",
         )
 
         # OTA autoresearch mode
@@ -890,6 +910,9 @@ See Also:
             net_server=parsed.net_server,
             net_client=parsed.net_client,
             net=parsed.net,
+            net_peer=parsed.net_peer,
+            peer_environment=parsed.peer_environment,
+            peer_upload_port=parsed.peer_upload_port,
             ota=parsed.ota,
             ble=parsed.ble,
             parallel=parsed.parallel,

--- a/ci/autoresearch/context.py
+++ b/ci/autoresearch/context.py
@@ -153,6 +153,7 @@ class RunContext:
     net_server_mode: bool
     net_client_mode: bool
     net_loopback_mode: bool
+    net_peer_mode: bool
     ota_mode: bool
     ble_mode: bool
     decode_mode: bool

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -4,6 +4,7 @@ Provides WiFi management, HTTP server, and autoresearch flows for
 --net-server and --net-client modes.
 """
 
+import asyncio
 import os
 import platform as platform_mod
 import subprocess
@@ -429,6 +430,162 @@ async def run_net_loopback_autoresearch(
         if client:
             try:
                 await client.send("stopNet", timeout=10.0)
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
+            except Exception:
+                pass
+            await client.close()
+
+
+async def run_net_peer_autoresearch(
+    upload_port: str,
+    peer_upload_port: str,
+    serial_iface: "SerialInterface | None",
+    timeout: float = 120.0,
+) -> int:
+    """Validate RP2350W <-> ESP32-C6 networking without touching host WiFi.
+
+    Both firmware images have already been deployed through fbuild by the
+    caller. The C6 hosts its SoftAP and HTTP server, while the RP2350W joins
+    as a station. Each cycle validates HTTP in both directions, tears down the
+    RP network state, and verifies that its serial JSON-RPC endpoint remains
+    responsive before reconnecting.
+    """
+    from ci.util.serial_interface import create_serial_interface
+
+    print()
+    print("=" * 60)
+    print("NETWORK AUTORESEARCH MODE: RP2350W <-> ESP32-C6 PEER")
+    print("=" * 60)
+    print("  Host WiFi is not used or changed by this mode.")
+
+    deadline = time.monotonic() + timeout
+    primary: RpcClient | None = None
+    peer: RpcClient | None = None
+
+    def rpc_timeout() -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RpcTimeoutError("--net-peer deadline expired")
+        return min(15.0, remaining)
+
+    async def rpc_data(
+        client: RpcClient, method: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        response = await client.send(method, params or {}, timeout=rpc_timeout())
+        if not isinstance(response.data, dict):
+            raise RpcError(f"{method} returned a non-object response")
+        return response.data
+
+    async def assert_ping(client: RpcClient, name: str) -> None:
+        await rpc_data(client, "ping")
+        print(f"  {name} serial RPC ping: {Fore.GREEN}PASS{Style.RESET_ALL}")
+
+    try:
+        # The primary interface was built by the normal fbuild-backed setup
+        # phase. Construct the companion interface the same way; no raw
+        # pyserial connection and no direct flash utility is involved.
+        peer_iface = create_serial_interface(peer_upload_port)
+        primary = RpcClient(
+            upload_port, timeout=rpc_timeout(), serial_interface=serial_iface
+        )
+        peer = RpcClient(
+            peer_upload_port, timeout=rpc_timeout(), serial_interface=peer_iface
+        )
+        print(f"  Connecting RP2350W on {upload_port}...")
+        await primary.connect(boot_wait=3.0, drain_boot=True)
+        print(f"  Connecting ESP32-C6 on {peer_upload_port}...")
+        await peer.connect(boot_wait=3.0, drain_boot=True)
+
+        primary_status = await rpc_data(primary, "status")
+        if "rp2350" not in str(primary_status.get("platform", "")).lower():
+            raise RpcError(
+                "Primary --net-peer board did not identify as RP2350: "
+                f"{primary_status.get('platform')!r}"
+            )
+        peer_status = await rpc_data(peer, "status")
+        if "esp32-c6" not in str(peer_status.get("platform", "")).lower():
+            raise RpcError(
+                "Companion --net-peer board did not identify as ESP32-C6: "
+                f"{peer_status.get('platform')!r}"
+            )
+
+        c6_server = await rpc_data(peer, "startNetServer")
+        if not c6_server.get("success"):
+            raise RpcError(f"ESP32-C6 startNetServer failed: {c6_server}")
+        ssid = c6_server.get("ssid")
+        password = c6_server.get("password")
+        c6_ip = c6_server.get("ip")
+        c6_port = c6_server.get("port")
+        if (
+            not isinstance(ssid, str)
+            or not isinstance(password, str)
+            or not isinstance(c6_ip, str)
+            or not isinstance(c6_port, int)
+        ):
+            raise RpcError(f"ESP32-C6 returned incomplete AP details: {c6_server}")
+
+        for cycle in range(1, 11):
+            print(f"\n--- Peer network cycle {cycle}/10 ---")
+            connect = await rpc_data(
+                primary, "wifiConnect", {"ssid": ssid, "password": password}
+            )
+            if not connect.get("success"):
+                raise RpcError(f"RP2350W wifiConnect failed: {connect}")
+
+            rp_ip: str | None = None
+            for _ in range(20):
+                wifi_status = await rpc_data(primary, "wifiStatus")
+                candidate_ip = wifi_status.get("ip")
+                if wifi_status.get("connected") and isinstance(candidate_ip, str):
+                    rp_ip = candidate_ip
+                    break
+                await asyncio.sleep(min(0.5, rpc_timeout()))
+            if not rp_ip:
+                raise RpcTimeoutError("RP2350W did not join the ESP32-C6 AP")
+
+            rp_server = await rpc_data(primary, "startNetServer")
+            rp_port = rp_server.get("port")
+            if not rp_server.get("success") or not isinstance(rp_port, int):
+                raise RpcError(f"RP2350W startNetServer failed: {rp_server}")
+
+            rp_to_c6 = await rpc_data(
+                primary, "runNetClientTest", {"host_ip": c6_ip, "port": c6_port}
+            )
+            if not rp_to_c6.get("success"):
+                raise RpcError(f"RP2350W -> ESP32-C6 HTTP failed: {rp_to_c6}")
+            c6_to_rp = await rpc_data(
+                peer, "runNetClientTest", {"host_ip": rp_ip, "port": rp_port}
+            )
+            if not c6_to_rp.get("success"):
+                raise RpcError(f"ESP32-C6 -> RP2350W HTTP failed: {c6_to_rp}")
+
+            stop_result = await rpc_data(primary, "stopNet")
+            if not stop_result.get("success"):
+                raise RpcError(f"RP2350W stopNet failed: {stop_result}")
+            await assert_ping(primary, "RP2350W")
+
+        await assert_ping(peer, "ESP32-C6")
+        print(
+            f"\n{Fore.GREEN}NET PEER AUTORESEARCH PASSED (10 reconnect cycles){Style.RESET_ALL}"
+        )
+        return 0
+    except KeyboardInterrupt as ki:
+        print("\n\n  Interrupted by user")
+        handle_keyboard_interrupt(ki)
+        return 130
+    except (RpcError, RpcTimeoutError) as e:
+        print(f"\n  {Fore.RED}Network peer autoresearch failed: {e}{Style.RESET_ALL}")
+        return 1
+    except Exception as e:
+        print(f"\n  {Fore.RED}Network peer autoresearch error: {e}{Style.RESET_ALL}")
+        return 1
+    finally:
+        for client in (primary, peer):
+            if client is None:
+                continue
+            try:
+                await client.send("stopNet", timeout=2.0)
             except KeyboardInterrupt as ki:
                 handle_keyboard_interrupt(ki)
             except Exception:

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -569,6 +569,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
     net_server_mode = args.net_server
     net_client_mode = args.net_client
     net_loopback_mode = args.net
+    net_peer_mode = args.net_peer
     ota_mode = args.ota
     ble_mode = args.ble
     decode_mode = args.decode is not None
@@ -584,6 +585,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
             or net_server_mode
             or net_client_mode
             or net_loopback_mode
+            or net_peer_mode
             or ota_mode
             or ble_mode
         )
@@ -595,7 +597,12 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
 
     # Validate mutual exclusivity
     if (
-        net_server_mode or net_client_mode or net_loopback_mode or ota_mode or ble_mode
+        net_server_mode
+        or net_client_mode
+        or net_loopback_mode
+        or net_peer_mode
+        or ota_mode
+        or ble_mode
     ) and (
         drivers
         or simd_test_mode
@@ -604,15 +611,35 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         or rpc_smoke_mode
     ):
         print(
-            f"{Fore.RED}\u274c Error: --net/--net-server/--net-client/--ota/--ble cannot be combined with driver flags, --simd, or --coroutine{Style.RESET_ALL}"
+            f"{Fore.RED}\u274c Error: network, OTA, and BLE modes cannot be combined with driver flags, --simd, or --coroutine{Style.RESET_ALL}"
         )
         return 1
-    net_mode_count = sum([net_server_mode, net_client_mode, net_loopback_mode])
+    net_mode_count = sum(
+        [net_server_mode, net_client_mode, net_loopback_mode, net_peer_mode]
+    )
     if net_mode_count > 1:
         print(
-            f"{Fore.RED}\u274c Error: --net, --net-server, and --net-client are mutually exclusive{Style.RESET_ALL}"
+            f"{Fore.RED}\u274c Error: --net, --net-server, --net-client, and --net-peer are mutually exclusive{Style.RESET_ALL}"
         )
         return 1
+    if net_peer_mode:
+        primary_environment = (final_environment or "").lower()
+        peer_environment = args.peer_environment.lower()
+        if primary_environment not in {"rp2350w", "rpipico2w"}:
+            print(
+                f"{Fore.RED}\u274c --net-peer requires rp2350w or rpipico2w as the primary environment{Style.RESET_ALL}"
+            )
+            return 1
+        if peer_environment != "esp32c6":
+            print(
+                f"{Fore.RED}\u274c --net-peer currently requires --peer-environment esp32c6{Style.RESET_ALL}"
+            )
+            return 1
+        if not args.upload_port or not args.peer_upload_port:
+            print(
+                f"{Fore.RED}\u274c --net-peer requires both --upload-port and --peer-upload-port{Style.RESET_ALL}"
+            )
+            return 1
     if ota_mode and net_mode_count > 0:
         print(
             f"{Fore.RED}\u274c Error: --ota cannot be combined with --net/--net-server/--net-client{Style.RESET_ALL}"
@@ -637,6 +664,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         and not net_server_mode
         and not net_client_mode
         and not net_loopback_mode
+        and not net_peer_mode
         and not ota_mode
         and not ble_mode
     )
@@ -1191,6 +1219,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         net_server_mode=net_server_mode,
         net_client_mode=net_client_mode,
         net_loopback_mode=net_loopback_mode,
+        net_peer_mode=net_peer_mode,
         ota_mode=ota_mode,
         ble_mode=ble_mode,
         decode_mode=decode_mode,
@@ -1553,6 +1582,58 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
             qctx.emit_log_path()
             return 1
 
+    if ctx.net_peer_mode:
+        # A peer run must remain entirely on fbuild's deploy path.  In
+        # particular, do not open a direct serial flasher or fall back to a
+        # host-managed WiFi workflow: both boards are selected by explicit
+        # ports and the subsequent validation is device-to-device.
+        if build_driver.name != "fbuild":
+            print("❌ --net-peer requires the fbuild deployment backend")
+            return 1
+        peer_environment = args.peer_environment.lower()
+        peer_upload_port = args.peer_upload_port
+        assert peer_upload_port is not None
+        from ci.autoresearch.staging import synthesise_autoresearch_project
+
+        try:
+            peer_build_dir = synthesise_autoresearch_project(
+                peer_environment,
+                project_root=args.project_dir.resolve(),
+                verbose=args.verbose,
+            )
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception as e:
+            print(f"❌ Failed to stage --net-peer companion project: {e}")
+            return 1
+
+        print(
+            f"📦 Deploying --net-peer companion {peer_environment} "
+            f"to explicit port {peer_upload_port}"
+        )
+        peer_result = build_driver.deploy(
+            peer_build_dir,
+            environment=peer_environment,
+            upload_port=peer_upload_port,
+            verbose=args.verbose,
+            clean=args.clean,
+            quiet=args.quiet,
+            log_file=qctx.log_file,
+        )
+        peer_success = (
+            peer_result.success
+            if isinstance(peer_result, DeployResult)
+            else bool(peer_result)
+        )
+        if isinstance(peer_result, DeployResult) and peer_result.port:
+            args.peer_upload_port = peer_result.port
+            print(f"✅ fbuild returned companion application port: {peer_result.port}")
+        if not peer_success:
+            qctx.emit("BUILD+FLASH FAIL (--net-peer companion)")
+            qctx.emit_log_path()
+            return 1
+
     # Wait for serial port to become available after upload
     if upload_port and build_driver.name == "platformio":
         print(
@@ -1778,7 +1859,12 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         print("\n\U0001f4cc RPC smoke mode: skipping pin discovery and GPIO pre-test")
     elif ctx.perf_wave2d_grid is not None:
         print("\n\U0001f4cc Wave2D mode: skipping pin discovery and GPIO pre-test")
-    elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
+    elif (
+        ctx.net_server_mode
+        or ctx.net_client_mode
+        or ctx.net_loopback_mode
+        or ctx.net_peer_mode
+    ):
         print("\n\U0001f4cc Network mode: skipping pin discovery and GPIO pre-test")
     elif ctx.ota_mode:
         print("\n\U0001f4cc OTA mode: skipping pin discovery and GPIO pre-test")
@@ -1866,7 +1952,12 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
         pass
     elif ctx.perf_wave2d_grid is not None:
         pass
-    elif ctx.net_server_mode or ctx.net_client_mode or ctx.net_loopback_mode:
+    elif (
+        ctx.net_server_mode
+        or ctx.net_client_mode
+        or ctx.net_loopback_mode
+        or ctx.net_peer_mode
+    ):
         pass
     elif ctx.ota_mode:
         pass
@@ -2399,6 +2490,18 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     net_server_mode = ctx.net_server_mode
     net_client_mode = ctx.net_client_mode
     net_loopback_mode = ctx.net_loopback_mode
+
+    if ctx.net_peer_mode:
+        from ci.autoresearch.net import run_net_peer_autoresearch
+
+        peer_upload_port = ctx.args.peer_upload_port
+        assert peer_upload_port is not None
+        return await run_net_peer_autoresearch(
+            upload_port=upload_port,
+            peer_upload_port=peer_upload_port,
+            serial_iface=serial_iface,
+            timeout=ctx.remaining_seconds(),
+        )
 
     if (net_server_mode or net_client_mode) and ctx.final_environment:
         if not environment_has_wifi(ctx.final_environment):

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -1,0 +1,82 @@
+"""Unit tests for device-to-device network AutoResearch flows."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ci.autoresearch.net import run_net_peer_autoresearch
+
+
+def _response(data: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.data = data
+    return response
+
+
+def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:
+    """The peer path uses RPC/fbuild serial only, never a host WiFi manager."""
+    primary = MagicMock()
+    peer = MagicMock()
+    primary.connect = AsyncMock()
+    primary.close = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    primary_methods: list[str] = []
+    peer_methods: list[str] = []
+
+    async def primary_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
+        primary_methods.append(method)
+        responses = {
+            "status": {"platform": "Raspberry Pi Pico 2 W (RP2350)"},
+            "wifiConnect": {"success": True},
+            "wifiStatus": {"connected": True, "ip": "192.168.4.2"},
+            "startNetServer": {"success": True, "port": 80},
+            "runNetClientTest": {"success": True},
+            "stopNet": {"success": True},
+            "ping": {"success": True},
+        }
+        return _response(responses[method])
+
+    async def peer_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
+        peer_methods.append(method)
+        responses = {
+            "status": {"platform": "ESP32-C6 (RISC-V)"},
+            "startNetServer": {
+                "success": True,
+                "ssid": "FastLED-AutoResearch",
+                "password": "fastled123",
+                "ip": "192.168.4.1",
+                "port": 80,
+            },
+            "runNetClientTest": {"success": True},
+            "stopNet": {"success": True},
+            "ping": {"success": True},
+        }
+        return _response(responses[method])
+
+    primary.send = AsyncMock(side_effect=primary_send)
+    peer.send = AsyncMock(side_effect=peer_send)
+
+    with (
+        patch("ci.autoresearch.net.RpcClient", side_effect=[primary, peer]),
+        patch("ci.util.serial_interface.create_serial_interface"),
+    ):
+        result = asyncio.run(
+            run_net_peer_autoresearch(
+                upload_port="COM17",
+                peer_upload_port="COM9",
+                serial_iface=MagicMock(),
+                timeout=60.0,
+            )
+        )
+
+    assert result == 0
+    assert primary_methods.count("wifiConnect") == 10
+    assert primary_methods.count("runNetClientTest") == 10
+    assert primary_methods.count("stopNet") >= 11
+    assert peer_methods.count("runNetClientTest") == 10
+    assert "ping" in peer_methods
+    primary.close.assert_awaited_once()
+    peer.close.assert_awaited_once()

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -133,6 +133,9 @@ def _make_args(**overrides) -> Args:
         net_server=False,
         net_client=False,
         net=False,
+        net_peer=False,
+        peer_environment="esp32c6",
+        peer_upload_port=None,
         ota=False,
         ble=False,
         parallel=False,
@@ -206,6 +209,7 @@ def _make_ctx(**overrides) -> RunContext:
         net_server_mode=False,
         net_client_mode=False,
         net_loopback_mode=False,
+        net_peer_mode=False,
         ota_mode=False,
         ble_mode=False,
         decode_mode=False,
@@ -1002,6 +1006,48 @@ class TestParseArgsAndBuildCommands:
         result = _parse_args_and_build_commands(args)
         assert isinstance(result, int)
         assert result == 1
+
+    def test_net_peer_requires_explicit_rp2350w_and_c6_ports(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            net_peer=True,
+            environment_positional="rp2350w",
+            upload_port="COM17",
+            peer_upload_port="COM9",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=True,
+        )
+        result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.net_peer_mode is True
+        assert result.gpio_only_mode is False
+
+    def test_net_peer_rejects_missing_companion_port(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            net_peer=True,
+            environment_positional="rp2350w",
+            upload_port="COM17",
+            project_dir=fake_project_dir,
+        )
+        assert _parse_args_and_build_commands(args) == 1
+
+    def test_net_peer_rejects_wrong_primary_environment(
+        self, fake_project_dir: Path
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            net_peer=True,
+            environment_positional="esp32c6",
+            upload_port="COM17",
+            peer_upload_port="COM9",
+            project_dir=fake_project_dir,
+        )
+        assert _parse_args_and_build_commands(args) == 1
 
     def test_lane_range_parsing(self, fake_project_dir: Path) -> None:
         args = _make_args(lanes="1-4", project_dir=fake_project_dir)
@@ -1929,6 +1975,34 @@ class TestRunBuildDeploy:
 
         assert rc is None
         assert mock_driver.deploy.call_args.kwargs["environment"] == "rp2350w"
+
+    def test_net_peer_deploys_c6_through_fbuild_on_explicit_port(self) -> None:
+        mock_driver = _make_mock_driver()
+        ctx = _make_ctx(
+            args=_make_args(
+                skip_lint=True,
+                net_peer=True,
+                environment_positional="rp2350w",
+                upload_port="COM17",
+                peer_upload_port="COM9",
+            ),
+            build_driver=mock_driver,
+            final_environment="rp2350w",
+            upload_port="COM17",
+            net_peer_mode=True,
+        )
+        qctx = QuietContext(quiet=False)
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=Path("/fake/peer-project"),
+        ) as stage_peer:
+            rc = asyncio.run(_run_build_deploy(ctx, qctx))
+
+        assert rc is None
+        stage_peer.assert_called_once()
+        assert mock_driver.deploy.call_count == 2
+        assert mock_driver.deploy.call_args.kwargs["environment"] == "esp32c6"
+        assert mock_driver.deploy.call_args.kwargs["upload_port"] == "COM9"
 
     def test_build_deploy_install_failure(self) -> None:
         mock_driver = _make_mock_driver(install_ok=False)

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -40,6 +40,7 @@ def _make_ctx(
         net_server_mode=False,
         net_client_mode=False,
         net_loopback_mode=False,
+        net_peer_mode=False,
         ota_mode=False,
         ble_mode=False,
         decode_mode=False,


### PR DESCRIPTION
## Summary
- add a strict fbuild-only \--net-peer\ AutoResearch mode for RP2350W/Pico 2 W plus ESP32-C6
- require explicit primary and companion ports, then test ten device-to-device WiFi/HTTP reconnect cycles without host WiFi switching
- verify post-teardown serial JSON-RPC responsiveness and cover parser, deployment, and orchestration behavior

## Verification
- \uv run pytest ci/tests/test_autoresearch_net.py ci/tests/test_autoresearch_phases.py ci/tests/test_autoresearch_rpc_acceptance.py -q\ (180 passed)
- \ash lint ci/autoresearch/args.py ci/autoresearch/context.py ci/autoresearch/phases.py ci/autoresearch/net.py ci/tests/test_autoresearch_phases.py ci/tests/test_autoresearch_rpc_acceptance.py ci/tests/test_autoresearch_net.py\

Live HIL remains intentionally blocked: fbuild reports the attached RP2350W as a non-selectable phantom while Windows reports USB Code 43.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network peer testing for RP2350W and ESP32-C6 devices.
  * Added configuration options for selecting the peer environment and upload port.
  * Added device-to-device HTTP testing with automatic reconnection and cleanup.
  * Added validation for compatible boards, environments, and required ports.

* **Tests**
  * Added coverage for peer configuration, deployment, communication, and repeated network test cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->