### PR TITLE
fix(ci): recover stale locks after Windows process exit

### DIFF
--- a/ci/tests/test_file_lock_rw.py
+++ b/ci/tests/test_file_lock_rw.py
@@ -11,10 +11,12 @@ These tests validate:
 - Re-entrancy
 """
 
+import errno
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from ci.util.file_lock_rw import (
     FileLock,
@@ -40,6 +42,24 @@ class TestProcessAlive(unittest.TestCase):
         self.assertFalse(is_process_alive(0))
         self.assertFalse(is_process_alive(-1))
         self.assertFalse(is_process_alive(999999))  # Unlikely to exist
+
+    @patch("ci.util.file_lock_rw_util.platform.system", return_value="Linux")
+    @patch(
+        "ci.util.file_lock_rw_util.os.kill",
+        side_effect=PermissionError(errno.EPERM, "operation not permitted"),
+    )
+    def test_permission_denied_process_is_alive(self, _kill, _system) -> None:
+        """EPERM proves a POSIX PID exists and must not permit lock stealing."""
+        self.assertTrue(is_process_alive(12345))
+
+    @patch("ci.util.file_lock_rw_util.platform.system", return_value="Linux")
+    @patch(
+        "ci.util.file_lock_rw_util.os.kill",
+        side_effect=ProcessLookupError(errno.ESRCH, "no such process"),
+    )
+    def test_missing_process_is_dead(self, _kill, _system) -> None:
+        """ESRCH is authoritative evidence that a POSIX PID is dead."""
+        self.assertFalse(is_process_alive(12345))
 
 
 class TestStaleLockDetection(unittest.TestCase):

--- a/ci/util/build_lock.py
+++ b/ci/util/build_lock.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from types import TracebackType
 from typing import Generator, Optional
 
-from ci.util.lock_database import LockDatabase
+from ci.util.file_lock_rw_util import is_process_alive
+from ci.util.lock_database import get_lock_database
 
 
 # Default timeout for lock acquisition (seconds).
@@ -59,22 +60,6 @@ def _diag(message: str) -> None:
     `logger.info` for the same reason.)
     """
     print(message, file=sys.stderr)
-
-
-def _is_process_alive_psutil(pid: int) -> bool:
-    """Check if a process is alive using psutil (more reliable than kernel32 on Windows)."""
-    try:
-        import psutil
-
-        return psutil.pid_exists(pid)
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception:
-        # Fallback to the existing kernel32/os.kill checker
-        from ci.util.file_lock_rw_util import is_process_alive
-
-        return is_process_alive(pid)
 
 
 def _get_process_info(pid: int) -> str:
@@ -143,7 +128,10 @@ class BuildLock:
             project_root = Path(__file__).parent.parent.parent
             db_path = project_root / ".cache" / "locks.db"
 
-        self._db = LockDatabase(db_path)
+        # Use the shared resolver so FASTLED_LOCK_DB_PATH can isolate tests and
+        # callers that explicitly provide a lock database. The path hint keeps
+        # the normal project/global selection unchanged when no override exists.
+        self._db = get_lock_database(db_path)
         self._lock_name = f"build:{lock_name}"
         self.lock_name = lock_name
         # Keep lock_file attribute for backward compatibility (logging/display)
@@ -173,7 +161,8 @@ class BuildLock:
              blocked indefinitely. The wedged process gets a deadman force-exit
              from test.py's watchdog separately.
 
-        Uses psutil for process liveness checks (more reliable than kernel32 on Windows).
+        Uses the shared platform liveness check, including Windows process wait
+        state so terminated-but-still-open process objects count as dead.
 
         Returns:
             True if lock was stale and removed, False otherwise
@@ -183,10 +172,7 @@ class BuildLock:
             if not holders:
                 return False
 
-            # Check all holders with psutil (more reliable than kernel32)
-            all_dead = all(
-                not _is_process_alive_psutil(h["owner_pid"]) for h in holders
-            )
+            all_dead = all(not is_process_alive(h["owner_pid"]) for h in holders)
 
             # Check for alive-but-wedged: any holder past max-hold threshold.
             now = time.time()

--- a/ci/util/file_lock_rw_util.py
+++ b/ci/util/file_lock_rw_util.py
@@ -8,6 +8,7 @@ Contains the cross-platform process alive check used by both
 lock_database.py and file_lock_rw.py.
 """
 
+import errno
 import logging
 import os
 import platform
@@ -32,25 +33,73 @@ def is_process_alive(pid: int) -> bool:
     try:
         # Unix/Linux/macOS: send signal 0 (doesn't actually send signal, just checks)
         if platform.system() != "Windows":
-            os.kill(pid, 0)
-            return True
-        else:
-            # Windows: Try to open process handle
-            import ctypes
-
-            windll = getattr(ctypes, "windll")
-            kernel32 = windll.kernel32
-            PROCESS_QUERY_INFORMATION = 0x0400
-            handle = kernel32.OpenProcess(PROCESS_QUERY_INFORMATION, False, pid)
-            if handle:
-                kernel32.CloseHandle(handle)
+            try:
+                os.kill(pid, 0)
                 return True
-            return False
-    except (OSError, ProcessLookupError):
-        return False
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                # The process exists, but this user cannot signal it.
+                return True
+            except OSError as e:
+                if e.errno == errno.ESRCH:
+                    return False
+                logger.warning(f"Unable to determine whether PID {pid} is alive: {e}")
+                return True
+        else:
+            # Opening a Windows process handle only proves that the process
+            # object still exists. A terminated child remains openable while
+            # its parent retains a handle, so using OpenProcess alone makes a
+            # dead lock owner look alive indefinitely. Query whether the
+            # process object is signaled instead.
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.OpenProcess.argtypes = [
+                wintypes.DWORD,
+                wintypes.BOOL,
+                wintypes.DWORD,
+            ]
+            kernel32.OpenProcess.restype = wintypes.HANDLE
+            kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+            kernel32.WaitForSingleObject.restype = wintypes.DWORD
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+            kernel32.CloseHandle.restype = wintypes.BOOL
+
+            synchronize = 0x00100000
+            error_invalid_parameter = 87
+            wait_object_0 = 0
+            wait_timeout = 258
+            handle = kernel32.OpenProcess(synchronize, False, pid)
+            if not handle:
+                error = ctypes.get_last_error()
+                if error == error_invalid_parameter:
+                    return False
+                # Access denied and transient query failures are not proof of
+                # death. Treat them as alive rather than stealing their lock.
+                logger.warning(
+                    f"Unable to open PID {pid} for liveness check "
+                    f"(Windows error {error}); treating it as alive"
+                )
+                return True
+
+            try:
+                wait_result = kernel32.WaitForSingleObject(handle, 0)
+                if wait_result == wait_object_0:
+                    return False
+                if wait_result == wait_timeout:
+                    return True
+                logger.warning(
+                    f"Unable to query wait state for PID {pid} "
+                    f"(result {wait_result}); treating it as alive"
+                )
+                return True
+            finally:
+                kernel32.CloseHandle(handle)
     except KeyboardInterrupt as ki:
         handle_keyboard_interrupt(ki)
         raise
     except Exception as e:
         logger.warning(f"Error checking if PID {pid} is alive: {e}")
-        return False  # Assume dead if we can't check
+        return True  # Indeterminate is not safe evidence for stealing a lock


### PR DESCRIPTION
## Summary
- detect terminated Windows process objects via their wait state
- treat indeterminate liveness checks conservatively to prevent lock theft
- honor FASTLED_LOCK_DB_PATH for BuildLock isolation
- add POSIX EPERM/ESRCH regression coverage

## Verification
- bash lint ci/util/file_lock_rw_util.py ci/util/build_lock.py ci/tests/test_file_lock_rw.py
- uv run pytest ci/tests/test_file_lock_rw.py ci/tests/test_stale_lock_real_scenario.py -q --runslow (19 passed)

Closes #3794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build-lock handling when checking whether a process is still active across Linux, Unix, and Windows.
  - Prevented active processes from being incorrectly treated as stopped when access is restricted or the operating system cannot determine their status.
  - Improved detection and cleanup of genuinely stale locks.
  - Respect configured lock-database paths consistently.

- **Tests**
  - Added coverage for platform-specific process-status and permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->