### PR TITLE
fix(controller): correctly override parallel controller size

### DIFF
--- a/src/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/src/platforms/arm/k20/clockless_block_arm_k20.h
@@ -60,7 +60,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) FL_NO_EXCEPT {
 		mWait.wait();

--- a/src/platforms/arm/k20/octows2811_controller.h
+++ b/src/platforms/arm/k20/octows2811_controller.h
@@ -33,7 +33,7 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   }
 public:
   COctoWS2811Controller() { pocto = nullptr; }
-  virtual int size() { return CLEDController::size() * 8; }
+  int size() const FL_NO_EXCEPT override { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }
 

--- a/src/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/src/platforms/arm/k66/clockless_block_arm_k66.h
@@ -66,7 +66,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, LANE_MASK> & pixels) FL_NO_EXCEPT {
 		mWait.wait();

--- a/src/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
+++ b/src/platforms/arm/mxrt1062/block_clockless_arm_mxrt1062.h
@@ -36,7 +36,7 @@ class FlexibleInlineBlockClocklessController : public CPixelLEDController<RGB_OR
     CMinWait<WAIT_TIME> mWait;
 
 public:
-    virtual int size() { return CLEDController::size() * mNActualLanes; }
+    int size() const FL_NO_EXCEPT override { return CLEDController::size() * mNActualLanes; }
 
     // For each pin, if we've hit our lane count, break, otherwise set the pin to output,
     // store the bit offset in our offset array, add this pin to the write mask, and if this

--- a/src/platforms/arm/mxrt1062/octows2811_controller.h
+++ b/src/platforms/arm/mxrt1062/octows2811_controller.h
@@ -32,7 +32,7 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   }
 public:
   COctoWS2811Controller() { pocto = nullptr; }
-  virtual int size() { return CLEDController::size() * 8; }
+  int size() const FL_NO_EXCEPT override { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }
 

--- a/src/platforms/arm/sam/clockless_block_arm_sam.h
+++ b/src/platforms/arm/sam/clockless_block_arm_sam.h
@@ -56,7 +56,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 	virtual void init() FL_NO_EXCEPT {
         FL_STATIC_ASSERT(LANES <= 8, "Maximum of 8 lanes for Due parallel controllers!");
         if(FIRST_PIN == PORTA_FIRST_PIN) {

--- a/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
+++ b/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
@@ -48,7 +48,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) FL_NO_EXCEPT {
 		mWait.wait();

--- a/src/platforms/arm/teensy/teensy31_32/octows2811_controller.h
+++ b/src/platforms/arm/teensy/teensy31_32/octows2811_controller.h
@@ -33,7 +33,7 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   }
 public:
   COctoWS2811Controller() { pocto = nullptr; }
-  virtual int size() { return CLEDController::size() * 8; }
+  int size() const FL_NO_EXCEPT override { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }
 

--- a/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
+++ b/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
@@ -52,7 +52,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, LANE_MASK> & pixels) FL_NO_EXCEPT {
 		mWait.wait();

--- a/src/platforms/arm/teensy/teensy4_common/block_clockless_arm_mxrt1062.h
+++ b/src/platforms/arm/teensy/teensy4_common/block_clockless_arm_mxrt1062.h
@@ -35,7 +35,7 @@ class FlexibleInlineBlockClocklessController : public CPixelLEDController<RGB_OR
     CMinWait<WAIT_TIME> mWait;
 
 public:
-    virtual int size() { return CLEDController::size() * mNActualLanes; }
+    int size() const FL_NO_EXCEPT override { return CLEDController::size() * mNActualLanes; }
 
     // For each pin, if we've hit our lane count, break, otherwise set the pin to output,
     // store the bit offset in our offset array, add this pin to the write mask, and if this

--- a/src/platforms/arm/teensy/teensy4_common/octows2811_controller.h
+++ b/src/platforms/arm/teensy/teensy4_common/octows2811_controller.h
@@ -32,7 +32,7 @@ class COctoWS2811Controller : public CPixelLEDController<RGB_ORDER, 8, 0xFF> {
   }
 public:
   COctoWS2811Controller() { pocto = nullptr; }
-  virtual int size() { return CLEDController::size() * 8; }
+  int size() const FL_NO_EXCEPT override { return CLEDController::size() * 8; }
 
   virtual void init() { /* do nothing yet */ }
 

--- a/src/platforms/esp/32/clockless_block_esp32.h
+++ b/src/platforms/esp/32/clockless_block_esp32.h
@@ -76,7 +76,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
     CMinWait<WAIT_TIME> mWait;
 
 public:
-    virtual int size() { return CLEDController::size() * LANES; }
+    int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
     virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) FL_NO_EXCEPT {
 	// mWait.wait();

--- a/src/platforms/esp/8266/clockless_block_esp8266.h
+++ b/src/platforms/esp/8266/clockless_block_esp8266.h
@@ -46,7 +46,7 @@ class InlineBlockClocklessController : public CPixelLEDController<RGB_ORDER, LAN
 	CMinWait<WAIT_TIME> mWait;
 
 public:
-	virtual int size() { return CLEDController::size() * LANES; }
+	int size() const FL_NO_EXCEPT override { return CLEDController::size() * LANES; }
 
 	virtual void showPixels(PixelController<RGB_ORDER, LANES, PORT_MASK> & pixels) FL_NO_EXCEPT {
 		mWait.wait();

--- a/tests/cled_controller.cpp
+++ b/tests/cled_controller.cpp
@@ -24,6 +24,9 @@ namespace {
 class FakeParallelController : public CLEDController {
   public:
     explicit FakeParallelController(int lanes) : mLanes(lanes) {}
+    int size() const FL_NO_EXCEPT override {
+        return CLEDController::size() * mLanes;
+    }
     int lanes() FL_NO_EXCEPT override { return mLanes; }
     void showColor(const CRGB &, int, fl::u8) FL_NO_EXCEPT override {}
     void show(const CRGB *, int, fl::u8) FL_NO_EXCEPT override {}
@@ -34,6 +37,18 @@ class FakeParallelController : public CLEDController {
 };
 
 }  // namespace
+
+FL_TEST_CASE("size dispatch includes every parallel-controller lane (#3828)") {
+    constexpr int kLanes = 4;
+    constexpr int kPerLane = 7;
+    static CRGB buffer[kLanes * kPerLane];
+
+    FakeParallelController ctrl(kLanes);
+    ctrl.setLeds(buffer, kPerLane);  // Parallel controllers store a per-lane span.
+    const CLEDController *base = &ctrl;
+
+    FL_CHECK_EQ(base->size(), kLanes * kPerLane);
+}
 
 FL_TEST_CASE("clearLedData clears every lane of a parallel controller (#1017)") {
     constexpr int kLanes = 4;


### PR DESCRIPTION
## Summary
- make every parallel controller's `size()` a `const FL_NO_EXCEPT override` of `CLEDController::size()`
- restore total LED counts through `CLEDController*`, so power limiting and show bookkeeping include every lane
- add a portable regression test for const virtual dispatch

## User-visible behavior
Parallel-controller power limiting now uses the actual total LED count rather than a per-lane count. Configurations whose draw exceeds the configured maximum may dim after this fix, which is the intended correction.

## Verification
- `bash test cled_controller`
- `bash lint`

Closes #3828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected LED size reporting for parallel controllers so totals include all active lanes.
  - Standardized controller size handling across supported platforms without changing existing calculations.

- **Tests**
  - Added regression coverage verifying accurate multi-lane LED counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->