### PR TITLE
fix(autoresearch): singletonize BLE runtime state

### DIFF
--- a/examples/AutoResearch/AutoResearchBle.cpp
+++ b/examples/AutoResearch/AutoResearchBle.cpp
@@ -15,12 +15,14 @@
 #if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
 
 #include "AutoResearchBle.h"
+#include "fl/stl/singleton.h"
 
-// Global BLE state
-static AutoResearchBleState s_ble_state;
+struct BleStateHolder {
+    AutoResearchBleState state;
+};
 
 AutoResearchBleState& getBleState() {
-    return s_ble_state;
+    return fl::Singleton<BleStateHolder>::instance().state;
 }
 
 #endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY


### PR DESCRIPTION
Replaces mutable file-static AutoResearch BLE state with fl::Singleton-owned state. Validation: strict C++ lint, rp2350w AutoResearch compile, and esp32c6 AutoResearch compile. No BLE transport capability changes are claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal BLE state management while preserving existing behavior and access to shared BLE state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->