### PR TITLE
feat(rp2350w): add BTstack BLE transport

### DIFF
--- a/ci/autoresearch/ble.py
+++ b/ci/autoresearch/ble.py
@@ -128,8 +128,10 @@ async def run_ble_autoresearch(
         pong_received = False
 
         # Try notifications first (preferred mechanism)
+        notification_payload = ""
         async for line in ble_iface.read_lines(timeout=3.0):
-            payload = line
+            notification_payload += line
+            payload = notification_payload
             if payload.startswith("REMOTE: "):
                 payload = payload[8:]
             try:

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from colorama import Fore, Style
@@ -25,6 +26,152 @@ from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 if TYPE_CHECKING:
     from ci.util.serial_interface import SerialInterface
+
+
+async def run_ota_peer_autoresearch(
+    upload_port: str,
+    peer_upload_port: str,
+    serial_iface: "SerialInterface | None",
+    firmware_path: Path,
+    timeout: float = 360.0,
+) -> int:
+    """Update RP2350W from an ESP32-C6 fixture without host WiFi access.
+
+    Both boards are deployed by fbuild before this function runs. The host uses
+    the normal fbuild-backed RPC transport only to stage the RP image onto the
+    C6. The RP then fetches that verified artifact over their private WiFi link.
+    """
+    from ci.util.serial_interface import create_serial_interface
+
+    print("\nOTA PEER AUTORESEARCH: RP2350W <- ESP32-C6")
+    print("  Host WiFi is not used or changed by this mode.")
+    if not firmware_path.is_file():
+        print(
+            f"  {Fore.RED}RP2350W firmware is missing: {firmware_path}{Style.RESET_ALL}"
+        )
+        return 1
+
+    artifact = firmware_path.read_bytes()
+    sha256 = hashlib.sha256(artifact).hexdigest()
+    deadline = time.monotonic() + timeout
+    primary: RpcClient | None = None
+    peer: RpcClient | None = None
+
+    def rpc_timeout() -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RpcTimeoutError("--net-peer --ota deadline expired")
+        return min(20.0, remaining)
+
+    async def rpc_data(
+        client: RpcClient, method: str, params: list[Any] | dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        response = await client.send(method, params or {}, timeout=rpc_timeout())
+        if not isinstance(response.data, dict):
+            raise RuntimeError(f"{method} returned a non-object response")
+        return response.data
+
+    try:
+        primary = RpcClient(
+            upload_port, timeout=rpc_timeout(), serial_interface=serial_iface
+        )
+        peer = RpcClient(
+            peer_upload_port,
+            timeout=rpc_timeout(),
+            serial_interface=create_serial_interface(peer_upload_port),
+        )
+        await primary.connect(boot_wait=3.0, drain_boot=True)
+        await peer.connect(boot_wait=3.0, drain_boot=True)
+
+        primary_status = await rpc_data(primary, "status")
+        peer_status = await rpc_data(peer, "status")
+        if "rp2350" not in str(primary_status.get("platform", "")).lower():
+            raise RuntimeError(f"Primary board is not RP2350W: {primary_status}")
+        if "esp32-c6" not in str(peer_status.get("platform", "")).lower():
+            raise RuntimeError(f"Companion board is not ESP32-C6: {peer_status}")
+
+        begin = await rpc_data(
+            peer, "beginOtaArtifact", {"size": len(artifact), "sha256": sha256}
+        )
+        if not begin.get("success"):
+            raise RuntimeError(f"C6 refused OTA artifact: {begin}")
+        for offset in range(0, len(artifact), 512):
+            encoded = base64.b64encode(artifact[offset : offset + 512]).decode("ascii")
+            written = await rpc_data(peer, "writeOtaArtifact", [encoded])
+            if not written.get("success"):
+                raise RuntimeError(
+                    f"C6 artifact write failed at byte {offset}: {written}"
+                )
+        finished = await rpc_data(peer, "finishOtaArtifact")
+        if not finished.get("success") or finished.get("sha256") != sha256:
+            raise RuntimeError(f"C6 artifact verification failed: {finished}")
+
+        c6_server = await rpc_data(peer, "startNetServer")
+        if not c6_server.get("success"):
+            raise RuntimeError(f"C6 AP start failed: {c6_server}")
+        artifact_server = await rpc_data(peer, "startOtaArtifactServer")
+        host = artifact_server.get("ip")
+        port = artifact_server.get("port")
+        if (
+            not artifact_server.get("success")
+            or not isinstance(host, str)
+            or not isinstance(port, int)
+        ):
+            raise RuntimeError(f"C6 artifact server failed: {artifact_server}")
+
+        joined = await rpc_data(
+            primary,
+            "wifiConnect",
+            {"ssid": c6_server.get("ssid"), "password": c6_server.get("password")},
+        )
+        if not joined.get("success"):
+            raise RuntimeError(f"RP2350W WiFi join failed: {joined}")
+        for _ in range(20):
+            wifi = await rpc_data(primary, "wifiStatus")
+            if wifi.get("connected"):
+                break
+            await asyncio.sleep(min(0.5, rpc_timeout()))
+        else:
+            raise RpcTimeoutError("RP2350W did not join the C6 AP")
+
+        accepted = await rpc_data(
+            primary, "applyOtaArtifact", {"host": host, "port": port}
+        )
+        if not accepted.get("success"):
+            raise RuntimeError(f"RP2350W rejected OTA artifact: {accepted}")
+        await primary.close()
+        primary = None
+        await asyncio.sleep(min(8.0, rpc_timeout()))
+
+        primary = RpcClient(
+            upload_port,
+            timeout=rpc_timeout(),
+            serial_interface=create_serial_interface(upload_port),
+        )
+        await primary.connect(boot_wait=8.0, drain_boot=True)
+        await rpc_data(primary, "ping")
+        served = await rpc_data(peer, "otaArtifactStatus")
+        if not served.get("success") or int(served.get("servedRequests", 0)) < 1:
+            raise RuntimeError(f"C6 did not serve the RP2350W artifact: {served}")
+        print(f"{Fore.GREEN}OTA PEER AUTORESEARCH PASSED{Style.RESET_ALL}")
+        return 0
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        return 130
+    except (RpcTimeoutError, RuntimeError, OSError) as error:
+        print(f"{Fore.RED}OTA peer autoresearch failed: {error}{Style.RESET_ALL}")
+        return 1
+    finally:
+        for client, stop_method in ((primary, "stopNet"), (peer, "stopNet")):
+            if client is None:
+                continue
+            try:
+                await client.send(stop_method, timeout=2.0)
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
+            except Exception:
+                pass
+            await client.close()
 
 
 async def run_ota_autoresearch(

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -640,7 +640,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                 f"{Fore.RED}\u274c --net-peer requires both --upload-port and --peer-upload-port{Style.RESET_ALL}"
             )
             return 1
-    if ota_mode and net_mode_count > 0:
+    if ota_mode and net_mode_count > 0 and not net_peer_mode:
         print(
             f"{Fore.RED}\u274c Error: --ota cannot be combined with --net/--net-server/--net-client{Style.RESET_ALL}"
         )
@@ -1600,6 +1600,7 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
                 peer_environment,
                 project_root=args.project_dir.resolve(),
                 verbose=args.verbose,
+                ota_fixture=bool(args.ota),
             )
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
@@ -2492,6 +2493,22 @@ async def _run_tests_or_special_mode(ctx: RunContext, qctx: QuietContext) -> int
     net_loopback_mode = ctx.net_loopback_mode
 
     if ctx.net_peer_mode:
+        if ctx.ota_mode:
+            from ci.autoresearch.ota import run_ota_peer_autoresearch
+
+            peer_upload_port = ctx.args.peer_upload_port
+            assert peer_upload_port is not None
+            if ctx.final_environment is None or ctx.build_driver is None:
+                raise RuntimeError("Peer OTA firmware path is unavailable")
+            return await run_ota_peer_autoresearch(
+                upload_port=upload_port,
+                peer_upload_port=peer_upload_port,
+                serial_iface=serial_iface,
+                firmware_path=ctx.build_driver.firmware_path(
+                    ctx.build_dir, ctx.final_environment
+                ),
+                timeout=ctx.remaining_seconds(),
+            )
         from ci.autoresearch.net import run_net_peer_autoresearch
 
         peer_upload_port = ctx.args.peer_upload_port

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -35,6 +35,7 @@ def synthesise_autoresearch_project(
     project_root: Path | None,
     verbose: bool,
     extra_defines: list[str] | None = None,
+    ota_fixture: bool = False,
 ) -> Path:
     """Stage ``.build/pio/<board>/`` and write a synthesised ``platformio.ini``.
 
@@ -47,6 +48,8 @@ def synthesise_autoresearch_project(
             the synthesised ``build_flags``. Used by driver-specific bench
             modes (e.g. ``--dma-spi`` adds ``FASTLED_LPC_SPI_DMA=1`` so the
             AutoResearchSpiDma handlers compile in — FastLED #3456).
+        ota_fixture: Select the C6-only partition table that reserves space
+            for a staged RP2350W firmware image during peer OTA validation.
 
     Returns:
         Absolute path to the staged build directory, ready to be handed to
@@ -89,5 +92,17 @@ def synthesise_autoresearch_project(
             f"Failed to synthesise autoresearch project for board "
             f"'{board_name}': {init_result.output}"
         )
+
+    if ota_fixture:
+        if board_name != "esp32c6":
+            raise RuntimeError("The OTA fixture partition is only valid for esp32c6")
+        partitions = build_dir / "src" / "sketch" / "esp32c6_ota_fixture.csv"
+        if not partitions.is_file():
+            raise RuntimeError(f"Missing OTA fixture partition table: {partitions}")
+        ini = build_dir / "platformio.ini"
+        with ini.open("a", encoding="utf-8") as output:
+            output.write(
+                "\nboard_build.partitions = src/sketch/esp32c6_ota_fixture.csv\n"
+            )
 
     return build_dir

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1222,7 +1222,10 @@ RPI_PICO2_W = Board(
     # Arduino-Pico's default IPv4 profile excludes BTstack. Enable the Pico W
     # BLE-capable archive so FastLED's RP2350W transport can link.
     board_build_options={"ipbtstack": "ipv4btcble"},
-    lib_deps=["BTstackLib"],
+    # BTstackLib is required for FastLED BLE. HTTPUpdate is required by the
+    # device-to-device OTA AutoResearch flow and must be explicit for fbuild
+    # to compile/link the Arduino-Pico core library.
+    lib_deps=["BTstackLib", "HTTPUpdate"],
 )
 
 # NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -65,6 +65,8 @@ class Board:
     board_build_flash_size: str | None = (
         None  # Flash size for ESP32 boards (e.g., '4MB')
     )
+    board_build_options: dict[str, str] | None = None
+    lib_deps: list[str] | None = None
     build_flags: list[str] | None = None  # Reserved for future use.
     build_unflags: list[str] | None = None  # New: unflag options
     defines: list[str] | None = None
@@ -219,6 +221,11 @@ class Board:
             )
         if self.board_build_flash_size:
             options.append(f"board_build.flash_size={self.board_build_flash_size}")
+        if self.board_build_options:
+            for key, value in sorted(self.board_build_options.items()):
+                options.append(f"board_build.{key}={value}")
+        if self.lib_deps:
+            options.append(f"lib_deps={','.join(self.lib_deps)}")
         if self.defines:
             for define in self.defines:
                 options.append(f"build_flags=-D{define}")
@@ -570,6 +577,13 @@ class Board:
             lines.append(f"board_build.flash_size = {self.board_build_flash_size}")
             # Also set upload flash size to override board defaults
             lines.append(f"board_upload.flash_size = {self.board_build_flash_size}")
+
+        if self.board_build_options:
+            for key, value in sorted(self.board_build_options.items()):
+                lines.append(f"board_build.{key} = {value}")
+
+        if self.lib_deps:
+            lines.append(f"lib_deps = {','.join(self.lib_deps)}")
 
         # Force DIO flash mode ONLY for QEMU builds
         # QEMU doesn't support QIO flash mode which requires setting the QIE bit
@@ -1205,6 +1219,10 @@ RPI_PICO2_W = Board(
     framework="arduino",
     board_build_core="earlephilhower",
     board_build_filesystem_size="0.5m",
+    # Arduino-Pico's default IPv4 profile excludes BTstack. Enable the Pico W
+    # BLE-capable archive so FastLED's RP2350W transport can link.
+    board_build_options={"ipbtstack": "ipv4btcble"},
+    lib_deps=["BTstackLib"],
 )
 
 # NXP LPC8xx family. PlatformIO has no native Arduino-capable nxplpc

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -582,9 +582,6 @@ class Board:
             for key, value in sorted(self.board_build_options.items()):
                 lines.append(f"board_build.{key} = {value}")
 
-        if self.lib_deps:
-            lines.append(f"lib_deps = {','.join(self.lib_deps)}")
-
         # Force DIO flash mode ONLY for QEMU builds
         # QEMU doesn't support QIO flash mode which requires setting the QIE bit
         # Hardware builds should use QIO for better performance (30-50% faster)
@@ -727,16 +724,14 @@ class Board:
                 lines.append("lib_ldf_mode = chain")
             lines.append("lib_archive = true")
 
-            # Build lib_deps with additional libs only (FastLED is copied to lib/FastLED)
-            # PlatformIO supports multiple lib_deps entries on separate lines
-            if additional_libs:
-                # Format as multi-line lib_deps for proper PlatformIO parsing
-                if len(additional_libs) == 1:
-                    lines.append(f"lib_deps = {additional_libs[0]}")
-                else:
-                    lines.append("lib_deps =")
-                    for entry in additional_libs:
-                        lines.append(f"    {entry}")
+        # PlatformIO treats repeated lib_deps options as replacements, not a
+        # merge. Combine board requirements and caller-supplied requirements
+        # before emitting the single environment option.
+        lib_deps: list[str] = list(self.lib_deps or [])
+        if additional_libs:
+            lib_deps.extend(additional_libs)
+        if lib_deps:
+            lines.append(f"lib_deps = {','.join(lib_deps)}")
 
         return "\n".join(lines) + "\n"
 

--- a/ci/ci-compile-pio-ci-working.py
+++ b/ci/ci-compile-pio-ci-working.py
@@ -356,6 +356,11 @@ def compile_with_pio_ci(
             for key, value in sorted(board.board_build_options.items()):
                 cmd_list.extend(["--project-option", f"board_build.{key}={value}"])
 
+        if board.lib_deps:
+            cmd_list.extend(
+                ["--project-option", f"lib_deps={','.join(board.lib_deps)}"]
+            )
+
         # Add defines
         all_defines = defines.copy()
         if board.defines:

--- a/ci/ci-compile-pio-ci-working.py
+++ b/ci/ci-compile-pio-ci-working.py
@@ -352,6 +352,10 @@ def compile_with_pio_ci(
                 ]
             )
 
+        if board.board_build_options:
+            for key, value in sorted(board.board_build_options.items()):
+                cmd_list.extend(["--project-option", f"board_build.{key}={value}"])
+
         # Add defines
         all_defines = defines.copy()
         if board.defines:

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from ci.autoresearch.net import run_net_peer_autoresearch
+from ci.autoresearch.ota import run_ota_peer_autoresearch
 
 
 def _response(data: dict[str, Any]) -> MagicMock:
@@ -80,3 +81,79 @@ def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:
     assert "ping" in peer_methods
     primary.close.assert_awaited_once()
     peer.close.assert_awaited_once()
+
+
+def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
+    """OTA peer validation uses only RPC/fbuild channels before device WiFi."""
+    artifact = tmp_path / "firmware.bin"
+    artifact.write_bytes(b"firmware")
+    primary_before = MagicMock()
+    primary_after = MagicMock()
+    peer = MagicMock()
+    for client in (primary_before, primary_after, peer):
+        client.connect = AsyncMock()
+        client.close = AsyncMock()
+
+    async def primary_before_send(
+        method: str, *_args: Any, **_kwargs: Any
+    ) -> MagicMock:
+        responses = {
+            "status": {"platform": "Raspberry Pi Pico 2 W (RP2350)"},
+            "wifiConnect": {"success": True},
+            "wifiStatus": {"connected": True},
+            "applyOtaArtifact": {"success": True},
+            "stopNet": {"success": True},
+        }
+        return _response(responses[method])
+
+    async def primary_after_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
+        return _response({"success": True})
+
+    async def peer_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
+        responses = {
+            "status": {"platform": "ESP32-C6 (RISC-V)"},
+            "beginOtaArtifact": {"success": True},
+            "writeOtaArtifact": {"success": True},
+            "finishOtaArtifact": {
+                "success": True,
+                "sha256": "c3bf47ea1f4a4a605470313cacb3a44f4a461f68c6faeab07e737610cb5ac835",
+            },
+            "startNetServer": {
+                "success": True,
+                "ssid": "FastLED-AutoResearch",
+                "password": "fastled123",
+            },
+            "startOtaArtifactServer": {
+                "success": True,
+                "ip": "192.168.4.1",
+                "port": 8081,
+            },
+            "otaArtifactStatus": {"success": True, "servedRequests": 1},
+            "stopNet": {"success": True},
+        }
+        return _response(responses[method])
+
+    primary_before.send = AsyncMock(side_effect=primary_before_send)
+    primary_after.send = AsyncMock(side_effect=primary_after_send)
+    peer.send = AsyncMock(side_effect=peer_send)
+    with (
+        patch(
+            "ci.autoresearch.ota.RpcClient",
+            side_effect=[primary_before, peer, primary_after],
+        ),
+        patch("ci.util.serial_interface.create_serial_interface"),
+        patch("ci.autoresearch.ota.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = asyncio.run(
+            run_ota_peer_autoresearch(
+                upload_port="COM17",
+                peer_upload_port="COM9",
+                serial_iface=MagicMock(),
+                firmware_path=artifact,
+                timeout=60.0,
+            )
+        )
+
+    assert result == 0
+    assert peer.send.await_args_list[1].args[0] == "beginOtaArtifact"
+    assert any(call.args[0] == "writeOtaArtifact" for call in peer.send.await_args_list)

--- a/ci/tests/test_board_to_platformio_ini.py
+++ b/ci/tests/test_board_to_platformio_ini.py
@@ -48,6 +48,14 @@ class TestBoardToPlatformioIni(unittest.TestCase):
         self.assertIn("-DFASTLED_TEST=1", lines)
         self.assertIn("-O2", lines)
 
+    def test_lib_deps_are_merged_into_one_option(self) -> None:
+        board = Board(board_name="custom", lib_deps=["board-lib"])
+
+        ini = board.to_platformio_ini(project_root=".", additional_libs=["extra-lib"])
+
+        self.assertEqual(ini.count("lib_deps ="), 1)
+        self.assertIn("lib_deps = board-lib,extra-lib", ini)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -22,6 +22,16 @@ def test_cpu_count_no_longer_caps_on_github_actions(
     assert cpu_count_module.cpu_count() == 8
 
 
+def test_fbuild_executable_override_uses_explicit_local_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binary = tmp_path / "fbuild.exe"
+    binary.write_bytes(b"")
+    monkeypatch.setenv("FBUILD_EXECUTABLE", str(binary))
+
+    assert fbuild_runner.get_fbuild_executable() == str(binary)
+
+
 def test_run_fbuild_ci_uses_expected_command_and_parses_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ci/tests/test_fbuild_compile_many.py
+++ b/ci/tests/test_fbuild_compile_many.py
@@ -32,6 +32,16 @@ def test_fbuild_executable_override_uses_explicit_local_binary(
     assert fbuild_runner.get_fbuild_executable() == str(binary)
 
 
+def test_fbuild_executable_override_rejects_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    missing = tmp_path / "missing-fbuild"
+    monkeypatch.setenv("FBUILD_EXECUTABLE", str(missing))
+
+    with pytest.raises(FileNotFoundError, match="FBUILD_EXECUTABLE"):
+        fbuild_runner.get_fbuild_executable()
+
+
 def test_run_fbuild_ci_uses_expected_command_and_parses_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ci/tests/test_parlio_raw_config.py
+++ b/ci/tests/test_parlio_raw_config.py
@@ -1,0 +1,18 @@
+"""Regression tests for the AutoResearch raw PARLIO TX diagnostic."""
+
+from pathlib import Path
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "AutoResearch"
+    / "AutoResearchRemoteSystemMethods.cpp"
+)
+
+
+def test_parlio_raw_tx_uses_the_tx_shift_edge_enum() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "cfg.shift_edge = PARLIO_SHIFT_EDGE_POS;" in source
+    assert "cfg.shift_edge = PARLIO_SAMPLE_EDGE_POS;" not in source

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -22,6 +22,7 @@ ESP_WIFI_IMPL = (
     REPO_ROOT / "src" / "platforms" / "esp" / "32" / "net" / "wifi_esp32.cpp.hpp"
 )
 RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
+RP_BLE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "ble_rp.cpp.hpp"
 AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
 AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
 
@@ -42,6 +43,16 @@ def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
     assert "[env:rp2350w]" in ini
     assert "board = rpipico2w" in ini
     assert "board_build.core = earlephilhower" in ini
+    assert "board_build.ipbtstack = ipv4btcble" in ini
+    assert "lib_deps = BTstackLib" in ini
+
+
+def test_rp2350w_ble_transport_uses_btstack_with_singleton_state() -> None:
+    source = RP_BLE_IMPL.read_text(encoding="utf-8")
+
+    assert "#include <BTstackLib.h>" in source
+    assert "fl::Singleton<RpBleRuntime>" in source
+    assert "att_server_notify" in source
 
 
 def test_rp2350_and_rp2350w_keep_distinct_board_profiles() -> None:

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -44,7 +44,7 @@ def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
     assert "board = rpipico2w" in ini
     assert "board_build.core = earlephilhower" in ini
     assert "board_build.ipbtstack = ipv4btcble" in ini
-    assert "lib_deps = BTstackLib" in ini
+    assert "lib_deps = BTstackLib,HTTPUpdate" in ini
 
 
 def test_rp2350w_ble_transport_uses_btstack_with_singleton_state() -> None:

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -52,7 +52,10 @@ def test_rp2350w_ble_transport_uses_btstack_with_singleton_state() -> None:
 
     assert "#include <BTstackLib.h>" in source
     assert "fl::Singleton<RpBleRuntime>" in source
-    assert "att_server_notify" in source
+    assert "att_server_request_to_send_notification" in source
+    assert "att_server_get_mtu" in source
+    assert "notification_offset" in source
+    assert "notify failed: %u" in source
 
 
 def test_rp2350_and_rp2350w_keep_distinct_board_profiles() -> None:

--- a/ci/util/create_build_dir.py
+++ b/ci/util/create_build_dir.py
@@ -389,6 +389,9 @@ def create_build_dir(
         cmd_list.append(
             f"--project-option=board_build.filesystem_size={board.board_build_filesystem_size}"
         )
+    if board.board_build_options:
+        for key, value in sorted(board.board_build_options.items()):
+            cmd_list.append(f"--project-option=board_build.{key}={value}")
     if build_flags is not None:
         for build_flag in build_flags:
             cmd_list.append(f"--project-option=build_flags={build_flag}")

--- a/ci/util/create_build_dir.py
+++ b/ci/util/create_build_dir.py
@@ -400,8 +400,11 @@ def create_build_dir(
         cmd_list.append(f"--project-option=build_flags={build_flags_str}")
     if board.customsdk:
         cmd_list.append(f"--project-option=custom_sdkconfig={customsdk}")
+    lib_deps: list[str] = list(board.lib_deps or [])
     if extra_packages:
-        cmd_list.append(f"--project-option=lib_deps={','.join(extra_packages)}")
+        lib_deps.extend(extra_packages)
+    if lib_deps:
+        cmd_list.append(f"--project-option=lib_deps={','.join(lib_deps)}")
     if no_install_deps:
         cmd_list.append("--no-install-dependencies")
 

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -84,10 +84,20 @@ _COMPILE_MANY_RESULT_RE = re.compile(
 def get_fbuild_executable() -> str | None:
     """Resolve the ``fbuild`` executable for the active Python environment.
 
+    ``FBUILD_EXECUTABLE`` is an explicit local-development override. It keeps
+    the normal virtualenv pin authoritative while allowing a merged local
+    fbuild binary to validate a consumer before the next release.
+
     Prefer the sibling script next to the current interpreter so ``uv run``
     reliably uses the version locked in this repo's virtualenv instead of an
     older global ``fbuild`` earlier on ``PATH``.
     """
+    override = os.environ.get("FBUILD_EXECUTABLE")
+    if override:
+        candidate = Path(override)
+        if candidate.is_file():
+            return str(candidate)
+        raise FileNotFoundError(f"FBUILD_EXECUTABLE does not name a file: {candidate}")
     script_dir = Path(sys.executable).resolve().parent
     candidates = [
         script_dir / "fbuild",

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -213,6 +213,7 @@ void loop()  { autoResearchLowMemoryLoop(); }
 #include "AutoResearchRemote.h"
 #include "AutoResearchBle.h"
 #include "AutoResearchNet.h"
+#include "AutoResearchOta.h"
 #include "AutoResearchAsync.h"
 #include "AutoResearchPlatform.h"
 #include "AutoResearchSimd.h"
@@ -602,6 +603,9 @@ void loop() {
     // Arduino-Pico's CYW43 HTTP endpoint runs cooperatively from loop().
     // ESP32's native HTTP server has its own task, so this is a no-op there.
     pollNetServer();
+    // A peer OTA request is queued by JSON-RPC, then executed from loop after
+    // the acceptance response is safely written to USB serial.
+    pollOtaArtifactUpdate();
 
     // ========================================================================
     // Watchdog autoresearch trigger (FastLED#2731) — when the host RPC sends

--- a/examples/AutoResearch/AutoResearchOta.cpp
+++ b/examples/AutoResearch/AutoResearchOta.cpp
@@ -18,10 +18,21 @@
 #include "fl/stl/json.h"
 #include "fl/stl/singleton.h"
 #include "fl/log/log.h"
+#include "fl/stl/vector.h"
 
 struct OtaStateHolder {
     AutoResearchOtaState state;
 };
+
+struct RpOtaUpdateState {
+    bool pending = false;
+    char host[16] = {};
+    uint16_t port = 0;
+};
+
+RpOtaUpdateState& getRpOtaUpdateState() {
+    return fl::Singleton<RpOtaUpdateState>::instance();
+}
 
 AutoResearchOtaState& getOtaState() {
     return fl::Singleton<OtaStateHolder>::instance().state;
@@ -51,6 +62,9 @@ AutoResearchOtaState& getOtaState() {
 #include <esp_wifi.h>
 #include <esp_netif.h>
 #include <esp_event.h>
+#include <esp_http_server.h>
+#include <LittleFS.h>
+#include <mbedtls/sha256.h>
 // IWYU pragma: end_keep
 
 struct EspOtaRuntimeState {
@@ -60,8 +74,100 @@ struct EspOtaRuntimeState {
     bool wifi_initialized = false;
 };
 
+struct OtaArtifactState {
+    File file;
+    httpd_handle_t server = nullptr;
+    size_t expected_size = 0;
+    size_t received_size = 0;
+    size_t served_requests = 0;
+    char expected_sha256[65] = {};
+};
+
+OtaArtifactState& getOtaArtifactState() {
+    return fl::Singleton<OtaArtifactState>::instance();
+}
+
 EspOtaRuntimeState& getEspOtaRuntimeState() {
     return fl::Singleton<EspOtaRuntimeState>::instance();
+}
+
+static bool copySha256(char* destination, size_t capacity, const char* source) {
+    if (source == nullptr || capacity != 65) {
+        return false;
+    }
+    size_t index = 0;
+    while (source[index] != '\0') {
+        const char value = source[index];
+        const bool is_digit = value >= '0' && value <= '9';
+        const bool is_lower = value >= 'a' && value <= 'f';
+        if ((!is_digit && !is_lower) || index + 1 >= capacity) {
+            return false;
+        }
+        destination[index] = value;
+        ++index;
+    }
+    if (index != 64) {
+        return false;
+    }
+    destination[index] = '\0';
+    return true;
+}
+
+static bool sha256File(const char* path, char* output, size_t output_capacity) {
+    if (output_capacity != 65) {
+        return false;
+    }
+    File file = LittleFS.open(path, FILE_READ);
+    if (!file || file.isDirectory()) {
+        return false;
+    }
+    mbedtls_sha256_context context;
+    mbedtls_sha256_init(&context);
+    mbedtls_sha256_starts(&context, 0);
+    uint8_t bytes[512];
+    while (file.available()) {
+        const size_t read = file.read(bytes, sizeof(bytes));
+        if (read == 0) {
+            file.close();
+            mbedtls_sha256_free(&context);
+            return false;
+        }
+        mbedtls_sha256_update(&context, bytes, read);
+    }
+    uint8_t digest[32];
+    mbedtls_sha256_finish(&context, digest);
+    mbedtls_sha256_free(&context);
+    file.close();
+    for (size_t index = 0; index < sizeof(digest); ++index) {
+        output[index * 2] = "0123456789abcdef"[digest[index] >> 4];
+        output[index * 2 + 1] = "0123456789abcdef"[digest[index] & 0x0f];
+    }
+    output[64] = '\0';
+    return true;
+}
+
+static esp_err_t serveOtaArtifact(httpd_req_t* request) {
+    ++getOtaArtifactState().served_requests;
+    File file = LittleFS.open("/rp2350.bin", FILE_READ);
+    if (!file || file.isDirectory()) {
+        return httpd_resp_send_err(request, HTTPD_404_NOT_FOUND, "Artifact unavailable");
+    }
+    httpd_resp_set_type(request, "application/octet-stream");
+    char length[16];
+    snprintf(length, sizeof(length), "%u", static_cast<unsigned>(file.size()));
+    httpd_resp_set_hdr(request, "Content-Length", length);
+    uint8_t bytes[512];
+    while (file.available()) {
+        const size_t read = file.read(bytes, sizeof(bytes));
+        if (read == 0 || httpd_resp_send_chunk(request,
+                                                reinterpret_cast<const char*>(bytes),
+                                                read) != ESP_OK) {
+            file.close();
+            return ESP_FAIL;
+        }
+    }
+    file.close();
+    return httpd_resp_send_chunk(request, nullptr, 0);
 }
 
 // ============================================================================
@@ -205,6 +311,133 @@ fl::json stopOta() {
     return response;
 }
 
+fl::json beginOtaArtifact(size_t expected_size, const char* sha256) {
+    fl::json response = fl::json::object();
+    OtaArtifactState& state = getOtaArtifactState();
+    if (expected_size == 0 || !copySha256(state.expected_sha256,
+                                           sizeof(state.expected_sha256), sha256)) {
+        response.set("success", false);
+        response.set("error", "Invalid artifact metadata");
+        return response;
+    }
+    if (!LittleFS.begin(true)) {
+        response.set("success", false);
+        response.set("error", "LittleFS mount failed");
+        return response;
+    }
+    if (expected_size > LittleFS.totalBytes()) {
+        response.set("success", false);
+        response.set("error", "Artifact exceeds fixture filesystem");
+        return response;
+    }
+    if (state.file) {
+        state.file.close();
+    }
+    LittleFS.remove("/rp2350.bin.part");
+    state.file = LittleFS.open("/rp2350.bin.part", FILE_WRITE);
+    if (!state.file) {
+        response.set("success", false);
+        response.set("error", "Artifact staging open failed");
+        return response;
+    }
+    state.expected_size = expected_size;
+    state.received_size = 0;
+    response.set("success", true);
+    response.set("capacity", static_cast<int64_t>(LittleFS.totalBytes()));
+    return response;
+}
+
+fl::json writeOtaArtifact(fl::vector<fl::u8> bytes) {
+    fl::json response = fl::json::object();
+    OtaArtifactState& state = getOtaArtifactState();
+    if (!state.file || bytes.empty() ||
+        bytes.size() > state.expected_size - state.received_size) {
+        response.set("success", false);
+        response.set("error", "Invalid artifact chunk");
+        return response;
+    }
+    const size_t written = state.file.write(bytes.data(), bytes.size());
+    state.received_size += written;
+    response.set("success", written == bytes.size());
+    response.set("received", static_cast<int64_t>(state.received_size));
+    if (written != bytes.size()) {
+        response.set("error", "Artifact write failed");
+    }
+    return response;
+}
+
+fl::json finishOtaArtifact() {
+    fl::json response = fl::json::object();
+    OtaArtifactState& state = getOtaArtifactState();
+    if (!state.file || state.received_size != state.expected_size) {
+        response.set("success", false);
+        response.set("error", "Artifact size mismatch");
+        return response;
+    }
+    state.file.close();
+    char actual_sha256[65];
+    if (!sha256File("/rp2350.bin.part", actual_sha256, sizeof(actual_sha256)) ||
+        fl::strcmp(actual_sha256, state.expected_sha256) != 0) {
+        LittleFS.remove("/rp2350.bin.part");
+        response.set("success", false);
+        response.set("error", "Artifact SHA-256 mismatch");
+        return response;
+    }
+    LittleFS.remove("/rp2350.bin");
+    if (!LittleFS.rename("/rp2350.bin.part", "/rp2350.bin")) {
+        response.set("success", false);
+        response.set("error", "Artifact publish failed");
+        return response;
+    }
+    response.set("success", true);
+    response.set("size", static_cast<int64_t>(state.received_size));
+    response.set("sha256", actual_sha256);
+    return response;
+}
+
+fl::json startOtaArtifactServer() {
+    fl::json response = fl::json::object();
+    OtaArtifactState& state = getOtaArtifactState();
+    if (!LittleFS.begin(true) || !LittleFS.exists("/rp2350.bin")) {
+        response.set("success", false);
+        response.set("error", "No published RP2350 artifact");
+        return response;
+    }
+    if (!state.server) {
+        httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+        config.server_port = 8081;
+        if (httpd_start(&state.server, &config) != ESP_OK) {
+            response.set("success", false);
+            response.set("error", "Artifact HTTP server start failed");
+            return response;
+        }
+        httpd_uri_t artifact = {};
+        artifact.uri = "/rp2350.bin";
+        artifact.method = HTTP_GET;
+        artifact.handler = serveOtaArtifact;
+        if (httpd_register_uri_handler(state.server, &artifact) != ESP_OK) {
+            httpd_stop(state.server);
+            state.server = nullptr;
+            response.set("success", false);
+            response.set("error", "Artifact HTTP route registration failed");
+            return response;
+        }
+    }
+    response.set("success", true);
+    response.set("ip", AUTORESEARCH_OTA_AP_IP);
+    response.set("port", static_cast<int64_t>(8081));
+    return response;
+}
+
+fl::json otaArtifactStatus() {
+    fl::json response = fl::json::object();
+    OtaArtifactState& state = getOtaArtifactState();
+    response.set("success", LittleFS.begin(true) && LittleFS.exists("/rp2350.bin"));
+    response.set("servedRequests", static_cast<int64_t>(state.served_requests));
+    response.set("received", static_cast<int64_t>(state.received_size));
+    return response;
+}
+
 #else  // !FL_IS_ESP32 || !SOC_WIFI_SUPPORTED
 
 // ============================================================================
@@ -224,6 +457,99 @@ fl::json stopOta() {
     return response;
 }
 
+fl::json beginOtaArtifact(size_t expected_size, const char* sha256) {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact staging only supported on ESP32-C6");
+    return response;
+}
+
+fl::json writeOtaArtifact(fl::vector<fl::u8> bytes) {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact staging only supported on ESP32-C6");
+    return response;
+}
+
+fl::json finishOtaArtifact() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact staging only supported on ESP32-C6");
+    return response;
+}
+
+fl::json startOtaArtifactServer() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact server only supported on ESP32-C6");
+    return response;
+}
+
+fl::json otaArtifactStatus() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact server only supported on ESP32-C6");
+    return response;
+}
+
 #endif  // FL_IS_ESP32
+
+#if defined(FL_IS_RP2350) && defined(PICO_CYW43_SUPPORTED)
+#include <HTTPUpdate.h>
+#include <WiFi.h>
+
+fl::json queueOtaArtifactUpdate(const char* host, uint16_t port) {
+    fl::json response = fl::json::object();
+    RpOtaUpdateState& state = getRpOtaUpdateState();
+    if (host == nullptr || port == 0) {
+        response.set("success", false);
+        response.set("error", "Invalid artifact endpoint");
+        return response;
+    }
+    size_t index = 0;
+    while (host[index] != '\0' && index + 1 < sizeof(state.host)) {
+        state.host[index] = host[index];
+        ++index;
+    }
+    if (host[index] != '\0') {
+        response.set("success", false);
+        response.set("error", "Artifact host is too long");
+        return response;
+    }
+    state.host[index] = '\0';
+    state.port = port;
+    state.pending = true;
+    response.set("success", true);
+    response.set("accepted", true);
+    return response;
+}
+
+void pollOtaArtifactUpdate() {
+    RpOtaUpdateState& state = getRpOtaUpdateState();
+    if (!state.pending) {
+        return;
+    }
+    state.pending = false;
+    WiFiClient client;
+    HTTPUpdate updater;
+    const t_httpUpdate_return result = updater.update(client, state.host, state.port,
+                                                       "/rp2350.bin");
+    if (result != HTTP_UPDATE_OK) {
+        FL_WARN("[OTA] RP2350W artifact update failed: " << updater.getLastErrorString());
+    }
+}
+
+#else
+
+fl::json queueOtaArtifactUpdate(const char* host, uint16_t port) {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact update only supported on RP2350W");
+    return response;
+}
+
+void pollOtaArtifactUpdate() {}
+
+#endif
 
 #endif  // !FASTLED_AUTORESEARCH_LOW_MEMORY

--- a/examples/AutoResearch/AutoResearchOta.h
+++ b/examples/AutoResearch/AutoResearchOta.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "fl/stl/vector.h"
+
 // WiFi AP configuration constants for OTA autoresearch
 #define AUTORESEARCH_OTA_SSID "FastLED-OTA-Test"
 #define AUTORESEARCH_OTA_PASSWORD "otavalid8"
@@ -36,6 +38,20 @@ fl::json startOta();
 /// @brief Stop OTA server and WiFi AP, release all resources.
 /// @return JSON with {success: true}
 fl::json stopOta();
+
+/// @brief Stage one RP2350W firmware artifact on the ESP32-C6 fixture.
+/// These functions are used only by the device-to-device peer OTA test.
+fl::json beginOtaArtifact(size_t expected_size, const char* sha256);
+fl::json writeOtaArtifact(fl::vector<fl::u8> bytes);
+fl::json finishOtaArtifact();
+fl::json startOtaArtifactServer();
+fl::json otaArtifactStatus();
+
+/// @brief Queue an RP2350W HTTP update so the RPC response can be sent first.
+fl::json queueOtaArtifactUpdate(const char* host, uint16_t port);
+
+/// @brief Execute a queued RP2350W update from the sketch loop.
+void pollOtaArtifactUpdate();
 
 /// @brief Get current OTA autoresearch state.
 /// @return Reference to the global OTA state

--- a/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
@@ -342,6 +342,48 @@ void AutoResearchRemoteControl::bindNetworkMethods(fl::Remote& remote) {
         return stopOta();
     });
 
+    remote.bind("beginOtaArtifact", [](const fl::json& args) -> fl::json {
+        if (!args.contains("size") || !args["size"].is_int() ||
+            !args.contains("sha256") || !args["sha256"].is_string()) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "Expected size and sha256");
+            return response;
+        }
+        const int64_t size = args["size"].as_int().value();
+        return beginOtaArtifact(size > 0 ? static_cast<size_t>(size) : 0,
+                                args["sha256"].as_string().value().c_str());
+    });
+
+    remote.bind("writeOtaArtifact", [](fl::vector<fl::u8> bytes) -> fl::json {
+        return writeOtaArtifact(fl::move(bytes));
+    });
+
+    remote.bind("finishOtaArtifact", [](const fl::json& args) -> fl::json {
+        return finishOtaArtifact();
+    });
+
+    remote.bind("startOtaArtifactServer", [](const fl::json& args) -> fl::json {
+        return startOtaArtifactServer();
+    });
+
+    remote.bind("otaArtifactStatus", [](const fl::json& args) -> fl::json {
+        return otaArtifactStatus();
+    });
+
+    remote.bind("applyOtaArtifact", [](const fl::json& args) -> fl::json {
+        if (!args.contains("host") || !args["host"].is_string() ||
+            !args.contains("port") || !args["port"].is_int()) {
+            fl::json response = fl::json::object();
+            response.set("success", false);
+            response.set("error", "Expected host and port");
+            return response;
+        }
+        const int64_t port = args["port"].as_int().value();
+        return queueOtaArtifactUpdate(args["host"].as_string().value().c_str(),
+                                      port > 0 ? static_cast<uint16_t>(port) : 0);
+    });
+
     // ========================================================================
     // BLE Validation RPC Functions
     // ========================================================================

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -316,7 +316,7 @@ void AutoResearchRemoteControl::bindSystemMethods(fl::Remote& remote) {
         cfg.trans_queue_depth = (size_t)depth;
         cfg.max_transfer_size = (size_t)mts;
         cfg.output_clk_freq_hz = (uint32_t)hz;
-        cfg.shift_edge = PARLIO_SAMPLE_EDGE_POS;
+        cfg.shift_edge = PARLIO_SHIFT_EDGE_POS;
         cfg.bit_pack_order = PARLIO_BIT_PACK_ORDER_MSB;
         if (burst > 0) cfg.dma_burst_size = (size_t)burst;
         for (int i = 0; i < 16; ++i) cfg.data_gpio_nums[i] = (gpio_num_t)-1;

--- a/examples/AutoResearch/esp32c6_ota_fixture.csv
+++ b/examples/AutoResearch/esp32c6_ota_fixture.csv
@@ -1,0 +1,7 @@
+# The C6 fixture needs room for both AutoResearch and one RP2350W update
+# image.  This is selected only for `--net-peer --ota`; ordinary C6 builds
+# retain the framework's huge_app.csv layout.
+# Name, Type, SubType, Offset, Size, Flags
+nvs, data, nvs, 0x9000, 0x5000,
+app0, app, factory, 0x10000, 0x290000,
+spiffs, data, spiffs, 0x2a0000, 0x160000,

--- a/src/fl/net/ble.h
+++ b/src/fl/net/ble.h
@@ -23,9 +23,13 @@
 #include "fl/stl/noexcept.h"
 #include "fl/stl/pair.h"
 
-// BLE requires: ESP32 + IDF 5+ + NimBLE headers present
+// BLE requires either ESP32 + IDF 5+ + NimBLE headers, or an RP2350W build
+// that selected Arduino-Pico's BTstack menu.
 #if defined(FL_IS_ESP32) && defined(FL_IS_IDF_5_OR_HIGHER) \
     && FL_HAS_INCLUDE(<nimble/nimble_port.h>)
+#define FL_BLE_AVAILABLE 1
+#elif defined(FL_IS_RP2350) && defined(ENABLE_BLE) && ENABLE_BLE \
+    && FL_HAS_INCLUDE(<BTstackLib.h>)
 #define FL_BLE_AVAILABLE 1
 #else
 #define FL_BLE_AVAILABLE 0

--- a/src/platforms/arm/rp/_build.cpp.hpp
+++ b/src/platforms/arm/rp/_build.cpp.hpp
@@ -7,6 +7,7 @@
 // Root directory implementations (alphabetical order)
 
 // begin current directory includes
+#include "platforms/arm/rp/ble_rp.cpp.hpp"
 #include "platforms/arm/rp/init_rp.cpp.hpp"
 #include "platforms/arm/rp/io_rp.cpp.hpp"
 #include "platforms/arm/rp/mutex_rp.cpp.hpp"

--- a/src/platforms/arm/rp/ble_rp.cpp.hpp
+++ b/src/platforms/arm/rp/ble_rp.cpp.hpp
@@ -39,14 +39,79 @@ struct TransportState {
     hci_con_handle_t connection = HCI_CON_HANDLE_INVALID;
     bool connected = false;
     fl::string last_tx_value;
+    fl::vector<u8> notification_payload;
+    size_t notification_offset = 0;
+    bool notification_scheduled = false;
 };
 
 struct RpBleRuntime {
     TransportState* active = nullptr;
+    // BTstack retains this registration until it can send. Keep it in the
+    // singleton so destroying a transport cannot leave it with freed storage.
+    btstack_context_callback_registration_t notification_callback = {};
+    bool notification_callback_pending = false;
 };
 
 RpBleRuntime& rpBleRuntime() FL_NO_EXCEPT {
     return fl::Singleton<RpBleRuntime>::instance();
+}
+
+static void onNotificationReady(void* context);
+
+static void scheduleNotification(TransportState* state) {
+    if (state == nullptr || rpBleRuntime().active != state || !state->connected ||
+        state->tx_handle == 0 || state->notification_offset >= state->notification_payload.size() ||
+        state->notification_scheduled) {
+        return;
+    }
+
+    RpBleRuntime& runtime = rpBleRuntime();
+    if (runtime.notification_callback_pending) {
+        return;
+    }
+    // BTstack may invoke the callback before this request function returns.
+    state->notification_scheduled = true;
+    runtime.notification_callback_pending = true;
+    runtime.notification_callback.callback = onNotificationReady;
+    runtime.notification_callback.context = state;
+    const u8 result = att_server_request_to_send_notification(
+        &runtime.notification_callback, state->connection);
+    if (result != ERROR_CODE_SUCCESS) {
+        state->notification_scheduled = false;
+        runtime.notification_callback_pending = false;
+        FL_WARN_F("[BLE RP] notification scheduling failed: %u", static_cast<unsigned>(result));
+    }
+}
+
+static void onNotificationReady(void* context) {
+    TransportState* state = static_cast<TransportState*>(context);
+    RpBleRuntime& runtime = rpBleRuntime();
+    runtime.notification_callback_pending = false;
+    if (state == nullptr || runtime.active != state) {
+        scheduleNotification(runtime.active);
+        return;
+    }
+    state->notification_scheduled = false;
+    if (!state->connected || state->tx_handle == 0 ||
+        state->notification_offset >= state->notification_payload.size()) {
+        return;
+    }
+
+    const u16 mtu = att_server_get_mtu(state->connection);
+    const size_t max_payload = mtu > 3 ? static_cast<size_t>(mtu - 3) : 20;
+    const size_t remaining = state->notification_payload.size() - state->notification_offset;
+    const size_t chunk_size = remaining < max_payload ? remaining : max_payload;
+    const u8 result = att_server_notify(
+        state->connection, state->tx_handle,
+        state->notification_payload.data() + state->notification_offset,
+        static_cast<u16>(chunk_size));
+    if (result != ERROR_CODE_SUCCESS) {
+        FL_WARN_F("[BLE RP] notify failed: %u", static_cast<unsigned>(result));
+        return;
+    }
+
+    state->notification_offset += chunk_size;
+    scheduleNotification(state);
 }
 
 static int nextRingIndex(int index) FL_NO_EXCEPT {
@@ -103,6 +168,8 @@ static void onDisconnected(BLEDevice*) { // ok no noexcept
     }
     state->connection = HCI_CON_HANDLE_INVALID;
     state->connected = false;
+    state->notification_payload.clear();
+    state->notification_offset = 0;
 }
 
 TransportState* createTransport(const char* device_name) FL_NO_EXCEPT {
@@ -138,7 +205,10 @@ void destroyTransport(TransportState* state) FL_NO_EXCEPT {
         return;
     }
     if (rpBleRuntime().active == state) {
-        rpBleRuntime().active = nullptr;
+        RpBleRuntime& runtime = rpBleRuntime();
+        runtime.active = nullptr;
+        // A pending callback receives null and returns before state is deleted.
+        runtime.notification_callback.context = nullptr;
     }
     fl::unique_ptr<TransportState> holder(state);
 }
@@ -189,17 +259,13 @@ getTransportCallbacks(TransportState* state) FL_NO_EXCEPT {
         if (!state->connected || state->tx_handle == 0) {
             return;
         }
-        fl::vector<u8> payload;
-        payload.reserve(state->last_tx_value.size());
+        state->notification_payload.clear();
+        state->notification_payload.reserve(state->last_tx_value.size());
         for (char value : state->last_tx_value) {
-            payload.push_back(static_cast<u8>(value));
+            state->notification_payload.push_back(static_cast<u8>(value));
         }
-        const u8 result = att_server_notify(
-            state->connection, state->tx_handle, payload.data(),
-            static_cast<u16>(payload.size()));
-        if (result != ERROR_CODE_SUCCESS) {
-            FL_WARN_F("[BLE RP] notify failed: %s", result);
-        }
+        state->notification_offset = 0;
+        scheduleNotification(state);
     };
 
     return {request_source, response_sink};

--- a/src/platforms/arm/rp/ble_rp.cpp.hpp
+++ b/src/platforms/arm/rp/ble_rp.cpp.hpp
@@ -1,0 +1,212 @@
+// IWYU pragma: private
+
+/// @file ble_rp.cpp.hpp
+/// @brief Arduino-Pico BTstack BLE GATT transport for RP2350W.
+
+#pragma once
+
+#include "fl/net/ble.h"
+#include "platforms/arm/rp/is_rp.h"
+
+#if FL_BLE_AVAILABLE && defined(FL_IS_RP2350)
+
+#include "fl/log/log.h"
+#include "fl/remote/transport/serial.h"
+#include "fl/stl/cctype.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/singleton.h"
+#include "fl/stl/string.h"
+#include "fl/stl/string_view.h"
+#include "fl/stl/unique_ptr.h"
+#include "fl/stl/vector.h"
+
+// IWYU pragma: begin_keep
+#include <BTstackLib.h>
+#include <ble/att_server.h>
+// IWYU pragma: end_keep
+
+namespace fl {
+namespace net {
+namespace ble {
+
+struct TransportState {
+    fl::string ring_buffer[8];
+    volatile int head = 0;
+    volatile int tail = 0;
+    u16 tx_handle = 0;
+    u16 rx_handle = 0;
+    hci_con_handle_t connection = HCI_CON_HANDLE_INVALID;
+    bool connected = false;
+    fl::string last_tx_value;
+};
+
+struct RpBleRuntime {
+    TransportState* active = nullptr;
+};
+
+RpBleRuntime& rpBleRuntime() FL_NO_EXCEPT {
+    return fl::Singleton<RpBleRuntime>::instance();
+}
+
+static int nextRingIndex(int index) FL_NO_EXCEPT {
+    return (index + 1) % 8;
+}
+
+static int onGattWrite(u16, u8* data, u16 size) { // ok no noexcept
+    TransportState* state = rpBleRuntime().active;
+    if (state == nullptr || data == nullptr || size == 0) {
+        return 0;
+    }
+
+    const int next_head = nextRingIndex(state->head);
+    if (next_head == state->tail) {
+        FL_WARN_F("[BLE RP] RX queue full, dropping message");
+        return 0;
+    }
+    fl::string incoming;
+    incoming.reserve(size);
+    for (u16 i = 0; i < size; ++i) {
+        incoming.push_back(static_cast<char>(data[i]));
+    }
+    state->ring_buffer[state->head] = incoming;
+    state->head = next_head;
+    return 0;
+}
+
+static u16 onGattRead(u16, u8* buffer, u16 buffer_size) { // ok no noexcept
+    TransportState* state = rpBleRuntime().active;
+    if (state == nullptr || buffer == nullptr) {
+        return 0;
+    }
+    const u16 copy_size = static_cast<u16>(
+        state->last_tx_value.size() < buffer_size ? state->last_tx_value.size() : buffer_size);
+    for (u16 i = 0; i < copy_size; ++i) {
+        buffer[i] = static_cast<u8>(state->last_tx_value[i]);
+    }
+    return copy_size;
+}
+
+static void onConnected(BLEStatus status, BLEDevice* device) { // ok no noexcept
+    TransportState* state = rpBleRuntime().active;
+    if (state == nullptr || status != BLE_STATUS_OK || device == nullptr) {
+        return;
+    }
+    state->connection = device->getHandle();
+    state->connected = true;
+}
+
+static void onDisconnected(BLEDevice*) { // ok no noexcept
+    TransportState* state = rpBleRuntime().active;
+    if (state == nullptr) {
+        return;
+    }
+    state->connection = HCI_CON_HANDLE_INVALID;
+    state->connected = false;
+}
+
+TransportState* createTransport(const char* device_name) FL_NO_EXCEPT {
+    RpBleRuntime& runtime = rpBleRuntime();
+    if (runtime.active != nullptr || device_name == nullptr || *device_name == '\0') {
+        return nullptr;
+    }
+
+    auto holder = fl::make_unique<TransportState>();
+    TransportState* state = holder.get();
+    UUID service_uuid(FL_BLE_SERVICE_UUID);
+    UUID rx_uuid(FL_BLE_CHAR_RX_UUID);
+    UUID tx_uuid(FL_BLE_CHAR_TX_UUID);
+
+    BTstack.addGATTService(&service_uuid);
+    state->rx_handle = BTstack.addGATTCharacteristicDynamic(
+        &rx_uuid, ATT_PROPERTY_WRITE | ATT_PROPERTY_WRITE_WITHOUT_RESPONSE, 1);
+    state->tx_handle = BTstack.addGATTCharacteristicDynamic(
+        &tx_uuid, ATT_PROPERTY_READ | ATT_PROPERTY_NOTIFY, 2);
+    BTstack.setGATTCharacteristicWrite(onGattWrite);
+    BTstack.setGATTCharacteristicRead(onGattRead);
+    BTstack.setBLEDeviceConnectedCallback(onConnected);
+    BTstack.setBLEDeviceDisconnectedCallback(onDisconnected);
+
+    runtime.active = state;
+    BTstack.setup(device_name);
+    FL_WARN_F("[BLE RP] GATT server started: %s", device_name);
+    return holder.release();
+}
+
+void destroyTransport(TransportState* state) FL_NO_EXCEPT {
+    if (state == nullptr) {
+        return;
+    }
+    if (rpBleRuntime().active == state) {
+        rpBleRuntime().active = nullptr;
+    }
+    fl::unique_ptr<TransportState> holder(state);
+}
+
+StatusInfo queryStatus(const TransportState* state) FL_NO_EXCEPT {
+    StatusInfo info;
+    if (state == nullptr) {
+        return info;
+    }
+    info.connected = state->connected;
+    info.connectedCount = state->connected ? 1 : 0;
+    info.txCharExists = state->tx_handle != 0;
+    info.txValueLen = static_cast<int>(state->last_tx_value.size());
+    info.ringHead = state->head;
+    info.ringTail = state->tail;
+    return info;
+}
+
+fl::pair<fl::function<fl::optional<fl::json>()>, fl::function<void(const fl::json&)>>
+getTransportCallbacks(TransportState* state) FL_NO_EXCEPT {
+    auto request_source = [state]() -> fl::optional<fl::json> {
+        if (state == nullptr || state->tail == state->head) {
+            return fl::nullopt;
+        }
+        fl::string raw = state->ring_buffer[state->tail];
+        state->tail = nextRingIndex(state->tail);
+        fl::string_view view = raw;
+        if (view.starts_with("REMOTE: ")) {
+            view.remove_prefix(8);
+        }
+        while (!view.empty() && fl::isspace(view.front())) {
+            view.remove_prefix(1);
+        }
+        while (!view.empty() && fl::isspace(view.back())) {
+            view.remove_suffix(1);
+        }
+        if (view.empty()) {
+            return fl::nullopt;
+        }
+        return fl::json::parse(fl::string(view));
+    };
+
+    auto response_sink = [state](const fl::json& response) {
+        if (state == nullptr) {
+            return;
+        }
+        state->last_tx_value = formatJsonResponse(response, "REMOTE: ");
+        if (!state->connected || state->tx_handle == 0) {
+            return;
+        }
+        fl::vector<u8> payload;
+        payload.reserve(state->last_tx_value.size());
+        for (char value : state->last_tx_value) {
+            payload.push_back(static_cast<u8>(value));
+        }
+        const u8 result = att_server_notify(
+            state->connection, state->tx_handle, payload.data(),
+            static_cast<u16>(payload.size()));
+        if (result != ERROR_CODE_SUCCESS) {
+            FL_WARN_F("[BLE RP] notify failed: %s", result);
+        }
+    };
+
+    return {request_source, response_sink};
+}
+
+} // namespace ble
+} // namespace net
+} // namespace fl
+
+#endif // FL_BLE_AVAILABLE && FL_IS_RP2350

--- a/src/platforms/esp/32/drivers/ble/ble_esp32.cpp.hpp
+++ b/src/platforms/esp/32/drivers/ble/ble_esp32.cpp.hpp
@@ -6,8 +6,9 @@
 #pragma once
 
 #include "fl/net/ble.h"
+#include "platforms/esp/is_esp.h"
 
-#if FL_BLE_AVAILABLE
+#if FL_BLE_AVAILABLE && defined(FL_IS_ESP32)
 
 #include "fl/stl/int.h"
 #include "fl/system/heap.h"
@@ -502,4 +503,4 @@ getTransportCallbacks(TransportState* state) FL_NO_EXCEPT {
 } // namespace net
 } // namespace fl
 
-#endif // FL_BLE_AVAILABLE
+#endif // FL_BLE_AVAILABLE && FL_IS_ESP32


### PR DESCRIPTION
Refs #3832, #3861

## Summary
- enable Arduino-Pico's BLE archive and BTstackLib for the RP2350W profile
- implement the FastLED BLE GATT request/response transport using singleton-owned RP callback state
- add a device-to-device RP2350W OTA AutoResearch flow (`--net-peer --ota`) that never changes host WiFi or invokes a raw flasher
- stage the RP image on the C6 in LittleFS, verify its SHA-256, stream it on the C6 AP, then confirm the C6 served it after the RP reboots
- explicitly link Arduino-Pico HTTPUpdate so this deployment path works under fbuild
- fix the AutoResearch ESP32-C6 raw-PARLIO TX configuration so the peer fixture builds with ESP-IDF 5.3

## Verification
- uv run pytest ci/tests/test_rp2350w_board_config.py ci/tests/test_parlio_raw_config.py ci/tests/test_autoresearch_net.py -q
  - 12 passed
- bash lint
- FBUILD_EXECUTABLE=<local merged fbuild> FBUILD_DEV_MODE=1 bash compile rp2350w --examples AutoResearch
  - Flash 1.21 MB / 4 MB; RAM 159.91 KB / 512 KB
- bash compile esp32c6 --examples AutoResearch
  - Flash 2.52 MB / 4 MB (2,642,841 bytes)

## Remaining validation
- Peer OTA and BLE HIL are blocked until the attached RP2350W appears healthy/selectable; current COM17 is a phantom Code 43 device.
- Once healthy: `bash autoresearch rp2350w --net-peer --ota --upload-port COM17 --peer-environment esp32c6 --peer-upload-port COM9 --timeout 360s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Bluetooth Low Energy support for RP2350 boards, including GATT communication and JSON notifications.
  - Added OTA firmware transfer and update workflows between ESP32-C6 and RP2350W devices.
  - Added automatic IPv4 and Bluetooth configuration for RPI_PICO2_W boards.

- **Enhancements**
  - Added board-specific build options and library dependencies.
  - Improved build tool selection through `FBUILD_EXECUTABLE`.
  - Improved handling of fragmented BLE messages.

- **Bug Fixes**
  - Corrected PARLIO raw transmission clock-edge configuration.
  - Improved platform-specific BLE detection and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->