### PR TITLE
feat: add Chipintelli CI13XX support

### DIFF
--- a/src/fl/math/fixed_point/s16x16.h
+++ b/src/fl/math/fixed_point/s16x16.h
@@ -32,7 +32,7 @@ class s16x16 {
     // Integer constructor — any integer width (portable: AVR 16-bit int, ARM/x86 32-bit).
     // Compile error if constexpr value exceeds INT_BITS range.
     template <typename IntT, detail::enable_if_integer_t<IntT> = 0>
-    explicit constexpr s16x16(IntT n) FL_NO_EXCEPT
+    explicit constexpr FASTLED_FORCE_INLINE s16x16(IntT n) FL_NO_EXCEPT
         : mValue(detail::int_to_fixed<INT_BITS, FRAC_BITS>::from_signed(n)) {}
 
     // Auto-promotion from other fixed-point types

--- a/src/fl/stl/cstdlib.cpp.hpp
+++ b/src/fl/stl/cstdlib.cpp.hpp
@@ -19,7 +19,8 @@ namespace fl {
 // ============================================================================
 
 void *aligned_alloc(fl::size_t alignment, fl::size_t size) {
-#if defined(FL_IS_AVR) || defined(FL_IS_ESP8266) || defined(FL_IS_ARM) || defined(FL_IS_APOLLO3)
+#if defined(FL_IS_AVR) || defined(FL_IS_ESP8266) || defined(FL_IS_ARM) || \
+    defined(FL_IS_APOLLO3) || defined(FL_IS_CI13XX)
     // Many bare-metal toolchains (newlib-nano on STM32, nRF52, SAMD, RP2040,
     // Teensy, etc.) ship an aligned_alloc that internally calls
     // posix_memalign, which doesn't exist on bare-metal and causes an
@@ -42,7 +43,8 @@ void *aligned_alloc(fl::size_t alignment, fl::size_t size) {
 }
 
 void aligned_free(void *ptr) {
-#if defined(FL_IS_AVR) || defined(FL_IS_ESP8266) || defined(FL_IS_ARM) || defined(FL_IS_APOLLO3)
+#if defined(FL_IS_AVR) || defined(FL_IS_ESP8266) || defined(FL_IS_ARM) || \
+    defined(FL_IS_APOLLO3) || defined(FL_IS_CI13XX)
     ::free(ptr);
 #elif defined(FL_IS_WIN)
     ::_aligned_free(ptr);

--- a/src/led_sysdefs.h
+++ b/src/led_sysdefs.h
@@ -58,6 +58,8 @@
 #include "platforms/esp/8266/led_sysdefs_esp8266.h"  // ok platform headers
 #elif defined(ESP32)
 #include "platforms/esp/32/core/led_sysdefs_esp32.h"  // ok platform headers
+#elif defined(ARDUINO_ARCH_CI13XX)
+#include "platforms/ci13xx/led_sysdefs_ci13xx.h"  // ok platform headers
 #elif defined(__AVR__) || defined(__AVR_ATmega4809__)
 // AVR platforms
 #include "platforms/avr/led_sysdefs_avr.h"  // ok platform headers

--- a/src/platforms.h
+++ b/src/platforms.h
@@ -48,6 +48,8 @@
 #include "platforms/esp/8266/fastled_esp8266.h"  // ok platform headers
 #elif defined(ESP32)
 #include "platforms/esp/32/core/fastled_esp32.h"  // ok platform headers
+#elif defined(ARDUINO_ARCH_CI13XX)
+#include "platforms/ci13xx/fastled_ci13xx.h"  // ok platform headers
 #elif defined(ARDUINO_ARCH_APOLLO3)
 #include "platforms/apollo3/fastled_apollo3.h"  // ok platform headers
 #elif defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_RENESAS_UNO) || defined(ARDUINO_ARCH_RENESAS_PORTENTA)

--- a/src/platforms/_build.cpp.hpp
+++ b/src/platforms/_build.cpp.hpp
@@ -20,6 +20,7 @@
 #include "platforms/arduino/_build.cpp.hpp"
 #include "platforms/arm/_build.cpp.hpp"
 #include "platforms/avr/_build.cpp.hpp"
+#include "platforms/ci13xx/_build.cpp.hpp"
 #include "platforms/esp/_build.cpp.hpp"
 #include "platforms/posix/_build.cpp.hpp"
 #include "platforms/shared/_build.cpp.hpp"

--- a/src/platforms/ci13xx/README.md
+++ b/src/platforms/ci13xx/README.md
@@ -1,0 +1,38 @@
+# Chipintelli CI13XX
+
+This backend adds clockless LED output for the 32-bit RISC-V CI1302, CI1303,
+and CI1306 Arduino targets. It uses the machine cycle counter for waveform
+timing and masked GPIO data registers for single-store pin transitions.
+
+The implementation is selected only when `ARDUINO_ARCH_CI13XX` is defined.
+Other FastLED platform paths and their pin implementations are unchanged.
+
+## Supported pins
+
+- CI1302/CI1303: PA2-PA6, PB5-PB6 and PC4. PA0-PA1 are also available when
+  the internal oscillator is selected.
+- CI1306 / CI-D06GT01D: PA2-PA7, PB0-PB7, PC0-PC5, PD0-PD1 and PD3-PD4.
+
+The Arduino pin aliases (for example `PA4` or `PD0`) can be used directly as
+the `DATA_PIN` template argument. PD2 and PD5 are not bonded on the supported
+CI1306 boards and are intentionally rejected at compile time.
+
+The CI13XX clockless implementation keeps interrupts disabled while a frame is
+transmitted so WS2812-family timing is not disturbed.
+
+## Nuclei GCC 9.2 LTO compatibility
+
+The CI13XX Arduino toolchain's GCC 9.2 linker can fail internally while
+processing weak constructor aliases emitted in multiple FastLED unity-build
+objects. The small `s16x16` integer constructor is force-inlined so those
+out-of-line aliases are not emitted; CI13XX builds can retain LTO without extra
+flags.
+
+Older FastLED packages that predate this fix can use the following fallback:
+
+```console
+arduino-cli compile --build-property compiler.cpp.extra_flags=-fno-lto ...
+```
+
+The fallback is scoped to the CI13XX build and is not required by other FastLED
+targets.

--- a/src/platforms/ci13xx/_build.cpp.hpp
+++ b/src/platforms/ci13xx/_build.cpp.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "platforms/ci13xx/is_ci13xx.h"
+
+#if defined(FL_IS_CI13XX)
+#include "platforms/arduino/io_arduino.hpp"
+#endif

--- a/src/platforms/ci13xx/clockless_ci13xx.h
+++ b/src/platforms/ci13xx/clockless_ci13xx.h
@@ -1,0 +1,102 @@
+// IWYU pragma: private
+
+#pragma once
+
+#include "fastled_delay.h"
+#include "fl/chipsets/timing_traits.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+#define FL_CLOCKLESS_CONTROLLER_DEFINED 1
+
+// The CI13XX SDK enables the RISC-V machine cycle counter during startup. Only
+// the low 32 bits are needed; signed subtraction keeps waits correct at wrap.
+FASTLED_FORCE_INLINE static u32 ci13xxCycleCount() FL_NO_EXCEPT {
+    u32 cycles;
+    __asm__ __volatile__("csrr %0, mcycle" : "=r"(cycles));
+    return cycles;
+}
+
+template <u8 DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0,
+          bool FLIP = false, int WAIT_TIME = 280>
+class ClocklessController : public CPixelLEDController<RGB_ORDER> {
+    static constexpr u32 T1 =
+        (TIMING::T1 * (F_CPU / 1000000UL) + 500U) / 1000U;
+    static constexpr u32 T2 =
+        (TIMING::T2 * (F_CPU / 1000000UL) + 500U) / 1000U;
+    static constexpr u32 T3 =
+        (TIMING::T3 * (F_CPU / 1000000UL) + 500U) / 1000U;
+    static constexpr u32 TOTAL = T1 + T2 + T3;
+
+    CMinWait<WAIT_TIME> mWait;
+
+    FASTLED_FORCE_INLINE static void waitUntil(u32 target) FL_NO_EXCEPT {
+        while (static_cast<i32>(ci13xxCycleCount() - target) < 0) {
+        }
+    }
+
+    template <int BITS>
+    FASTLED_FORCE_INLINE static void writeBits(u32 &nextBit,
+                                               u8 &value) FL_NO_EXCEPT {
+        for (u8 bit = 0; bit < BITS; ++bit) {
+            waitUntil(nextBit);
+            FastPin<DATA_PIN>::hi();
+
+            const u32 highEnd =
+                nextBit + ((value & 0x80U) ? (T1 + T2) : T1);
+            waitUntil(highEnd);
+            FastPin<DATA_PIN>::lo();
+
+            nextBit += TOTAL;
+            value <<= 1;
+        }
+    }
+
+    static void showRGBInternal(PixelController<RGB_ORDER> pixels)
+        FL_NO_EXCEPT {
+        if (!pixels.has(1)) {
+            return;
+        }
+
+        pixels.preStepFirstByteDithering();
+        FASTLED_REGISTER u8 value = pixels.loadAndScale0();
+
+        cli();
+        u32 nextBit = ci13xxCycleCount() + 16U;
+
+        while (pixels.has(1)) {
+            pixels.stepDithering();
+
+            writeBits<8 + XTRA0>(nextBit, value);
+            value = pixels.loadAndScale1();
+
+            writeBits<8 + XTRA0>(nextBit, value);
+            value = pixels.loadAndScale2();
+
+            writeBits<8 + XTRA0>(nextBit, value);
+            value = pixels.advanceAndLoadAndScale0();
+        }
+
+        FastPin<DATA_PIN>::lo();
+        sei();
+    }
+
+public:
+    void init() FL_NO_EXCEPT override {
+        FastPin<DATA_PIN>::setOutput();
+        FastPin<DATA_PIN>::lo();
+    }
+
+    u16 getMaxRefreshRate() const override { return 400; }
+
+protected:
+    void showPixels(PixelController<RGB_ORDER> &pixels) FL_NO_EXCEPT override {
+        mWait.wait();
+        showRGBInternal(pixels);
+        mWait.mark();
+    }
+};
+
+}  // namespace fl

--- a/src/platforms/ci13xx/compile_test.hpp
+++ b/src/platforms/ci13xx/compile_test.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/system/fastled.h"
+#include "fl/stl/static_assert.h"
+
+namespace fl {
+
+static void ci13xx_compile_tests() {
+#ifndef FL_IS_CI13XX
+#error "FL_IS_CI13XX should be defined for CI13XX"
+#endif
+
+#ifndef FASTLED_RISCV
+#error "FASTLED_RISCV should be defined for CI13XX"
+#endif
+
+#ifndef F_CPU
+#error "F_CPU should be defined for CI13XX"
+#endif
+
+#if FASTLED_ALLOW_INTERRUPTS != 0
+#error "CI13XX clockless output requires FASTLED_ALLOW_INTERRUPTS=0"
+#endif
+
+#if FASTLED_USE_PROGMEM != 0
+#error "FASTLED_USE_PROGMEM should be 0 for CI13XX"
+#endif
+
+    FL_STATIC_ASSERT(sizeof(uptr) == 4,
+                     "CI13XX requires 32-bit pointer types");
+    FL_STATIC_ASSERT(sizeof(size) == 4,
+                     "CI13XX requires 32-bit size types");
+}
+
+}  // namespace fl

--- a/src/platforms/ci13xx/fastled_ci13xx.h
+++ b/src/platforms/ci13xx/fastled_ci13xx.h
@@ -1,0 +1,8 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+
+#pragma once
+
+#include "platforms/ci13xx/fastpin_ci13xx.h"
+#include "platforms/ci13xx/clockless_ci13xx.h"

--- a/src/platforms/ci13xx/fastpin_ci13xx.h
+++ b/src/platforms/ci13xx/fastpin_ci13xx.h
@@ -1,0 +1,123 @@
+// IWYU pragma: private
+
+#pragma once
+
+#include "fl/stl/bit_cast.h"
+#include "fl/stl/compiler_control.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+#include "fl/system/arduino.h"
+#include "fl/system/fastpin_base.h"
+
+namespace fl {
+
+#if defined(FASTLED_FORCE_SOFTWARE_PINS)
+#warning "Software pin support forced; the CI13XX clockless driver requires hardware FastPin support."
+#define NO_HARDWARE_PIN_SUPPORT
+#undef HAS_HARDWARE_PIN_SUPPORT
+#else
+
+// CI13XX GPIO blocks implement ARM PL061-style masked data registers. Each
+// pin has a dedicated word at base + ((1 << bit) * 4), allowing one store to
+// update that pin without a read/modify/write sequence.
+template <u8 PIN, uptr PORT_BASE, u8 BIT>
+class _CI13XXPin : public ValidPinBase {
+public:
+    typedef volatile u32 *port_ptr_t;
+    typedef u32 port_t;
+
+    static void setOutput() { ::pinMode(PIN, OUTPUT); }
+    static void setInput() { ::pinMode(PIN, INPUT); }
+
+    FASTLED_FORCE_INLINE static void hi() FL_NO_EXCEPT { *port() = 0xFFU; }
+    FASTLED_FORCE_INLINE static void lo() FL_NO_EXCEPT { *port() = 0U; }
+    FASTLED_FORCE_INLINE static void set(port_t value) FL_NO_EXCEPT {
+        *port() = value ? 0xFFU : 0U;
+    }
+    FASTLED_FORCE_INLINE static void strobe() FL_NO_EXCEPT {
+        toggle();
+        toggle();
+    }
+    FASTLED_FORCE_INLINE static void toggle() FL_NO_EXCEPT {
+        *port() = *port() ? 0U : 0xFFU;
+    }
+
+    FASTLED_FORCE_INLINE static void hi(port_ptr_t gpio) FL_NO_EXCEPT {
+        *gpio = 0xFFU;
+    }
+    FASTLED_FORCE_INLINE static void lo(port_ptr_t gpio) FL_NO_EXCEPT {
+        *gpio = 0U;
+    }
+    FASTLED_FORCE_INLINE static void fastset(port_ptr_t gpio,
+                                             port_t value) FL_NO_EXCEPT {
+        *gpio = value;
+    }
+
+    FASTLED_FORCE_INLINE static port_t hival() FL_NO_EXCEPT { return 0xFFU; }
+    FASTLED_FORCE_INLINE static port_t loval() FL_NO_EXCEPT { return 0U; }
+    FASTLED_FORCE_INLINE static port_ptr_t port() FL_NO_EXCEPT {
+        return fl::bit_cast<port_ptr_t>(
+            PORT_BASE + ((static_cast<uptr>(1U) << BIT) * sizeof(u32)));
+    }
+    FASTLED_FORCE_INLINE static port_t mask() FL_NO_EXCEPT { return 0xFFU; }
+};
+
+#define _FL_CI13XX_PA 0x40020000UL
+#define _FL_CI13XX_PB 0x40021000UL
+#define _FL_CI13XX_PC 0x40031000UL
+#define _FL_CI13XX_PD 0x40028000UL
+
+#define _FL_CI13XX_DEFPIN(PIN, PORT, BIT)                                     \
+    template <>                                                               \
+    class FastPin<PIN> : public _CI13XXPin<PIN, PORT, BIT> {};
+
+// Pins common to the CI1302, CI1303 and CI1306 Arduino variants.
+_FL_CI13XX_DEFPIN(2, _FL_CI13XX_PA, 2)
+_FL_CI13XX_DEFPIN(3, _FL_CI13XX_PA, 3)
+_FL_CI13XX_DEFPIN(4, _FL_CI13XX_PA, 4)
+_FL_CI13XX_DEFPIN(5, _FL_CI13XX_PA, 5)
+_FL_CI13XX_DEFPIN(6, _FL_CI13XX_PA, 6)
+_FL_CI13XX_DEFPIN(13, _FL_CI13XX_PB, 5)
+_FL_CI13XX_DEFPIN(14, _FL_CI13XX_PB, 6)
+_FL_CI13XX_DEFPIN(20, _FL_CI13XX_PC, 4)
+
+#if defined(ARDUINO_CI1306) || defined(ARDUINO_CI_D06GT01D)
+// Additional GPIOs bonded out by CI1306-based boards. Logical pins 24 (PD2)
+// and 27 (PD5) are intentionally absent because those pads are not bonded.
+_FL_CI13XX_DEFPIN(7, _FL_CI13XX_PA, 7)
+_FL_CI13XX_DEFPIN(8, _FL_CI13XX_PB, 0)
+_FL_CI13XX_DEFPIN(9, _FL_CI13XX_PB, 1)
+_FL_CI13XX_DEFPIN(10, _FL_CI13XX_PB, 2)
+_FL_CI13XX_DEFPIN(11, _FL_CI13XX_PB, 3)
+_FL_CI13XX_DEFPIN(12, _FL_CI13XX_PB, 4)
+_FL_CI13XX_DEFPIN(15, _FL_CI13XX_PB, 7)
+_FL_CI13XX_DEFPIN(16, _FL_CI13XX_PC, 0)
+_FL_CI13XX_DEFPIN(17, _FL_CI13XX_PC, 1)
+_FL_CI13XX_DEFPIN(18, _FL_CI13XX_PC, 2)
+_FL_CI13XX_DEFPIN(19, _FL_CI13XX_PC, 3)
+_FL_CI13XX_DEFPIN(21, _FL_CI13XX_PC, 5)
+_FL_CI13XX_DEFPIN(22, _FL_CI13XX_PD, 0)
+_FL_CI13XX_DEFPIN(23, _FL_CI13XX_PD, 1)
+_FL_CI13XX_DEFPIN(25, _FL_CI13XX_PD, 3)
+_FL_CI13XX_DEFPIN(26, _FL_CI13XX_PD, 4)
+#define MAX_PIN 26
+#else
+// PA0 and PA1 are reserved by the external crystal option on CI1302/CI1303.
+#if !defined(USE_EXTERNAL_CRYSTAL_OSC) || !USE_EXTERNAL_CRYSTAL_OSC
+_FL_CI13XX_DEFPIN(0, _FL_CI13XX_PA, 0)
+_FL_CI13XX_DEFPIN(1, _FL_CI13XX_PA, 1)
+#endif
+#define MAX_PIN 20
+#endif
+
+#define HAS_HARDWARE_PIN_SUPPORT 1
+
+#undef _FL_CI13XX_DEFPIN
+#undef _FL_CI13XX_PA
+#undef _FL_CI13XX_PB
+#undef _FL_CI13XX_PC
+#undef _FL_CI13XX_PD
+
+#endif  // FASTLED_FORCE_SOFTWARE_PINS
+
+}  // namespace fl

--- a/src/platforms/ci13xx/int.h
+++ b/src/platforms/ci13xx/int.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// IWYU pragma: private
+
+// Use compiler-provided primitive types so these aliases exactly match the
+// Nuclei RISC-V toolchain's stdint.h and stddef.h definitions.
+namespace fl {
+typedef __INT16_TYPE__ i16;
+typedef __UINT16_TYPE__ u16;
+typedef __INT32_TYPE__ i32;
+typedef __UINT32_TYPE__ u32;
+typedef __INT64_TYPE__ i64;
+typedef __UINT64_TYPE__ u64;
+typedef __SIZE_TYPE__ size;
+typedef __UINTPTR_TYPE__ uptr;
+typedef __INTPTR_TYPE__ iptr;
+typedef __PTRDIFF_TYPE__ ptrdiff;
+}  // namespace fl

--- a/src/platforms/ci13xx/is_ci13xx.h
+++ b/src/platforms/ci13xx/is_ci13xx.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// IWYU pragma: private
+
+// ok no namespace fl
+
+#if defined(ARDUINO_ARCH_CI13XX)
+#define FL_IS_CI13XX
+#endif

--- a/src/platforms/ci13xx/led_sysdefs_ci13xx.h
+++ b/src/platforms/ci13xx/led_sysdefs_ci13xx.h
@@ -1,0 +1,29 @@
+// IWYU pragma: private
+
+// ok no namespace fl
+
+#pragma once
+
+#include "fl/stl/stdint.h"
+
+// CI13XX devices use a 32-bit Nuclei RISC-V core.
+#define FASTLED_RISCV
+
+// The Chipintelli Arduino core does not expose the AVR-style PINMAP macros.
+// Hardware FastPin specializations are provided by fastpin_ci13xx.h instead.
+#define FASTLED_NO_PINMAP
+
+#ifndef FASTLED_ALLOW_INTERRUPTS
+#define FASTLED_ALLOW_INTERRUPTS 0
+#endif
+
+#ifndef FASTLED_USE_PROGMEM
+#define FASTLED_USE_PROGMEM 0
+#endif
+
+#ifndef INTERRUPT_THRESHOLD
+#define INTERRUPT_THRESHOLD 1
+#endif
+
+typedef volatile fl::u32 RoReg;
+typedef volatile fl::u32 RwReg;

--- a/src/platforms/ci13xx/pin_ci13xx.hpp
+++ b/src/platforms/ci13xx/pin_ci13xx.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+// IWYU pragma: private
+
+// Adapters from FastLED's type-safe pin API to the Chipintelli Arduino core.
+
+#include "fl/stl/noexcept.h"
+#include "fl/system/arduino.h"
+
+namespace fl {
+namespace platforms {
+
+inline void pinMode(int pin, PinMode mode) FL_NO_EXCEPT {
+    u8 arduinoMode = INPUT;
+    switch (mode) {
+        case PinMode::Input:
+            arduinoMode = INPUT;
+            break;
+        case PinMode::Output:
+            arduinoMode = OUTPUT;
+            break;
+        case PinMode::InputPullup:
+            arduinoMode = INPUT_PULLUP;
+            break;
+        case PinMode::InputPulldown:
+            arduinoMode = INPUT_PULLDOWN;
+            break;
+    }
+    ::pinMode(static_cast<u8>(pin), arduinoMode);
+}
+
+inline void digitalWrite(int pin, PinValue value) FL_NO_EXCEPT {
+    ::digitalWrite(static_cast<u8>(pin),
+                   value == PinValue::High ? HIGH : LOW);
+}
+
+inline PinValue digitalRead(int pin) FL_NO_EXCEPT {
+    return ::digitalRead(static_cast<u8>(pin)) ? PinValue::High
+                                               : PinValue::Low;
+}
+
+inline u16 analogRead(int pin) FL_NO_EXCEPT {
+    const int value = ::analogRead(static_cast<u8>(pin));
+    return value > 0 ? static_cast<u16>(value) : 0U;
+}
+
+inline void analogWrite(int pin, u16 value) FL_NO_EXCEPT {
+    ::analogWrite(static_cast<u8>(pin), static_cast<int>(value));
+}
+
+inline void setPwm16(int pin, u16 value) FL_NO_EXCEPT {
+    ::analogWriteResolution(16);
+    ::analogWrite(static_cast<u8>(pin), static_cast<int>(value));
+    ::analogWriteResolution(8);
+}
+
+inline void setAdcRange(AdcRange /*range*/) FL_NO_EXCEPT {
+    // CI13XX ADC reference selection is managed by the Arduino core.
+}
+
+inline bool needsPwmIsrFallback(int /*pin*/, u32 /*frequencyHz*/) {
+    return false;
+}
+
+inline int setPwmFrequencyNative(int /*pin*/, u32 frequencyHz)
+    FL_NO_EXCEPT {
+    ::analogWriteFrequency(frequencyHz);
+    return 0;
+}
+
+inline u32 getPwmFrequencyNative(int /*pin*/) FL_NO_EXCEPT { return 0; }
+
+}  // namespace platforms
+}  // namespace fl

--- a/src/platforms/compile_test.cpp.hpp
+++ b/src/platforms/compile_test.cpp.hpp
@@ -30,6 +30,8 @@ FL_DISABLE_WARNING(unused-parameter)
 #include "platforms/avr/compile_test.hpp"
 #elif defined(ESP32) || defined(ESP8266)
 #include "platforms/esp/compile_test.hpp"
+#elif defined(ARDUINO_ARCH_CI13XX)
+#include "platforms/ci13xx/compile_test.hpp"
 #elif defined(FL_IS_ARM)
 #include "platforms/arm/compile_test.hpp"
 #elif defined(APOLLO3) || defined(ARDUINO_ARCH_APOLLO3)
@@ -121,6 +123,8 @@ FL_MAYBE_UNUSED static void compile_tests() FL_NO_EXCEPT {
     esp32_compile_tests();
 #elif defined(ESP8266)
     esp8266_compile_tests();
+#elif defined(ARDUINO_ARCH_CI13XX)
+    ci13xx_compile_tests();
 #elif defined(FL_IS_ARM)
     arm_compile_tests();
 #elif defined(APOLLO3) || defined(ARDUINO_ARCH_APOLLO3)

--- a/src/platforms/fastpin.h
+++ b/src/platforms/fastpin.h
@@ -34,6 +34,11 @@
     #include "platforms/generic_pin.h"
     #include "platforms/esp/8266/fastpin_esp8266.h"
 
+#elif defined(ARDUINO_ARCH_CI13XX)
+    // Chipintelli CI1302/CI1303/CI1306 RISC-V microcontrollers
+    #include "platforms/generic_pin.h"
+    #include "platforms/ci13xx/fastpin_ci13xx.h"
+
 #elif defined(__AVR__)
     // AVR 8-bit microcontrollers (Arduino UNO, Nano, etc.)
     #include "platforms/generic_pin.h"

--- a/src/platforms/int.h
+++ b/src/platforms/int.h
@@ -11,6 +11,8 @@
     #include "platforms/esp/int_8266.h"
 #elif defined(ESP32)
     #include "platforms/esp/int.h"
+#elif defined(ARDUINO_ARCH_CI13XX)
+    #include "platforms/ci13xx/int.h"
 #elif defined(__AVR__)
     #include "platforms/avr/int.h"
 #elif defined(__IMXRT1062__)

--- a/src/platforms/is_platform.h
+++ b/src/platforms/is_platform.h
@@ -93,6 +93,9 @@
 /// Apollo3 Platforms:
 /// - FL_IS_APOLLO3: Ambiq Apollo3 platform (SparkFun Artemis family)
 ///
+/// Chipintelli Platforms:
+/// - FL_IS_CI13XX: Chipintelli CI1302/CI1303/CI1306 RISC-V platform
+///
 /// WebAssembly Platforms:
 /// - FL_IS_WASM: WebAssembly platform (Emscripten)
 ///
@@ -149,6 +152,7 @@
 #include "platforms/arm/stm32/is_stm32.h"
 #include "platforms/arm/teensy/is_teensy.h"
 #include "platforms/avr/is_avr.h"
+#include "platforms/ci13xx/is_ci13xx.h"
 #include "platforms/esp/is_esp.h"
 #include "platforms/posix/is_posix.h"
 #include "platforms/stub/is_stub.h"

--- a/src/platforms/pin.h
+++ b/src/platforms/pin.h
@@ -41,6 +41,8 @@
     #include "platforms/arm/silabs/pin_silabs.hpp"
 #elif defined(FL_IS_APOLLO3)
     #include "platforms/apollo3/pin_apollo3.hpp"
+#elif defined(FL_IS_CI13XX)
+    #include "platforms/ci13xx/pin_ci13xx.hpp"
 #elif defined(FL_IS_STUB)
     // Stub platform for testing — tracks pin state via fl::stub::setPinState
     #include "platforms/stub/pin_stub.hpp"


### PR DESCRIPTION
feat: add Chipintelli CI13XX support(https://github.com/coloz/arduino-ci130x)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Chipintelli CI13XX RISC-V platforms.
  * Enabled CI13XX LED control with hardware GPIO support, timing-accurate output, dithering, and up to 400 Hz refresh rates.
  * Added platform-specific pin, PWM, ADC, interrupt, and memory support.
* **Documentation**
  * Added CI13XX setup guidance, supported targets and pins, timing details, and compatibility notes.
* **Performance**
  * Improved inlining for fixed-point integer construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->