### PR TITLE
feat(examples/MoodRing): VisualControlBus + pulse overlay

### DIFF
--- a/examples/MoodRing/MoodRing.ino
+++ b/examples/MoodRing/MoodRing.ino
@@ -24,10 +24,11 @@
 ///
 /// Landed so far:
 ///   * 3-state classifier + per-state visual banks + per-state audio mapping
+///   * VisualControlBus -- one struct of derived signals both engines consume
+///   * overlay compositor: trails + expanding pulse rings (engine-agnostic)
 ///
 /// Still to land (see #2256):
-///   * VisualControlBus -- one struct of derived signals both engines consume
-///   * engine-agnostic overlay compositor (trails / pulse / sector / sparkle)
+///   * overlay: sector emphasis and sparkle rendering
 ///   * mood-quadrant bias from MoodAnalyzer (valence x arousal)
 ///   * a second engine (NoiseRing) behind the same bus, with cross-fade
 ///   * patch schema + URL serialization, curated presets

--- a/examples/MoodRing/MoodRing.ino
+++ b/examples/MoodRing/MoodRing.ino
@@ -56,8 +56,10 @@
 #include "fl/ui/ui.h"
 
 #include "auto_brightness.h"
+#include "ring_overlay.h"
 #include "ring_screenmap.h"
 #include "sound_orchestrator.h"
+#include "visual_control_bus.h"
 
 FASTLED_TITLE("MoodRing");
 
@@ -118,9 +120,22 @@ fl::UISlider orchestratorDwellMs("Orchestrator Min Dwell (ms)", 1500, 200, 5000,
 fl::UISlider orchestratorHysteresisMs("Orchestrator Hysteresis (ms)", 400, 0,
                                       2000, 50);
 
+// Visual control bus tunables.
+fl::UISlider busBaseSpeed("Base Speed", 1.0, 0, 4, 0.05);
+fl::UISlider busBassPunchGain("Bass Punch Gain", 1.5, 0, 3, 0.05);
+
+// Overlay. Turning both off leaves the engine's own output untouched, which is
+// how you check the overlay is purely additive.
+fl::UICheckbox overlayTrails("Overlay: Trails", true);
+fl::UICheckbox overlayPulse("Overlay: Pulse Ring", true);
+fl::UISlider overlayPulseOrigin("Pulse Origin Offset", 0, 0, NUM_LEDS - 1, 1);
+fl::UISlider overlayTrailDecay("Trail Decay Override", -1, -1, 1, 0.05);
+fl::UICheckbox debugPrintBus("Debug: Print Bus", false);
+
 // Processor + orchestrator (initialized in setup)
 fl::shared_ptr<fl::audio::Processor> gAudioProcessor;
 fl::shared_ptr<mood_ring::SoundOrchestrator> gOrchestrator;
+mood_ring::RingOverlay gOverlay;
 bool gAutoPump = false;
 
 void setup() {
@@ -182,6 +197,11 @@ void loop() {
             static_cast<fl::u32>(orchestratorHysteresisMs.value());
         gOrchestrator->setConfig(cfg);
 
+        mood_ring::BusConfig busCfg;
+        busCfg.baseSpeed = busBaseSpeed.value();
+        busCfg.bassPunchGain = busBassPunchGain.value();
+        gOrchestrator->setBusConfig(busCfg);
+
         const fl::u32 now = millis();
         gOrchestrator->tick(now, timeSpeed.value());
 
@@ -199,6 +219,33 @@ void loop() {
 
     // Draw the effect
     fxEngine.draw(millis(), leds);
+
+    // Composite the overlay on top of whatever the engine produced. This is a
+    // post-process on the 1D ring -- it never reaches into Animartrix, which is
+    // why a second engine will be able to reuse it unchanged.
+    if (enableOrchestrator.value()) {
+        gOverlay.config.trails = overlayTrails.value();
+        gOverlay.config.pulse = overlayPulse.value();
+        gOverlay.config.pulseOrigin = static_cast<int>(overlayPulseOrigin.value());
+        gOverlay.config.trailDecayOverride = overlayTrailDecay.value();
+        gOverlay.apply(leds, gOrchestrator->bus(), millis());
+
+        if (debugPrintBus.value()) {
+            static fl::u32 sFrame = 0;
+            if ((sFrame++ % 30) == 0) {
+                const mood_ring::VisualControlBus &b = gOrchestrator->bus();
+                printf("MoodRing bus: state=%s speed=%.2f radial=%.2f rot=%.2f "
+                       "drift=%.2f sparkle=%.2f decay=%.2f bands=%.2f/%.2f/%.2f "
+                       "pulse=%.2f%s pulses=%d\n",
+                       mood_ring::toString(gOrchestrator->state()),
+                       b.transportSpeed, b.radialPressure, b.rotationBias,
+                       b.paletteDrift, b.sparkleDensity, b.decayAmount,
+                       b.lowBand, b.midBand, b.highBand, b.pulseStrength,
+                       b.pulseIsDownbeat ? " DOWNBEAT" : "",
+                       gOverlay.activePulseCount());
+            }
+        }
+    }
 
     // Calculate final brightness
     uint8_t finalBrightness;

--- a/examples/MoodRing/README.md
+++ b/examples/MoodRing/README.md
@@ -38,7 +38,9 @@ it into ambient mode.
 | File | Purpose |
 |------|---------|
 | `MoodRing.ino` | Wiring: audio input, orchestrator, ring rendering, UI |
-| `sound_orchestrator.{h,cpp}` | The 3-state classifier and per-state audio→visual mapping |
+| `sound_orchestrator.{h,cpp}` | The 3-state classifier and animation-bank selection |
+| `visual_control_bus.{h,cpp}` | `SoundState`, the derived-signal bus, and its per-state policy |
+| `ring_overlay.{h,cpp}` | Post-process passes on the ring: trails and pulse rings |
 | `ring_screenmap.{h,cpp}` | Builds the circular `ScreenMap` inside a rectangular grid |
 | `auto_brightness.{h,cpp}` | Content-aware brightness compression |
 
@@ -58,16 +60,21 @@ Landed:
 
 - 3-state classifier with hysteresis and minimum dwell (#2713, PR #2809)
 - Per-state Animartrix visual banks and per-state audio→visual mapping
+- **VisualControlBus** (#3885) — one struct of derived signals
+  (`transportSpeed`, `radialPressure`, `rotationBias`, `paletteDrift`,
+  `sparkleDensity`, `decayAmount`, band levels, `pulseStrength`) that every
+  engine consumes. Keyed on `max(0, vibeBass - vibeBassAtt)`, so a transient
+  reads as a hit while sustained loudness does not.
+- **Overlay compositor** (#3885) — trails and expanding pulse rings on the 1D
+  ring buffer after the engine writes it, so it costs one implementation rather
+  than one per engine
 
 Still to land — see [#2256](https://github.com/FastLED/FastLED/issues/2256) for
 the full design and PR split:
 
-- **VisualControlBus** — one struct of derived signals (`transportSpeed`,
-  `radialPressure`, `rotationBias`, `paletteDrift`, `sparkleDensity`,
-  `decayAmount`, band levels, `pulseStrength`) that every engine consumes
-- **Overlay compositor** — trails, expanding pulse rings, sector emphasis, and
-  sparkle, running on the 1D ring buffer after the engine writes it, so it costs
-  one implementation rather than one per engine
+- **Overlay: sector emphasis and sparkle** — the remaining two passes. The bus
+  already carries `lowBand`/`midBand`/`highBand` and `sparkleDensity`, so they
+  attach without reopening the derivation
 - **Mood-quadrant bias** — `MoodAnalyzer` valence × arousal steering palette
   family and motion character
 - **NoiseRing engine** — a second, cheaper engine behind the same bus, with

--- a/examples/MoodRing/ring_overlay.cpp
+++ b/examples/MoodRing/ring_overlay.cpp
@@ -70,13 +70,27 @@ void RingOverlay::compositeTrails(fl::span<CRGB> leds, float decay) {
     if (keep > 0.98f) keep = 0.98f; // never fully self-sustaining
     const fl::u8 keep8 = static_cast<fl::u8>(keep * 255.0f);
 
+    // Persistence by per-channel max, NOT by accumulation.
+    //
+    // The obvious formulation -- fold a fraction of the live frame into the
+    // history and then add the history back -- has DC gain above 1: for a
+    // steady input L and survival k the echo settles at (L/4)/(1-k), so the
+    // output is L*(1 + 0.25/(1-k)). At the ambient decay of 0.85 that is 2.7x
+    // the engine's output, which clips the whole ring to white -- the exact
+    // opposite of the restrained look Silence is supposed to have.
+    //
+    // Taking the max of the live pixel and the decayed history is unity-gain
+    // by construction: a static frame yields exactly itself, and only a pixel
+    // that was brighter in the past can add anything. A decay of 0 collapses
+    // to a pure passthrough, which is what makes the overlay honestly additive.
     for (fl::size i = 0; i < n; ++i) {
         CRGB &t = mTrail[i];
         t.nscale8(keep8);
-        // Feed a quarter of the live frame into the history each frame.
-        t += CRGB(leds[i].r >> 2, leds[i].g >> 2, leds[i].b >> 2);
-        // Blend the echo back on top. CRGB::operator+= saturates.
-        leds[i] += t;
+        const CRGB live = leds[i];
+        if (live.r > t.r) t.r = live.r;
+        if (live.g > t.g) t.g = live.g;
+        if (live.b > t.b) t.b = live.b;
+        leds[i] = t;
     }
 }
 

--- a/examples/MoodRing/ring_overlay.cpp
+++ b/examples/MoodRing/ring_overlay.cpp
@@ -1,0 +1,163 @@
+// ring_overlay.cpp - trails and expanding pulse rings on the 1D strip.
+#include "ring_overlay.h"
+
+#include "fl/math/math.h"
+
+namespace mood_ring {
+
+namespace {
+
+// How long a pulse ring takes to travel from the origin to the far side.
+constexpr fl::u32 kPulseLifetimeMs = 700;
+
+// Ring half-width as a fraction of strip length. Downbeats are visibly fatter
+// so a bar boundary reads as larger than an ordinary beat.
+constexpr float kSigmaBeat = 0.035f;
+constexpr float kSigmaDownbeat = 0.060f;
+
+/// Smoothstep falloff. Cheaper than a true Gaussian and visually equivalent at
+/// this scale, with no libm dependency.
+float smoothFalloff(float distance, float sigma) {
+    if (sigma <= 0.0f) return 0.0f;
+    float t = 1.0f - (distance / sigma);
+    if (t <= 0.0f) return 0.0f;
+    if (t >= 1.0f) return 1.0f;
+    return t * t * (3.0f - 2.0f * t);
+}
+
+/// Shortest distance between two indices on a closed ring.
+float ringDistance(int a, int b, int n) {
+    int d = a - b;
+    if (d < 0) d = -d;
+    const int wrapped = n - d;
+    return static_cast<float>(d < wrapped ? d : wrapped);
+}
+
+} // namespace
+
+void RingOverlay::apply(fl::span<CRGB> leds, const VisualControlBus &bus,
+                        fl::u32 nowMs) {
+    if (leds.empty()) return;
+
+    if (config.trails) {
+        const float decay = (config.trailDecayOverride >= 0.0f)
+                                ? config.trailDecayOverride
+                                : bus.decayAmount;
+        compositeTrails(leds, decay);
+    } else {
+        // Drop the history so re-enabling trails does not smear a stale frame
+        // from minutes ago onto the current one.
+        mTrail.clear();
+    }
+
+    if (config.pulse) {
+        if (bus.pulseStrength > 0.0f) {
+            emitPulse(bus.pulseStrength, bus.pulseIsDownbeat, nowMs);
+        }
+        drawPulses(leds, nowMs);
+    }
+}
+
+void RingOverlay::compositeTrails(fl::span<CRGB> leds, float decay) {
+    const fl::size n = leds.size();
+    if (mTrail.size() != n) {
+        mTrail.assign(n, CRGB::Black);
+    }
+
+    // decay is "how much persists", so the surviving fraction is decay itself.
+    float keep = decay;
+    if (keep < 0.0f) keep = 0.0f;
+    if (keep > 0.98f) keep = 0.98f; // never fully self-sustaining
+    const fl::u8 keep8 = static_cast<fl::u8>(keep * 255.0f);
+
+    for (fl::size i = 0; i < n; ++i) {
+        CRGB &t = mTrail[i];
+        t.nscale8(keep8);
+        // Feed a quarter of the live frame into the history each frame.
+        t += CRGB(leds[i].r >> 2, leds[i].g >> 2, leds[i].b >> 2);
+        // Blend the echo back on top. CRGB::operator+= saturates.
+        leds[i] += t;
+    }
+}
+
+void RingOverlay::emitPulse(float strength, bool downbeat, fl::u32 nowMs) {
+    int slot = -1;
+    for (int i = 0; i < kMaxPulses; ++i) {
+        if (!mPulses[i].active) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot < 0) {
+        // All busy: recycle the oldest.
+        fl::u32 oldest = mPulses[0].startMs;
+        slot = 0;
+        for (int i = 1; i < kMaxPulses; ++i) {
+            if (mPulses[i].startMs < oldest) {
+                oldest = mPulses[i].startMs;
+                slot = i;
+            }
+        }
+    }
+    mPulses[slot].startMs = nowMs;
+    mPulses[slot].strength = strength;
+    mPulses[slot].downbeat = downbeat;
+    mPulses[slot].active = true;
+}
+
+void RingOverlay::drawPulses(fl::span<CRGB> leds, fl::u32 nowMs) {
+    const int n = static_cast<int>(leds.size());
+    if (n <= 0) return;
+
+    int origin = config.pulseOrigin % n;
+    if (origin < 0) origin += n;
+
+    const float halfRing = static_cast<float>(n) * 0.5f;
+
+    for (int pi = 0; pi < kMaxPulses; ++pi) {
+        Pulse &pulse = mPulses[pi];
+        if (!pulse.active) continue;
+
+        const fl::u32 elapsed = nowMs - pulse.startMs;
+        if (elapsed >= kPulseLifetimeMs) {
+            pulse.active = false;
+            continue;
+        }
+
+        const float life =
+            static_cast<float>(elapsed) / static_cast<float>(kPulseLifetimeMs);
+        // Radius sweeps from the origin to the far side over the lifetime.
+        const float radius = life * halfRing;
+        const float sigma =
+            static_cast<float>(n) *
+            (pulse.downbeat ? kSigmaDownbeat : kSigmaBeat);
+        // Fade out as it travels so the ring dissolves instead of vanishing.
+        const float amplitude = pulse.strength * (1.0f - life);
+        if (amplitude <= 0.0f) continue;
+
+        // Downbeats flip to a contrasting hue; ordinary beats stay neutral so
+        // the bar boundary is distinguishable by colour as well as by width.
+        const CRGB tint = pulse.downbeat ? CRGB(255, 170, 60) : CRGB(255, 255, 255);
+
+        for (int i = 0; i < n; ++i) {
+            const float d = ringDistance(i, origin, n);
+            const float k = smoothFalloff(fl::fabs(d - radius), sigma);
+            if (k <= 0.0f) continue;
+            const fl::u8 level =
+                static_cast<fl::u8>(fl::min(255.0f, amplitude * k * 255.0f));
+            CRGB add = tint;
+            add.nscale8(level);
+            leds[i] += add;
+        }
+    }
+}
+
+int RingOverlay::activePulseCount() const {
+    int count = 0;
+    for (int i = 0; i < kMaxPulses; ++i) {
+        if (mPulses[i].active) ++count;
+    }
+    return count;
+}
+
+} // namespace mood_ring

--- a/examples/MoodRing/ring_overlay.h
+++ b/examples/MoodRing/ring_overlay.h
@@ -1,0 +1,59 @@
+// ring_overlay.h - engine-agnostic post-process passes on the 1D ring.
+//
+// Runs after the engine has drawn and before FastLED.show(). It never touches
+// Animartrix internals, which is what makes it reusable: when the NoiseRing
+// engine lands it inherits trails and pulses for free.
+//
+// See issue #3885.
+#pragma once
+
+#include "FastLED.h"
+#include "fl/stl/span.h"
+#include "fl/stl/stdint.h"
+#include "fl/stl/vector.h"
+
+#include "visual_control_bus.h"
+
+namespace mood_ring {
+
+struct OverlayConfig {
+    bool trails = true;
+    bool pulse = true;
+    int pulseOrigin = 0;           ///< ring index a pulse expands from
+    float trailDecayOverride = -1.0f; ///< <0 = follow bus.decayAmount
+};
+
+/// Trails plus expanding pulse rings, composited onto the strip in place.
+class RingOverlay {
+  public:
+    OverlayConfig config;
+
+    /// Composite this frame. Safe to call with an empty span.
+    void apply(fl::span<CRGB> leds, const VisualControlBus &bus, fl::u32 nowMs);
+
+    /// How many pulse rings are currently in flight (for the debug readout).
+    int activePulseCount() const;
+
+  private:
+    void compositeTrails(fl::span<CRGB> leds, float decay);
+    void emitPulse(float strength, bool downbeat, fl::u32 nowMs);
+    void drawPulses(fl::span<CRGB> leds, fl::u32 nowMs);
+
+    /// A pulse ring travelling outward from the origin index.
+    struct Pulse {
+        fl::u32 startMs = 0;
+        float strength = 0.0f;
+        bool downbeat = false;
+        bool active = false;
+    };
+
+    // Bounded so a dense passage cannot grow unbounded state. Oldest is
+    // recycled when full, which reads correctly: the newest hits are the ones
+    // the eye tracks.
+    static const int kMaxPulses = 8;
+    Pulse mPulses[kMaxPulses];
+
+    fl::vector<CRGB> mTrail; ///< persistence shadow buffer, sized on first use
+};
+
+} // namespace mood_ring

--- a/examples/MoodRing/sound_orchestrator.cpp
+++ b/examples/MoodRing/sound_orchestrator.cpp
@@ -186,8 +186,11 @@ float SoundOrchestrator::tick(fl::u32 nowMs, float manualSpeedScalar) {
         mDeriver.derive(*mProcessor, mState, mBusCfg, events, nowMs,
                         manualSpeedScalar, &mBus);
     } else {
+        // No processor: publish a neutral bus driven only by the manual slider,
+        // bounded the same way the derived path is so this branch cannot hand
+        // FxEngine something the normal path never would.
         mBus = VisualControlBus{};
-        mBus.transportSpeed = manualSpeedScalar;
+        mBus.transportSpeed = clampTransportSpeed(manualSpeedScalar);
     }
 
     if (mEngine) mEngine->setSpeed(mBus.transportSpeed);

--- a/examples/MoodRing/sound_orchestrator.cpp
+++ b/examples/MoodRing/sound_orchestrator.cpp
@@ -6,15 +6,6 @@
 
 namespace mood_ring {
 
-const char *toString(SoundState s) {
-    switch (s) {
-    case SoundState::Silence:      return "Silence";
-    case SoundState::Disorganized: return "Disorganized";
-    case SoundState::BpmLocked:    return "BpmLocked";
-    }
-    return "?";
-}
-
 namespace {
 
 // State -> visual bank lookup tables.
@@ -173,63 +164,6 @@ SoundState SoundOrchestrator::classify(fl::u32 nowMs) {
     return mState;
 }
 
-float SoundOrchestrator::driveSilence(fl::u32 /*nowMs*/, float manualSpeedScalar) {
-    // Ambient: very slow, restrained. Time warp essentially off.
-    return mCfg.silenceSpeed * manualSpeedScalar;
-}
-
-float SoundOrchestrator::driveDisorganized(fl::u32 /*nowMs*/, float manualSpeedScalar) {
-    if (!mProcessor) return manualSpeedScalar;
-    // Map vibe.bass (self-normalizing, ~1.0 = average) into a speed modulation.
-    // This is the "time warp as secondary effect" knob: it still exists, but
-    // it's bounded by disorganizedSpeedSpan rather than dominating.
-    const float bass = mProcessor->getVibeBass();      // ~1.0 nominal
-    const float bassBoost = (bass - 1.0f) * mCfg.disorganizedSpeedSpan;
-    float speed = 1.0f + bassBoost;
-    if (speed < 0.1f) speed = 0.1f;
-    if (speed > 4.0f) speed = 4.0f;
-    return speed * manualSpeedScalar;
-}
-
-float SoundOrchestrator::driveBpmLocked(fl::u32 nowMs, float manualSpeedScalar) {
-    if (!mProcessor) return manualSpeedScalar;
-
-    // Baseline speed scales gently with BPM so faster songs read faster.
-    const float bpm = mProcessor->getBPM();
-    // Normalize BPM to a 0.6..1.6 multiplier around the nominal 120 BPM.
-    float bpmScale = 1.0f;
-    if (bpm > 1.0f) {
-        bpmScale = bpm / 120.0f;
-        if (bpmScale < 0.6f) bpmScale = 0.6f;
-        if (bpmScale > 1.6f) bpmScale = 1.6f;
-    }
-
-    // Pulse: kick/snare/downbeat events bump speed briefly and decay.
-    // Downbeats hit hardest (palette-level event); kicks medium; snares light.
-    auto pulseFromEvent = [&](fl::u32 t, float weight) -> float {
-        if (t == 0) return 0.0f;
-        const fl::u32 dt = nowMs - t;
-        if (dt >= mCfg.pulseDecayMs) return 0.0f;
-        const float k = 1.0f - (static_cast<float>(dt) / mCfg.pulseDecayMs);
-        return weight * k * k;  // ease-out square
-    };
-    const float kickPulse     = pulseFromEvent(mLastKickMs,     0.50f);
-    const float snarePulse    = pulseFromEvent(mLastSnareMs,    0.25f);
-    const float downbeatPulse = pulseFromEvent(mLastDownbeatMs, 0.80f);
-    float pulse = kickPulse + snarePulse + downbeatPulse;
-    if (pulse > 1.5f) pulse = 1.5f;
-
-    // measurePhase smoothly fills the inter-beat gap so visuals breathe
-    // between pulses rather than freezing. Phase is 0..1 within the measure.
-    const float phase = mProcessor->getMeasurePhase(); // 0..1
-    // Sine bow so phase contributes gently throughout the measure.
-    const float phaseBow = 0.15f * fl::sin(phase * 6.2831853f);
-
-    float speed = mCfg.bpmLockedBaseSpeed * bpmScale + pulse + phaseBow;
-    if (speed < 0.2f) speed = 0.2f;
-    return speed * manualSpeedScalar;
-}
-
 float SoundOrchestrator::tick(fl::u32 nowMs, float manualSpeedScalar) {
     if (mStateEnteredAtMs == 0) mStateEnteredAtMs = nowMs;
 
@@ -240,17 +174,25 @@ float SoundOrchestrator::tick(fl::u32 nowMs, float manualSpeedScalar) {
     }
     switchAnimationIfNeeded(mState, nowMs);
 
-    float speed;
-    switch (mState) {
-    case SoundState::Silence:      speed = driveSilence(nowMs, manualSpeedScalar);      break;
-    case SoundState::Disorganized: speed = driveDisorganized(nowMs, manualSpeedScalar); break;
-    case SoundState::BpmLocked:    speed = driveBpmLocked(nowMs, manualSpeedScalar);    break;
-    default:                       speed = manualSpeedScalar;                            break;
+    // Derive the bus, then apply only the field the engine owns. Everything
+    // else on the bus is for the overlay and, later, the second engine.
+    if (mProcessor) {
+        AudioEvents events;
+        events.lastKickMs = mLastKickMs;
+        events.lastSnareMs = mLastSnareMs;
+        events.lastDownbeatMs = mLastDownbeatMs;
+        events.hiHat = mProcessor->isHiHat();
+        events.beatNumber = mProcessor->getCurrentBeatNumber();
+        mDeriver.derive(*mProcessor, mState, mBusCfg, events, nowMs,
+                        manualSpeedScalar, &mBus);
+    } else {
+        mBus = VisualControlBus{};
+        mBus.transportSpeed = manualSpeedScalar;
     }
 
-    if (mEngine) mEngine->setSpeed(speed);
-    mLastEngineSpeed = speed;
-    return speed;
+    if (mEngine) mEngine->setSpeed(mBus.transportSpeed);
+    mLastEngineSpeed = mBus.transportSpeed;
+    return mBus.transportSpeed;
 }
 
 } // namespace mood_ring

--- a/examples/MoodRing/sound_orchestrator.h
+++ b/examples/MoodRing/sound_orchestrator.h
@@ -31,15 +31,12 @@
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/stdint.h"
 
+#include "visual_control_bus.h"
+
 namespace mood_ring {
 
-enum class SoundState : fl::u8 {
-    Silence = 0,
-    Disorganized = 1,
-    BpmLocked = 2,
-};
-
-const char *toString(SoundState s);
+// SoundState and toString() live in visual_control_bus.h -- they are shared
+// vocabulary between the classifier, the bus derivation, and the overlay.
 
 struct OrchestratorConfig {
     // Classifier thresholds.
@@ -57,18 +54,11 @@ struct OrchestratorConfig {
     // before we accept a transition (additional hysteresis on top of dwell).
     fl::u32 classifierHysteresisMs = 400;
 
-    // BpmLocked: pulse decay (ms) for a single kick/snare/downbeat event.
-    fl::u32 pulseDecayMs       = 220;
-
-    // Disorganized: how much vibe.bass scales engine speed (above baseline 1.0).
-    float disorganizedSpeedSpan = 1.5f;
-
-    // Silence: ambient engine speed.
-    float silenceSpeed         = 0.25f;
-
-    // BpmLocked: engine baseline speed (BPM modulation rides on top).
-    float bpmLockedBaseSpeed   = 1.0f;
 };
+
+// NOTE: speed/pulse tuning used to live here. It moved to BusConfig and the
+// per-state policy in visual_control_bus.cpp when the bus landed (#3885):
+// events now drive a visible pulse on the ring instead of yanking the clock.
 
 /// Top-level orchestrator. Owns no audio data of its own; polls the supplied
 /// Processor on every tick() and drives the supplied FxEngine / Animartrix.
@@ -84,9 +74,19 @@ public:
     void begin();
 
     /// Per-frame tick. Pass the current millis() and a manual-speed scalar
-    /// (so the existing "Time Speed" slider still composes).
+    /// (so the existing "Time Speed" slider still composes). Classifies the
+    /// audio, switches the animation bank, derives the visual control bus, and
+    /// applies bus.transportSpeed to the engine.
     /// Returns the engine speed actually applied this tick.
     float tick(fl::u32 nowMs, float manualSpeedScalar);
+
+    /// The bus derived on the most recent tick. Consumers read this rather
+    /// than the raw detectors.
+    const VisualControlBus &bus() const { return mBus; }
+
+    /// Bus tunables (base speed, punch gain). Cheap; safe to set every tick.
+    void setBusConfig(const BusConfig &cfg) { mBusCfg = cfg; }
+    const BusConfig &busConfig() const { return mBusCfg; }
 
     /// Observability.
     SoundState state() const { return mState; }
@@ -102,11 +102,6 @@ private:
     static fl::AnimartrixAnim pickAnimationFor(SoundState s, fl::u32 nowMs);
     void switchAnimationIfNeeded(SoundState newState, fl::u32 nowMs);
 
-    // Per-state behavior.
-    float driveSilence(fl::u32 nowMs, float manualSpeedScalar);
-    float driveDisorganized(fl::u32 nowMs, float manualSpeedScalar);
-    float driveBpmLocked(fl::u32 nowMs, float manualSpeedScalar);
-
     // Classifier.
     SoundState classify(fl::u32 nowMs);
 
@@ -116,6 +111,9 @@ private:
     fl::FxEngine *mEngine;
 
     OrchestratorConfig mCfg{};
+    BusConfig mBusCfg{};
+    BusDeriver mDeriver;
+    VisualControlBus mBus{};
 
     SoundState mState = SoundState::Silence;
     fl::u32    mStateEnteredAtMs = 0;

--- a/examples/MoodRing/visual_control_bus.cpp
+++ b/examples/MoodRing/visual_control_bus.cpp
@@ -27,7 +27,19 @@ float clampf(float v, float lo, float hi) {
 // Ambient breathing rate for the Silence state, in cycles per second.
 constexpr float kSilenceBreathHz = 0.12f;
 
+// Sign-preserving bound on the value handed to FxEngine. 4.0 (the audio-derived
+// ceiling) times 10.0 (the Time Speed slider's extreme) -- generous enough that
+// legitimate settings pass through untouched, tight enough that a bad scalar
+// cannot publish something wild.
+constexpr float kMaxAbsTransportSpeed = 40.0f;
+
 } // namespace
+
+float clampTransportSpeed(float v) {
+    if (v > kMaxAbsTransportSpeed) return kMaxAbsTransportSpeed;
+    if (v < -kMaxAbsTransportSpeed) return -kMaxAbsTransportSpeed;
+    return v;
+}
 
 float softKnee(float x) {
     if (x <= 0.0f) return 0.0f;
@@ -109,7 +121,14 @@ void BusDeriver::derive(fl::audio::Processor &p, SoundState state,
         speed = cfg.baseSpeed;
         break;
     }
-    out->transportSpeed = clampf(speed, 0.1f, 4.0f) * manualSpeedScalar;
+    // The audio-derived component is clamped to its documented band, then
+    // composed with the sketch's Time Speed scalar. The scalar is deliberately
+    // NOT folded into that clamp: the slider spans -10..10 and negative values
+    // run the animation backwards, so clamping the product to [0.1, 4.0] would
+    // silently delete reverse and slow-motion. The product still gets a
+    // sign-preserving magnitude bound so nothing unbounded reaches FxEngine.
+    out->transportSpeed =
+        clampTransportSpeed(clampf(speed, 0.1f, 4.0f) * manualSpeedScalar);
 
     // --- radial pressure ---
     if (state == SoundState::Silence) {

--- a/examples/MoodRing/visual_control_bus.cpp
+++ b/examples/MoodRing/visual_control_bus.cpp
@@ -1,0 +1,188 @@
+// visual_control_bus.cpp - derive the visual control bus from the audio stream.
+#include "visual_control_bus.h"
+
+#include "fl/math/math.h"
+
+namespace mood_ring {
+
+const char *toString(SoundState s) {
+    switch (s) {
+    case SoundState::Silence:      return "Silence";
+    case SoundState::Disorganized: return "Disorganized";
+    case SoundState::BpmLocked:    return "BpmLocked";
+    }
+    return "?";
+}
+
+namespace {
+
+constexpr float kTwoPi = 6.2831853f;
+
+float clampf(float v, float lo, float hi) {
+    if (v < lo) return lo;
+    if (v > hi) return hi;
+    return v;
+}
+
+// Ambient breathing rate for the Silence state, in cycles per second.
+constexpr float kSilenceBreathHz = 0.12f;
+
+} // namespace
+
+float softKnee(float x) {
+    if (x <= 0.0f) return 0.0f;
+    if (x >= 1.0f) {
+        // Above unity, compress hard rather than clip: keeps a very loud band
+        // distinguishable from a merely loud one.
+        return 1.0f - 0.25f / (1.0f + (x - 1.0f) * 4.0f);
+    }
+    // Below unity the curve is close to linear but eases at the top so the
+    // last 20% of range still moves.
+    return x * (1.25f - 0.25f * x);
+}
+
+float EnvFollower::update(float target, float dtMs, float attackMs,
+                          float releaseMs) {
+    if (dtMs <= 0.0f) return mValue;
+    const float tau = (target > mValue) ? attackMs : releaseMs;
+    if (tau <= 0.0f) {
+        mValue = target;
+        return mValue;
+    }
+    // One-pole: alpha = 1 - exp(-dt/tau), approximated to avoid expf().
+    float alpha = dtMs / (tau + dtMs);
+    if (alpha > 1.0f) alpha = 1.0f;
+    mValue += (target - mValue) * alpha;
+    return mValue;
+}
+
+void BusDeriver::derive(fl::audio::Processor &p, SoundState state,
+                        const BusConfig &cfg, const AudioEvents &events,
+                        fl::u32 nowMs, float manualSpeedScalar,
+                        VisualControlBus *out) {
+    if (!out) return;
+
+    const float dtMs =
+        (mLastMs == 0) ? 16.0f : static_cast<float>(nowMs - mLastMs);
+    mLastMs = nowMs;
+
+    // --- punch: relative minus attenuated ---
+    // This is the whole reason a hit reads differently from loudness. During a
+    // sustained loud passage the attenuated (slow) level catches up to the
+    // instantaneous level, so punch falls to ~0 and nothing pulses. Only a
+    // transient -- fast level above slow level -- produces punch.
+    const float bassPunch = fl::max(0.0f, p.getVibeBass() - p.getVibeBassAtt());
+    const float trebPunch = fl::max(0.0f, p.getVibeTreb() - p.getVibeTrebAtt());
+
+    // --- continuous bands ---
+    out->lowBand = softKnee(p.getEqBass());
+    out->midBand = softKnee(p.getEqMid());
+    out->highBand = softKnee(p.getEqTreble());
+
+    // --- transport speed, per state policy ---
+    float speed;
+    switch (state) {
+    case SoundState::Silence:
+        // Ambient: fixed and slow. Audio deliberately does not drive speed
+        // here -- silence should look intentional, not idle-twitchy.
+        speed = 0.25f;
+        break;
+    case SoundState::Disorganized:
+        speed = cfg.baseSpeed + 0.8f * cfg.bassPunchGain * bassPunch;
+        break;
+    case SoundState::BpmLocked: {
+        // Baseline tracks tempo so a fast song reads fast; the transient
+        // contribution is halved because pulses now carry the accent visually
+        // instead of by yanking the clock.
+        const float bpm = p.getTempoBPM();
+        float bpmScale = 1.0f;
+        if (bpm > 1.0f) {
+            bpmScale = clampf(bpm / 120.0f, 0.6f, 1.6f);
+        }
+        speed = cfg.baseSpeed * bpmScale + 0.4f * cfg.bassPunchGain * bassPunch;
+        break;
+    }
+    default:
+        speed = cfg.baseSpeed;
+        break;
+    }
+    out->transportSpeed = clampf(speed, 0.1f, 4.0f) * manualSpeedScalar;
+
+    // --- radial pressure ---
+    if (state == SoundState::Silence) {
+        // Slow breathing LFO rather than an audio follower.
+        mSilenceLfoPhase += kTwoPi * kSilenceBreathHz * (dtMs / 1000.0f);
+        while (mSilenceLfoPhase > kTwoPi) mSilenceLfoPhase -= kTwoPi;
+        out->radialPressure = 0.5f + 0.5f * fl::sin(mSilenceLfoPhase);
+        mRadial.update(out->radialPressure, dtMs, 200.0f, 200.0f);
+    } else {
+        const float target = 0.7f * out->lowBand + 0.3f * bassPunch;
+        out->radialPressure = mRadial.update(target, dtMs, 15.0f, 220.0f);
+    }
+
+    // --- rotation bias ---
+    out->rotationBias = (out->midBand - 0.5f) * 2.0f;
+    if (state == SoundState::BpmLocked) {
+        out->rotationBias += 0.3f * fl::sin(kTwoPi * p.getMeasurePhase());
+    }
+    out->rotationBias = clampf(out->rotationBias, -1.0f, 1.0f);
+
+    // --- palette drift ---
+    if (state == SoundState::Silence) {
+        out->paletteDrift = 0.05f;
+    } else {
+        const float tempoTerm = clampf(p.getTempoBPM() / 180.0f, 0.0f, 1.0f);
+        out->paletteDrift = clampf(0.5f * out->midBand + 0.35f * out->highBand +
+                                       0.15f * tempoTerm,
+                                   0.0f, 1.0f);
+    }
+
+    // --- sparkle ---
+    if (state == SoundState::Silence) {
+        out->sparkleDensity = mSparkle.update(0.0f, dtMs, 5.0f, 180.0f);
+    } else {
+        const float target =
+            0.6f * trebPunch + 0.4f * (events.hiHat ? 1.0f : 0.0f);
+        out->sparkleDensity =
+            clampf(mSparkle.update(target, dtMs, 5.0f, 180.0f), 0.0f, 1.0f);
+    }
+
+    // --- decay: long trails when ambient, crisp when locked ---
+    out->decayAmount = (state == SoundState::Silence)   ? 0.85f
+                       : (state == SoundState::BpmLocked) ? 0.35f
+                                                          : 0.60f;
+
+    // --- event lane ---
+    // Cleared every frame; only BpmLocked populates it. Disorganized expresses
+    // itself through the continuous fields, which is what keeps non-rhythmic
+    // audio from faking a pulse grid.
+    out->pulseStrength = 0.0f;
+    out->pulseIsDownbeat = false;
+    out->snareAccent = false;
+    out->hihatTick = false;
+
+    const bool newKick = events.lastKickMs != 0 && events.lastKickMs != mSeenKickMs;
+    const bool newSnare =
+        events.lastSnareMs != 0 && events.lastSnareMs != mSeenSnareMs;
+    const bool newDownbeat =
+        events.lastDownbeatMs != 0 && events.lastDownbeatMs != mSeenDownbeatMs;
+
+    if (state == SoundState::BpmLocked) {
+        if (newDownbeat) {
+            out->pulseStrength = 1.0f;
+            out->pulseIsDownbeat = true;
+        } else if (newKick) {
+            out->pulseStrength = 0.75f;
+        }
+        out->snareAccent = newSnare;
+        out->hihatTick = events.hiHat;
+    }
+
+    // Consume the edges regardless of state, so re-entering BpmLocked does not
+    // immediately fire a stale event that happened while we were elsewhere.
+    if (newKick) mSeenKickMs = events.lastKickMs;
+    if (newSnare) mSeenSnareMs = events.lastSnareMs;
+    if (newDownbeat) mSeenDownbeatMs = events.lastDownbeatMs;
+}
+
+} // namespace mood_ring

--- a/examples/MoodRing/visual_control_bus.cpp
+++ b/examples/MoodRing/visual_control_bus.cpp
@@ -33,12 +33,15 @@ float softKnee(float x) {
     if (x <= 0.0f) return 0.0f;
     if (x >= 1.0f) {
         // Above unity, compress hard rather than clip: keeps a very loud band
-        // distinguishable from a merely loud one.
+        // distinguishable from a merely loud one. Meets the lower branch at
+        // exactly 0.75 when x == 1.
         return 1.0f - 0.25f / (1.0f + (x - 1.0f) * 4.0f);
     }
-    // Below unity the curve is close to linear but eases at the top so the
-    // last 20% of range still moves.
-    return x * (1.25f - 0.25f * x);
+    // Below unity: near-linear at the bottom, easing toward the knee. Must
+    // evaluate to 0.75 at x == 1 so the two branches join -- an earlier
+    // version used (1.25 - 0.25x), which hit 1.0 here and made a band pinned
+    // at full scale read DIMMER than one at 0.999.
+    return x * (1.0f - 0.25f * x);
 }
 
 float EnvFollower::update(float target, float dtMs, float attackMs,

--- a/examples/MoodRing/visual_control_bus.h
+++ b/examples/MoodRing/visual_control_bus.h
@@ -42,7 +42,11 @@ struct AudioEvents {
 /// fires and cleared on the next derive.
 struct VisualControlBus {
     // --- continuous ---
-    float transportSpeed = 1.0f;  ///< [0.1 .. 4.0] -> FxEngine::setSpeed
+    /// Engine speed handed to FxEngine::setSpeed. The audio-derived component
+    /// is [0.1 .. 4.0]; the sketch's Time Speed scalar is then composed on top
+    /// and MAY BE NEGATIVE (the slider spans -10..10 and reverse is a feature),
+    /// so the published value is the product, bounded by clampTransportSpeed().
+    float transportSpeed = 1.0f;
     float radialPressure = 0.0f;  ///< [0 .. 1] inward/outward bias
     float rotationBias = 0.0f;    ///< [-1 .. 1] clockwise vs counter
     float paletteDrift = 0.0f;    ///< [0 .. 1] rate of hue travel
@@ -98,6 +102,10 @@ class BusDeriver {
     fl::u32 mSeenSnareMs = 0;
     fl::u32 mSeenDownbeatMs = 0;
 };
+
+/// Sign-preserving bound on the value handed to FxEngine. Shared so the
+/// no-processor fallback cannot publish something the derived path never would.
+float clampTransportSpeed(float v);
 
 /// Soft-knee clip into [0,1]. Keeps the top of the range from pinning to 1.0
 /// the moment a band gets loud, which is what makes band-driven visuals look

--- a/examples/MoodRing/visual_control_bus.h
+++ b/examples/MoodRing/visual_control_bus.h
@@ -1,0 +1,107 @@
+// visual_control_bus.h - the stable authoring surface between audio and visuals.
+//
+// The classifier decides WHAT KIND of sound the room contains; the bus decides
+// WHAT THE VISUALS SHOULD DO about it. Consumers (the Animartrix engine, the
+// ring overlay, and later the NoiseRing engine) read only the bus and never the
+// raw detectors, so the audio pipeline can change without churning every visual.
+// This is the MilkDrop q1..q32 analogue.
+//
+// See issue #3885 for the derivation rationale and #2256 for the wider design.
+#pragma once
+
+#include "FastLED.h"
+#include "fl/audio/audio_processor.h"
+#include "fl/stl/stdint.h"
+
+namespace mood_ring {
+
+/// What kind of sound the room contains. Lives here rather than in
+/// sound_orchestrator.h because it is shared vocabulary: the bus derivation,
+/// the overlay policy, and the classifier all speak it.
+enum class SoundState : fl::u8 {
+    Silence = 0,
+    Disorganized = 1,
+    BpmLocked = 2,
+};
+
+const char *toString(SoundState s);
+
+/// Rising-edge audio events for the frame being derived. The orchestrator owns
+/// the timestamps (it installs the Processor callbacks); the deriver turns them
+/// into one-frame pulses by noticing when a timestamp changes.
+struct AudioEvents {
+    fl::u32 lastKickMs = 0;
+    fl::u32 lastSnareMs = 0;
+    fl::u32 lastDownbeatMs = 0;
+    bool hiHat = false; ///< polled, not timestamped -- Processor::isHiHat()
+    fl::u8 beatNumber = 0;
+};
+
+/// Everything a visual is allowed to react to. Continuous fields are smoothed
+/// and valid every frame; the event lane is populated on the frame an event
+/// fires and cleared on the next derive.
+struct VisualControlBus {
+    // --- continuous ---
+    float transportSpeed = 1.0f;  ///< [0.1 .. 4.0] -> FxEngine::setSpeed
+    float radialPressure = 0.0f;  ///< [0 .. 1] inward/outward bias
+    float rotationBias = 0.0f;    ///< [-1 .. 1] clockwise vs counter
+    float paletteDrift = 0.0f;    ///< [0 .. 1] rate of hue travel
+    float sparkleDensity = 0.0f;  ///< [0 .. 1] treble-driven shimmer
+    float decayAmount = 0.6f;     ///< [0 .. 1] post-process persistence
+    float lowBand = 0.0f;         ///< [0 .. 1] smoothed band energy
+    float midBand = 0.0f;
+    float highBand = 0.0f;
+
+    // --- event lane ---
+    float pulseStrength = 0.0f;   ///< 0 = no pulse this frame, else 0.2 .. 1.0
+    bool pulseIsDownbeat = false;
+    bool snareAccent = false;
+    bool hihatTick = false;
+};
+
+/// Tunables exposed to the UI.
+struct BusConfig {
+    float baseSpeed = 1.0f;      ///< engine speed before any audio contribution
+    float bassPunchGain = 1.5f;  ///< how hard a transient pushes transportSpeed
+};
+
+/// Smoothed one-pole follower with independent attack and release. Rising
+/// signals track fast (a hit should look instant); falling signals decay slowly
+/// (so the visual has body instead of flickering off between samples).
+class EnvFollower {
+  public:
+    float update(float target, float dtMs, float attackMs, float releaseMs);
+    float value() const { return mValue; }
+
+  private:
+    float mValue = 0.0f;
+};
+
+/// Holds the cross-frame state the derivation needs (envelope followers, the
+/// ambient LFO phase, and the event timestamps already consumed).
+class BusDeriver {
+  public:
+    /// Fill *out for this frame. manualSpeedScalar is the sketch's "Time Speed"
+    /// slider, composed on top of whatever the state policy chose.
+    void derive(fl::audio::Processor &p, SoundState state, const BusConfig &cfg,
+                const AudioEvents &events, fl::u32 nowMs,
+                float manualSpeedScalar, VisualControlBus *out);
+
+  private:
+    EnvFollower mRadial;
+    EnvFollower mSparkle;
+    fl::u32 mLastMs = 0;
+    float mSilenceLfoPhase = 0.0f;
+
+    // Event edge detection: an event fires on the frame its timestamp changes.
+    fl::u32 mSeenKickMs = 0;
+    fl::u32 mSeenSnareMs = 0;
+    fl::u32 mSeenDownbeatMs = 0;
+};
+
+/// Soft-knee clip into [0,1]. Keeps the top of the range from pinning to 1.0
+/// the moment a band gets loud, which is what makes band-driven visuals look
+/// like an on/off switch instead of a level.
+float softKnee(float x);
+
+} // namespace mood_ring


### PR DESCRIPTION
Closes #3885. Implements PR-B and the pulse half of PR-E from #2256.

## The problem

Before this, every audio event in every state funnelled into a single scalar — engine speed:

```cpp
float pulse = kickPulse + snarePulse + downbeatPulse;
float speed = mCfg.bpmLockedBaseSpeed * bpmScale + pulse + phaseBow;
if (mEngine) mEngine->setSpeed(speed);
```

A kick, a snare and a downbeat are three different musical events producing three different magnitudes of *the same effect*. The three states differed in **which animation played**, not in **how the ring behaved** — structurally the same critique #2256 opens with.

## VisualControlBus

`visual_control_bus.{h,cpp}` — the stable authoring surface between audio and visuals. Nine continuous fields plus an event lane. Consumers read the bus and never the raw detectors, so the audio pipeline can change without churning every visual (the MilkDrop `q1..q32` analogue).

The load-bearing signal is **punch**:

```cpp
const float bassPunch = fl::max(0.0f, p.getVibeBass() - p.getVibeBassAtt());
```

Relative minus attenuated. During a sustained loud passage the slow level catches up to the fast one, punch falls to ~0, and nothing pulses. Only a transient — fast level above slow level — produces punch. That is what stops loudness from faking a beat, and it is why the acceptance criterion about sustained noise is satisfiable at all.

Per-state policy for `transportSpeed`, `radialPressure`, `paletteDrift`, `sparkleDensity` and `decayAmount` lives in one `switch`, so "what does Silence do" is answerable by reading one function.

`SoundState` and `toString()` move into `visual_control_bus.h` — they are shared vocabulary between the classifier, the derivation and the overlay, and leaving them in the orchestrator would have made the include graph circular.

## RingOverlay

`ring_overlay.{h,cpp}` — composites after `fxEngine.draw()` and before `FastLED.show()`. Two passes:

- **Trails** — a persistence shadow buffer scaled by `decayAmount` each frame. This is what gives `decayAmount` a visible meaning: `Silence` (0.85) holds long echoes, `BpmLocked` (0.35) stays crisp.
- **Pulse rings** — on an event, an expanding band travels outward from a configurable origin, widening and fading over 700 ms. Downbeats are wider (`sigma` 0.060 vs 0.035 of ring length) and hue-flipped to amber, so a bar boundary reads as larger *and* differently coloured than an ordinary beat. Up to 8 composite additively, so a dense passage reads as overlapping rings rather than one retriggered ring.

It touches only the 1D strip and never reaches into Animartrix, which is the property that lets the NoiseRing engine inherit it unchanged later.

Uses `fl::span<CRGB>` per the convention in `agents/docs/cpp-standards.md:137`.

## Behaviour deviation — flagging explicitly

Acceptance criterion 5 in #3885 said "turning every overlay toggle off reproduces today's behaviour exactly". **That criterion was written too strongly and this PR does not meet it.** Two intentional changes to the base signal path:

1. Pulses no longer contribute to engine speed — that is the entire point of the change.
2. `Disorganized` keys off `bassPunch` rather than raw `vibeBass`, so loudness no longer drives speed the way it did.

What *is* true, and what the criterion was reaching for: with both overlay toggles off, the strip contains exactly what the engine drew. The overlay is provably additive. The issue has been corrected rather than the code bent to match a criterion that was wrong.

## Scope

`OrchestratorConfig`'s speed/pulse knobs (`pulseDecayMs`, `disorganizedSpeedSpan`, `silenceSpeed`, `bpmLockedBaseSpeed`) are superseded by `BusConfig` plus the per-state policy and are removed rather than left as dead knobs. Classifier thresholds are untouched.

Deferred to follow-ups per #3885: sector emphasis, sparkle rendering, mood-quadrant bias (PR-F), NoiseRing (PR-G), patch schema (PR-H). The bus populates `sparkleDensity`, `rotationBias` and the band levels already, so those overlays have a surface to attach to without reopening the derivation.

**No `src/fl/**` changes.**

## Verification

- `bash test --cpp --clean` — 279/279 unit, 84/84 examples
- `bash compile wasm --examples MoodRing` — green
- `bash lint` — clean
- New UI: Base Speed, Bass Punch Gain, Overlay: Trails, Overlay: Pulse Ring, Pulse Origin Offset, Trail Decay Override, Debug: Print Bus

## Note: zccache #710 again

Adding source files to an existing example re-triggered the stale-`build.ninja` restore described in the #3884 body — the link failed with `undefined symbol: mood_ring::RingOverlay::apply(...)` because the new `.cpp` files were absent from the target's source list, while the WASM path (which reconfigures independently) picked them up correctly. `--clean` does not help; purging the key under `~/.zccache/<version>/meson-configure/` does. Second occurrence in two PRs — the key needs to cover the examples tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio-responsive controls for speed, bass intensity, movement, palette drift, sparkle, and decay.
  * Added optional trail persistence and expanding pulse-ring overlays.
  * Added controls for pulse origin, trail decay, overlay behavior, and bus tuning.
  * Added configurable visual behavior for sound states and beat events.
* **Enhancements**
  * Added optional visual-control diagnostics.
  * Improved responses to kicks, snares, and downbeats.
  * Refined pulse fading and trail compositing.
* **Documentation**
  * Updated documentation to reflect completed visual features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->