### PR TITLE
fix(autoresearch): own persistent state with singletons

### DIFF
--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from colorama import Fore, Style
 
-from ci.rpc_client import RpcClient, RpcTimeoutError
+from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 

--- a/examples/AutoResearch/AutoResearchAnimartrixBench.h
+++ b/examples/AutoResearch/AutoResearchAnimartrixBench.h
@@ -20,13 +20,25 @@
 #include "fl/fx/2d/animartrix_detail/perlin_float.h"
 #include "fl/fx/2d/animartrix_detail/perlin_i16_optimized.h"
 #include "fl/math/fixed_point/s16x16.h"
+#include "fl/stl/singleton.h"
 
 namespace autoresearch {
 namespace animartrix_check {
 
 // Volatile sink to defeat dead-code elimination on both the float and
 // the i16 outputs. Same trick the SIMD multiply benchmark uses.
-static volatile int32_t g_animartrix_bench_sink;
+struct PerlinBenchState {
+    volatile int32_t sink;
+    int32_t fade_lut[257];
+
+    PerlinBenchState() : sink(0) {
+        fl::perlin_i16_optimized::init_fade_lut(fade_lut);
+    }
+};
+
+inline PerlinBenchState& perlinBenchState() {
+    return fl::SingletonShared<PerlinBenchState>::instance();
+}
 
 struct PerlinBenchResult {
     int64_t iterations;
@@ -50,12 +62,8 @@ inline PerlinBenchResult runPerlinBenchmark(int iters) {
     // static-in-header rule stays happy and C++11's thread-safe init
     // guarantees a single initialization across calls. The float path
     // has no equivalent setup.
-    struct FadeLut {
-        int32_t table[257];
-        FadeLut() { fl::perlin_i16_optimized::init_fade_lut(table); }
-    };
-    static const FadeLut fade_lut_holder;  // C++11 magic statics
-    const int32_t* fade_lut = fade_lut_holder.table;
+    PerlinBenchState& state = perlinBenchState();
+    const int32_t* fade_lut = state.fade_lut;
 
     constexpr int GRID = 16;          // 16x16 pixel pass per iteration
     constexpr float STEP_F = 0.05f;   // Animartrix-typical pixel step in noise space
@@ -85,7 +93,7 @@ inline PerlinBenchResult runPerlinBenchmark(int iters) {
             }
         }
         uint32_t t1 = micros();
-        g_animartrix_bench_sink = sink;
+        state.sink = sink;
         r.pnoise_float_us = static_cast<int64_t>(t1 - t0);
     }
 
@@ -115,7 +123,7 @@ inline PerlinBenchResult runPerlinBenchmark(int iters) {
             }
         }
         uint32_t t1 = micros();
-        g_animartrix_bench_sink = sink;
+        state.sink = sink;
         r.pnoise_i16_us = static_cast<int64_t>(t1 - t0);
     }
 

--- a/examples/AutoResearch/AutoResearchAsync.h
+++ b/examples/AutoResearch/AutoResearchAsync.h
@@ -9,8 +9,17 @@
 #include "AutoResearchHelpers.h"  // autoResearchSetExclusiveDriverByName
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
+#include "fl/stl/singleton.h"
 
 namespace autoresearch {
+
+struct StubAutorunLedState {
+    CRGB leds[10];
+};
+
+inline StubAutorunLedState& stubAutorunLedState() {
+    return fl::SingletonShared<StubAutorunLedState>::instance();
+}
 
 /// @brief Setup async task for JSON-RPC processing
 /// @param remote_control Reference to RemoteControl singleton
@@ -73,7 +82,7 @@ inline void maybeRegisterStubAutorun(
             fl::makeTimingConfig<fl::TIMING_WS2812B_V5>(), "WS2812B-V5");
 
         // Static LED storage — span must remain valid for the entire call
-        static CRGB stub_leds[10];
+        CRGB* stub_leds = stubAutorunLedState().leds;
         const int num_leds = 10;
 
         // ChannelConfig stores timing by value internally, so passing a local ref is fine

--- a/examples/AutoResearch/AutoResearchEdgeProbe.cpp
+++ b/examples/AutoResearch/AutoResearchEdgeProbe.cpp
@@ -6,6 +6,7 @@
 #if SKETCH_HAS_LOTS_OF_MEMORY
 
 #include "AutoResearchEdgeProbe.h"
+#include "fl/stl/singleton.h"
 
 #include "platforms/is_platform.h"
 
@@ -196,7 +197,12 @@ const fl::u32 *edgeProbeStamps(fl::u32 &count) {
 fl::u32 edgeProbeCpuMhz() { return 1; }
 fl::u32 edgeProbeSelfTestEdges() { return 0; }
 fl::u32 edgeProbeState() { return 0; }
-const fl::u32 *edgeProbeRmtLive() { static const fl::u32 z[4] = {0}; return z; }
+struct EdgeProbeNoopState {
+    fl::u32 rmt_live[4];
+};
+const fl::u32 *edgeProbeRmtLive() {
+    return fl::Singleton<EdgeProbeNoopState>::instance().rmt_live;
+}
 
 #endif // FL_IS_ESP32
 

--- a/examples/AutoResearch/AutoResearchIeee754.h
+++ b/examples/AutoResearch/AutoResearchIeee754.h
@@ -7,6 +7,7 @@
 #include "fl/stl/int.h"
 #include "fl/stl/string.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/singleton.h"
 
 namespace autoresearch {
 namespace ieee754_check {
@@ -31,6 +32,45 @@ struct FormatCase {
     int precision;
     const char* expected_text;
 };
+
+struct Ieee754CaseState {
+    ParseCase parse_cases[15];
+    FormatCase format_cases[9];
+    fl::u32 round_trip_bits[10];
+
+    Ieee754CaseState()
+        : parse_cases{{"0", 0x00000000u, true},
+                      {"-0", 0x80000000u, true},
+                      {"1", 0x3F800000u, true},
+                      {"-1", 0xBF800000u, true},
+                      {"0.5", 0x3F000000u, true},
+                      {"2.5", 0x40200000u, true},
+                      {"3.14159", 0x40490FD0u, false},
+                      {"2.71828", 0x402DF84Du, false},
+                      {"100", 0x42C80000u, true},
+                      {"1000", 0x447A0000u, true},
+                      {"1e30", 0x7149F2CAu, false},
+                      {"1e-30", 0x0DA24260u, false},
+                      {"1e-40", 0x00000000u, true},
+                      {"1e40", 0x7F800000u, true},
+                      {"-1e40", 0xFF800000u, true}},
+          format_cases{{0x00000000u, 6, "0.000000"},
+                       {0x80000000u, 6, "-0.000000"},
+                       {0x3F800000u, 6, "1.000000"},
+                       {0xBF800000u, 6, "-1.000000"},
+                       {0x3F000000u, 6, "0.500000"},
+                       {0x41200000u, 2, "10.00"},
+                       {0x7F800000u, 6, "inf"},
+                       {0xFF800000u, 6, "-inf"},
+                       {0x7FC00000u, 6, "nan"}},
+          round_trip_bits{0x00000000u, 0x80000000u, 0x3F800000u, 0xBF800000u,
+                          0x3F000000u, 0x40200000u, 0x40490FDBu, 0x40B00000u,
+                          0x42C80000u, 0x447A0000u} {}
+};
+
+inline Ieee754CaseState& ieee754CaseState() {
+    return fl::SingletonShared<Ieee754CaseState>::instance();
+}
 
 inline fl::u32 absDiff(fl::u32 a, fl::u32 b) FL_NO_EXCEPT {
     return a > b ? a - b : b - a;
@@ -65,26 +105,10 @@ inline Result run() {
     r.success = true;
     r.first_failure = nullptr;
 
-    static const ParseCase kParseCases[] = {
-        {"0", 0x00000000u, true},
-        {"-0", 0x80000000u, true},
-        {"1", 0x3F800000u, true},
-        {"-1", 0xBF800000u, true},
-        {"0.5", 0x3F000000u, true},
-        {"2.5", 0x40200000u, true},
-        {"3.14159", 0x40490FD0u, false},
-        {"2.71828", 0x402DF84Du, false},
-        {"100", 0x42C80000u, true},
-        {"1000", 0x447A0000u, true},
-        {"1e30", 0x7149F2CAu, false},
-        {"1e-30", 0x0DA24260u, false},
-        {"1e-40", 0x00000000u, true},
-        {"1e40", 0x7F800000u, true},
-        {"-1e40", 0xFF800000u, true},
-    };
+    Ieee754CaseState& state = ieee754CaseState();
 
-    for (fl::size i = 0; i < sizeof(kParseCases) / sizeof(kParseCases[0]); ++i) {
-        const ParseCase& c = kParseCases[i];
+    for (fl::size i = 0; i < sizeof(state.parse_cases) / sizeof(state.parse_cases[0]); ++i) {
+        const ParseCase& c = state.parse_cases[i];
         fl::size consumed = 0;
         const fl::u32 actual =
             fl::ieee754_parse_decimal(c.text, fl::strlen(c.text), &consumed);
@@ -95,33 +119,15 @@ inline Result run() {
                     c.expected_bits, actual);
     }
 
-    static const FormatCase kFormatCases[] = {
-        {0x00000000u, 6, "0.000000"},
-        {0x80000000u, 6, "-0.000000"},
-        {0x3F800000u, 6, "1.000000"},
-        {0xBF800000u, 6, "-1.000000"},
-        {0x3F000000u, 6, "0.500000"},
-        {0x41200000u, 2, "10.00"},
-        {0x7F800000u, 6, "inf"},
-        {0xFF800000u, 6, "-inf"},
-        {0x7FC00000u, 6, "nan"},
-    };
-
-    for (fl::size i = 0; i < sizeof(kFormatCases) / sizeof(kFormatCases[0]); ++i) {
-        const FormatCase& c = kFormatCases[i];
+    for (fl::size i = 0; i < sizeof(state.format_cases) / sizeof(state.format_cases[0]); ++i) {
+        const FormatCase& c = state.format_cases[i];
         const fl::string actual = fl::ieee754_format_decimal(c.bits, c.precision);
         recordCheck(r, c.expected_text, actual == c.expected_text,
                     c.bits, c.bits);
     }
 
-    static const fl::u32 kRoundTripBits[] = {
-        0x00000000u, 0x80000000u, 0x3F800000u, 0xBF800000u,
-        0x3F000000u, 0x40200000u, 0x40490FDBu, 0x40B00000u,
-        0x42C80000u, 0x447A0000u,
-    };
-
-    for (fl::size i = 0; i < sizeof(kRoundTripBits) / sizeof(kRoundTripBits[0]); ++i) {
-        const fl::u32 expected = kRoundTripBits[i];
+    for (fl::size i = 0; i < sizeof(state.round_trip_bits) / sizeof(state.round_trip_bits[0]); ++i) {
+        const fl::u32 expected = state.round_trip_bits[i];
         const fl::string text = fl::ieee754_format_decimal(expected, 9);
         const fl::u32 actual =
             fl::ieee754_parse_decimal(text.c_str(), text.size());

--- a/examples/AutoResearch/AutoResearchLowMemory.h
+++ b/examples/AutoResearch/AutoResearchLowMemory.h
@@ -76,6 +76,7 @@
 #include "fl/wdt/watchdog.h"
 #include "fl/log/log.h"
 #include "fl/stl/cstdio.h"  // fl::serial_begin -- HWCDC-safe Serial.begin wrapper
+#include "fl/stl/singleton.h"
 
 #if defined(FASTLED_AUTORESEARCH_IEEE754_MODE)
 #include "AutoResearchIeee754.h"
@@ -139,8 +140,52 @@
 #include "AutoResearchUartDma.h"
 #endif
 
+namespace autoresearch {
+namespace low_memory {
+
+struct RemoteState {
+    fl::Remote remote;
+
+    RemoteState()
+        : remote(fl::createSerialRequestSource(),
+                 fl::createSerialResponseSink("REMOTE: ")) {}
+};
+
+inline RemoteState& remoteState() {
+    return fl::SingletonShared<RemoteState>::instance();
+}
+
+#if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
+    !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
+struct PinToggleState {
+    fl::EdgeTime edges[64];
+};
+
+inline PinToggleState& pinToggleState() {
+    return fl::SingletonShared<PinToggleState>::instance();
+}
+#endif
+
+#if defined(FASTLED_AUTORESEARCH_LPC_WS2812)
+struct Ws2812State {
+    CRGB leds[100];
+    uint8_t expected[300];
+    uint8_t decoded[300];
+    fl::EdgeTime probe[64];
+    bool fastled_initialized;
+
+    Ws2812State() : fastled_initialized(false) {}
+};
+
+inline Ws2812State& ws2812State() {
+    return fl::SingletonShared<Ws2812State>::instance();
+}
+#endif
+
+}  // namespace low_memory
+}  // namespace autoresearch
+
 namespace {
-fl::Remote* g_low_memory_remote = nullptr;
 
 #if defined(FL_IS_ARM_LPC) && !defined(FASTLED_AUTORESEARCH_IEEE754_MODE) && \
     !defined(FASTLED_AUTORESEARCH_FAULT_TEST)
@@ -230,10 +275,7 @@ inline void autoResearchLowMemorySetup() {
     // exactly what we want (one Remote bound to the singleton Serial
     // transport). The included-once-per-sketch model of `.ino` builds
     // also reduces to a single TU in practice.
-    static fl::Remote remote(  // okay static in header
-        fl::createSerialRequestSource(),
-        fl::createSerialResponseSink("REMOTE: "));
-    g_low_memory_remote = &remote;
+    fl::Remote& remote = autoresearch::low_memory::remoteState().remote;
     remote.bind("echo", [](int v) -> int {
         FL_WARN_LIT("FL_WARN: echo invoked");
         return v;
@@ -326,7 +368,7 @@ inline void autoResearchLowMemorySetup() {
 
             // Static storage keeps this off the stack; the small fixed size
             // keeps .bss below the LPC845-BRK early-init failure threshold.
-            static fl::EdgeTime edges_buf[kLowMemEdgeBufSize];
+            fl::EdgeTime* edges_buf = autoresearch::low_memory::pinToggleState().edges;
             const fl::size n_read = rx->getRawEdgeTimes(
                 fl::span<fl::EdgeTime>(edges_buf, sizeof(edges_buf) / sizeof(edges_buf[0])));
 
@@ -354,7 +396,9 @@ inline void autoResearchLowMemorySetup() {
                 case 4: num_leds = 100; break;
                 default: num_leds = 1; break;
             }
-            static CRGB leds_buf[100];
+            autoresearch::low_memory::Ws2812State& ws_state =
+                autoresearch::low_memory::ws2812State();
+            CRGB* leds_buf = ws_state.leds;
             for (int i = 0; i < num_leds; ++i) {
                 switch (test_case) {
                     case 0: leds_buf[i] = CRGB(0xFF, 0x00, 0x00); break;
@@ -376,7 +420,7 @@ inline void autoResearchLowMemorySetup() {
                 }
             }
             const int expected_bytes = num_leds * 3;
-            static uint8_t expected_buf[300];
+            uint8_t* expected_buf = ws_state.expected;
             for (int i = 0; i < num_leds; ++i) {
                 expected_buf[i * 3 + 0] = leds_buf[i].g;
                 expected_buf[i * 3 + 1] = leds_buf[i].r;
@@ -402,15 +446,14 @@ inline void autoResearchLowMemorySetup() {
             if (tx_pin != kFixedTxPin) {
                 return fl::string("0,0,0,0,0,0,0,0");
             }
-            static bool fastled_inited = false;
-            if (!fastled_inited) {
+            if (!ws_state.fastled_initialized) {
                 FastLED.addLeds<WS2812, kFixedTxPin, GRB>(leds_buf, 100);
-                fastled_inited = true;
+                ws_state.fastled_initialized = true;
             }
             FastLED.show();
             rx->wait(capture_ms);
 
-            static uint8_t decoded_buf[300];
+            uint8_t* decoded_buf = ws_state.decoded;
             for (int i = 0; i < expected_bytes; ++i) decoded_buf[i] = 0;
 
             fl::ChipsetTiming4Phase timing =
@@ -433,7 +476,7 @@ inline void autoResearchLowMemorySetup() {
             // Diagnostic-only raw-edge sample. Keep this small in .bss; the
             // decoder uses the RX channel's bounded capture vector above.
             constexpr fl::size kLowMemWs2812ProbeSize = 64u;
-            static fl::EdgeTime probe[kLowMemWs2812ProbeSize];
+            fl::EdgeTime* probe = ws_state.probe;
             const fl::size edges_captured = rx->getRawEdgeTimes(
                 fl::span<fl::EdgeTime>(probe, kLowMemWs2812ProbeSize));
 
@@ -475,7 +518,5 @@ inline void autoResearchLowMemorySetup() {
 
 inline void autoResearchLowMemoryLoop() {
     fl::Watchdog::instance().feed();
-    if (g_low_memory_remote) {
-        g_low_memory_remote->update(millis());
-    }
+    autoresearch::low_memory::remoteState().remote.update(millis());
 }

--- a/examples/AutoResearch/AutoResearchParlioStream.h
+++ b/examples/AutoResearch/AutoResearchParlioStream.h
@@ -29,6 +29,7 @@
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/int.h"
 #include "fl/stl/span.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/vector.h"
 
 #if defined(ESP32) && FASTLED_ESP32_HAS_PARLIO
@@ -44,6 +45,15 @@ namespace parlio_stream {
 
 constexpr int kMaxIterations = 16;  // result struct iter timing array fixed size
 constexpr int kMaxLanes = 16;
+constexpr int kMaxLeds = 256;
+
+struct ParlioLedState {
+    CRGB leds[kMaxLanes][kMaxLeds];
+};
+
+inline ParlioLedState& parlioLedState() {
+    return fl::SingletonShared<ParlioLedState>::instance();
+}
 
 inline bool isFastLedOutputPinValid(int pin) {
     if (pin < 0 || pin >= 64) {
@@ -129,9 +139,8 @@ inline ValidateResult validateParlioStreaming(int base_tx_pin,
     // Reuse a single static heap-resident LED buffer sized for the canonical
     // worst case (16 lanes × 256 LEDs). Test callers must stay within these
     // bounds. Static to avoid repeated allocation across RPC calls.
-    constexpr int kMaxLEDs = 256;
-    if (num_leds > kMaxLEDs) return r;
-    static CRGB leds[kMaxLanes][kMaxLEDs];
+    if (num_leds > kMaxLeds) return r;
+    CRGB (*leds)[kMaxLeds] = parlioLedState().leds;
     for (int lane = 0; lane < num_lanes; ++lane) {
         for (int i = 0; i < num_leds; ++i) {
             leds[lane][i] = CRGB(0xF0, 0x0F, 0xAA);  // Pattern A (mixed bits)

--- a/examples/AutoResearch/AutoResearchPwmDmaClockless.h
+++ b/examples/AutoResearch/AutoResearchPwmDmaClockless.h
@@ -53,12 +53,21 @@
 #include "fl/remote/remote.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/vector.h"
 #include "platforms/arm/lpc/drivers/sct_dma/channel_engine_lpc_sct_dma.h" // ok platform headers — AutoResearch driver-specific test needs the concrete engine type
 
 namespace autoresearch {
 namespace pwm_dma_cl {
+
+struct PwmDmaClocklessState {
+    fl::u8 decoded[128];
+};
+
+inline PwmDmaClocklessState& pwmDmaClocklessState() FL_NO_EXCEPT {
+    return fl::SingletonShared<PwmDmaClocklessState>::instance();
+}
 
 // Standard WS2812B timing. Callers can override per-frame if the engine
 // gains multi-chipset support later; today the engine's `canHandle()`
@@ -209,7 +218,7 @@ inline fl::string captureSelfHandler(int led_count, fl::u32 rgb,
 
     // Decode captured edges → GRB bytes.
     const fl::size decoded_cap = static_cast<fl::size>(led_count * 3);
-    static fl::u8 decoded[128] = {0};
+    fl::u8* decoded = pwmDmaClocklessState().decoded;
     if (decoded_cap > sizeof(decoded)) return fl::string("0");
     auto result = rx->decode(ws2812b_decoder_timing(),
                              fl::span<fl::u8>(decoded, decoded_cap));

--- a/examples/AutoResearch/AutoResearchRemote.cpp
+++ b/examples/AutoResearch/AutoResearchRemote.cpp
@@ -93,8 +93,7 @@ void printRemoteResponseRaw(const fl::json& response) {
 }
 
 void printRemoteStreamRaw(fl::JsonStreamCallback writeJson) {
-    static const char kPrefix[] = "REMOTE: ";
-    Serial.write(reinterpret_cast<const uint8_t*>(kPrefix), sizeof(kPrefix) - 1);  // ok serial - ok autoresearch rpc serial - RPC response boundary
+    Serial.print("REMOTE: ");  // ok serial - ok autoresearch rpc serial - RPC response boundary
 
     fl::JsonStreamWriter writer([](const char* data, fl::size len) {
         Serial.write(reinterpret_cast<const uint8_t*>(data), static_cast<size_t>(len));  // ok serial - ok autoresearch rpc serial - streamed JSON bytes

--- a/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteBenchmarkMethods.cpp
@@ -20,6 +20,7 @@
 #include "AutoResearchOta.h"
 #include "fl/remote/transport/serial.h"
 #include "fl/stl/vector.h"
+#include "fl/stl/singleton.h"
 #include "fl/system/heap.h"
 #include "Common.h"
 #include "AutoResearchTest.h"
@@ -52,6 +53,18 @@
 #include "fl/stl/detail/memory_file_handle.h"
 #include "fl/fx/frame.h"
 
+namespace {
+
+struct PerfProbeMemcpyState {
+    fl::vector<uint8_t> source;
+    fl::vector<uint8_t> destination;
+};
+
+PerfProbeMemcpyState& perfProbeMemcpyState() {
+    return fl::Singleton<PerfProbeMemcpyState>::instance();
+}
+
+}  // namespace
 
 void AutoResearchRemoteControl::bindBenchmarkMethods(fl::Remote& remote) {
     // ====== AutoResearch perf-instrumentation sanity probes ======
@@ -86,8 +99,9 @@ void AutoResearchRemoteControl::bindBenchmarkMethods(fl::Remote& remote) {
         // Heap-allocated on first use: 16 KB of static buffers
         // overflowed ESP32-S2's dram0 bss by 3.7 KB (FastLED#3576
         // Phase 4 compile matrix).
-        static fl::vector<uint8_t> src_vec;
-        static fl::vector<uint8_t> dst_vec;
+        PerfProbeMemcpyState& state = perfProbeMemcpyState();
+        fl::vector<uint8_t>& src_vec = state.source;
+        fl::vector<uint8_t>& dst_vec = state.destination;
         if (src_vec.size() < 8192) {
             src_vec.resize(8192);
             dst_vec.resize(8192);

--- a/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteDriverMethods.cpp
@@ -43,6 +43,7 @@
 #include "fl/chipsets/spi.h"
 #include "fl/channels/config.h"
 #include "fl/stl/span.h"
+#include "fl/stl/singleton.h"
 #include <Arduino.h>
 
 // #3428: FlexIO2 SPI mode bring-up smoke test (`flexioSpiSelfTest` RPC).
@@ -61,6 +62,19 @@
 #include "fl/stl/detail/memory_file_handle.h"
 #include "fl/fx/frame.h"
 
+namespace {
+
+#if defined(FL_IS_TEENSY_4X)
+struct FlexIoObjectFledState {
+    CRGB leds[100];
+};
+
+FlexIoObjectFledState& flexIoObjectFledState() {
+    return fl::Singleton<FlexIoObjectFledState>::instance();
+}
+#endif
+
+}  // namespace
 
 void AutoResearchRemoteControl::bindDriverMethods(fl::Remote& remote) {
     // Register "flexioRxBenchmark" — square-wave validation for the new
@@ -287,7 +301,7 @@ void AutoResearchRemoteControl::bindDriverMethods(fl::Remote& remote) {
 
         // 1. Build the test pattern. Fixed upper bound (100 LEDs) covers
         //    case 4 — the larger cases reuse the same static buffer.
-        static CRGB leds_buf[100];
+        CRGB* leds_buf = flexIoObjectFledState().leds;
         int num_leds = 0;
         switch (test_case) {
             case 0:

--- a/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRpSpiMethods.cpp
@@ -17,6 +17,7 @@
 #include "fl/stl/json.h"
 #include "fl/stl/limits.h"
 #include "fl/stl/move.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/vector.h"
 #include "platforms/arm/rp/is_rp.h"
 
@@ -27,13 +28,6 @@
 namespace {
 
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
-
-constexpr fl::u8 kLoopbackPattern[] = {
-    0x00, 0xFF, 0x55, 0xAA, 0x12, 0x34, 0x56, 0x78,
-    0x87, 0x65, 0x43, 0x21, 0x0F, 0xF0, 0xCC, 0x33,
-    0x11, 0xEE, 0x22, 0xDD, 0x44, 0xBB, 0x88, 0x77,
-    0x66, 0x99, 0x3C, 0xC3, 0x5A, 0xA5, 0x7E, 0x81,
-};
 
 bool parseInt(const fl::json& config, const char* key, int* value) {
     if (!config.contains(key) || !config[key].is_int()) return false;
@@ -49,6 +43,12 @@ bool parseInt(const fl::json& config, const char* key, int* value) {
 template <fl::u8 Which>
 fl::json runLoopback(const fl::shared_ptr<AutoResearchState>& runtime_state,
                      int mosi_pin, int miso_pin, int sck_pin, int clock_hz) {
+    const fl::u8 loopback_pattern[] = {
+        0x00, 0xFF, 0x55, 0xAA, 0x12, 0x34, 0x56, 0x78,
+        0x87, 0x65, 0x43, 0x21, 0x0F, 0xF0, 0xCC, 0x33,
+        0x11, 0xEE, 0x22, 0xDD, 0x44, 0xBB, 0x88, 0x77,
+        0x66, 0x99, 0x3C, 0xC3, 0x5A, 0xA5, 0x7E, 0x81,
+    };
     fl::json response = fl::json::object();
     const int expected_mosi = Which == 0 ? 3 : 11;
     const int expected_miso = Which == 0 ? 0 : 8;
@@ -75,8 +75,8 @@ fl::json runLoopback(const fl::shared_ptr<AutoResearchState>& runtime_state,
     }
 
     fl::vector_psram<fl::u8> tx;
-    tx.assign(kLoopbackPattern, kLoopbackPattern + sizeof(kLoopbackPattern));
-    fl::u8 captured[sizeof(kLoopbackPattern)] = {};
+    tx.assign(loopback_pattern, loopback_pattern + sizeof(loopback_pattern));
+    fl::u8 captured[sizeof(loopback_pattern)] = {};
     auto channel = fl::ChannelData::create(
         fl::SpiChipsetConfig(mosi_pin, sck_pin,
                              fl::SpiEncoder::apa102(static_cast<fl::u32>(clock_hz))),
@@ -105,10 +105,10 @@ fl::json runLoopback(const fl::shared_ptr<AutoResearchState>& runtime_state,
     bool exact_match = state == fl::IChannelDriver::DriverState::READY;
     fl::json expected = fl::json::array();
     fl::json received = fl::json::array();
-    for (size_t index = 0; index < sizeof(kLoopbackPattern); ++index) {
-        expected.push_back(static_cast<int64_t>(kLoopbackPattern[index]));
+    for (size_t index = 0; index < sizeof(loopback_pattern); ++index) {
+        expected.push_back(static_cast<int64_t>(loopback_pattern[index]));
         received.push_back(static_cast<int64_t>(captured[index]));
-        exact_match = exact_match && captured[index] == kLoopbackPattern[index];
+        exact_match = exact_match && captured[index] == loopback_pattern[index];
     }
 
     fl::json data = fl::json::object();
@@ -128,6 +128,19 @@ fl::json runLoopback(const fl::shared_ptr<AutoResearchState>& runtime_state,
 }
 
 template <bool Sk9822>
+struct PublicApiLoopbackState {
+    CRGB leds[257];
+    bool initialized;
+
+    PublicApiLoopbackState() : initialized(false) {}
+};
+
+template <bool Sk9822>
+PublicApiLoopbackState<Sk9822>& publicApiLoopbackState() {
+    return fl::Singleton<PublicApiLoopbackState<Sk9822>>::instance();
+}
+
+template <bool Sk9822>
 fl::json runPublicApiLoopback(
     const fl::shared_ptr<AutoResearchState>& runtime_state,
     int pattern) {
@@ -135,8 +148,8 @@ fl::json runPublicApiLoopback(
     constexpr fl::u8 kSckPin = 10;
     constexpr size_t kLedCount = 257;
     constexpr size_t kFrameBytes = 4 + (kLedCount * 4) + 36;
-    static CRGB leds[kLedCount];
-    static bool initialized = false;
+    PublicApiLoopbackState<Sk9822>& state = publicApiLoopbackState<Sk9822>();
+    CRGB* leds = state.leds;
     fl::json response = fl::json::object();
 
     if (pattern < 0 || pattern > 5) {
@@ -150,7 +163,7 @@ fl::json runPublicApiLoopback(
         runtime_state->invalidateLedRxValidation();
     }
 
-    if (!initialized) {
+    if (!state.initialized) {
         if constexpr (Sk9822) {
             FastLED.addLeds<SK9822, kMosiPin, kSckPin, RGB, 8000000,
                             fl::Bus::SPI, 1>(leds, kLedCount);
@@ -158,7 +171,7 @@ fl::json runPublicApiLoopback(
             FastLED.addLeds<APA102, kMosiPin, kSckPin, RGB, 8000000,
                             fl::Bus::SPI, 1>(leds, kLedCount);
         }
-        initialized = true;
+        state.initialized = true;
     }
 
     for (size_t index = 0; index < kLedCount; ++index) leds[index] = CRGB::Black;

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -29,6 +29,7 @@
 #include "fl/wdt/watchdog.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
+#include "fl/stl/singleton.h"
 #include "platforms/is_platform.h"
 #ifdef FL_IS_ESP32
 #include "platforms/esp/32/feature_flags/enabled.h"
@@ -75,6 +76,16 @@ FL_EXTERN_C_END
 #include "fl/fx/frame.h"
 
 namespace {
+
+#if defined(FL_IS_ESP32) && FASTLED_ESP32_HAS_PARLIO
+struct ParlioRawTestState {
+    uint8_t buffer[512];
+};
+
+ParlioRawTestState& parlioRawTestState() {
+    return fl::Singleton<ParlioRawTestState>::instance();
+}
+#endif
 
 fl::json autoResearchDeviceJson(const fl::string& name) {
     if (name == "RMT") return fl::deviceJson<fl::Bus::RMT>();
@@ -305,7 +316,7 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         cfg.trans_queue_depth = (size_t)depth;
         cfg.max_transfer_size = (size_t)mts;
         cfg.output_clk_freq_hz = (uint32_t)hz;
-        cfg.sample_edge = PARLIO_SAMPLE_EDGE_POS;
+        cfg.shift_edge = PARLIO_SAMPLE_EDGE_POS;
         cfg.bit_pack_order = PARLIO_BIT_PACK_ORDER_MSB;
         if (burst > 0) cfg.dma_burst_size = (size_t)burst;
         for (int i = 0; i < 16; ++i) cfg.data_gpio_nums[i] = (gpio_num_t)-1;
@@ -318,7 +329,7 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
             return response;
         }
         err = parlio_tx_unit_enable(unit);
-        static uint8_t buf[512];
+        uint8_t* buf = parlioRawTestState().buffer;
         for (int i = 0; i < 512; ++i) buf[i] = (uint8_t)pattern;
         parlio_transmit_config_t tcfg = {};
         tcfg.idle_value = 0;

--- a/examples/AutoResearch/AutoResearchSimd.h
+++ b/examples/AutoResearch/AutoResearchSimd.h
@@ -1110,7 +1110,15 @@ inline bool test_f32_pipeline_mul_add_clamp() {
 // Each test runs 4-wide unrolled loops with feedback to prevent elimination.
 // s16x16x4 has no division operator, so that cell is skipped.
 
-static volatile uint32_t g_bench_sink;
+struct SimdBenchmarkState {
+    volatile uint32_t sink;
+
+    SimdBenchmarkState() : sink(0) {}
+};
+
+inline SimdBenchmarkState& simdBenchmarkState() {
+    return fl::SingletonShared<SimdBenchmarkState>::instance();
+}
 
 struct BenchmarkResult {
     int64_t iterations;
@@ -1135,7 +1143,7 @@ inline int64_t benchFloat4(int iters, Op op) {
     }
     uint32_t t1 = micros();
     uint32_t tmp; fl::memcpy(&tmp, &a0, sizeof(tmp));
-    g_bench_sink = tmp;
+    simdBenchmarkState().sink = tmp;
     return static_cast<int64_t>(t1 - t0);
 }
 
@@ -1153,7 +1161,7 @@ inline int64_t benchS16x16_4(int iters, Op op) {
         b2 = a2 + bump; b3 = a3 + bump;
     }
     uint32_t t1 = micros();
-    g_bench_sink = static_cast<uint32_t>(a0.raw());
+    simdBenchmarkState().sink = static_cast<uint32_t>(a0.raw());
     return static_cast<int64_t>(t1 - t0);
 }
 
@@ -1173,7 +1181,7 @@ inline int64_t benchSimd4(int iters, Op op) {
         b = a + bump;
     }
     uint32_t t1 = micros();
-    g_bench_sink = extract_u32_4(a.raw, 0);
+    simdBenchmarkState().sink = extract_u32_4(a.raw, 0);
     return static_cast<int64_t>(t1 - t0);
 }
 
@@ -1200,7 +1208,7 @@ inline int64_t benchS8x8_4(int iters, Op op) {
         b2 = a2 + bump; b3 = a3 + bump;
     }
     uint32_t t1 = micros();
-    g_bench_sink = static_cast<uint32_t>(a0.raw());
+    simdBenchmarkState().sink = static_cast<uint32_t>(a0.raw());
     return static_cast<int64_t>(t1 - t0);
 }
 
@@ -1218,7 +1226,7 @@ inline int64_t benchU16x16_4(int iters, Op op) {
         b2 = a2 + bump; b3 = a3 + bump;
     }
     uint32_t t1 = micros();
-    g_bench_sink = static_cast<uint32_t>(a0.raw());
+    simdBenchmarkState().sink = static_cast<uint32_t>(a0.raw());
     return static_cast<int64_t>(t1 - t0);
 }
 

--- a/examples/AutoResearch/AutoResearchSpiDma.h
+++ b/examples/AutoResearch/AutoResearchSpiDma.h
@@ -58,6 +58,7 @@
 
 #include "fl/remote/remote.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/sstream.h"
 #include "platforms/arm/lpc/spi_arm_lpc_dma.h" // ok platform headers — AutoResearch driver-specific test needs the concrete SPI DMA driver
 
@@ -91,22 +92,42 @@ using HarnessDriver = fl::ARMHardwareSPIOutputDMA<
     static_cast<fl::u8>(FASTLED_LPC_SPI_DMA_HARNESS_CLOCK_PIN),
     static_cast<fl::u32>(FASTLED_LPC_SPI_DMA_HARNESS_DIVIDER)>;
 
+struct SpiDmaHarnessState {
+    fl::u8 buffer[FASTLED_LPC_SPI_DMA_MAX_BYTES];
+    HarnessDriver driver;
+    bool initialized;
+
+    SpiDmaHarnessState() : initialized(false) {}
+};
+
+#if FASTLED_LPC_DMA_ISR
+struct SpiDmaStreamState {
+    fl::u8 source[FASTLED_LPC_SPI_DMA_STREAM_BYTES];
+};
+
+inline SpiDmaStreamState& spiDmaStreamState() FL_NO_EXCEPT {
+    return fl::SingletonShared<SpiDmaStreamState>::instance();
+}
+#endif
+
+inline SpiDmaHarnessState& spiDmaHarnessState() FL_NO_EXCEPT {
+    return fl::SingletonShared<SpiDmaHarnessState>::instance();
+}
+
 // Bench buffer: sized to the driver's encode-buffer capacity so callers
 // can hit the widest DMA descriptor the driver will accept.
 inline fl::u8* harnessBuffer() FL_NO_EXCEPT {
-    static fl::u8 buf[FASTLED_LPC_SPI_DMA_MAX_BYTES] = {0};
-    return buf;
+    return spiDmaHarnessState().buffer;
 }
 
 // Lazy driver instantiation — first RPC call configures SPI+DMA once.
 inline HarnessDriver& harnessDriver() FL_NO_EXCEPT {
-    static HarnessDriver drv;
-    static bool inited = false;
-    if (!inited) {
-        drv.init();
-        inited = true;
+    SpiDmaHarnessState& state = spiDmaHarnessState();
+    if (!state.initialized) {
+        state.driver.init();
+        state.initialized = true;
     }
-    return drv;
+    return state.driver;
 }
 
 // Bounds guard for host-supplied lengths — matches
@@ -244,7 +265,7 @@ inline fl::string measureSckHandler(int divider_hint) FL_NO_EXCEPT {
 #define FASTLED_LPC_SPI_DMA_STREAM_BYTES 512
 #endif
 inline fl::string streamOverlapHandler(int byte_count, int byte_pattern) FL_NO_EXCEPT {
-    static fl::u8 stream_src[FASTLED_LPC_SPI_DMA_STREAM_BYTES] = {0};
+    fl::u8* stream_src = spiDmaStreamState().source;
     int len = byte_count;
     if (len <= 0) return fl::string("0,0,0");
     if (len > FASTLED_LPC_SPI_DMA_STREAM_BYTES)

--- a/examples/AutoResearch/AutoResearchTimingDrift.h
+++ b/examples/AutoResearch/AutoResearchTimingDrift.h
@@ -29,6 +29,7 @@
 
 #include "FastLED.h"
 #include "fl/stl/int.h"
+#include "fl/stl/singleton.h"
 #include "LegacyClocklessProxy.h"
 
 #include <Arduino.h>  // millis(), micros(), delay()
@@ -38,6 +39,14 @@ namespace timing_drift {
 
 constexpr int kMaxIterations = 64;
 constexpr int kMaxLeds = 256;
+
+struct TimingDriftState {
+    CRGB leds[kMaxLeds];
+};
+
+inline TimingDriftState& timingDriftState() {
+    return fl::SingletonShared<TimingDriftState>::instance();
+}
 
 /// Faithful emulation of the millisDelay library used by the issue sketch:
 /// start(t) arms a deadline; justFinished() fires true exactly once when
@@ -85,7 +94,7 @@ inline DriftResult run(int pin, int num_leds, int iterations) {
     if (num_leds > kMaxLeds) num_leds = kMaxLeds;
     r.num_leds = num_leds;
 
-    static CRGB leds[kMaxLeds];
+    CRGB* leds = timingDriftState().leds;
     for (int i = 0; i < num_leds; ++i) {
         leds[i] = CRGB::Black;
     }

--- a/examples/AutoResearch/AutoResearchUartDma.h
+++ b/examples/AutoResearch/AutoResearchUartDma.h
@@ -39,6 +39,7 @@
 #endif
 #include "fl/remote/remote.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
 #include "fl/stl/sstream.h"
 #include "platforms/arm/lpc/uart_arm_lpc_dma.h" // ok platform headers — AutoResearch driver-specific test needs the concrete UART DMA driver
 
@@ -69,15 +70,23 @@ using HarnessDriver = fl::ARMHardwareUARTOutputDMA<
 #define FASTLED_LPC_UART_DMA_HARNESS_BYTES 2048
 #endif
 
+struct UartDmaHarnessState {
+    fl::u8 buffer[FASTLED_LPC_UART_DMA_HARNESS_BYTES];
+    HarnessDriver driver;
+};
+
+inline UartDmaHarnessState& uartDmaHarnessState() FL_NO_EXCEPT {
+    return fl::SingletonShared<UartDmaHarnessState>::instance();
+}
+
 inline fl::u8* harnessBuffer() FL_NO_EXCEPT {
-    static fl::u8 buf[FASTLED_LPC_UART_DMA_HARNESS_BYTES] = {0};
-    return buf;
+    return uartDmaHarnessState().buffer;
 }
 
 inline HarnessDriver& harnessDriver() FL_NO_EXCEPT {
-    static HarnessDriver drv;
-    drv.init();
-    return drv;
+    UartDmaHarnessState& state = uartDmaHarnessState();
+    state.driver.init();
+    return state.driver;
 }
 
 inline int clampByteCount(int n) FL_NO_EXCEPT {
@@ -185,20 +194,35 @@ inline int argInt(const fl::json& args, fl::size i, int fallback) FL_NO_EXCEPT {
 #define FL_LPC_UART_DMA_CLOCKLESS_LEDS 8
 #endif
 
+constexpr fl::size kClocklessEncodedBytes =
+    FL_LPC_UART_DMA_CLOCKLESS_LEDS * 3u * 4u;
+
+struct UartDmaClocklessState {
+    fl::CRGB leds[FL_LPC_UART_DMA_CLOCKLESS_LEDS];
+    fl::u8 expected[kClocklessEncodedBytes];
+    fl::u8 received[kClocklessEncodedBytes];
+    bool registered;
+
+    UartDmaClocklessState() : registered(false) {}
+};
+
+inline UartDmaClocklessState& uartDmaClocklessState() FL_NO_EXCEPT {
+    return fl::SingletonShared<UartDmaClocklessState>::instance();
+}
+
 inline fl::CRGB* clocklessLeds() FL_NO_EXCEPT {
-    static fl::CRGB leds[FL_LPC_UART_DMA_CLOCKLESS_LEDS];
-    return leds;
+    return uartDmaClocklessState().leds;
 }
 
 inline bool ensureClocklessFastLedRegistered() FL_NO_EXCEPT {
-    static bool registered = false;
-    if (!registered) {
+    UartDmaClocklessState& state = uartDmaClocklessState();
+    if (!state.registered) {
         FastLED.addLeds<WS2812,
                         static_cast<fl::u8>(FL_LPC_UART_DMA_CLOCKLESS_TX_PIN),
                         GRB>(clocklessLeds(), FL_LPC_UART_DMA_CLOCKLESS_LEDS);
-        registered = true;
+        state.registered = true;
     }
-    return registered;
+    return state.registered;
 }
 
 inline USART_Type* clocklessUartBlock() FL_NO_EXCEPT {
@@ -341,13 +365,12 @@ inline fl::string clocklessLoopbackSelfHandler(
         leds[i] = fl::CRGB(r, g, b);
     }
 
-    constexpr fl::size kMaxEncoded =
-        FL_LPC_UART_DMA_CLOCKLESS_LEDS * 3u * 4u;
-    static fl::u8 expected[kMaxEncoded];
-    static fl::u8 received[kMaxEncoded];
+    UartDmaClocklessState& state = uartDmaClocklessState();
+    fl::u8* expected = state.expected;
+    fl::u8* received = state.received;
     fl::u32 expected_baud = 0;
     const fl::size expected_count = clocklessEncodeExpectedUartBytes(
-        led_count, rgb, expected, kMaxEncoded, expected_baud);
+        led_count, rgb, expected, kClocklessEncodedBytes, expected_baud);
     if (expected_count == 0u) {
         return fl::string("0,encode");
     }


### PR DESCRIPTION
Moves persistent AutoResearch buffers, drivers, benchmark state, and low-memory RPC state behind fl::Singleton or fl::SingletonShared. Also imports RpcError for the network autoresearch type path and updates the deprecated PARLIO shift-edge field.\n\nValidation: bash lint; bash compile rp2350w --examples AutoResearch; bash compile esp32c6 --examples AutoResearch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AutoResearch benchmarks and hardware interface tests by preserving runtime state consistently across repeated executions.
  * Updated platform-specific LED, DMA, SPI, UART, PWM, PARLIO, and timing tests for more stable operation.
  * Corrected remote stream prefix formatting for clearer serial output.
  * Improved compatibility for ESP32 PARLIO configurations.
* **Refactor**
  * Standardized shared state handling across benchmark and hardware test scenarios without changing test validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->