### PR TITLE
chore(lint): document small singleton exceptions

### DIFF
--- a/src/fl/stl/asio/http/server.cpp.hpp
+++ b/src/fl/stl/asio/http/server.cpp.hpp
@@ -677,6 +677,7 @@ void espRequestCleanup(EspPendingRequest* item) {
     delete item; // ok bare allocation - see marshaling protocol
 }
 
+// FL_LINT_ALLOW_GLOBAL(constant-initialized ESP-IDF queue handle; Singleton<T> adds pointer storage and a branch without improving linker elision)
 QueueHandle_t s_esp_request_queue = nullptr;
 
 } // anonymous namespace
@@ -944,6 +945,7 @@ string Response::to_string() const {
 
 // We store the httpd_handle_t in a file-scoped variable since the Server class
 // members (mListenSocket, mClientSockets) are typed for POSIX sockets.
+// FL_LINT_ALLOW_GLOBAL(constant-initialized ESP-IDF server handle; Singleton<T> adds pointer storage and a branch without improving linker elision)
 static httpd_handle_t s_esp_httpd = nullptr;
 static fl::vector<fl::unique_ptr<EspRouteContext>> s_esp_route_contexts;
 

--- a/src/platforms/arm/lpc/platform_time_lpc.cpp.hpp
+++ b/src/platforms/arm/lpc/platform_time_lpc.cpp.hpp
@@ -14,7 +14,9 @@ namespace fl {
 namespace platforms {
 namespace lpc_time {
 
+// FL_LINT_ALLOW_GLOBAL(constant-initialized SysTick ISR state; Singleton<T> adds pointer storage and a branch without improving linker elision)
 static volatile u32 g_millis = 0;
+// FL_LINT_ALLOW_GLOBAL(constant-initialized SysTick setup flag; Singleton<T> adds pointer storage and a branch without improving linker elision)
 static bool g_systick_started = false;
 
 static u32 ticks_per_ms() FL_NO_EXCEPT {

--- a/src/platforms/avr/attiny/clockless_blocking.cpp.hpp
+++ b/src/platforms/avr/attiny/clockless_blocking.cpp.hpp
@@ -13,6 +13,7 @@
 namespace fl {
 
 #if (!defined(NO_CLOCK_CORRECTION) || (NO_CLOCK_CORRECTION == 0)) && (FASTLED_ALLOW_INTERRUPTS == 0)
+// FL_LINT_ALLOW_GLOBAL(constant-initialized ATtiny clock-correction state; Singleton<T> adds pointer storage and a branch without improving linker elision)
 u8 gTimeErrorAccum256ths = 0;
 #endif
 


### PR DESCRIPTION
## Summary
- document why the remaining small ESP-IDF handle globals should stay constant-initialized PODs
- document the direct-storage requirement for LPC SysTick ISR state
- document the ATtiny clock-correction byte's size-sensitive storage
- clear every live `SingletonElisionChecker` hit in files with at most two violations, excluding the public `FastLED` surface

## Verification
- `bash lint`
- `bash compile attiny85 --examples Blink`
- `bash compile esp32dev --examples Blink`
- `bash test server --unit`
- `bash test server_loopback --unit`
- focused SingletonElisionChecker scan: 33 warnings / 9 files -> 28 warnings / 6 files; no eligible <=2-hit modules remain
- `git diff --check`
- clud-review: clean

The LPC845 build did not reach compilation because the first-use arm-gcc 15.2.Rel1 package download stalled and timed out twice. This patch is annotation-only and does not alter LPC code generation.

Closes #3488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documentation for intentionally maintained global state across supported ESP-IDF, LPC, and ATtiny platform implementations.
  * Improved linting clarity without changing runtime behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->