### PR TITLE
fix(ci): install libslirp0 for QEMU jobs

### DIFF
--- a/.github/workflows/qemu_template.yml
+++ b/.github/workflows/qemu_template.yml
@@ -42,12 +42,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install QEMU runtime libraries (libSDL2)
+      - name: Install QEMU runtime libraries (libSDL2, libslirp)
         # The Espressif QEMU binary that fbuild downloads is dynamically
-        # linked against libSDL2-2.0.so.0 on Linux.
+        # linked against libSDL2-2.0.so.0 and libslirp.so.0 on Linux.
+        # Without libslirp0 the binary aborts at startup with
+        # "libslirp.so.0: cannot open shared object file" (exit 127).
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0
+          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libslirp0
 
       - name: Pin python version
         run: echo "3.11" > .python-version


### PR DESCRIPTION
## Problem

`esp32s3_qemu_rmt / qemu_test` fails with exit code 127 before running any test:

```
qemu-system-xtensa: error while loading shared libraries:
libslirp.so.0: cannot open shared object file: No such file or directory
QEMU ESP32S3 test-emu failed: failed: QEMU exited with code 127
```

Observed on https://github.com/FastLED/FastLED/actions/runs/31091411573/job/92583052211.

## Cause

The Espressif `qemu-system-*` binaries that fbuild downloads are dynamically linked
against `libslirp.so.0` (user-mode networking) in addition to `libSDL2-2.0.so.0`.
`.github/workflows/qemu_template.yml` installed only `libsdl2-2.0-0`, and
`ubuntu-latest` does not ship `libslirp0` by default. The failure is intermittent
across jobs only because the runner image occasionally has it pulled in transitively.

## Fix

Add `libslirp0` to the existing runtime-library install step in the shared QEMU
workflow template. This single change covers all three consumers:
`qemu_esp32c3_test.yml`, `qemu_esp32dev_test.yml`, `qemu_esp32s3_test.yml`.

## Validation

CI is the test for this change — the QEMU jobs on this PR exercise the modified
step directly. No source files are touched.

Refs #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Espressif QEMU workflow failures by installing required runtime libraries.
  * Added documentation explaining QEMU’s dynamic dependencies and missing-library errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->