### PR TITLE
fix(autoresearch): allowlist COMn before interpolating into PowerShell

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -214,7 +214,7 @@ An explicit `--upload-port` is checked for presence *before* the build, because
 a port that is not attached can only fail — and it used to fail at deploy, after
 roughly seven minutes of package install, lint and build:
 
-```
+```text
 ❌ COM17 is not attached, last seen 5d ago. Windows keeps the record after a
    board is unplugged, so this is a stale devnode, not a fault — plug the board
    in and re-run.

--- a/ci/autoresearch/usb_power.py
+++ b/ci/autoresearch/usb_power.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 
 import re
 import sys
+from dataclasses import dataclass
 from typing import Callable, Optional
+
+from typeguard import typechecked
 
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
@@ -61,13 +64,28 @@ def _powershell(script: str, run: CommandRunner) -> str:
     return run(["powershell", "-NoProfile", "-NonInteractive", "-Command", script])
 
 
-def parse_presence(output: str) -> tuple[Optional[bool], Optional[int]]:
-    """Parse `present|last_arrival_unix_seconds` into (present, seconds-ago).
+@typechecked
+@dataclass(frozen=True)
+class PortPresence:
+    """Whether a port is in the live device tree, and when it was last seen.
 
-    Both fields are independently optional. `(None, None)` means the host
-    could not say — which must never be reported as "absent", or a healthy
-    board would be blamed for a query failure.
+    `present` is deliberately tri-state. `None` means the host could not say,
+    and callers must treat that as "no opinion" rather than "absent" — see
+    `absent_port_error`, where conflating the two would abort a run against a
+    perfectly healthy board.
+
+    `last_seen_secs` is seconds since `DEVPKEY_Device_LastArrivalDate`, or
+    `None` when no arrival date is recorded. It is independent of `present`:
+    an attached board still has an arrival date, and an absent one usually
+    does too — that is exactly what makes it useful.
     """
+
+    present: Optional[bool]
+    last_seen_secs: Optional[int]
+
+
+def parse_presence(output: str) -> PortPresence:
+    """Parse a `present|last_arrival_seconds_ago` line."""
     for line in output.splitlines():
         line = line.strip()
         if "|" not in line:
@@ -85,21 +103,20 @@ def parse_presence(output: str) -> tuple[Optional[bool], Optional[int]]:
             arrived = int(arrived_raw.strip())
         except ValueError:
             arrived = None
-        return present, arrived
-    return None, None
+        return PortPresence(present=present, last_seen_secs=arrived)
+    return PortPresence(present=None, last_seen_secs=None)
 
 
 def port_presence(
     port: str, platform: str = sys.platform, run: CommandRunner = _run
-) -> tuple[Optional[bool], Optional[int]]:
-    """Whether `port` is in the live device tree, and when it was last seen.
+) -> PortPresence:
+    """Query the host for `port`'s presence and last-arrival time.
 
-    Returns `(present, seconds_since_last_arrival)`. `(None, _)` off Windows
-    or when the query fails. `platform` is injectable so this can be tested on
+    `platform` is injectable so the Windows behaviour is exercised on
     non-Windows CI, matching `selective_suspend_warnings`.
     """
     if platform != "win32":
-        return None, None
+        return PortPresence(present=None, last_seen_secs=None)
     script = f"""
 $ErrorActionPreference='SilentlyContinue'
 $d = Get-PnpDevice -Class Ports | Where-Object {{ $_.FriendlyName -match '\\({port}\\)' }} | Select-Object -First 1
@@ -141,10 +158,11 @@ def absent_port_error(
     fbuild can still reach an RP-series board through the BOOTSEL volume even
     with no working CDC record, so absence there is not fatal.
     """
-    present, arrived = port_presence(port, platform=platform, run=run)
-    if present is not False:
+    presence = port_presence(port, platform=platform, run=run)
+    if presence.present is not False:
         return None
-    seen = f", last seen {humanise_age(arrived)} ago" if arrived is not None else ""
+    age = presence.last_seen_secs
+    seen = f", last seen {humanise_age(age)} ago" if age is not None else ""
     return (
         f"{port} is not attached{seen}. Windows keeps the record after a board "
         f"is unplugged, so this is a stale devnode, not a fault — plug the board "

--- a/ci/autoresearch/usb_power.py
+++ b/ci/autoresearch/usb_power.py
@@ -36,7 +36,18 @@ _SELECTIVE_SUSPEND_GUID = "48e6b7a6-50f5-4782-a5d4-53bb8f07e226"
 
 # Only a plain COMn name is ever interpolated into a PowerShell script. See
 # `port_presence` for why this is an allowlist and not an escape.
+#
+# Matched with `fullmatch`, never `match`: `$` also matches *before* a final
+# newline, so `re.match(r"^COM\d+$", "COM1\n")` succeeds and would let a value
+# that is not a plain COMn name reach the script. The anchors are kept as
+# belt-and-braces for any future caller that reaches for `match` out of habit.
 _COM_PORT_RE = re.compile(r"^COM\d+$", re.IGNORECASE)
+
+
+def _is_com_port(port: str) -> bool:
+    """Is `port` a plain `COMn` name safe to interpolate into PowerShell?"""
+    return _COM_PORT_RE.fullmatch(port) is not None
+
 
 # How many parents to walk from the COM port up toward the root hub. Four
 # covers port -> composite device -> hub -> root hub with room to spare.
@@ -128,7 +139,7 @@ def port_presence(
     `UF2=E:\\`, whose trailing backslash would corrupt the `-match` regex.
     Neither form names a COM device, so there is nothing to look up.
     """
-    if platform != "win32" or not _COM_PORT_RE.match(port):
+    if platform != "win32" or not _is_com_port(port):
         return PortPresence(present=None, last_seen_secs=None)
     script = f"""
 $ErrorActionPreference='SilentlyContinue'
@@ -223,7 +234,7 @@ def hub_chain_power_off(port: str, run: CommandRunner = _run) -> list[tuple[str,
     Same `COMn` allowlist as `port_presence`: `port` lands in a single-quoted
     PowerShell literal, so anything else is refused rather than escaped.
     """
-    if not _COM_PORT_RE.match(port):
+    if not _is_com_port(port):
         return []
     script = f"""
 $ErrorActionPreference='SilentlyContinue'

--- a/ci/autoresearch/usb_power.py
+++ b/ci/autoresearch/usb_power.py
@@ -34,6 +34,10 @@ from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 _USB_SUBGROUP_GUID = "2a737441-1930-4402-8d77-b2bebba308a3"
 _SELECTIVE_SUSPEND_GUID = "48e6b7a6-50f5-4782-a5d4-53bb8f07e226"
 
+# Only a plain COMn name is ever interpolated into a PowerShell script. See
+# `port_presence` for why this is an allowlist and not an escape.
+_COM_PORT_RE = re.compile(r"^COM\d+$", re.IGNORECASE)
+
 # How many parents to walk from the COM port up toward the root hub. Four
 # covers port -> composite device -> hub -> root hub with room to spare.
 _MAX_ANCESTORS = 4
@@ -114,8 +118,17 @@ def port_presence(
 
     `platform` is injectable so the Windows behaviour is exercised on
     non-Windows CI, matching `selective_suspend_warnings`.
+
+    Anything that is not a plain `COMn` name returns "unknown" without
+    shelling out. That is an allowlist rather than an escape, for two
+    reasons. It closes the injection path — `port` reaches a single-quoted
+    PowerShell literal, so a value containing `'` could otherwise close the
+    string and run arbitrary code as the invoking user. And it is also a
+    correctness fix: `--upload-port` legitimately accepts forms like
+    `UF2=E:\\`, whose trailing backslash would corrupt the `-match` regex.
+    Neither form names a COM device, so there is nothing to look up.
     """
-    if platform != "win32":
+    if platform != "win32" or not _COM_PORT_RE.match(port):
         return PortPresence(present=None, last_seen_secs=None)
     script = f"""
 $ErrorActionPreference='SilentlyContinue'
@@ -206,7 +219,12 @@ def hub_chain_power_off(port: str, run: CommandRunner = _run) -> list[tuple[str,
     Returns (instance_id, power_off_allowed) pairs, nearest ancestor first.
     Empty when the port is not present or nothing can be resolved — an absent
     board has no live hub chain to inspect.
+
+    Same `COMn` allowlist as `port_presence`: `port` lands in a single-quoted
+    PowerShell literal, so anything else is refused rather than escaped.
     """
+    if not _COM_PORT_RE.match(port):
+        return []
     script = f"""
 $ErrorActionPreference='SilentlyContinue'
 $dev = Get-PnpDevice -Class Ports -PresentOnly |

--- a/ci/tests/test_usb_power.py
+++ b/ci/tests/test_usb_power.py
@@ -9,6 +9,7 @@ wedged board, and the reason a real investigation went down the wrong path.
 from __future__ import annotations
 
 from ci.autoresearch.usb_power import (
+    PortPresence,
     absent_port_error,
     hub_chain_power_off,
     humanise_age,
@@ -150,8 +151,10 @@ def test_warn_never_raises(capsys) -> None:
 
 
 def test_parse_presence_reads_both_fields() -> None:
-    assert parse_presence("True|42") == (True, 42)
-    assert parse_presence("False|432000") == (False, 432000)
+    assert parse_presence("True|42") == PortPresence(present=True, last_seen_secs=42)
+    assert parse_presence("False|432000") == PortPresence(
+        present=False, last_seen_secs=432000
+    )
 
 
 def test_parse_presence_unknown_is_not_absent() -> None:
@@ -160,11 +163,13 @@ def test_parse_presence_unknown_is_not_absent() -> None:
     A query failure that reported absence would abort a run against a board
     that is sitting there perfectly healthy.
     """
-    assert parse_presence("") == (None, None)
-    assert parse_presence("garbage with no pipe") == (None, None)
-    assert parse_presence("Maybe|42") == (None, 42)
+    assert parse_presence("") == PortPresence(present=None, last_seen_secs=None)
+    assert parse_presence("garbage with no pipe") == PortPresence(
+        present=None, last_seen_secs=None
+    )
+    assert parse_presence("Maybe|42") == PortPresence(present=None, last_seen_secs=42)
     # Present but no arrival date recorded — still a definite presence answer.
-    assert parse_presence("True|") == (True, None)
+    assert parse_presence("True|") == PortPresence(present=True, last_seen_secs=None)
 
 
 def test_humanise_age_scales() -> None:

--- a/ci/tests/test_usb_power.py
+++ b/ci/tests/test_usb_power.py
@@ -15,6 +15,7 @@ from ci.autoresearch.usb_power import (
     humanise_age,
     parse_presence,
     plan_selective_suspend_enabled,
+    port_presence,
     selective_suspend_warnings,
     warn_selective_suspend,
 )
@@ -206,3 +207,55 @@ def test_absent_port_error_explains_stale_record_and_bootsel() -> None:
     assert "5d ago" in msg
     assert "stale devnode, not a fault" in msg
     assert "BOOTSEL" in msg
+
+
+# --- PowerShell interpolation allowlist --------------------------------------
+
+
+def test_port_presence_refuses_non_com_names_without_shelling_out() -> None:
+    """`port` lands in a single-quoted PowerShell literal, so a value with a
+    quote could close the string and run code as the invoking user. Refused by
+    allowlist rather than escaped — and the runner must never even be called."""
+    calls: list[list[str]] = []
+
+    def run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        return "True|1"
+
+    hostile = "COM1') ; Remove-Item C:\\ -Recurse ; ('"
+    assert port_presence(hostile, platform="win32", run=run) == PortPresence(
+        present=None, last_seen_secs=None
+    )
+    # A legitimate non-COM upload-port form must also be refused: `UF2=E:\`
+    # names a volume, not a COM device, and its trailing backslash would
+    # corrupt the -match regex.
+    assert port_presence("UF2=E:\\", platform="win32", run=run) == PortPresence(
+        present=None, last_seen_secs=None
+    )
+    assert calls == [], "must not shell out for a non-COM port name"
+
+
+def test_absent_port_error_never_aborts_on_a_non_com_port() -> None:
+    """Refusal is 'unknown', so a UF2 deploy is never blocked by this check."""
+    assert (
+        absent_port_error("UF2=E:\\", platform="win32", run=lambda c: "False|9") is None
+    )
+
+
+def test_hub_chain_refuses_non_com_names() -> None:
+    calls: list[list[str]] = []
+
+    def run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        return "USB\\X|True\n"
+
+    assert hub_chain_power_off("COM1'; calc; '", run=run) == []
+    assert calls == []
+
+
+def test_com_allowlist_still_accepts_real_ports() -> None:
+    """The guard must not be so tight that it breaks the actual use case."""
+    for good in ("COM9", "COM17", "com3", "COM255"):
+        assert port_presence(good, platform="win32", run=lambda c: "True|5") == (
+            PortPresence(present=True, last_seen_secs=5)
+        )

--- a/ci/tests/test_usb_power.py
+++ b/ci/tests/test_usb_power.py
@@ -259,3 +259,23 @@ def test_com_allowlist_still_accepts_real_ports() -> None:
         assert port_presence(good, platform="win32", run=lambda c: "True|5") == (
             PortPresence(present=True, last_seen_secs=5)
         )
+
+
+def test_com_allowlist_rejects_trailing_newline() -> None:
+    """`$` matches before a final newline, so `re.match` accepts "COM1\n".
+
+    Only `fullmatch` rejects it. Without this the guard would pass a value
+    that is not a plain COMn name into PowerShell construction.
+    """
+    calls: list[list[str]] = []
+
+    def run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        return "True|1"
+
+    for sneaky in ("COM1\n", "COM1\r\n", "COM1 ", " COM1", "COM1\t"):
+        assert port_presence(sneaky, platform="win32", run=run) == PortPresence(
+            present=None, last_seen_secs=None
+        ), f"{sneaky!r} must be rejected"
+        assert hub_chain_power_off(sneaky, run=run) == []
+    assert calls == [], "must not shell out for a non-COM port name"


### PR DESCRIPTION
Follow-up to #3873. Those review fixes were pushed to the branch after #3873 had already been squash-merged, so they never reached master — this carries them over, rebased onto master.

**The security fix is the reason this matters.** It is currently live on master.

## 1. PowerShell injection via `--upload-port`

`port` was interpolated straight into a single-quoted PowerShell literal:

```powershell
Where-Object { $_.FriendlyName -match '\(COM17\)' }
```

A value containing `'` closes that string and runs arbitrary PowerShell as the invoking user. Now refused by allowlist (`^COM\d+$`); rejected values never spawn the subprocess at all.

**Allowlist rather than `[regex]::Escape`, deliberately.** Escaping here needs two independent layers to be correct — PowerShell quoting *and* regex metacharacters, since the value lands inside `-match` — and getting either wrong reintroduces the hole silently. A COM port name has no legitimate reason to contain anything outside `COM\d+`.

The same pattern existed in `hub_chain_power_off` from #3872; guarded too.

**It also fixes a real bug, which is what makes it more than hardening.** `--upload-port` legitimately accepts `UF2=E:\` for a board already in BOOTSEL. That trailing backslash would have corrupted the `-match` regex. It names a volume rather than a COM device, so there is nothing to look up — it now returns "unknown", and because unknown is permissive, a UF2 deploy is never blocked by the preflight.

## 2. Typed `PortPresence` instead of a tuple

`parse_presence`/`port_presence` returned a bare `(Optional[bool], Optional[int])` that `absent_port_error` unpacked positionally. Both fields are optional and neither is self-describing, so swapping them would still type-check while silently inverting the meaning of the check — on the one function that decides whether to abort a run.

`PortPresence` is frozen and `@typechecked`, matching the `ChipDetectionResult` convention in `ci/util/port_utils.py`. Its docstring now carries the tri-state rule that was buried in `parse_presence`: `present=None` means "the host could not say" and must never be read as "absent".

Also sets the `text` language on the diagnostic fence in `hardware-autoresearch.md` (markdownlint MD040).

## Validation

Live, against the real bench — not only the injected fakes:

```
COM17   -> PortPresence(present=False, last_seen_secs=483088)   # absent, 5d
COM9    -> PortPresence(present=True,  last_seen_secs=32196)    # attached C6
UF2=E:\ -> PortPresence(present=None,  last_seen_secs=None)     # refused
COM1'); calc; (' -> PortPresence(present=None, last_seen_secs=None)
```

Four new regression tests: a quote-bearing port, the `UF2=` form, the hub-chain path, and one pinning that real ports (`COM9`, `COM17`, `com3`, `COM255`) still resolve — a guard that broke the actual use case would be worse than the bug. The hostile-input tests assert the runner is never invoked, not merely that the result is empty.

`uv run pytest ci/tests/test_usb_power.py` — 20 passed. `bash lint` clean.

## Expected CI

Two reds are pre-existing on master, not from this PR (which touches only Python and one markdown file):

- `teensy41 all` — `undefined reference to SPIClass::*`; master's own `check_teensy41_size` fails with "no .bin/.uf2 file found" (#3838, FastLED/fbuild#1265).
- `esp32s3 all` — hits its 45-minute bound; cancelled on 10 of the last 10 master runs (#3791, data posted there).

Refs #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB power monitoring with clearer presence and last-seen status reporting.
  * Added safeguards to reject invalid or unsafe port names before system checks.
  * Prevented absent-port handling from failing for supported non-COM configurations.
  * Improved validation of USB hub-chain queries.
  * Added stronger handling for unknown or incomplete device-presence information.

* **Documentation**
  * Corrected syntax highlighting for the documented upload-port preflight error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->