### PR TITLE
fix(ci): exclude generated example artifacts from staging

### DIFF
--- a/ci/compiler/source_manager.py
+++ b/ci/compiler/source_manager.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
+_GENERATED_EXAMPLE_DIRS = frozenset({".build", ".fbuild", ".pio", "fastled_js"})
+_GENERATED_EXAMPLE_FILES = frozenset({"compile_commands.json"})
+
+
 def _scandir_sync(
     source: str, dest: str, purge: bool = True, content: bool = False
 ) -> None:
@@ -216,8 +220,10 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     # Copy all files and subdirectories from example directory to sketch subdirectory
     ino_files: list[str] = []
     for file_path in example_path.iterdir():
-        if "fastled_js" in str(file_path):
-            # skip fastled_js output folder.
+        if file_path.is_dir() and file_path.name in _GENERATED_EXAMPLE_DIRS:
+            # Build output inside an example must never become sketch source.
+            continue
+        if file_path.is_file() and file_path.name in _GENERATED_EXAMPLE_FILES:
             continue
 
         if file_path.is_file():

--- a/ci/tests/test_source_manager.py
+++ b/ci/tests/test_source_manager.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from ci.compiler.source_manager import copy_example_source
+
+
+@pytest.mark.parametrize("generated_dir", [".build", ".fbuild", ".pio", "fastled_js"])
+def test_copy_example_source_skips_generated_directories(
+    tmp_path: Path, generated_dir: str
+) -> None:
+    project_root = tmp_path / "project"
+    example_dir = project_root / "examples" / "Blink"
+    example_dir.mkdir(parents=True)
+    (example_dir / "Blink.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    artifact = example_dir / generated_dir / "generated.cpp"
+    artifact.parent.mkdir()
+    artifact.write_text("#error generated artifact was staged\n")
+
+    build_dir = tmp_path / "output"
+    build_dir.mkdir()
+    assert copy_example_source(project_root, build_dir, "Blink")
+
+    staged_sketch = build_dir / "src" / "sketch"
+    assert (staged_sketch / "Blink.ino").is_file()
+    assert not (staged_sketch / generated_dir).exists()
+
+
+def test_copy_example_source_skips_generated_files(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    example_dir = project_root / "examples" / "Blink"
+    example_dir.mkdir(parents=True)
+    (example_dir / "Blink.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    (example_dir / "compile_commands.json").write_text("[]\n")
+
+    build_dir = tmp_path / "output"
+    build_dir.mkdir()
+    assert copy_example_source(project_root, build_dir, "Blink")
+
+    staged_sketch = build_dir / "src" / "sketch"
+    assert (staged_sketch / "Blink.ino").is_file()
+    assert not (staged_sketch / "compile_commands.json").exists()


### PR DESCRIPTION
## Summary
- exclude generated build directories from PlatformIO sketch staging
- exclude generated compile_commands.json files
- cover each excluded artifact with focused tests

## Verification
- uv run pytest ci/tests/test_source_manager.py -q
- bash lint ci/compiler/source_manager.py ci/tests/test_source_manager.py
- bash bloat esp32dev --build --top 25
- clud-review: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated build artifacts and metadata from being included in staged example sources.
  * Ensured normal sketch files continue to be copied correctly.

* **Tests**
  * Added coverage confirming generated directories and compilation metadata are excluded while valid example files are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->