### PR TITLE
fix(esp32p4): include the esp_h264 sw decoder header, hold Frame by pointer

### DIFF
--- a/src/platforms/esp/32/codec/h264_hw_decoder.hpp
+++ b/src/platforms/esp/32/codec/h264_hw_decoder.hpp
@@ -14,11 +14,21 @@
 // Check if the esp_h264 component is available.
 // Install via: idf.py add-dependency "espressif/esp_h264^1.2.0"
 // Or add to idf_component.yml: espressif/esp_h264: "^1.2.0"
-#if FL_HAS_INCLUDE("esp_h264_dec.h")
+//
+// Probe the *software* decoder header specifically. `esp_h264_dec_sw_new`
+// and `esp_h264_dec_cfg_sw_t` — the two symbols this file actually uses —
+// live in `sw/include/esp_h264_dec_sw.h`, not in the interface-level
+// `esp_h264_dec.h`. Probing the latter reported the component as available
+// while leaving those two undeclared, which is why the esp32p4 build failed
+// with "'esp_h264_dec_sw_new' was not declared in this scope". The sw header
+// includes `esp_h264_dec.h` itself, so the interface types still come along.
+#if FL_HAS_INCLUDE("esp_h264_dec_sw.h")
 #define FL_H264_HW_AVAILABLE 1
 #include "esp_h264_dec.h"
+#include "esp_h264_dec_sw.h"
 #include "esp_h264_types.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/unique_ptr.h"
 #else
 #define FL_H264_HW_AVAILABLE 0
 #endif
@@ -88,7 +98,11 @@ struct H264HwDecoder::Impl {
     bool ready = false;
     bool error = false;
     fl::string errorMsg;
-    Frame currentFrame{0};
+    // Held by pointer because Frame has a const member and therefore a
+    // deleted copy-assignment (and no move-assignment), so a decoded frame
+    // cannot be assigned over a Frame value. Replacing the pointer is the
+    // only way to swap in a newly decoded frame.
+    fl::unique_ptr<Frame> currentFrame;
 
     fl::vector<fl::u8> mp4Data;
     fl::vector<fl::u8> annexB;
@@ -262,7 +276,8 @@ DecodeResult H264HwDecoder::decode() FL_NO_EXCEPT {
                 }
             }
 
-            mImpl->currentFrame = Frame(rgbBuf.data(), w, h, PixelFormat::RGB888, 0);
+            mImpl->currentFrame = fl::make_unique<Frame>(
+                rgbBuf.data(), w, h, PixelFormat::RGB888, 0);
             mImpl->frameDecoded = true;
             return DecodeResult::Success;
         }
@@ -274,7 +289,12 @@ DecodeResult H264HwDecoder::decode() FL_NO_EXCEPT {
 }
 
 Frame H264HwDecoder::getCurrentFrame() FL_NO_EXCEPT {
-    return mImpl->currentFrame;
+    // Matches the previous value-member behaviour: before any successful
+    // decode, hand back an empty frame rather than dereferencing null.
+    if (!mImpl->currentFrame) {
+        return Frame(0);
+    }
+    return *mImpl->currentFrame;
 }
 
 bool H264HwDecoder::hasMoreFrames() const FL_NO_EXCEPT {


### PR DESCRIPTION
## Problem

`esp32p4` has been **red on master** ([run 31143399255](https://github.com/FastLED/FastLED/actions/runs/31143399255)) with two compile errors in `platforms/esp/32/codec/h264_hw_decoder.hpp`:

```
error: 'esp_h264_dec_sw_new' was not declared in this scope; did you mean 'esp_h264_dec_open'?
error: use of deleted function 'fl::Frame& fl::Frame::operator=(const fl::Frame&)'
```

Both are genuine — this file has not compiled since the tree restore in #3347.

## Cause 1 — the availability probe checks the wrong header

The file gated on `FL_HAS_INCLUDE("esp_h264_dec.h")` and included only that. But the two symbols it actually uses, `esp_h264_dec_sw_new` and `esp_h264_dec_cfg_sw_t`, are declared in the component's **`sw/include/esp_h264_dec_sw.h`**:

```c
// espressif__esp_h264/sw/include/esp_h264_dec_sw.h
typedef esp_h264_dec_cfg_t esp_h264_dec_cfg_sw_t;
esp_h264_err_t esp_h264_dec_sw_new(const esp_h264_dec_cfg_sw_t *cfg, esp_h264_dec_handle_t *out_dec);
```

So `FL_H264_HW_AVAILABLE` went to 1 — the component *is* present — while those two stayed undeclared. Probing and including the sw header fixes it; that header includes `esp_h264_dec.h` itself, so the interface-level types still come along.

Checked against the vendor header actually shipped with `framework-arduinoespressif32` 3.3.11 (`esp32-arduino-libs/esp32p4/include/espressif__esp_h264/`), not inferred from the error message's `did you mean` suggestion.

## Cause 2 — `Frame` is not assignable

`fl::Frame` holds a `const size_t mPixelsCount`, so copy-assignment is explicitly `= delete`d (with that exact reason in the comment) and no move-assignment is generated. `mImpl->currentFrame = Frame(...)` therefore cannot compile at all.

Fixed by holding the decoded frame in a `fl::unique_ptr<Frame>` and replacing the pointer. `getCurrentFrame()` returns `Frame(0)` when nothing has been decoded yet, matching the previous `Frame currentFrame{0}` value-member behaviour rather than dereferencing null.

`fl::optional` was not an option here: its `emplace` does `mValue = fl::move(value)`, which needs the move-assignment `Frame` doesn't have.

## Validation

Reproduced and fixed against a **real esp32p4 build** on this machine, not just CI:

| | `sw_new` errors | deleted-`operator=` errors | result |
|---|---|---|---|
| before | 4 | 4 | board build **FAILED** |
| after | 0 | 0 | **SUCCESS: Blink** |

- `bash lint` → clean
- `bash test --cpp` → **362/362 passed**

No hardware run: this is a compile-level fix, and the decode path is unchanged apart from where the frame is stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved H.264 decoding availability detection on supported ESP platforms.
  * Prevented invalid frame access before decoding begins.
  * Ensured decoded frames are returned correctly after successful decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->