### PR TITLE
fix(esp32-c6): validate PARLIO with GPIO ISR RX capture backend (#3586)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -891,6 +891,22 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         }
     }
 
+    // ESP32-C6 RMT RX merges PARLIO's waveform into its frame envelope even
+    // while the GPIO input sees every edge (FastLED#3586). Keep explicit
+    // backend overrides available for diagnostics, but use the independent
+    // GPIO ISR timestamp path for normal C6 PARLIO wire validation.
+#if defined(FL_IS_ESP_32C6)
+    constexpr bool is_esp32_c6 = true;
+#else
+    constexpr bool is_esp32_c6 = false;
+#endif
+    rx_backend_override = fl::validation::resolveCaptureBackend(
+        rx_backend_override, have_backend_override,
+        driver_name == "PARLIO", is_esp32_c6);
+    if (rx_backend_override != fl::RxBackend::PLATFORM_DEFAULT) {
+        have_backend_override = true;
+    }
+
     if (have_backend_override) {
         fl::RxChannelConfig rx_cfg(pin_rx, rx_backend_override);
         rx_channel_to_use = FastLED.addRx(rx_cfg);

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -455,7 +455,12 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     bool is_uart_driver = (fl::strcmp(driver_name, "UART") == 0)
                        || (fl::strcmp(driver_name, "LPUART") == 0);
     bool is_object_fled_driver = (fl::strcmp(driver_name, "OBJECT_FLED") == 0);
-    rx_config.edge_capacity = rx_buffer.size() * 8;
+    rx_config.edge_capacity = fl::validation::captureEdgeCapacity(
+        rx_buffer.size(), expected_data_bytes, rx_channel->backend());
+    if (rx_config.edge_capacity == 0) {
+        FL_ERROR("[CAPTURE] RX edge-capacity overflow");
+        return 0;
+    }
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
     // RP's platform-default RX resolves to PIO, while RxChannel retains the
     // requested PLATFORM_DEFAULT enum. Recognize both that public default and

--- a/src/fl/channels/validation.h
+++ b/src/fl/channels/validation.h
@@ -10,6 +10,7 @@
 #include "fl/stl/optional.h"
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/channels/rx/types.h"
 
 // Forward declarations for detail modules
 namespace fl {
@@ -32,6 +33,56 @@ namespace validation {
 inline bool useRmtInternalLoopback(bool is_rmt_driver, int tx_pin,
                                    int rx_pin) FL_NO_EXCEPT {
     return is_rmt_driver && tx_pin == rx_pin;
+}
+
+/// @brief Select the independent capture backend used by AutoResearch.
+///
+/// ESP32-C6 RMT RX does not preserve PARLIO's sub-microsecond low phases even
+/// though the same pad's GPIO input sees them. Use the GPIO ISR timestamp
+/// backend for the default C6 PARLIO validation path. An explicit caller
+/// override remains authoritative for diagnostics.
+inline RxBackend resolveCaptureBackend(RxBackend requested_backend,
+                                       bool has_explicit_override,
+                                       bool is_parlio_driver,
+                                       bool is_esp32_c6) FL_NO_EXCEPT {
+    if (!has_explicit_override && is_parlio_driver && is_esp32_c6) {
+        return RxBackend::ISR;
+    }
+    return requested_backend;
+}
+
+/// @brief Compute the RX edge-buffer capacity for a validation frame.
+///
+/// GPIO ISR RX requires a power-of-two circular buffer. Size that buffer from
+/// the frame under test (two edges per bit plus framing headroom), rather than
+/// from AutoResearch's oversized shared byte buffer.
+inline size_t captureEdgeCapacity(size_t shared_buffer_bytes,
+                                  size_t expected_data_bytes,
+                                  RxBackend backend) FL_NO_EXCEPT {
+    constexpr size_t kEdgesPerByte = 16;
+    constexpr size_t kFramingEdges = 2;
+    const size_t max_size = static_cast<size_t>(-1);
+
+    if (backend != RxBackend::ISR) {
+        if (shared_buffer_bytes > max_size / 8) {
+            return 0;
+        }
+        return shared_buffer_bytes * 8;
+    }
+
+    if (expected_data_bytes > (max_size - kFramingEdges) / kEdgesPerByte) {
+        return 0;
+    }
+    const size_t required =
+        expected_data_bytes * kEdgesPerByte + kFramingEdges;
+    size_t capacity = 1;
+    while (capacity < required) {
+        if (capacity > max_size / 2) {
+            return 0;
+        }
+        capacity *= 2;
+    }
+    return capacity;
 }
 
 }  // namespace validation

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
@@ -84,7 +84,7 @@ _Static_assert(_Alignof(EdgeEntry) == 4, "EdgeEntry must be 4-byte aligned");
  * - Main thread: Initializes, polls done flag, reads output buffer
  *
  * Atomicity:
- * - write_index: Atomic uint32_t (updated by fast ISR with RV32A atomic ops or careful ordering)
+ * - write_index: Aligned uint32_t (single producer, acquire/release ordering)
  * - read_index: Updated only by slow ISR (no atomicity needed)
  * - armed: Atomic bool (slow ISR disarms when done)
  * - done: Atomic bool (slow ISR signals completion)
@@ -127,8 +127,8 @@ typedef struct __attribute__((aligned(64))) {
     /**
      * @brief Current write index (updated by fast ISR)
      * Type: uint32_t (atomic)
-     * Access: Fast ISR writes (atomic increment), slow ISR reads (atomic load)
-     * Atomicity: Updated with RV32A atomic instructions (lr.w/sc.w) or careful ordering
+     * Access: Fast ISR writes after a release fence, slow ISR uses an acquire load
+     * Atomicity: Aligned RV32 word store with a single writer
      * Range: [0, buffer_size - 1]
      */
     volatile uint32_t write_index;
@@ -171,8 +171,15 @@ typedef struct __attribute__((aligned(64))) {
      */
     uint32_t gpio_bit_mask;
 
+    /**
+     * @brief GPIO interrupt status write-one-to-clear register address
+     * Type: uint32_t (GPIO_STATUS_W1TC_REG or GPIO_STATUS1_W1TC_REG)
+     * Access: Fast ISR writes gpio_bit_mask after sampling each edge
+     */
+    uint32_t gpio_status_w1tc_reg_addr;
+
     // ========================================================================
-    // MEDIUM-HOT PATH: Configuration values (bytes 32-47)
+    // MEDIUM-HOT PATH: Configuration values (starts at byte 40)
     // ========================================================================
 
     /**
@@ -270,6 +277,22 @@ typedef struct __attribute__((aligned(64))) {
 #ifdef __cplusplus
 FL_STATIC_ASSERT(sizeof(DualIsrContext) <= 128, "DualIsrContext must fit in 2 cache lines or less");
 FL_STATIC_ASSERT(alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte aligned");
+#if defined(__riscv)
+FL_STATIC_ASSERT(__builtin_offsetof(DualIsrContext, buffer) == 0,
+                 "fast_isr.S buffer offset mismatch");
+FL_STATIC_ASSERT(__builtin_offsetof(DualIsrContext, armed) == 20,
+                 "fast_isr.S armed offset mismatch");
+FL_STATIC_ASSERT(
+    __builtin_offsetof(DualIsrContext, mcpwm_capture_reg_addr) == 24,
+    "fast_isr.S MCPWM register offset mismatch");
+FL_STATIC_ASSERT(__builtin_offsetof(DualIsrContext, gpio_in_reg_addr) == 28,
+                 "fast_isr.S GPIO input register offset mismatch");
+FL_STATIC_ASSERT(__builtin_offsetof(DualIsrContext, gpio_bit_mask) == 32,
+                 "fast_isr.S GPIO mask offset mismatch");
+FL_STATIC_ASSERT(
+    __builtin_offsetof(DualIsrContext, gpio_status_w1tc_reg_addr) == 36,
+    "fast_isr.S GPIO status register offset mismatch");
+#endif
 #else
 _Static_assert(sizeof(DualIsrContext) <= 128, "DualIsrContext must fit in 2 cache lines or less");
 _Static_assert(_Alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte aligned");
@@ -318,14 +341,13 @@ _Static_assert(_Alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte a
  * Atomic Access Patterns:
  *
  * 1. write_index (fast ISR to slow ISR communication):
- *    - Fast ISR: Atomic increment with wrap-around
+ *    - Fast ISR: Single-producer store with release ordering
  *      ```asm
- *      loop:
- *          lr.w t1, (write_index_addr)      # Load-reserved
- *          addi t2, t1, 1                    # Increment
- *          remu t2, t2, buffer_size          # Wrap-around (or AND if power of 2)
- *          sc.w t3, t2, (write_index_addr)   # Store-conditional
- *          bnez t3, loop                     # Retry if failed
+ *          lw t1, 0(write_index_addr)       # Sole producer reads index
+ *          addi t2, t1, 1                   # Increment
+ *          and t2, t2, buffer_size_mask     # Wrap around
+ *          fence rw, w                      # Publish entry before index
+ *          sw t2, 0(write_index_addr)       # Aligned atomic word store
  *      ```
  *    - Slow ISR: Atomic load
  *      ```c
@@ -382,10 +404,9 @@ _Static_assert(_Alignof(DualIsrContext) == 64, "DualIsrContext must be 64-byte a
  *    - GPIO register address precomputed (direct register access)
  *    - Bit mask precomputed (no shift in ISR)
  *
- * 4. Atomic operation cost:
- *    - RV32A lr.w/sc.w: ~5-10 cycles (depends on contention)
- *    - Non-atomic load: ~1-2 cycles
- *    - Use atomics only where strictly necessary
+ * 4. Synchronization cost:
+ *    - The producer uses one release fence and an aligned word store.
+ *    - The consumer uses an acquire load.
  */
 
 #ifdef __cplusplus

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/fast_isr.S
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/fast_isr.S
@@ -18,16 +18,17 @@
  *
  * ISR Workflow:
  * 1. Check armed flag - exit immediately if false
- * 2. Read MCPWM capture register (hardware timestamp)
- * 3. Read GPIO level from GPIO_IN register
- * 4. Load write_index atomically
- * 5. Calculate buffer offset: base + (write_index * sizeof(EdgeEntry))
+ * 2. Acknowledge the GPIO interrupt source
+ * 3. Read MCPWM capture register (hardware timestamp)
+ * 4. Read GPIO level from GPIO_IN register
+ * 5. Load the single-producer write_index
  * 6. Write {timestamp, level} to buffer[offset]
- * 7. Increment write_index (modulo buffer_size) atomically
- * 8. Return via mret (machine trap return)
+ * 7. Publish write_index with release ordering
+ * 8. Return to the ESP-IDF interrupt dispatcher
  *
  * Register Usage (RISC-V Calling Convention):
  * - a0: DualIsrContext pointer (input, preserved)
+ * - a1: Sampled GPIO level
  * - t0-t6: Temporary registers (can be clobbered)
  * - sp, ra: NEVER modified (no stack, no function calls)
  *
@@ -37,23 +38,19 @@
  *   - Halfword (16-bit): 2-byte aligned (lh/lhu/sh)
  *   - Byte (8-bit): No alignment requirement (lb/lbu/sb)
  *
- * Atomicity:
- * - write_index update uses RV32A atomic instructions (lr.w/sc.w)
- * - Ensures consistency between fast ISR and slow ISR
+ * Synchronization:
+ * - The GPIO ISR is the sole writer of write_index.
+ * - A release fence publishes each entry before the aligned index store.
  *
  * IRAM Placement:
  * - Entire ISR placed in .iram1 section for zero-wait-state access
  * - Critical for achieving <20 cycle target
  */
 
-// The fast ISR uses RV32A lr.w/sc.w atomics for the circular-buffer
-// index update. Only compile on RISC-V cores that ship the A extension
-// (ESP32-C6 / H2 / C5 / P4 — RV32IMAC+). ESP32-C3 and C2 are RV32IMC
-// and would fail the assembler with `extension 'zalrsc' required`.
-// The companion C++ glue in gpio_isr_rx_mcpwm.cpp.hpp already gates on
-// SOC_MCPWM_SUPPORTED, which excludes C3/C2 — this aligns the assembly
-// with that gate.
-#if defined(__riscv) && defined(__riscv_atomic)
+// The companion C++ glue gates this implementation on MCPWM-capable RISC-V
+// targets. The edge ISR is the sole producer, so aligned loads/stores plus a
+// release fence are sufficient for its single-producer circular buffer.
+#if defined(__riscv)
 
 // ============================================================================
 // Section Placement
@@ -79,6 +76,7 @@
 // 24     | 4    | uint32_t mcpwm_capture_reg_addr
 // 28     | 4    | uint32_t gpio_in_reg_addr
 // 32     | 4    | uint32_t gpio_bit_mask
+// 36     | 4    | uint32_t gpio_status_w1tc_reg_addr
 // ... (remaining fields not accessed by fast ISR)
 
 // Define offsets as constants for clarity
@@ -91,6 +89,7 @@
 .equ OFFSET_MCPWM_CAPTURE_REG_ADDR, 24
 .equ OFFSET_GPIO_IN_REG_ADDR, 28
 .equ OFFSET_GPIO_BIT_MASK, 32
+.equ OFFSET_GPIO_STATUS_W1TC_REG_ADDR, 36
 
 // EdgeEntry structure size (8 bytes: 4-byte timestamp + 1-byte level + 3-byte padding)
 .equ SIZEOF_EDGE_ENTRY, 8
@@ -108,7 +107,7 @@
  * @param a0 DualIsrContext* - Pointer to ISR context structure
  *
  * @note This function is called directly from the interrupt dispatcher
- * @note Returns via mret (machine trap return), NOT ret
+ * @note Returns via ret to ESP-IDF's interrupt dispatcher
  * @note NO stack operations - all work done in registers
  * @note Optimized for minimum cycle count (~15-20 cycles)
  */
@@ -116,45 +115,49 @@ gpio_fast_edge_isr:
     // ========================================================================
     // Step 1: Check armed flag (early exit if not armed)
     // ========================================================================
-    // Load armed flag (1 byte, offset 16)
+    // Load armed flag (1 byte, offset 20)
     // Use lbu (load byte unsigned) - no alignment requirement
     lbu     t0, OFFSET_ARMED(a0)    // t0 = ctx->armed (0 or 1)
     beqz    t0, .Lexit              // if (!armed) goto exit
 
     // ========================================================================
-    // Step 2: Read MCPWM capture register (hardware timestamp)
+    // Step 2: Acknowledge the GPIO edge
+    // ========================================================================
+    // Direct esp_intr_alloc handlers bypass gpio_intr_service, so they must
+    // clear the source themselves. Clear on entry so a subsequent edge can
+    // pend while this handler records the current one.
+    lw      t4, OFFSET_GPIO_BIT_MASK(a0)
+    lw      t3, OFFSET_GPIO_STATUS_W1TC_REG_ADDR(a0)
+    sw      t4, 0(t3)
+
+    // ========================================================================
+    // Step 3: Read MCPWM capture register (hardware timestamp)
     // ========================================================================
     // Load MCPWM capture register address (precomputed during init)
     lw      t1, OFFSET_MCPWM_CAPTURE_REG_ADDR(a0)  // t1 = register address
     lw      t2, 0(t1)               // t2 = *mcpwm_capture_reg (timestamp value)
 
     // ========================================================================
-    // Step 3: Read GPIO level from GPIO_IN register
+    // Step 4: Read GPIO level from GPIO_IN register
     // ========================================================================
     // Load GPIO register address and bit mask (precomputed during init)
     lw      t3, OFFSET_GPIO_IN_REG_ADDR(a0)        // t3 = GPIO_IN_REG address
-    lw      t4, OFFSET_GPIO_BIT_MASK(a0)           // t4 = bit mask (1 << pin)
-    lw      t5, 0(t3)               // t5 = GPIO_IN_REG value (all 32 pins)
-    and     t5, t5, t4              // t5 = gpio_value & mask
-    snez    t5, t5                  // t5 = (t5 != 0) ? 1 : 0 (normalize to 0 or 1)
+    lw      a1, 0(t3)               // a1 = GPIO_IN_REG value (all 32 pins)
+    and     a1, a1, t4              // a1 = gpio_value & mask
+    snez    a1, a1                  // a1 = (a1 != 0) ? 1 : 0
 
     // ========================================================================
-    // Step 4: Load circular buffer metadata
+    // Step 5: Load circular buffer metadata
     // ========================================================================
     // Load buffer base pointer and buffer size mask
     lw      t6, OFFSET_BUFFER(a0)           // t6 = buffer base address (EdgeEntry*)
     lw      t3, OFFSET_BUFFER_SIZE_MASK(a0) // t3 = buffer_size_mask (for fast modulo)
 
     // ========================================================================
-    // Step 5: Atomic read-modify-write of write_index
+    // Step 6: Read the single-producer write index
     // ========================================================================
-    // Use RV32A atomic instructions (lr.w/sc.w) for lock-free circular buffer
-    // Compute write_index address ONCE before atomic loop (optimization)
     addi    t4, a0, OFFSET_WRITE_INDEX  // t4 = &ctx->write_index
-
-.Lretry_atomic:
-    // Load-reserved: Atomically load write_index and set reservation
-    lr.w    t0, (t4)                // t0 = current write_index (atomic load)
+    lw      t0, 0(t4)               // t0 = current write_index
 
     // Calculate next write_index: (write_index + 1) & buffer_size_mask
     // This is equivalent to (write_index + 1) % buffer_size when buffer_size is power of 2
@@ -162,30 +165,33 @@ gpio_fast_edge_isr:
     addi    t1, t0, 1               // t1 = write_index + 1
     and     t1, t1, t3              // t1 = (write_index + 1) & mask (fast wrap-around)
 
-    // Store-conditional: Atomically store new write_index if reservation still valid
-    // If successful, t5 = 0; if failed (contention), t5 = nonzero
-    sc.w    t5, t1, (t4)            // Atomic store to &ctx->write_index
-    bnez    t5, .Lretry_atomic      // Retry if store-conditional failed
-
     // ========================================================================
-    // Step 6: Calculate buffer offset and write edge entry
+    // Step 7: Write the edge, then publish the new write index
     // ========================================================================
+    // The slow ISR uses an acquire load of write_index. Store the complete
+    // EdgeEntry before the release store below so it can never observe a new
+    // index with stale entry data.
     // Calculate offset: buffer_base + (write_index * sizeof(EdgeEntry))
     // sizeof(EdgeEntry) = 8 bytes, so multiply by 8 (shift left by 3)
-    slli    t1, t0, 3               // t1 = write_index * 8 (shift left 3 bits)
-    add     t1, t6, t1              // t1 = buffer + offset (address of EdgeEntry)
+    slli    t5, t0, 3               // t5 = write_index * 8 (shift left 3 bits)
+    add     t5, t6, t5              // t5 = buffer + offset (address of EdgeEntry)
 
     // Write EdgeEntry: {timestamp (4 bytes), level (1 byte), padding (3 bytes)}
-    sw      t2, 0(t1)               // EdgeEntry.timestamp = MCPWM capture value
-    sb      t5, 4(t1)               // EdgeEntry.level = GPIO level (0 or 1)
+    sw      t2, 0(t5)               // EdgeEntry.timestamp = MCPWM capture value
+    sb      a1, 4(t5)               // EdgeEntry.level = GPIO level (0 or 1)
     // Note: Padding bytes (5-7) are not initialized (don't care)
 
+    // This ISR is the only writer. An aligned RV32 word store is atomic; the
+    // release fence pairs with the slow ISR's acquire load.
+    fence   rw, w
+    sw      t1, 0(t4)
+
     // ========================================================================
-    // Step 7: Return from interrupt
+    // Step 8: Return from interrupt
     // ========================================================================
 .Lexit:
-    mret                            // Machine trap return (restores PC from MEPC)
+    ret                             // Return to ESP-IDF interrupt dispatcher
 
 .size gpio_fast_edge_isr, .-gpio_fast_edge_isr
 
-#endif // __riscv && __riscv_atomic
+#endif // __riscv

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
@@ -457,10 +457,13 @@ public:
 #ifdef GPIO_IN1_REG
             // Chips with >32 GPIOs (ESP32, ESP32-S2) have a second input register
             mIsrContext.gpio_in_reg_addr = (mPin < 32) ? GPIO_IN_REG : GPIO_IN1_REG;
+            mIsrContext.gpio_status_w1tc_reg_addr =
+                (mPin < 32) ? GPIO_STATUS_W1TC_REG : GPIO_STATUS1_W1TC_REG;
             u8 pin_bit = (mPin < 32) ? mPin : (mPin - 32);
 #else
             // Chips with <=32 GPIOs (ESP32-H2, ESP32-C3, ESP32-C6) only have GPIO_IN_REG
             mIsrContext.gpio_in_reg_addr = GPIO_IN_REG;
+            mIsrContext.gpio_status_w1tc_reg_addr = GPIO_STATUS_W1TC_REG;
             u8 pin_bit = mPin;
 #endif
             mIsrContext.gpio_bit_mask = (1U << pin_bit);

--- a/tests/fl/channels/validation.cpp
+++ b/tests/fl/channels/validation.cpp
@@ -99,6 +99,33 @@ FL_TEST_CASE("RMT internal loopback requires the same TX and RX GPIO") {
     FL_CHECK_FALSE(validation::useRmtInternalLoopback(false, 0, 0));
 }
 
+FL_TEST_CASE("C6 PARLIO validation avoids the conflicted RMT RX backend") {
+    FL_CHECK(validation::resolveCaptureBackend(
+                 RxBackend::PLATFORM_DEFAULT, false, true, true) ==
+             RxBackend::ISR);
+    FL_CHECK(validation::resolveCaptureBackend(
+                 RxBackend::PLATFORM_DEFAULT, false, true, false) ==
+             RxBackend::PLATFORM_DEFAULT);
+    FL_CHECK(validation::resolveCaptureBackend(
+                 RxBackend::PLATFORM_DEFAULT, false, false, true) ==
+             RxBackend::PLATFORM_DEFAULT);
+    FL_CHECK(validation::resolveCaptureBackend(
+                 RxBackend::RMT, true, true, true) ==
+             RxBackend::RMT);
+}
+
+FL_TEST_CASE("ISR validation capture uses a frame-sized power-of-two buffer") {
+    FL_CHECK_EQ(validation::captureEdgeCapacity(
+                    3300, 30, RxBackend::ISR),
+                512u);
+    FL_CHECK_EQ(validation::captureEdgeCapacity(
+                    3300, 300, RxBackend::ISR),
+                8192u);
+    FL_CHECK_EQ(validation::captureEdgeCapacity(
+                    3300, 30, RxBackend::RMT),
+                26400u);
+}
+
 FL_TEST_CASE("Invalid driver name - empty") {
     SingleTestConfig config = makeBasicConfig();
     config.driver_name = "";


### PR DESCRIPTION
Recovered from a stale worktree during a branch cleanup — the commit dates to 2026-07-29 but no PR was ever opened, so the work never reached master. Rebased onto current master (111 commits of drift) and re-verified.

Closes #3586.

## Problem

ESP32-C6 RMT RX does not preserve PARLIO's sub-microsecond low phases, even though the same pad's GPIO input does see them. That makes the RMT capture backend unusable for validating C6 PARLIO clockless TX on the loopback bench — which is the symptom reported in #3586 (UART/SPI pass on the same jumper; RMT and PARLIO do not).

## Changes

**Backend selection** (`src/fl/channels/validation.h`)
- `resolveCaptureBackend()` — routes C6 + PARLIO to the GPIO ISR timestamp backend by default. An explicit caller override stays authoritative, so diagnostics can still force RMT.
- `captureEdgeCapacity()` — sizes the RX edge buffer from the frame under test (2 edges/bit + framing headroom, rounded to a power of two, which GPIO ISR RX requires) instead of from AutoResearch's oversized shared byte buffer. Overflow-guarded at each step, returning 0 rather than wrapping.

**GPIO ISR RX** (`dual_isr_context.h`, `fast_isr.S`, `gpio_isr_rx_mcpwm.cpp.hpp`)
- Adds `gpio_status_w1tc_reg_addr` to `DualIsrContext` so the fast ISR clears the GPIO interrupt status (write-one-to-clear) after sampling each edge.
- Replaces the `lr.w`/`sc.w` atomic increment of `write_index` with a single-producer release-fence + aligned word store, paired with an acquire load on the consumer. There is exactly one producer, so the RMW was never needed.
- Adds `FL_STATIC_ASSERT(__builtin_offsetof(...))` guards for every context offset `fast_isr.S` hardcodes, under `#if defined(__riscv)`.

**Tests** (`tests/fl/channels/validation.cpp`) — 2 new cases covering backend selection (4 combinations incl. the override) and edge-capacity sizing (ISR power-of-two vs RMT byte-derived).

## Verification

- `bash test --cpp` — 279/279 unit, 83/83 examples pass
- `bash lint` — clean
- Rebase onto master applied without conflicts; all added symbols confirmed present afterward

## Reviewer notes

- The offset asserts cover `buffer`(0), `armed`(20), `mcpwm_capture_reg_addr`(24), `gpio_in_reg_addr`(28), `gpio_bit_mask`(32), `gpio_status_w1tc_reg_addr`(36). The four between `buffer` and `armed` — `buffer_size`, `buffer_size_mask`, `write_index`, `read_index` — are not individually asserted, but are bracketed: any size drift among them moves `armed` off 20 and trips that assert. Reordering within the group would not be caught. Worth tightening in a follow-up.
- The asserts are `__riscv`-only, so host CI does not exercise them; they fire on an actual C6 build.
- **Not validated on hardware in this session.** The original commit's premise (C6 RMT RX misses PARLIO's short low phases) came from bench work on 2026-07-29 and has not been re-confirmed against a live board post-rebase. This needs a loopback run on the C6 bench before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved ESP32-C6 PARLIO capture reliability by automatically selecting the appropriate GPIO ISR backend when needed.
  * Added backend-aware capture buffer sizing with overflow detection to prevent invalid captures.
  * Improved GPIO interrupt handling and synchronization for faster, more reliable signal capture.

* **Tests**
  * Added coverage for backend selection and capture-buffer capacity across supported capture modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->