### PR TITLE
fix(autoresearch): fail fast when --upload-port is not attached

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -210,6 +210,25 @@ reflexively can hurt:
 - **ESP32 / Teensy / LPC** benches usually *do* want an explicit port, because
   several identical boards are typically attached.
 
+An explicit `--upload-port` is checked for presence *before* the build, because
+a port that is not attached can only fail — and it used to fail at deploy, after
+roughly seven minutes of package install, lint and build:
+
+```
+❌ COM17 is not attached, last seen 5d ago. Windows keeps the record after a
+   board is unplugged, so this is a stale devnode, not a fault — plug the board
+   in and re-run.
+```
+
+Two deliberate limits on that check. It fires only when the port is named
+explicitly, since without one fbuild can still reach an RP board through the
+BOOTSEL volume with no CDC record at all. And it fires only on an unambiguous
+`Present = False`; if the host cannot answer, the run proceeds, because a query
+failure must never block a board that is sitting there healthy.
+
+For a fuller picture of one port — problem code, hub chain, last-seen,
+remediation — use `fbuild port doctor --port COM17`.
+
 ### Windows USB selective suspend
 
 Windows may power down a USB port mid-session ("USB selective suspend" in the

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -36,7 +36,7 @@ from ci.autoresearch.gpio import (
     run_pin_discovery,
     run_pin_discovery_segmented,
 )
-from ci.autoresearch.usb_power import warn_selective_suspend
+from ci.autoresearch.usb_power import absent_port_error, warn_selective_suspend
 from ci.debug_attached import run_cpp_lint
 from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 from ci.util.blocker_alert import blocker_alert
@@ -1522,6 +1522,17 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
     upload_port = ctx.upload_port
     build_driver = ctx.build_driver
     assert build_driver is not None
+
+    # Preflight: an explicitly-named port that is not attached can only fail,
+    # and it fails at deploy — after ~7 minutes of install, lint and build.
+    # Checked before Phase 0 so the operator gets the real reason in seconds.
+    # Only an explicit --upload-port is gated: without one, fbuild can still
+    # reach an RP-series board through the BOOTSEL volume with no CDC record.
+    if args.upload_port:
+        absent = absent_port_error(args.upload_port)
+        if absent:
+            print(f"\n❌ {absent}")
+            return 1
 
     # Phase 0: Package Installation
     if not build_driver.install_packages(build_dir, build_environment):

--- a/ci/autoresearch/usb_power.py
+++ b/ci/autoresearch/usb_power.py
@@ -61,6 +61,99 @@ def _powershell(script: str, run: CommandRunner) -> str:
     return run(["powershell", "-NoProfile", "-NonInteractive", "-Command", script])
 
 
+def parse_presence(output: str) -> tuple[Optional[bool], Optional[int]]:
+    """Parse `present|last_arrival_unix_seconds` into (present, seconds-ago).
+
+    Both fields are independently optional. `(None, None)` means the host
+    could not say — which must never be reported as "absent", or a healthy
+    board would be blamed for a query failure.
+    """
+    for line in output.splitlines():
+        line = line.strip()
+        if "|" not in line:
+            continue
+        present_raw, _, arrived_raw = line.partition("|")
+        present: Optional[bool]
+        if present_raw.strip().lower() == "true":
+            present = True
+        elif present_raw.strip().lower() == "false":
+            present = False
+        else:
+            present = None
+        arrived: Optional[int] = None
+        try:
+            arrived = int(arrived_raw.strip())
+        except ValueError:
+            arrived = None
+        return present, arrived
+    return None, None
+
+
+def port_presence(
+    port: str, platform: str = sys.platform, run: CommandRunner = _run
+) -> tuple[Optional[bool], Optional[int]]:
+    """Whether `port` is in the live device tree, and when it was last seen.
+
+    Returns `(present, seconds_since_last_arrival)`. `(None, _)` off Windows
+    or when the query fails. `platform` is injectable so this can be tested on
+    non-Windows CI, matching `selective_suspend_warnings`.
+    """
+    if platform != "win32":
+        return None, None
+    script = f"""
+$ErrorActionPreference='SilentlyContinue'
+$d = Get-PnpDevice -Class Ports | Where-Object {{ $_.FriendlyName -match '\\({port}\\)' }} | Select-Object -First 1
+if (-not $d) {{ exit 0 }}
+$a = (Get-PnpDeviceProperty -InstanceId $d.InstanceId -KeyName 'DEVPKEY_Device_LastArrivalDate').Data
+$secs = ''
+if ($a) {{ $secs = [int]((Get-Date) - $a).TotalSeconds }}
+Write-Output ("{{0}}|{{1}}" -f $d.Present, $secs)
+"""
+    return parse_presence(_powershell(script, run))
+
+
+def humanise_age(secs: int) -> str:
+    """Coarse age: `45s`, `12m`, `3h`, `6d` — enough to tell live from stale."""
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86_400:
+        return f"{secs // 3600}h"
+    return f"{secs // 86_400}d"
+
+
+def absent_port_error(
+    port: str, platform: str = sys.platform, run: CommandRunner = _run
+) -> Optional[str]:
+    """Error text when an explicitly-requested port is not attached.
+
+    `None` means "carry on" — including when presence is unknowable. Only an
+    unambiguous `Present = False` stops a run.
+
+    Why this exists: `bash autoresearch --upload-port COM17` used to install
+    packages, lint and build for ~7 minutes before fbuild refused the deploy
+    on a board that was never plugged in. Worse, the refusal reads as a wedged
+    devnode, which is how FastLED #3864 lost hours to a board that had simply
+    been unplugged for six days.
+
+    Deliberately scoped to an *explicitly named* port. With no `--upload-port`
+    fbuild can still reach an RP-series board through the BOOTSEL volume even
+    with no working CDC record, so absence there is not fatal.
+    """
+    present, arrived = port_presence(port, platform=platform, run=run)
+    if present is not False:
+        return None
+    seen = f", last seen {humanise_age(arrived)} ago" if arrived is not None else ""
+    return (
+        f"{port} is not attached{seen}. Windows keeps the record after a board "
+        f"is unplugged, so this is a stale devnode, not a fault — plug the board "
+        f"in and re-run. (Deploy would fail after the build otherwise. For an "
+        f"RP-series board already in BOOTSEL, omit --upload-port or pass "
+        f"--upload-port UF2=<volume>.)"
+    )
+
+
 def plan_selective_suspend_enabled(run: CommandRunner = _run) -> Optional[bool]:
     """Is USB selective suspend enabled in the active power plan?
 

--- a/ci/tests/test_usb_power.py
+++ b/ci/tests/test_usb_power.py
@@ -9,7 +9,10 @@ wedged board, and the reason a real investigation went down the wrong path.
 from __future__ import annotations
 
 from ci.autoresearch.usb_power import (
+    absent_port_error,
     hub_chain_power_off,
+    humanise_age,
+    parse_presence,
     plan_selective_suspend_enabled,
     selective_suspend_warnings,
     warn_selective_suspend,
@@ -141,3 +144,60 @@ def test_warn_never_raises(capsys) -> None:
 
     warn_selective_suspend("COM17", run=exploding)  # must not propagate
     warn_selective_suspend(None, run=exploding)
+
+
+# --- Absent-port preflight (the ~7-minute build that could only fail) --------
+
+
+def test_parse_presence_reads_both_fields() -> None:
+    assert parse_presence("True|42") == (True, 42)
+    assert parse_presence("False|432000") == (False, 432000)
+
+
+def test_parse_presence_unknown_is_not_absent() -> None:
+    """No output, or an unparseable field, must never mean "not attached".
+
+    A query failure that reported absence would abort a run against a board
+    that is sitting there perfectly healthy.
+    """
+    assert parse_presence("") == (None, None)
+    assert parse_presence("garbage with no pipe") == (None, None)
+    assert parse_presence("Maybe|42") == (None, 42)
+    # Present but no arrival date recorded — still a definite presence answer.
+    assert parse_presence("True|") == (True, None)
+
+
+def test_humanise_age_scales() -> None:
+    assert humanise_age(45) == "45s"
+    assert humanise_age(700) == "11m"
+    assert humanise_age(7200) == "2h"
+    assert humanise_age(432000) == "5d"
+
+
+def test_absent_port_error_fires_only_on_definite_absence() -> None:
+    win = {"platform": "win32"}
+    assert absent_port_error("COM17", run=lambda cmd: "False|432000", **win) is not None
+    assert absent_port_error("COM9", run=lambda cmd: "True|60", **win) is None
+    # Unknown must be permissive, not fatal.
+    assert absent_port_error("COM9", run=lambda cmd: "", **win) is None
+
+
+def test_absent_port_error_no_op_off_windows() -> None:
+    """Linux/macOS CI has no Get-PnpDevice; must never block a run there."""
+    calls: list[list[str]] = []
+
+    def run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        return "False|432000"
+
+    assert absent_port_error("COM17", platform="linux", run=run) is None
+    assert calls == [], "must not shell out on non-Windows"
+
+
+def test_absent_port_error_explains_stale_record_and_bootsel() -> None:
+    """The message has to pre-empt the wrong conclusion, not just say "no"."""
+    msg = absent_port_error("COM17", platform="win32", run=lambda cmd: "False|432000")
+    assert msg is not None
+    assert "5d ago" in msg
+    assert "stale devnode, not a fault" in msg
+    assert "BOOTSEL" in msg


### PR DESCRIPTION
`bash autoresearch rp2350w --upload-port COM17` used to install packages, lint and build for ~7 minutes before fbuild refused the deploy — on a board that had simply not been plugged in for five days.

The wasted time is the smaller problem. The refusal surfaces as a stale `health=phantom` COM record, which reads like a *wedged devnode*, and that misreading is what sent the #3864 investigation down a BOOTSEL and PnP-recovery hunt before anyone checked whether the board was attached at all.

Now checked before Phase 0:

```
❌ COM17 is not attached, last seen 5d ago. Windows keeps the record after a
   board is unplugged, so this is a stale devnode, not a fault — plug the
   board in and re-run.
```

The message states the conclusion rather than the symptom, because the symptom is exactly what gets misread.

## Two deliberate limits

**Explicit `--upload-port` only.** Without one, fbuild can still reach an RP-series board through the BOOTSEL volume with no working CDC record (fbuild#1147), so absence there is not fatal. Gating on `args.upload_port` rather than `ctx.upload_port` keeps auto-detected ports out of scope.

**Only an unambiguous `Present = False` stops a run.** If the host cannot answer, the run proceeds — a query failure that reported absence would abort against a board sitting there perfectly healthy. "Unknown" is permissive by construction and a test pins it.

`platform` is injectable, matching `selective_suspend_warnings`, so the Windows behaviour is actually exercised on Linux CI rather than silently short-circuiting to a pass.

## Validation

Verified live, not only against fakes — the mocked-tests-pass-but-the-feature-is-dead failure has bitten this exact module before (`capture_output=False` silently disabled every check in #3872):

- `port_presence("COM17")` → `(False, 474041)` — 5d, matching the independent `DEVPKEY_Device_LastArrivalDate` of 2026-08-01, and agreeing with `fbuild port doctor --port COM17`.
- `port_presence("COM9")` → `(True, 23149)` on the attached LOLIN S3.
- End-to-end `bash autoresearch rp2350w --upload-port COM17` aborts in seconds with **exit 1**, before any build.

One PowerShell CIM query, ~1.7s, against ~7 minutes saved.

`uv run pytest ci/tests/test_usb_power.py` — 16 passed. `bash lint` clean.

## Scope

This does not close #3864. That issue's acceptance criteria are hardware-in-the-loop results, and the RP2350W is still not attached to this bench. This fixes the diagnostic that made its absence hard to recognise.

Refs #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-build validation for explicitly selected upload ports.
  * Reports missing or stale ports before installation, linting, or compilation.
  * Added `fbuild port doctor --port` for detailed port diagnostics.
  * Preserves automatic port detection and RP BOOTSEL fallback behavior.

* **Bug Fixes**
  * Prevents builds from proceeding when Windows definitively reports the selected port as absent.

* **Tests**
  * Added coverage for port detection, unknown states, age formatting, platform behavior, and diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->