### PR TITLE
Fix Seeed nRF52840 Mbed support

### DIFF
--- a/src/platforms.cpp.hpp
+++ b/src/platforms.cpp.hpp
@@ -39,16 +39,16 @@ FL_LINK_WEAK volatile unsigned long timer_millis = 0;
 
     FL_EXTERN_C_BEGIN
             // NOTE: Update platforms.cpp in root of FastLED library if this changes        
-            #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE0)
+            #if FL_NRF52_ENABLE_PWM_INSTANCE0 && FL_NRF52_USE_PWM_INTERRUPTS
                 void PWM0_IRQHandler(void) { ++isrCount; PWM_Arbiter<0>::isr_handler(); }
             #endif
-            #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE1)
+            #if FL_NRF52_ENABLE_PWM_INSTANCE1 && FL_NRF52_USE_PWM_INTERRUPTS
                 void PWM1_IRQHandler(void) { ++isrCount; PWM_Arbiter<1>::isr_handler(); }
             #endif
-            #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE2)
+            #if FL_NRF52_ENABLE_PWM_INSTANCE2 && FL_NRF52_USE_PWM_INTERRUPTS
                 void PWM2_IRQHandler(void) { ++isrCount; PWM_Arbiter<2>::isr_handler(); }
             #endif
-            #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE3)
+            #if FL_NRF52_ENABLE_PWM_INSTANCE3 && FL_NRF52_USE_PWM_INTERRUPTS
                 void PWM3_IRQHandler(void) { ++isrCount; PWM_Arbiter<3>::isr_handler(); }
             #endif
     FL_EXTERN_C_END

--- a/src/platforms/arm/nrf52/README.md
+++ b/src/platforms/arm/nrf52/README.md
@@ -3,10 +3,9 @@
 Nordic nRF52 family support.
 
 The maintained backend targets the Adafruit nRF52 / Bluefruit Arduino BSP used
-by FastLED CI. That BSP provides the Nordic SDK headers, FreeRTOS integration,
-SoftDevice support, PWM EasyDMA, and SPIM HAL APIs this backend includes.
-Arduino mbed OS nRF52 boards such as Arduino Nano 33 BLE and Nano 33 BLE Sense
-are not supported by this backend today.
+by FastLED CI and the Seeed XIAO nRF52840 Plus/Sense Plus with Seeed's
+ArduinoCore-mbed. Other Arduino mbed OS nRF52 boards, such as Arduino Nano 33
+BLE and Nano 33 BLE Sense, are not supported by this backend today.
 
 ## Clocked SPI LEDs
 

--- a/src/platforms/arm/nrf52/README.md
+++ b/src/platforms/arm/nrf52/README.md
@@ -53,10 +53,10 @@ Notes:
 - **`FASTLED_ALLOW_INTERRUPTS`**: Default `1`.
 - **`FASTLED_ALL_PINS_HARDWARE_SPI`**: Enabled by default unless forcing software SPI.
 - **`FASTLED_NRF52_SPIM`**: Select SPIM instance (e.g., `NRF_SPIM0`).
-- **`FASTLED_NRF52_ENABLE_PWM_INSTANCE0`**: Enable PWM instance used by clockless.
+- **`FL_NRF52_ENABLE_PWM_INSTANCE0`**: Enable PWM instance used by clockless.
 - **`FASTLED_NRF52_NEVER_INLINE`**: Controls inlining attribute via `FASTLED_NRF52_INLINE_ATTRIBUTE`.
 - **`FASTLED_NRF52_MAXIMUM_PIXELS_PER_STRING`**: Limit pixels per string in PWM-encoded path (default 144).
-- **`FASTLED_NRF52_PWM_ID`**: Select PWM instance index used.
+- **`FL_NRF52_PWM_ID`**: Select PWM instance index used.
 - **`FASTLED_NRF52_SUPPRESS_UNTESTED_BOARD_WARNING`**: Suppress pin-map warnings for unverified boards.
 - **`FASTLED_NRF52_ALLOW_NFC_PINS`**: Re-enable `P0.09` / `P0.10` (NFC1/NFC2) as valid FastLED output pins on every nRF52840 variant block (SuperMini, nice!nano v2, nRFMicro, XIAO nRF52840, XIAO nRF52840 Sense). Defining this macro is necessary but **not** sufficient: you also need either `CONFIG_NFCT_PINS_AS_GPIOS=1` in the BSP/build flags, **or** a call to `NFC_PINS_AS_GPIO()` at boot (Adafruit nRF52 core helper).
 - **`FASTLED_NRF52_ALLOW_USR_LED`**: Re-enable on-board user-LED pins (`P0.15` SuperMini/nice!nano v2, `P1.10` nRFMicro, and the XIAO RGB LEDs at `P0.26`/`P0.06`/`P0.30`) as valid FastLED output pins. Be careful: defining this risks a clash with any sketch (or BSP background task) that calls `digitalWrite(LED_BUILTIN, ...)` on the same pin.

--- a/src/platforms/arm/nrf52/arbiter_nrf52.h
+++ b/src/platforms/arm/nrf52/arbiter_nrf52.h
@@ -22,22 +22,22 @@ typedef void (*FASTLED_NRF52_PWM_INTERRUPT_HANDLER)();
 // See led_sysdefs_arm_nrf52.h for selection....
 //
 typedef enum _FASTLED_NRF52_ENABLED_PWM_INSTANCE { // ok plain enum
-#if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE0)
+#if FL_NRF52_ENABLE_PWM_INSTANCE0
     FASTLED_NRF52_PWM0_INSTANCE_IDX,
 #endif
-#if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE1)
+#if FL_NRF52_ENABLE_PWM_INSTANCE1
     FASTLED_NRF52_PWM1_INSTANCE_IDX,
 #endif
-#if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE2)
+#if FL_NRF52_ENABLE_PWM_INSTANCE2
     FASTLED_NRF52_PWM2_INSTANCE_IDX,
 #endif
-#if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE3)
+#if FL_NRF52_ENABLE_PWM_INSTANCE3
     FASTLED_NRF52_PWM3_INSTANCE_IDX,
 #endif
-    FASTLED_NRF52_PWM_INSTANCE_COUNT
+    FL_NRF52_PWM_INSTANCE_COUNT
 } FASTLED_NRF52_ENABLED_PWM_INSTANCES;
 
-FL_STATIC_ASSERT(FASTLED_NRF52_PWM_INSTANCE_COUNT > 0, "Instance count must be greater than zero -- define FASTLED_NRF52_ENABLE_PWM_INSTNACE[n] (replace `[n]` with digit)");
+FL_STATIC_ASSERT(FL_NRF52_PWM_INSTANCE_COUNT > 0, "Instance count must be greater than zero -- define FL_NRF52_ENABLE_PWM_INSTANCE[n] (replace `[n]` with digit)");
 
 template <fl::u32 _PWM_ID>
 class PWM_Arbiter {
@@ -83,29 +83,29 @@ public:
     FASTLED_NRF52_INLINE_ATTRIBUTE static IRQn_Type       getIRQn() { return s_PWM_IRQ; }
 };
 template <fl::u32 _PWM_ID> NRF_PWM_Type * const PWM_Arbiter<_PWM_ID>::s_PWM           =
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE0)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE0
         (_PWM_ID == 0 ? NRF_PWM0 :
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE1)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE1
         (_PWM_ID == 1 ? NRF_PWM1 :
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE2)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE2
         (_PWM_ID == 2 ? NRF_PWM2 :
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE3)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE3
         (_PWM_ID == 3 ? NRF_PWM3 :
     #endif
         (NRF_PWM_Type*)-1
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE0)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE0
         )
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE1)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE1
         )
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE2)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE2
         )
     #endif
-    #if defined(FASTLED_NRF52_ENABLE_PWM_INSTANCE3)
+    #if FL_NRF52_ENABLE_PWM_INSTANCE3
         )
     #endif
     ;

--- a/src/platforms/arm/nrf52/arbiter_nrf52.h
+++ b/src/platforms/arm/nrf52/arbiter_nrf52.h
@@ -38,6 +38,12 @@ typedef enum _FASTLED_NRF52_ENABLED_PWM_INSTANCE { // ok plain enum
 } FASTLED_NRF52_ENABLED_PWM_INSTANCES;
 
 FL_STATIC_ASSERT(FL_NRF52_PWM_INSTANCE_COUNT > 0, "Instance count must be greater than zero -- define FL_NRF52_ENABLE_PWM_INSTANCE[n] (replace `[n]` with digit)");
+FL_STATIC_ASSERT(
+    (FL_NRF52_PWM_ID == 0 && FL_NRF52_ENABLE_PWM_INSTANCE0) ||
+    (FL_NRF52_PWM_ID == 1 && FL_NRF52_ENABLE_PWM_INSTANCE1) ||
+    (FL_NRF52_PWM_ID == 2 && FL_NRF52_ENABLE_PWM_INSTANCE2) ||
+    (FL_NRF52_PWM_ID == 3 && FL_NRF52_ENABLE_PWM_INSTANCE3),
+    "FL_NRF52_PWM_ID must identify an enabled PWM instance");
 
 template <fl::u32 _PWM_ID>
 class PWM_Arbiter {

--- a/src/platforms/arm/nrf52/clockless_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/clockless_arm_nrf52.h
@@ -12,6 +12,7 @@
 #include "fastled_delay.h"
 
 #include "eorder.h"
+#include "fl/system/yield.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/static_assert.h"
 namespace fl {
@@ -23,7 +24,6 @@ namespace fl {
 // nRF52832 has three PWM peripherals (PWM0, PWM1, PWM2)
 // nRF52840 has four PWM peripherals (PWM0, PWM1, PWM2, PWM3)
 // NOTE: Update platforms.cpp in root of FastLED library if this changes
-#define FASTLED_NRF52_PWM_ID 0
 
 extern u32 isrCount;
 
@@ -112,14 +112,16 @@ private:
 
     }
     FASTLED_NRF52_INLINE_ATTRIBUTE static void startPwmPlayback_EnableInterruptsAndShortcuts(NRF_PWM_Type * pwm) FL_NO_EXCEPT {
-        IRQn_Type irqn = PWM_Arbiter<FASTLED_NRF52_PWM_ID>::getIRQn();
+#if FL_NRF52_USE_PWM_INTERRUPTS
+        IRQn_Type irqn = PWM_Arbiter<FL_NRF52_PWM_ID>::getIRQn();
         // TODO: check API results...
         u32 result;
 
-        result = sd_nvic_SetPriority(irqn, configMAX_SYSCALL_INTERRUPT_PRIORITY);
+        result = sd_nvic_SetPriority(irqn, FL_NRF52_PWM_INTERRUPT_PRIORITY);
         (void)result;
         result = sd_nvic_EnableIRQ(irqn);
         (void)result;
+#endif
 
         // shortcuts prevent (up to) 4-cycle delay from interrupt handler to next action
         u32 shortsToEnable = 0;
@@ -130,13 +132,18 @@ private:
         shortsToEnable |= NRF_PWM_SHORT_LOOPSDONE_STOP_MASK;      ///< LOOPSDONE --> STOP task.
         nrf_pwm_shorts_set(pwm, shortsToEnable);
 
-        // mark which events should cause interrupts...
+        // Mark which events should cause interrupts. ArduinoCore-mbed owns the
+        // PWM IRQ handlers, so its playback completion is polled instead.
+#if FL_NRF52_USE_PWM_INTERRUPTS
         u32 interruptsToEnable = 0;
         interruptsToEnable |= NRF_PWM_INT_SEQEND0_MASK;
         interruptsToEnable |= NRF_PWM_INT_SEQEND1_MASK;
         interruptsToEnable |= NRF_PWM_INT_LOOPSDONE_MASK;
         interruptsToEnable |= NRF_PWM_INT_STOPPED_MASK;
         nrf_pwm_int_set(pwm, interruptsToEnable);
+#else
+        nrf_pwm_int_set(pwm, 0);
+#endif
 
     }
     FASTLED_NRF52_INLINE_ATTRIBUTE static void startPwmPlayback_StartTask(NRF_PWM_Type * pwm) FL_NO_EXCEPT {
@@ -157,8 +164,7 @@ private:
 
 public:
     static void isr_handler() FL_NO_EXCEPT {
-        NRF_PWM_Type * pwm = PWM_Arbiter<FASTLED_NRF52_PWM_ID>::getPWM();
-        IRQn_Type irqn = PWM_Arbiter<FASTLED_NRF52_PWM_ID>::getIRQn();
+        NRF_PWM_Type * pwm = PWM_Arbiter<FL_NRF52_PWM_ID>::getPWM();
 
         // Currently, only use SEQUENCE 0, so only event
         // of consequence is LOOPSDONE ...
@@ -171,15 +177,18 @@ public:
             releaseSequenceBuffer();
             // prevent further interrupts from PWM events
             nrf_pwm_int_set(pwm, 0);
-            // disable PWM interrupts - None of the PWM IRQs are shared
+            // Disable PWM interrupts. None of the PWM IRQs are shared
             // with other peripherals, avoiding complexity of shared IRQs.
+#if FL_NRF52_USE_PWM_INTERRUPTS
+            IRQn_Type irqn = PWM_Arbiter<FL_NRF52_PWM_ID>::getIRQn();
             sd_nvic_DisableIRQ(irqn);
+#endif
             // disable the PWM instance
             nrf_pwm_disable(pwm);
             // may take up to 4 cycles for writes to propagate (APB bus @ 16MHz)
             asm __volatile__ ( "NOP; NOP; NOP; NOP;" ) FL_NO_EXCEPT;
             // release the PWM arbiter to be re-used by another LED string
-            PWM_Arbiter<FASTLED_NRF52_PWM_ID>::releaseFromIsr();
+            PWM_Arbiter<FL_NRF52_PWM_ID>::releaseFromIsr();
         }
     }
 
@@ -276,8 +285,8 @@ public:
 
 
     FASTLED_NRF52_INLINE_ATTRIBUTE static void startPwmPlayback(u16 bytesToSend) FL_NO_EXCEPT {
-        PWM_Arbiter<FASTLED_NRF52_PWM_ID>::acquire(isr_handler);
-        NRF_PWM_Type * pwm = PWM_Arbiter<FASTLED_NRF52_PWM_ID>::getPWM();
+        PWM_Arbiter<FL_NRF52_PWM_ID>::acquire(isr_handler);
+        NRF_PWM_Type * pwm = PWM_Arbiter<FL_NRF52_PWM_ID>::getPWM();
 
         // mark the sequence as being in-use
         __sync_fetch_and_or(&s_SequenceBufferInUse, 1);
@@ -287,6 +296,32 @@ public:
         startPwmPlayback_ConfigurePwmSequence(pwm);
         startPwmPlayback_EnableInterruptsAndShortcuts(pwm);
         startPwmPlayback_StartTask(pwm);
+#if !FL_NRF52_USE_PWM_INTERRUPTS
+        const u32 playbackMicros = static_cast<u32>(
+            (static_cast<u64>(bytesToSend) * static_cast<u64>(_TOP) *
+             1000000ULL) /
+            static_cast<u64>(CLOCKLESS_FREQUENCY));
+        const u32 timeoutMicros = playbackMicros + 1000UL;
+        const u32 startMicros = fl::micros();
+        while (!nrf_pwm_event_check(pwm, NRF_PWM_EVENT_STOPPED)) {
+            if (static_cast<u32>(fl::micros() - startMicros) > timeoutMicros) {
+                nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_STOP);
+                const u32 stopStartMicros = fl::micros();
+                while (!nrf_pwm_event_check(pwm, NRF_PWM_EVENT_STOPPED) &&
+                       static_cast<u32>(fl::micros() - stopStartMicros) <=
+                           1000UL) {
+                    fl::yield();
+                }
+                nrf_pwm_int_set(pwm, 0);
+                nrf_pwm_disable(pwm);
+                releaseSequenceBuffer();
+                PWM_Arbiter<FL_NRF52_PWM_ID>::releaseFromIsr();
+                return;
+            }
+            fl::yield();
+        }
+        isr_handler();
+#endif
         return;
     }
 

--- a/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
+++ b/src/platforms/arm/nrf52/fastpin_arm_nrf52_variants.h
@@ -18,7 +18,10 @@
 #if defined(TARGET_SUPERMINI_NRF52840)    || \
     defined(TARGET_NICE_NANO_V2)          || \
     defined(TARGET_NRFMICRO)              || \
-    defined(TARGET_XIAOBLE_NRF52840_SENSE)
+    defined(TARGET_XIAOBLE_NRF52840_SENSE) || \
+    defined(TARGET_SEEED_XIAO_NRF52840_PLUS) || \
+    defined(SEEED_XIAO_NRF52840_PLUS)       || \
+    defined(ARDUINO_SEEED_XIAO_NRF52840_PLUS)
     #define __FASTLED_NRF52_USER_TARGET_OVERRIDE
 #endif
 
@@ -900,6 +903,44 @@
     // VBAT
     _FL_DEF_INVALID_PIN(32, 31, 0);  // D32 is P0.31 (VBAT)
 #endif // defined(ARDUINO_Seeed_XIAO_nRF52840_Sense)
+
+// Seeed XIAO nRF52840 Plus and Sense Plus. The ArduinoCore-mbed 2.9.3
+// variants use TARGET_SEEED_XIAO_NRF52840_PLUS for both models; Seeed's
+// PlatformIO package uses SEEED_XIAO_NRF52840_PLUS. The external header and
+// bottom-pad mappings are identical between them.
+#if defined(TARGET_SEEED_XIAO_NRF52840_PLUS) || \
+    defined(SEEED_XIAO_NRF52840_PLUS) || \
+    defined(ARDUINO_SEEED_XIAO_NRF52840_PLUS)
+    #if defined(__FASTPIN_ARM_NRF52_VARIANT_FOUND)
+        #error "Cannot define more than one board at a time"
+    #else
+        #define __FASTPIN_ARM_NRF52_VARIANT_FOUND
+    #endif
+
+    // External castellated pins D0..D10.
+    _FL_DEFPIN( 0,  2, 0); // D0  is P0.02
+    _FL_DEFPIN( 1,  3, 0); // D1  is P0.03
+    _FL_DEFPIN( 2, 28, 0); // D2  is P0.28
+    _FL_DEFPIN( 3, 29, 0); // D3  is P0.29
+    _FL_DEFPIN( 4,  4, 0); // D4  is P0.04
+    _FL_DEFPIN( 5,  5, 0); // D5  is P0.05
+    _FL_DEFPIN( 6, 43, 1); // D6  is P1.11
+    _FL_DEFPIN( 7, 44, 1); // D7  is P1.12
+    _FL_DEFPIN( 8, 45, 1); // D8  is P1.13
+    _FL_DEFPIN( 9, 46, 1); // D9  is P1.14
+    _FL_DEFPIN(10, 47, 1); // D10 is P1.15
+
+    // Extra bottom pads D11..D19 are Arduino pin numbers 30..38.
+    _FL_DEFPIN(30, 15, 0); // D11 is P0.15 (I2S SD)
+    _FL_DEFPIN(31, 19, 0); // D12 is P0.19 (I2S SCK)
+    _FL_DEFPIN(32, 33, 1); // D13 is P1.01 (I2S WS)
+    _FL_DEF_INVALID_PIN(33,  9, 0); // D14 is P0.09 (I2C pull / NFC1)
+    _FL_DEF_INVALID_PIN(34, 10, 0); // D15 is P0.10 (VDD enable / NFC2)
+    _FL_DEF_INVALID_PIN(35, 31, 0); // D16 is P0.31 (VBAT read)
+    _FL_DEFPIN(36, 39, 1); // D17 is P1.07 (MOSI1)
+    _FL_DEFPIN(37, 37, 1); // D18 is P1.05 (MISO1)
+    _FL_DEFPIN(38, 35, 1); // D19 is P1.03 (SCK1)
+#endif
 
 #if defined(ARDUINO_Seeed_XIAO_nRF52840)
     #if defined(__FASTPIN_ARM_NRF52_VARIANT_FOUND)

--- a/src/platforms/arm/nrf52/is_nrf52.h
+++ b/src/platforms/arm/nrf52/is_nrf52.h
@@ -38,3 +38,14 @@
     defined(ARDUINO_NRF52_ADAFRUIT)
 #define FL_IS_NRF52
 #endif
+
+// Nordic renamed several nrfx HAL APIs after the SDK 15 generation bundled by
+// ArduinoCore-mbed. Keep the capability selection centralized and overridable
+// so newer Mbed board packages can select their actual HAL API generation.
+#if !defined(FL_NRF52_USE_LEGACY_HAL)
+    #if defined(__MBED__)
+        #define FL_NRF52_USE_LEGACY_HAL 1
+    #else
+        #define FL_NRF52_USE_LEGACY_HAL 0
+    #endif
+#endif

--- a/src/platforms/arm/nrf52/isr_nrf52.hpp
+++ b/src/platforms/arm/nrf52/isr_nrf52.hpp
@@ -51,6 +51,86 @@ namespace fl {
 namespace isr {
 namespace platforms {
 
+// ArduinoCore-mbed ships Nordic's SDK 15 HAL, whose GPIOTE functions omit the
+// peripheral argument and use the older plural event type. Keep those API
+// differences isolated here so the ISR implementation also builds with the
+// newer nrfx HAL used by the Adafruit nRF52 core.
+#if FL_NRF52_USE_LEGACY_HAL
+using fastled_nrf_gpiote_event_t = nrf_gpiote_events_t;
+
+static bool fastled_gpiote_event_check(fastled_nrf_gpiote_event_t event) FL_NO_EXCEPT {
+    return nrf_gpiote_event_is_set(event);
+}
+
+static void fastled_gpiote_event_clear(fastled_nrf_gpiote_event_t event) FL_NO_EXCEPT {
+    nrf_gpiote_event_clear(event);
+}
+
+static void fastled_gpiote_event_configure(u32 channel, u32 pin,
+                                           nrf_gpiote_polarity_t polarity) FL_NO_EXCEPT {
+    nrf_gpiote_event_configure(channel, pin, polarity);
+}
+
+static void fastled_gpiote_event_enable(u32 channel) FL_NO_EXCEPT {
+    nrf_gpiote_event_enable(channel);
+}
+
+static void fastled_gpiote_event_disable(u32 channel) FL_NO_EXCEPT {
+    nrf_gpiote_event_disable(channel);
+}
+
+static void fastled_gpiote_int_enable(u32 mask) FL_NO_EXCEPT {
+    nrf_gpiote_int_enable(mask);
+}
+
+static void fastled_gpiote_int_disable(u32 mask) FL_NO_EXCEPT {
+    nrf_gpiote_int_disable(mask);
+}
+
+static void fastled_timer_cc_set(NRF_TIMER_Type* timer,
+                                 nrf_timer_cc_channel_t channel,
+                                 u32 value) FL_NO_EXCEPT {
+    nrf_timer_cc_write(timer, channel, value);
+}
+#else
+using fastled_nrf_gpiote_event_t = nrf_gpiote_event_t;
+
+static bool fastled_gpiote_event_check(fastled_nrf_gpiote_event_t event) FL_NO_EXCEPT {
+    return nrf_gpiote_event_check(NRF_GPIOTE, event);
+}
+
+static void fastled_gpiote_event_clear(fastled_nrf_gpiote_event_t event) FL_NO_EXCEPT {
+    nrf_gpiote_event_clear(NRF_GPIOTE, event);
+}
+
+static void fastled_gpiote_event_configure(u32 channel, u32 pin,
+                                           nrf_gpiote_polarity_t polarity) FL_NO_EXCEPT {
+    nrf_gpiote_event_configure(NRF_GPIOTE, channel, pin, polarity);
+}
+
+static void fastled_gpiote_event_enable(u32 channel) FL_NO_EXCEPT {
+    nrf_gpiote_event_enable(NRF_GPIOTE, channel);
+}
+
+static void fastled_gpiote_event_disable(u32 channel) FL_NO_EXCEPT {
+    nrf_gpiote_event_disable(NRF_GPIOTE, channel);
+}
+
+static void fastled_gpiote_int_enable(u32 mask) FL_NO_EXCEPT {
+    nrf_gpiote_int_enable(NRF_GPIOTE, mask);
+}
+
+static void fastled_gpiote_int_disable(u32 mask) FL_NO_EXCEPT {
+    nrf_gpiote_int_disable(NRF_GPIOTE, mask);
+}
+
+static void fastled_timer_cc_set(NRF_TIMER_Type* timer,
+                                 nrf_timer_cc_channel_t channel,
+                                 u32 value) FL_NO_EXCEPT {
+    nrf_timer_cc_set(timer, channel, value);
+}
+#endif
+
 // =============================================================================
 // Platform-Specific Handle Storage
 // =============================================================================
@@ -257,21 +337,19 @@ static void timer_interrupt_handler(int timer_idx, u8 channel) FL_NO_EXCEPT {
 }
 
 // Map GPIOTE channel index to event enum
-static nrf_gpiote_event_t get_gpiote_event(u8 channel) FL_NO_EXCEPT {
-    // Use proper enum values defined by Nordic SDK (offsetof-based)
-    switch (channel) {
-        case 0: return NRF_GPIOTE_EVENT_IN_0;
-        case 1: return NRF_GPIOTE_EVENT_IN_1;
-        case 2: return NRF_GPIOTE_EVENT_IN_2;
-        case 3: return NRF_GPIOTE_EVENT_IN_3;
-#if MAX_GPIOTE_CHANNELS > 4
-        case 4: return NRF_GPIOTE_EVENT_IN_4;
-        case 5: return NRF_GPIOTE_EVENT_IN_5;
-        case 6: return NRF_GPIOTE_EVENT_IN_6;
-        case 7: return NRF_GPIOTE_EVENT_IN_7;
-#endif
-        default: return NRF_GPIOTE_EVENT_IN_0;  // Fallback (should never happen)
+static fastled_nrf_gpiote_event_t get_gpiote_event(u8 channel) FL_NO_EXCEPT {
+    if (channel >= MAX_GPIOTE_CHANNELS) {
+        channel = 0;
     }
+    // Both Nordic HAL generations define these enum values as register
+    // offsets into the contiguous EVENTS_IN array.
+#if FL_NRF52_USE_LEGACY_HAL
+    return static_cast<fastled_nrf_gpiote_event_t>(
+        NRF_GPIOTE_EVENTS_IN_0 + channel * sizeof(u32));
+#else
+    return static_cast<fastled_nrf_gpiote_event_t>(
+        NRF_GPIOTE_EVENT_IN_0 + channel * sizeof(u32));
+#endif
 }
 
 // Timer ISR wrappers for each instance
@@ -324,10 +402,10 @@ extern "C" {
     // GPIOTE handler - weak to allow Arduino framework (WInterrupts.c) to override
     FL_LINK_WEAK void GPIOTE_IRQHandler(void) FL_NO_EXCEPT {
         for (u8 ch = 0; ch < MAX_GPIOTE_CHANNELS; ch++) {
-            nrf_gpiote_event_t event = get_gpiote_event(ch);
+            fastled_nrf_gpiote_event_t event = get_gpiote_event(ch);
 
-            if (nrf_gpiote_event_check(NRF_GPIOTE, event) && gpiote_handles[ch]) {
-                nrf_gpiote_event_clear(NRF_GPIOTE, event);
+            if (fastled_gpiote_event_check(event) && gpiote_handles[ch]) {
+                fastled_gpiote_event_clear(event);
 
                 if (gpiote_handles[ch]->user_handler) {
                     gpiote_handles[ch]->user_handler(gpiote_handles[ch]->user_data);
@@ -444,7 +522,7 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
     // Set compare value using nrf_timer_cc_channel_t enum
     // SDK provides NRF_TIMER_CC_CHANNEL0..5 as the proper channel type
     nrf_timer_cc_channel_t cc_channel = static_cast<nrf_timer_cc_channel_t>(NRF_TIMER_CC_CHANNEL0 + channel);
-    nrf_timer_cc_set(timer, cc_channel, compare_value);
+    fastled_timer_cc_set(timer, cc_channel, compare_value);
 
     // Enable auto-reload unless one-shot mode requested
     if (!(config.flags & ISR_FLAG_ONE_SHOT)) {
@@ -527,12 +605,11 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     }
 
     // Configure GPIOTE channel
-    // SDK 15.x+ HAL functions require NRF_GPIOTE register pointer as first arg
-    nrf_gpiote_event_configure(NRF_GPIOTE, static_cast<u32>(gpiote_ch), pin, polarity);
-    nrf_gpiote_event_enable(NRF_GPIOTE, static_cast<u32>(gpiote_ch));
+    fastled_gpiote_event_configure(static_cast<u32>(gpiote_ch), pin, polarity);
+    fastled_gpiote_event_enable(static_cast<u32>(gpiote_ch));
 
     // Enable GPIOTE interrupt
-    nrf_gpiote_int_enable(NRF_GPIOTE, 1U << gpiote_ch);
+    fastled_gpiote_int_enable(1U << gpiote_ch);
 
     // Set NVIC priority and enable IRQ
     u8 nvic_priority = map_priority_to_nvic(config.priority);
@@ -579,8 +656,8 @@ int detach_handler(isr_handle_t& handle) FL_NO_EXCEPT {
     } else {
         // Disable GPIOTE interrupt
         if (handle_data->gpiote_channel >= 0) {
-            nrf_gpiote_event_disable(NRF_GPIOTE, static_cast<u32>(handle_data->gpiote_channel));
-            nrf_gpiote_int_disable(NRF_GPIOTE, 1U << handle_data->gpiote_channel);
+            fastled_gpiote_event_disable(static_cast<u32>(handle_data->gpiote_channel));
+            fastled_gpiote_int_disable(1U << handle_data->gpiote_channel);
 
             free_gpiote_channel(handle_data->gpiote_channel);
         }
@@ -611,8 +688,8 @@ int enable_handler(const isr_handle_t& handle) FL_NO_EXCEPT {
             static_cast<u32>(NRF_TIMER_INT_COMPARE0_MASK << handle_data->timer_channel));
         handle_data->is_enabled = true;
     } else {
-        nrf_gpiote_event_enable(NRF_GPIOTE, static_cast<u32>(handle_data->gpiote_channel));
-        nrf_gpiote_int_enable(NRF_GPIOTE, 1U << handle_data->gpiote_channel);
+        fastled_gpiote_event_enable(static_cast<u32>(handle_data->gpiote_channel));
+        fastled_gpiote_int_enable(1U << handle_data->gpiote_channel);
         handle_data->is_enabled = true;
     }
 
@@ -636,8 +713,8 @@ int disable_handler(const isr_handle_t& handle) FL_NO_EXCEPT {
             static_cast<u32>(NRF_TIMER_INT_COMPARE0_MASK << handle_data->timer_channel));
         handle_data->is_enabled = false;
     } else {
-        nrf_gpiote_event_disable(NRF_GPIOTE, static_cast<u32>(handle_data->gpiote_channel));
-        nrf_gpiote_int_disable(NRF_GPIOTE, 1U << handle_data->gpiote_channel);
+        fastled_gpiote_event_disable(static_cast<u32>(handle_data->gpiote_channel));
+        fastled_gpiote_int_disable(1U << handle_data->gpiote_channel);
         handle_data->is_enabled = false;
     }
 

--- a/src/platforms/arm/nrf52/led_sysdefs_arm_nrf52.h
+++ b/src/platforms/arm/nrf52/led_sysdefs_arm_nrf52.h
@@ -34,9 +34,24 @@
     #define FASTLED_ALLOW_INTERRUPTS 1
 #endif
 
-// Use PWM instance 0
+// Use PWM instance 0 by default. Individual instance flags remain overridable
+// for applications that reserve or coordinate more than one PWM peripheral.
 // See clockless_arm_nrf52.h and (in root of library) platforms.cpp
-#define FASTLED_NRF52_ENABLE_PWM_INSTANCE0
+#if !defined(FL_NRF52_PWM_ID)
+    #define FL_NRF52_PWM_ID 0
+#endif
+#if !defined(FL_NRF52_ENABLE_PWM_INSTANCE0)
+    #define FL_NRF52_ENABLE_PWM_INSTANCE0 (FL_NRF52_PWM_ID == 0)
+#endif
+#if !defined(FL_NRF52_ENABLE_PWM_INSTANCE1)
+    #define FL_NRF52_ENABLE_PWM_INSTANCE1 (FL_NRF52_PWM_ID == 1)
+#endif
+#if !defined(FL_NRF52_ENABLE_PWM_INSTANCE2)
+    #define FL_NRF52_ENABLE_PWM_INSTANCE2 (FL_NRF52_PWM_ID == 2)
+#endif
+#if !defined(FL_NRF52_ENABLE_PWM_INSTANCE3)
+    #define FL_NRF52_ENABLE_PWM_INSTANCE3 (FL_NRF52_PWM_ID == 3)
+#endif
 
 #if defined(FASTLED_NRF52_NEVER_INLINE)
     #define FASTLED_NRF52_INLINE_ATTRIBUTE FASTLED_FORCE_INLINE
@@ -52,6 +67,32 @@
 #include <nrf_pwm.h>    // for Clockless
 #include <nrf_nvic.h>   // for Clockless / anything else using interrupts
 // IWYU pragma: end_keep
+
+// Adafruit's FreeRTOS core requires PWM interrupts to use its maximum
+// syscall-safe priority. Mbed does not define that FreeRTOS setting, so use
+// the nRF52840's lowest application interrupt priority instead. Allow board
+// cores and applications to override the selection when needed.
+#if !defined(FL_NRF52_PWM_INTERRUPT_PRIORITY)
+    #if defined(configMAX_SYSCALL_INTERRUPT_PRIORITY)
+        #define FL_NRF52_PWM_INTERRUPT_PRIORITY configMAX_SYSCALL_INTERRUPT_PRIORITY
+    #elif defined(NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY)
+        #define FL_NRF52_PWM_INTERRUPT_PRIORITY NRFX_PWM_DEFAULT_CONFIG_IRQ_PRIORITY
+    #else
+        #define FL_NRF52_PWM_INTERRUPT_PRIORITY 7
+    #endif
+#endif
+
+// Mbed owns the nrfx PWM interrupt handlers. Use synchronous EasyDMA playback
+// there so FastLED does not replace a framework ISR or disturb its callback
+// dispatch. The Adafruit core keeps the existing asynchronous interrupt path.
+#if !defined(FL_NRF52_USE_PWM_INTERRUPTS)
+    #if defined(__MBED__)
+        #define FL_NRF52_USE_PWM_INTERRUPTS 0
+    #else
+        #define FL_NRF52_USE_PWM_INTERRUPTS 1
+    #endif
+#endif
+
 #include "fl/stl/stdint.h"
 #include "fl/stl/noexcept.h"
 typedef __I  fl::u32 RoReg;
@@ -76,12 +117,16 @@ typedef __IO fl::u32 RwReg;
 // or placed in a discardable section, but the references ensure the linker
 // pulls in heap_3.c.o from libFrameworkArduino.a
 //
-// Can be disabled by defining FASTLED_FORCE_NRF52_WRAP_MALLOC=0
-#if !defined(FASTLED_FORCE_NRF52_WRAP_MALLOC)
-    #define FASTLED_FORCE_NRF52_WRAP_MALLOC 1
+// Can be disabled by defining FL_NRF52_FORCE_WRAP_MALLOC=0
+#if !defined(FL_NRF52_FORCE_WRAP_MALLOC)
+    #if defined(__MBED__)
+        #define FL_NRF52_FORCE_WRAP_MALLOC 0
+    #else
+        #define FL_NRF52_FORCE_WRAP_MALLOC 1
+    #endif
 #endif
 
-#if FASTLED_FORCE_NRF52_WRAP_MALLOC && defined(FL_IS_NRF52)
+#if FL_NRF52_FORCE_WRAP_MALLOC && defined(FL_IS_NRF52)
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,6 +161,6 @@ static volatile void* fastled_nrf52_force_malloc_wrappers_link(void) FL_NO_EXCEP
 #ifdef __cplusplus
 }
 #endif
-#endif // FASTLED_FORCE_NRF52_WRAP_MALLOC && FL_IS_NRF52
+#endif // FL_NRF52_FORCE_WRAP_MALLOC && FL_IS_NRF52
 
 #endif // __LED_SYSDEFS_ARM_NRF52

--- a/src/platforms/arm/nrf52/spi_hw_2_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/spi_hw_2_nrf52.cpp.hpp
@@ -396,7 +396,11 @@ void SPIDualNRF52::configureTimer(u32 clock_speed_hz) {
     // Set compare value to trigger at start of transmission
     // For dual-SPI, we just need a single trigger event
     // The SPIM peripherals will handle their own clock generation
+#if FL_NRF52_USE_LEGACY_HAL
+    nrf_timer_cc_write(mTimer, NRF_TIMER_CC_CHANNEL0, 1);
+#else
     nrf_timer_cc_set(mTimer, NRF_TIMER_CC_CHANNEL0, 1);
+#endif
 
     // Enable compare event
     nrf_timer_event_clear(mTimer, NRF_TIMER_EVENT_COMPARE0);

--- a/src/platforms/arm/nrf52/spi_hw_4_nrf52.cpp.hpp
+++ b/src/platforms/arm/nrf52/spi_hw_4_nrf52.cpp.hpp
@@ -470,7 +470,11 @@ void SPIQuadNRF52::configureTimer(u32 clock_speed_hz) {
     // Set compare value to trigger at start of transmission
     // For quad-SPI, we just need a single trigger event
     // The SPIM peripherals will handle their own clock generation
+#if FL_NRF52_USE_LEGACY_HAL
+    nrf_timer_cc_write(mTimer, NRF_TIMER_CC_CHANNEL0, 1);
+#else
     nrf_timer_cc_set(mTimer, NRF_TIMER_CC_CHANNEL0, 1);
+#endif
 
     // Enable compare event
     nrf_timer_event_clear(mTimer, NRF_TIMER_EVENT_COMPARE0);


### PR DESCRIPTION
## Summary

- support the Seeed XIAO nRF52840 Plus/Sense Plus pin map used by ArduinoCore-mbed 2.9.3
- avoid FreeRTOS-only PWM interrupt handling on Mbed by using bounded synchronous EasyDMA completion
- adapt to the legacy Nordic SDK 15 HAL bundled by the Seeed core while preserving the Adafruit nRF52 path
- rename the touched nRF52 PWM configuration surface from `FASTLED_*` to `FL_*`
- skip Adafruit-specific malloc wrapper forcing on Mbed

## Root cause

The Seeed Mbed core defines `NRF52840_XXAA`, so FastLED selected its nRF52 backend. That backend assumed Adafruit's FreeRTOS core and unconditionally referenced `configMAX_SYSCALL_INTERRUPT_PRIORITY`; Mbed/RTX does not define it. Mbed also owns the PWM IRQ handlers and ships older Nordic HAL signatures, while the generic nRF52840 fallback selected the wrong Feather pin map.

## Reproduction

RED against FastLED 3.10.5 and Seeed nRF52 Mbed Boards 2.9.3:

```text
arduino-cli compile --fqbn Seeeduino:mbed:xiaonRF52840Plus --library <FastLED-3.10.5> --build-path <red-build> <FastLED-3.10.5>/examples/Blink
```

```text
clockless_arm_nrf52.h:119:44: error: 'configMAX_SYSCALL_INTERRUPT_PRIORITY' was not declared in this scope
```

GREEN with this branch:

```text
arduino-cli compile --fqbn Seeeduino:mbed:xiaonRF52840Plus --library . --build-path .build/arduino-cli/issue-3876-merge-candidate examples/Blink
Sketch uses 102608 bytes (12%) of program storage space.
Global variables use 54600 bytes (22%) of dynamic memory.
```

## Validation

- `bash lint`
- `bash test --cpp` — 279/279 unit tests passed
- exact Seeed FQBN compile above
- `bash compile adafruit_feather_nrf52840_sense --examples Blink --backend platformio` — existing Adafruit/FreeRTOS nRF52 path passed
- pre-push review: PASS after addressing board-safety, timeout, HAL-selection, and PWM-instance invariants

FQBN-native fbuild research is tracked separately in FastLED/fbuild#1298.

Closes #3876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Seeed XIAO nRF52840 Plus and Sense Plus board pin mappings.
  * Added configurable nRF52 PWM instances, interrupt behavior, priority, and memory-allocation settings.
  * Added compatibility across legacy and newer nRF52 hardware APIs.
* **Bug Fixes**
  * Improved PWM playback when interrupts are unavailable with polling and cooperative yielding.
  * Improved timer and GPIO interrupt handling across supported nRF52 environments.
* **Documentation**
  * Documented supported Seeed XIAO boards and nRF52 PWM configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->