### PR TITLE
feat(autoresearch): warn when USB selective suspend can drop a HIL board

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -192,6 +192,62 @@ bash autoresearch teensy41 --flex-io --tx-pin <tx> --rx-pin <rx> --timeout 120s
 `ci/autoresearch/args.py`; `--env <environment>` is the equivalent named form.
 Use the positional form in docs unless the task specifically needs `--env`.
 
+### Choosing (and not choosing) `--upload-port`
+
+`--upload-port` disambiguates *which* board to flash when several are attached.
+It is not a way to force a board that is not enumerating, and passing it
+reflexively can hurt:
+
+- **RP-series (RP2040 / RP2350).** fbuild deliberately excludes known-unhealthy
+  Raspberry Pi CDC records from deploy selection and continues via the
+  BOOTSEL-volume path (FastLED/fbuild#1147). Naming the port explicitly pins
+  deploy to that one record and skips the fallback, turning a recoverable
+  situation into a hard failure. Omit `--upload-port` unless two RP boards are
+  attached at once.
+- **If a board is in BOOTSEL with no working CDC port**, flash the UF2 directly:
+  `--upload-port UF2=<volume>` (e.g. `UF2=E:\`). This bypasses the serial port
+  entirely and uses the bootrom's own USB stack.
+- **ESP32 / Teensy / LPC** benches usually *do* want an explicit port, because
+  several identical boards are typically attached.
+
+### Windows USB selective suspend
+
+Windows may power down a USB port mid-session ("USB selective suspend" in the
+power plan, "allow the computer to turn off this device" per device). A board
+that does not resume cleanly comes back as
+`Unknown USB Device (Device Descriptor Request Failed)` — problem code 43 — and
+its stale COM record then shows `health=phantom` in `fbuild port scan`.
+
+That looks identical to a wedged board and has sent investigations down the
+wrong path (see #3864). Before assuming a board is wedged, check whether it is
+even attached:
+
+```powershell
+Get-PnpDevice -Class Ports | Select-Object Status, Present, FriendlyName
+Get-PnpDeviceProperty -InstanceId '<instance>' -KeyName DEVPKEY_Device_LastArrivalDate
+```
+
+`health=phantom` means **the devnode is a leftover record for hardware that is
+not currently attached** — not that the device is broken. `Present = False`
+plus an old `LastArrivalDate` means "plug it in", not "recover it".
+
+`bash autoresearch` runs a preflight (`ci/autoresearch/usb_power.py`) that warns
+before deploy when selective suspend is allowed on the target's hub chain, or —
+when the board is absent so the chain cannot be resolved — when it is enabled in
+the active power plan. The warning is advisory and never fails a run. To turn it
+off, from an elevated shell:
+
+```powershell
+powercfg -setacvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 `
+    48e6b7a6-50f5-4782-a5d4-53bb8f07e226 0
+```
+
+Distinguishing firmware wedge from hardware fault: **BOOTSEL uses the bootrom's
+USB stack**, independent of application firmware. A board that enumerates in
+BOOTSEL but not in application mode has a firmware problem; one that fails even
+in BOOTSEL has a cable/power/hardware problem, and no software recovery will
+help.
+
 ### Validation Levels
 
 Pick the narrowest validation level that proves the claim:

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -36,6 +36,7 @@ from ci.autoresearch.gpio import (
     run_pin_discovery,
     run_pin_discovery_segmented,
 )
+from ci.autoresearch.usb_power import warn_selective_suspend
 from ci.debug_attached import run_cpp_lint
 from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 from ci.util.blocker_alert import blocker_alert
@@ -1538,6 +1539,12 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
         print()
 
     # Phase 2+3: Build + Deploy
+    # Host power management is a common cause of a board vanishing mid-session
+    # and coming back as code 43 / health=phantom, which reads like a wedged
+    # board. Surface it before deploy so the operator sees it next to the
+    # failure rather than after a recovery hunt. Warning only — never fatal.
+    warn_selective_suspend(upload_port)
+
     print(f"\U0001f4e6 Using {build_driver.name}")
 
     if final_environment_norm in LPC_BRING_UP_ENVS:

--- a/ci/autoresearch/usb_power.py
+++ b/ci/autoresearch/usb_power.py
@@ -1,0 +1,175 @@
+"""Preflight warning for Windows USB selective suspend on HIL boards.
+
+Windows may power down a USB port to save energy ("selective suspend" in the
+power plan, "allow the computer to turn off this device" per device). A dev
+board that does not handle suspend/resume cleanly can fail to come back and
+land as `Unknown USB Device (Device Descriptor Request Failed)` — problem code
+43. In `fbuild port scan` that board's old COM record then shows as
+`health=phantom`, which reads like a wedged board and sends people chasing
+BOOTSEL and PnP recovery when the real cause is host power management.
+
+This module only *warns*. It never fails a run, never mutates host settings,
+and is a no-op off Windows. Changing the setting needs an elevated shell and
+is the operator's call:
+
+    powercfg -setacvalueindex SCHEME_CURRENT 2a737441-1930-4402-8d77-b2bebba308a3 \
+        48e6b7a6-50f5-4782-a5d4-53bb8f07e226 0
+
+See agents/docs/hardware-autoresearch.md and FastLED #3864.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Callable, Optional
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+# Windows power-setting GUIDs for the USB subgroup / selective suspend.
+_USB_SUBGROUP_GUID = "2a737441-1930-4402-8d77-b2bebba308a3"
+_SELECTIVE_SUSPEND_GUID = "48e6b7a6-50f5-4782-a5d4-53bb8f07e226"
+
+# How many parents to walk from the COM port up toward the root hub. Four
+# covers port -> composite device -> hub -> root hub with room to spare.
+_MAX_ANCESTORS = 4
+
+CommandRunner = Callable[[list[str]], str]
+
+
+def _run(cmd: list[str]) -> str:
+    """Run a command, returning stdout. Empty string on any failure."""
+    from running_process import RunningProcess
+
+    try:
+        # capture_output=True is load-bearing: it defaults to False, which
+        # streams to the console and leaves result.stdout empty, silently
+        # disabling every check in this module.
+        result = RunningProcess.run(
+            cmd, cwd=None, check=False, timeout=30, capture_output=True
+        )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        return ""
+    return result.stdout or ""
+
+
+def _powershell(script: str, run: CommandRunner) -> str:
+    return run(["powershell", "-NoProfile", "-NonInteractive", "-Command", script])
+
+
+def plan_selective_suspend_enabled(run: CommandRunner = _run) -> Optional[bool]:
+    """Is USB selective suspend enabled in the active power plan?
+
+    None when it cannot be determined (not Windows, powercfg missing, output
+    shape changed) — callers must treat None as "no opinion", not "disabled".
+    """
+    out = _run_powercfg(run)
+    if not out:
+        return None
+    # `powercfg /q` prints "Current AC Power Setting Index: 0x00000001"
+    match = re.search(r"Current AC Power Setting Index:\s*0x([0-9a-fA-F]+)", out)
+    if not match:
+        return None
+    return int(match.group(1), 16) != 0
+
+
+def _run_powercfg(run: CommandRunner) -> str:
+    return run(
+        [
+            "powercfg",
+            "/q",
+            "SCHEME_CURRENT",
+            _USB_SUBGROUP_GUID,
+            _SELECTIVE_SUSPEND_GUID,
+        ]
+    )
+
+
+def hub_chain_power_off(port: str, run: CommandRunner = _run) -> list[tuple[str, bool]]:
+    """USB ancestors of `port` and whether each may be powered off.
+
+    Returns (instance_id, power_off_allowed) pairs, nearest ancestor first.
+    Empty when the port is not present or nothing can be resolved — an absent
+    board has no live hub chain to inspect.
+    """
+    script = f"""
+$ErrorActionPreference='SilentlyContinue'
+$dev = Get-PnpDevice -Class Ports -PresentOnly |
+    Where-Object {{ $_.FriendlyName -match '\\({port}\\)' }} | Select-Object -First 1
+if (-not $dev) {{ exit 0 }}
+$id = $dev.InstanceId
+for ($i = 0; $i -lt {_MAX_ANCESTORS}; $i++) {{
+    $parent = (Get-PnpDeviceProperty -InstanceId $id -KeyName 'DEVPKEY_Device_Parent').Data
+    if (-not $parent) {{ break }}
+    if ($parent -notmatch '^USB') {{ break }}
+    $pw = Get-CimInstance -Namespace root\\wmi -ClassName MSPower_DeviceEnable |
+        Where-Object {{ $_.InstanceName -like ($parent + '*') }} | Select-Object -First 1
+    if ($pw) {{ Write-Output ("{{0}}|{{1}}" -f $parent, $pw.Enable) }}
+    $id = $parent
+}}
+"""
+    out = _powershell(script, run)
+    chain: list[tuple[str, bool]] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if "|" not in line:
+            continue
+        instance, _, enable = line.partition("|")
+        chain.append((instance.strip(), enable.strip().lower() == "true"))
+    return chain
+
+
+def selective_suspend_warnings(
+    port: str | None,
+    *,
+    platform: str | None = None,
+    run: CommandRunner = _run,
+) -> list[str]:
+    """Warning lines for a HIL run. Empty list means nothing to report."""
+    if (platform or sys.platform) != "win32":
+        return []
+
+    warnings: list[str] = []
+
+    chain = hub_chain_power_off(port, run=run) if port else []
+    powered_off = [instance for instance, enabled in chain if enabled]
+    if powered_off:
+        warnings.append(
+            f"USB selective suspend is allowed on the hub chain for {port}: "
+            + ", ".join(powered_off)
+        )
+    elif plan_selective_suspend_enabled(run=run):
+        # Fall back to the plan-wide setting when the specific chain cannot be
+        # resolved (typical when the board is not currently attached).
+        warnings.append(
+            "USB selective suspend is enabled in the active Windows power plan"
+        )
+
+    if warnings:
+        warnings.append(
+            "Windows may power down the port mid-session; a board that does not "
+            "resume cleanly then appears as 'Device Descriptor Request Failed' "
+            "(code 43) and its COM record shows health=phantom. "
+            "Disable with an elevated: powercfg -setacvalueindex SCHEME_CURRENT "
+            f"{_USB_SUBGROUP_GUID} {_SELECTIVE_SUSPEND_GUID} 0"
+        )
+    return warnings
+
+
+def warn_selective_suspend(port: str | None, *, run: CommandRunner = _run) -> None:
+    """Print selective-suspend warnings, if any. Never raises."""
+    try:
+        lines = selective_suspend_warnings(port, run=run)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception:
+        return  # a preflight hint must never break a run
+    for line in lines:
+        print(f"⚠️  {line}")
+    if lines:
+        print()

--- a/ci/tests/test_usb_power.py
+++ b/ci/tests/test_usb_power.py
@@ -1,0 +1,143 @@
+"""Tests for the USB selective-suspend preflight warning (FastLED #3864).
+
+The check exists because a Windows-suspended port makes a board come back as
+`Unknown USB Device (Device Descriptor Request Failed)` (code 43), whose stale
+COM record then shows `health=phantom` — indistinguishable at a glance from a
+wedged board, and the reason a real investigation went down the wrong path.
+"""
+
+from __future__ import annotations
+
+from ci.autoresearch.usb_power import (
+    hub_chain_power_off,
+    plan_selective_suspend_enabled,
+    selective_suspend_warnings,
+    warn_selective_suspend,
+)
+
+
+POWERCFG_ENABLED = """
+Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)
+    Power Setting GUID: 48e6b7a6-50f5-4782-a5d4-53bb8f07e226  (USB selective suspend setting)
+      Current AC Power Setting Index: 0x00000001
+      Current DC Power Setting Index: 0x00000001
+"""
+
+POWERCFG_DISABLED = POWERCFG_ENABLED.replace("0x00000001", "0x00000000")
+
+
+def _runner(mapping: dict[str, str]):
+    """Fake command runner: first matching key in argv wins."""
+
+    def run(cmd: list[str]) -> str:
+        joined = " ".join(cmd)
+        for needle, output in mapping.items():
+            if needle in joined:
+                return output
+        return ""
+
+    return run
+
+
+def test_plan_setting_parsed_enabled_and_disabled() -> None:
+    assert plan_selective_suspend_enabled(run=_runner({"powercfg": POWERCFG_ENABLED}))
+    assert not plan_selective_suspend_enabled(
+        run=_runner({"powercfg": POWERCFG_DISABLED})
+    )
+
+
+def test_plan_setting_is_none_when_undeterminable() -> None:
+    """Unparseable output must be 'no opinion', never a false 'disabled'."""
+    assert plan_selective_suspend_enabled(run=_runner({})) is None
+    assert plan_selective_suspend_enabled(run=_runner({"powercfg": "garbage"})) is None
+
+
+def test_hub_chain_parsed() -> None:
+    ps = "USB\\VID_05E3&PID_0610\\7&3afc677d&0&1|True\nUSB\\ROOT_HUB30\\5&4087d53&0&0|False\n"
+    chain = hub_chain_power_off("COM17", run=_runner({"powershell": ps}))
+    assert chain == [
+        ("USB\\VID_05E3&PID_0610\\7&3afc677d&0&1", True),
+        ("USB\\ROOT_HUB30\\5&4087d53&0&0", False),
+    ]
+
+
+def test_hub_chain_empty_when_port_absent() -> None:
+    assert hub_chain_power_off("COM17", run=_runner({"powershell": ""})) == []
+
+
+def test_warns_on_specific_hub_when_resolvable() -> None:
+    ps = "USB\\VID_05E3&PID_0610\\7&3afc677d&0&1|True\n"
+    warnings = selective_suspend_warnings(
+        "COM17", platform="win32", run=_runner({"powershell": ps})
+    )
+    assert any("hub chain for COM17" in w for w in warnings)
+    assert any("05E3" in w for w in warnings)
+    # remediation must always accompany the finding
+    assert any("powercfg -setacvalueindex" in w for w in warnings)
+
+
+def test_falls_back_to_plan_setting_when_hub_unresolvable() -> None:
+    """The board is usually absent when someone is debugging this, so the
+    per-device chain is empty; the plan-wide setting still tells us something."""
+    warnings = selective_suspend_warnings(
+        "COM17",
+        platform="win32",
+        run=_runner({"powershell": "", "powercfg": POWERCFG_ENABLED}),
+    )
+    assert any("active Windows power plan" in w for w in warnings)
+
+
+def test_silent_when_nothing_is_suspendable() -> None:
+    ps = "USB\\ROOT_HUB30\\5&4087d53&0&0|False\n"
+    assert (
+        selective_suspend_warnings(
+            "COM17",
+            platform="win32",
+            run=_runner({"powershell": ps, "powercfg": POWERCFG_DISABLED}),
+        )
+        == []
+    )
+
+
+def test_no_op_off_windows() -> None:
+    """Must stay silent on Linux/macOS CI rather than shelling out."""
+    calls: list[list[str]] = []
+
+    def run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        return POWERCFG_ENABLED
+
+    assert selective_suspend_warnings("COM17", platform="linux", run=run) == []
+    assert calls == [], "must not shell out on non-Windows"
+
+
+def test_default_runner_captures_output(monkeypatch) -> None:
+    """Regression: RunningProcess.run defaults to capture_output=False, which
+    streams to the console and leaves stdout empty — silently disabling every
+    check here. The injected-runner tests cannot catch this."""
+    import running_process
+
+    from ci.autoresearch import usb_power
+
+    seen: dict[str, object] = {}
+
+    class _Result:
+        stdout = "ok"
+
+    def fake_run(args, **kwargs):
+        seen.update(kwargs)
+        return _Result()
+
+    monkeypatch.setattr(running_process.RunningProcess, "run", staticmethod(fake_run))
+    assert usb_power._run(["powercfg"]) == "ok"
+    assert seen.get("capture_output") is True
+
+
+def test_warn_never_raises(capsys) -> None:
+    """A preflight hint must never be able to fail a HIL run."""
+
+    def exploding(cmd: list[str]) -> str:
+        raise RuntimeError("wmi exploded")
+
+    warn_selective_suspend("COM17", run=exploding)  # must not propagate
+    warn_selective_suspend(None, run=exploding)


### PR DESCRIPTION
## Why

Windows may power down a USB port mid-session. A board that does not resume cleanly comes back as `Unknown USB Device (Device Descriptor Request Failed)` — code 43 — and its stale COM record then shows `health=phantom` in `fbuild port scan`.

That is indistinguishable at a glance from a wedged board. It sent the #3864 investigation on a long detour into BOOTSEL and scoped PnP recovery, when the board was in fact simply **not attached** (`Present = False`, `LastArrivalDate` six days old).

## What

A preflight in `ci/autoresearch/usb_power.py`, called from `_run_build_deploy` just before deploy:

- resolves the target port's USB ancestor chain and warns if any hop allows power-off
- falls back to the power-plan setting when the chain can't be resolved — which is the normal case when the board is absent, i.e. exactly when someone is debugging this
- advisory only: never fails a run, never mutates host settings, no-op off Windows

Verified live on this bench — all three hops of COM9's chain (two Realtek hubs + root hub) allow power-off, and 18/18 USB nodes on the host have it enabled:

```
⚠️  USB selective suspend is allowed on the hub chain for COM9:
    USB\VID_0BDA&PID_5411\7&25f0bd90&1&3, USB\VID_0BDA&PID_5411\6&2838f1dc&0&1,
    USB\ROOT_HUB30\5&23f8e3f5&0&0
⚠️  Windows may power down the port mid-session; ... Disable with an elevated:
    powercfg -setacvalueindex SCHEME_CURRENT 2a737441-... 48e6b7a6-... 0
```

## Docs

`agents/docs/hardware-autoresearch.md` gains the three things that would have prevented the detour:

1. **`health=phantom` means "leftover record for hardware that is NOT attached"**, not "broken device". Check `Present` and `DEVPKEY_Device_LastArrivalDate` *before* attempting recovery — absent and broken hardware look identical in a port scan but need opposite responses.
2. **BOOTSEL runs the bootrom's USB stack**, so it cleanly separates a firmware wedge from a cable/power/hardware fault.
3. **When to pass `--upload-port` and when not to.** For RP-series it pins deploy to one record and defeats fbuild's own exclusion of unhealthy CDC records plus its BOOTSEL-volume fallback (FastLED/fbuild#1147); `--upload-port UF2=<volume>` is the escape hatch. ESP32 / Teensy / LPC benches usually *do* want an explicit port, so this is a targeted note rather than a blanket removal.

## A bug worth calling out

The first version used `subprocess.run`; the linter correctly pushed me to `RunningProcess.run`. That call defaults to **`capture_output=False`**, which streams to the console and leaves `stdout` empty — silently disabling every check in the module. My unit tests inject a fake runner, so they passed while the feature was completely broken; only re-running the live check caught it.

Fixed, with `test_default_runner_captures_output` monkeypatching `RunningProcess.run` to assert `capture_output=True` is requested. Worth knowing about for any other module that switches over.

## Validation

- `bash lint` clean (including the KBI and `SRC001`/RunningProcess ratchets)
- `bash test --cpp` passing
- 10 new tests, covering both resolution paths, the fallback, the silent case, the non-Windows no-op, never-raises, and the capture_output regression

Refs #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows diagnostics for USB selective suspend, helping identify connection issues before device uploads.
  * Added non-blocking warnings when power settings may affect hardware detection or flashing.
  * Added guidance for selecting upload ports, including RP-series fallback behavior, direct UF2 flashing, and BOOTSEL troubleshooting.

* **Documentation**
  * Expanded hardware setup and troubleshooting guidance for Windows USB behavior and upload workflows.

* **Tests**
  * Added coverage for power-plan detection, USB hub analysis, warning behavior, and safe handling of unavailable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->