### PR TITLE
chore(deps): bump fbuild pin to 2.5.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.14",
+    "fbuild==2.5.15",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
fbuild **2.5.15** was published to PyPI at 2026-08-07 05:34:16Z (tag `v2.5.15`). Bumping the pin from 2.5.14.

## What this unblocks

Three fixes, all confirmed ancestors of the tag (`git merge-base --is-ancestor`):

| Commit | |
|---|---|
| `2976d863` | fix(rp): honor Arduino Bluetooth menu (FastLED/fbuild#1263) |
| `0dd68b24` | fix(teensy): run the link in the build dir (FastLED/fbuild#1268) |
| `1324d6c6` | fix(arm): run the link in the build dir for every ARM linker (FastLED/fbuild#1270) |

- **#1263** makes `board_build.ipbtstack = ipv4btcble` actually take effect, so `libipv4-bt.a` is linked instead of `libipv4.a` and `BTstackLib` compiles. Without it the rp2350w build dies at `_needsbt.h`'s `static_assert(ENABLE_CLASSIC, ...)` — the blocker on every RP2350W HIL flow in #3864.
- **#1268 / #1270** stop the ARM link running in the fbuild daemon's inherited cwd, which was dropping a stray 0-byte `-r` into the repo root on every clean build (#3867).

## Validation — against the published wheel

This matters specifically because the earlier rp2350w validation on #3864 was done with a *local fbuild development executable* and was therefore **not reproducible from a clean checkout**. This run uses the registry install:

```
$ bash compile rp2350w --examples AutoResearch
build succeeded in 253.7s (flash: 1177936 bytes, ram: 132048 bytes)
SUCCESS: AutoResearch
```

- Working tree clean afterwards — **no stray `-r`**, confirming the link-cwd fix in the shipped artifact.
- Byte-identical flash/RAM to the local-build result, so the published wheel behaves the same as what was tested pre-release.
- `bash lint` → clean.
- C++ tests fingerprint-skipped (this commit changes no C++); cached result is 362/362.

`uv.lock` is gitignored here, so `pyproject.toml` is the only tracked change.

## Note

This clears blocker 1 of 3 on #3864. The remaining two are physical: COM17 still enumerates as `health=phantom`, and no ESP32-C6 is attached for the `--net-peer` / `--ota` legs.

Refs #3864, #3867, FastLED/fbuild#1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to version 2.5.15 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->