### PR TITLE
fix(teensy4): vendor set_audioClock instead of the Audio library

### DIFF
--- a/src/platforms/arm/teensy/audio/pjrc_i2s_config.cpp.hpp
+++ b/src/platforms/arm/teensy/audio/pjrc_i2s_config.cpp.hpp
@@ -1,12 +1,12 @@
 // IWYU pragma: private
 
 #include "platforms/arm/teensy/audio/pjrc_i2s_config.h" // IWYU pragma: keep
+#include "fl/stl/stdint.h"
 
 #if defined(__IMXRT1062__)
 
 // IWYU pragma: begin_keep
 #include <Arduino.h>
-#include "utility/imxrt_hw.h"
 // IWYU pragma: end_keep
 
 namespace fl {
@@ -17,6 +17,43 @@ namespace {
 
 // Keep this import independent of the PJRC Audio library's AudioStream.h.
 constexpr int kAudioSampleRateHz = 44100;
+
+// FastLED change: vendored from the Teensyduino 1.60 Audio library
+// (`libraries/Audio/utility/imxrt_hw.cpp`, MIT, Copyright (c) 2019 Frank Bösing).
+//
+// This file previously reached outside the directory via
+// `#include "utility/imxrt_hw.h"` to call the library's `set_audioClock`. That
+// contradicted this directory's design (see README.md: it is a FastLED-owned
+// subset that "deliberately does not use the umbrella Audio.h header") and it
+// only linked when a sketch happened to pull the whole Audio library in.
+// Sketches that use FastLED's I2S input without the Audio library failed at
+// link time with `undefined reference to set_audioClock(int, long, unsigned
+// long, bool)`. Importing the one routine we actually need removes the last
+// dependency on the external library. See FastLED #3838.
+//
+// Kept in this anonymous namespace on purpose: a file-local definition cannot
+// collide with the Audio library's global `::set_audioClock` in sketches that
+// legitimately link both.
+FLASHMEM void set_audioClock(int nfact, fl::i32 nmult, fl::u32 ndiv,
+                             bool force = false) { // sets PLL4
+	if (!force && (CCM_ANALOG_PLL_AUDIO & CCM_ANALOG_PLL_AUDIO_ENABLE)) return;
+
+	CCM_ANALOG_PLL_AUDIO = CCM_ANALOG_PLL_AUDIO_BYPASS
+	                     | CCM_ANALOG_PLL_AUDIO_ENABLE
+	                     | CCM_ANALOG_PLL_AUDIO_POWERDOWN
+	                     | CCM_ANALOG_PLL_AUDIO_DIV_SELECT(nfact);
+
+	CCM_ANALOG_PLL_AUDIO_NUM   = nmult & CCM_ANALOG_PLL_AUDIO_NUM_MASK;
+	CCM_ANALOG_PLL_AUDIO_DENOM = ndiv & CCM_ANALOG_PLL_AUDIO_DENOM_MASK;
+
+	CCM_ANALOG_PLL_AUDIO &= ~CCM_ANALOG_PLL_AUDIO_POWERDOWN; // switch on PLL
+	while (!(CCM_ANALOG_PLL_AUDIO & CCM_ANALOG_PLL_AUDIO_LOCK)) {} // wait for lock
+
+	// post-divider: the audio path uses 1 (other valid values are 2 and 4)
+	CCM_ANALOG_MISC2 &= ~(CCM_ANALOG_MISC2_DIV_MSB | CCM_ANALOG_MISC2_DIV_LSB);
+
+	CCM_ANALOG_PLL_AUDIO &= ~CCM_ANALOG_PLL_AUDIO_BYPASS; // disable bypass
+}
 
 } // namespace
 


### PR DESCRIPTION
## Problem

`teensy41` has been **red on master itself** (e.g. [run 31084792473](https://github.com/FastLED/FastLED/actions/runs/31084792473) at `e1190d455`), failing to link `Audio`, `AudioInput`, `AudioReactive` and `ElPanelReactive`:

```
ld: .lto-tmp/ccKa7mBe.ltrans0.ltrans.o: in function `loop':
<artificial>:(.text+0x5626): undefined reference to `set_audioClock(int, long, unsigned long, bool)'
collect2: error: ld returned 1 exit status
```

## Cause

`src/platforms/arm/teensy/audio/` is a FastLED-owned subset of the PJRC Teensy Audio implementation. Its `README.md` says it *"deliberately does not use the umbrella `Audio.h` header"*.

`pjrc_i2s_config.cpp.hpp` broke that rule: it reached outside the directory via `#include "utility/imxrt_hw.h"` to call the Audio library's `set_audioClock`. The **declaration** resolved fine, which is why this compiled — but the **defining** translation unit (`libraries/Audio/utility/imxrt_hw.cpp`) is only built when a sketch pulls the entire Audio library in. Any sketch using FastLED's I2S input without the Audio library fails at link time.

Put differently: the README says the I2S clock configuration was imported from `output_i2s.cpp`, but the PLL4 setup routine that code *calls* was never imported alongside it.

## Fix

Import that one routine (from Teensyduino 1.60 `libraries/Audio/utility/imxrt_hw.cpp`, MIT, © 2019 Frank Bösing) and drop the external include. This removes the directory's last dependency on the Audio library, restoring the invariant the README already documents.

It is deliberately **file-local in an anonymous namespace**, so it cannot collide with the Audio library's global `::set_audioClock` in sketches that legitimately link both.

Upstream's `div_post_pll` branch is simplified away: the audio path only ever uses a post-divider of 1, so the two conditional `CCM_ANALOG_MISC2` bit-sets were dead in this context. The register is still cleared exactly as upstream does.

## Validation — all local

**GitHub Actions is in a major outage right now**, so this was validated on the bench instead of in CI:

- **Reproduced the failure**: reverted the change and rebuilt on `master` → the exact CI error, `undefined reference to set_audioClock(int, long, unsigned long, bool)`.
- **Confirmed the fix**: with the change, all four previously-failing examples compile and link (`Audio` 126KB flash / 78.91KB RAM; `AudioInput`, `AudioReactive`, `ElPanelReactive` all `SUCCESS`).
- `bash lint` → all checks passed.
- `bash test --cpp` → **362/362 passed**.

No hardware run: this is a link-level fix and the register sequence is byte-for-byte upstream's.

Fixes #3838
Refs #3775, #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio clock configuration on supported Teensy devices.
  * Enhanced audio PLL initialization and stability before I2S audio setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->