### PR TITLE
docs(esp32): correct GPIO ISR RX performance claims with measured data

### DIFF
--- a/src/platforms/esp/32/drivers/gpio_isr_rx/README.md
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/README.md
@@ -6,12 +6,20 @@ High-performance GPIO edge capture driver for ESP32 RISC-V platforms (ESP32-C6, 
 
 | Metric | Value |
 |--------|-------|
-| ISR latency | ~130-150 ns (25-31 cycles @ 160 MHz) |
+| Sustained edge capture rate | **~385 kHz measured** — min 2000 ns / avg 2599 ns between captures on ESP32-C6 @ 160 MHz, 0 of 1137 intervals under 1 us (FastLED#3586) |
+| Fast ISR body | 25-31 cycles — the `fast_isr.S` assembly ONLY, not the cost of servicing an edge. The ~2 us floor is ~320 cycles, dominated by ESP-IDF interrupt entry/exit. |
 | Timestamp resolution | 12.5 ns (MCPWM @ 80 MHz) |
-| Edge capture rate | >1 MHz |
-| CPU overhead | <20% during capture |
+| CPU overhead | <20% during capture (unverified) |
 
-Compared to ESP-IDF standard GPIO ISR (~400 ns), this achieves **3-4x faster** edge capture.
+> **Not suitable for WS28xx waveform capture.** At ~2.6 us between captures this
+> cannot resolve the ~300 ns T0H a WS2812 bit requires — it is off by ~6.7x. For
+> clockless LED validation on SoCs with a PARLIO RX unit, use the `PARLIO_RX`
+> oversampling backend (`drivers/parlio_rx/`): 16 MHz DMA sampling, 62.5 ns
+> resolution, no interrupt per edge. See FastLED#3586.
+
+The "3-4x faster than a standard GPIO ISR" claim previously stated here compared
+the `fast_isr.S` body against a full ISR dispatch, which is not a like-for-like
+comparison: this driver still pays ESP-IDF's interrupt entry/exit on every edge.
 
 ## Architecture
 
@@ -19,7 +27,9 @@ Compared to ESP-IDF standard GPIO ISR (~400 ns), this achieves **3-4x faster** e
 GPIO Edge Event --> MCPWM Hardware Capture (~5-15 ns, automatic)
     |
     v
-Fast ISR (RISC-V assembly, ~130 ns total)
+Fast ISR (RISC-V assembly, ~130 ns of instructions — NOT the ~2.6 us
+            end-to-end cost per serviced edge, which is dominated by
+            ESP-IDF interrupt entry/exit)
   - Reads MCPWM timestamp register (2-3 cycles, precomputed address)
   - Reads GPIO level from GPIO_IN register (4-5 cycles)
   - Writes {timestamp, level} to circular buffer (atomic, RV32A lr.w/sc.w)

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/dual_isr_context.h
@@ -17,8 +17,10 @@
  * Performance:
  * - Fast ISR target: <20 cycles (~83 ns @ 240 MHz)
  * - Timestamp resolution: 12.5 ns (MCPWM hardware timer)
- * - Edge capture rate: >1 MHz
- * - CPU load: <20% during active capture
+ * - Sustained edge capture rate: ~385 kHz measured on ESP32-C6 @ 160 MHz
+ *   (min=2000 ns / avg=2599 ns between captures, 0 of 1137 intervals
+ *   under 1 us). NOT >1 MHz — the limit is ESP-IDF interrupt
+ *   entry/exit, not the fast ISR body. See FastLED#3586.
  *
  * Memory Layout:
  * - All structures placed in IRAM (.iram1 section) for zero-wait-state access

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx.h
@@ -48,7 +48,9 @@ struct EdgeTimestamp {
  * - Ultra-fast edge capture: <130 ns ISR latency
  * - Circular buffer: Lock-free communication between ISRs
  * - Filtering: Skip signals, jitter filter, timeout detection
- * - Edge capture rate: >1 MHz
+ * - Sustained edge capture rate: ~385 kHz measured on ESP32-C6 @ 160 MHz
+ *   (FastLED#3586). Too slow for WS28xx (~300 ns T0H) — use the
+ *   PARLIO_RX oversampling backend for clockless LED validation.
  *
  * Pin Configuration:
  * - IMPORTANT: The pin must be configured (pinMode) by the user BEFORE calling begin()

--- a/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
+++ b/src/platforms/esp/32/drivers/gpio_isr_rx/gpio_isr_rx_mcpwm.cpp.hpp
@@ -8,11 +8,27 @@
  * - Fast ISR (RISC-V assembly, GPIO edge-triggered): Captures edges with MCPWM timestamps
  * - Slow ISR (C, GPTimer 10µs interval): Processes buffer, applies filtering, manages completion
  *
- * Performance:
- * - Fast ISR: 25-31 cycles (~104-129 ns @ 240 MHz)
+ * Performance (MEASURED on ESP32-C6 @ 160 MHz — FastLED#3586):
  * - Timestamp resolution: 12.5 ns (MCPWM @ 80 MHz)
- * - Edge capture rate: >1 MHz
- * - CPU load target: <20% during active capture
+ * - Sustained edge capture rate: ~385 kHz, i.e. ~2.6 us between captures.
+ *   Instrumenting a full 100-LED WS2812 frame gave min=2000 ns,
+ *   max=3550 ns, avg=2599 ns, with ZERO of 1137 intervals under 1 us.
+ *   The distribution is tight, which is an ISR saturated at its service
+ *   rate rather than one dropping edges sporadically.
+ * - Fast ISR body: 25-31 cycles. This is the assembly in fast_isr.S ONLY
+ *   and is NOT the cost of servicing an edge. The ~2 us floor above is
+ *   ~320 cycles at 160 MHz, dominated by ESP-IDF interrupt entry/exit:
+ *   a handler registered through esp_intr_alloc() runs via the IDF
+ *   vector with full context save/restore, not as a true high-priority
+ *   vectored interrupt.
+ *
+ * Consequence: this backend CANNOT capture WS28xx-rate signals, which
+ * need ~300 ns resolution (T0H). It is off by ~6.7x. For clockless LED
+ * waveform validation on SoCs with a PARLIO RX unit, use the PARLIO_RX
+ * oversampling backend (drivers/parlio_rx/) — 16 MHz DMA sampling,
+ * 62.5 ns resolution, no interrupt per edge. An earlier version of this
+ * header advertised ">1 MHz edge capture rate" and "25-31 cycles",
+ * which sent debugging down the wrong path before the rate was measured.
  *
  * Integration:
  * - Uses DualIsrContext from dual_isr_context.h


### PR DESCRIPTION
Follow-up to #3881. **Documentation only — no behavior change.**

## The problem

`gpio_isr_rx`'s headers and README advertise:

```
 * - Fast ISR: 25-31 cycles (~104-129 ns @ 240 MHz)
 * - Edge capture rate: >1 MHz
```

Both are misleading. The cycle figure counts the `fast_isr.S` assembly **body** only — not the cost of servicing an edge — and the ">1 MHz" rate is off by more than 2.5x.

## Measured reality

Instrumenting `getEdges()` to compute inter-capture intervals across a full 100-LED WS2812 frame on ESP32-C6 @ 160 MHz:

```
count=1138  n=1137  min=2000  max=3550  avg=2599  under1us=0  under500ns=0
```

(ns) — **not one of 1137 intervals below 2 us.** The tight spread is an ISR saturated at its service rate, not one dropping edges sporadically. That is a sustained ~385 kHz, or ~2.6 us per edge.

~2 us is ~320 cycles at 160 MHz. The gap between that and the advertised 25-31 is ESP-IDF interrupt entry/exit: a handler registered through `esp_intr_alloc()` runs via the IDF vector with full context save/restore, not as a true high-priority vectored interrupt.

## Why it matters

WS2812 needs ~300 ns (T0H) resolution. At ~2.6 us this backend is off by ~6.7x and cannot capture WS28xx waveforms at all — which is exactly what #3586 turned out to be. The advertised ">1 MHz" made an interrupt-per-edge design look viable for LED capture when the measurement shows it never was, and cost real debugging time before anyone measured it.

The docs now state the limitation explicitly and point readers at the `PARLIO_RX` oversampling backend (16 MHz DMA sampling, 62.5 ns, no interrupt per edge) for clockless LED validation.

## Changes

- `gpio_isr_rx_mcpwm.cpp.hpp`, `dual_isr_context.h`, `gpio_isr_rx.h`, `README.md` — measured rate, with the ISR-body figure explicitly labelled as body-only
- Drops the README's "**3-4x faster** than a standard GPIO ISR" claim: it compared the assembly body against a full ISR dispatch, not like-for-like, since this driver still pays IDF entry/exit on every edge
- Labels the architecture diagram's "~130 ns" as instruction time rather than per-edge cost
- Marks the unverified "<20% CPU overhead" row as unverified rather than deleting it — I did not measure it, so I am not asserting a replacement number

## Testing

`bash test --cpp` → 279/279 unit, 83/83 examples. `bash lint` clean. Comments only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESP32-C6 GPIO capture performance figures to reflect measured sustained throughput of approximately 385 kHz.
  * Clarified the difference between assembly ISR timing and end-to-end interrupt servicing overhead.
  * Removed unsupported performance claims and CPU-load estimates.
  * Documented that this backend cannot validate WS28xx waveforms and recommends PARLIO RX instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->