### PR TITLE
perf(channels): isolate addDriver slow path

### DIFF
--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -5,8 +5,6 @@
 #include "fl/channels/detail/wait_spin_budget.h"
 #include "fl/stl/singleton.h"
 #include "fl/log/log.h"
-#include "fl/log/log.h"
-#include "fl/log/log.h"
 #include "fl/system/engine_events.h"
 #include "fl/stl/chrono.h"
 #include "fl/stl/algorithm.h"
@@ -84,9 +82,58 @@ u32 ChannelManager::pollNeededWaitSliceMs(u32 startTime, u32 timeoutMs) const FL
     return remaining < kPollNeededFallbackSliceMs ? remaining : kPollNeededFallbackSliceMs;
 }
 
+FL_NO_INLINE FL_COLD bool ChannelManager::addDriverSlow(
+    int priority,
+    const fl::shared_ptr<IChannelDriver>& driver,
+    const fl::string* engineName,
+    AddDriverSlowReason reason) FL_NO_EXCEPT {
+    if (reason == AddDriverSlowReason::NULL_DRIVER) {
+        FL_WARN_F("ChannelManager::addDriver() - Null driver provided");
+        return false;
+    }
+    if (reason == AddDriverSlowReason::EMPTY_NAME) {
+        FL_WARN_F("ChannelManager::addDriver() - Engine has empty name (driver->getName() returned empty string)");
+        return false;
+    }
+
+    for (const auto& entry : mDrivers) {
+        if (entry.name == *engineName) {
+            // True-duplicate fast path: same shared_ptr at same priority is
+            // a no-op (legacy clockless controllers may pre-bind the same
+            // driver singleton from many template instantiations). Skip the
+            // replace flow entirely so we don't waitForReady() or emit a
+            // spurious "Replacing" warning.
+            if (entry.driver == driver && entry.priority == priority) {
+                FL_DBG_F("ChannelManager::addDriver() - '%s' already registered at priority %s (idempotent no-op)", engineName->c_str(), priority);
+                return false;
+            }
+            FL_WARN_F("ChannelManager::addDriver() - Replacing existing driver '%s'", engineName->c_str());
+
+            FL_DBG_F("ChannelManager: Waiting for all drivers to become READY before replacement");
+            waitForReady();
+
+            // Re-scan after waiting: task pumping in waitForReady() can run
+            // callbacks, so do not retain an index or iterator across it.
+            for (size_t i = 0; i < mDrivers.size(); ++i) {
+                if (mDrivers[i].name != *engineName) {
+                    continue;
+                }
+                FL_DBG_F("ChannelManager: Removing old driver '%s' (shared_ptr may delete)", engineName->c_str());
+                if (mDrivers[i].driver) {
+                    mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
+                }
+                mDrivers.erase(mDrivers.begin() + i);
+                break;
+            }
+            return true;
+        }
+    }
+    return true;
+}
+
 void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driver) {
     if (!driver) {
-        FL_WARN_F("ChannelManager::addDriver() - Null driver provided");
+        (void)addDriverSlow(priority, driver, nullptr, AddDriverSlowReason::NULL_DRIVER);
         return;
     }
 
@@ -95,44 +142,17 @@ void ChannelManager::addDriver(int priority, fl::shared_ptr<IChannelDriver> driv
 
     // Reject drivers with empty names
     if (engineName.empty()) {
-        FL_WARN_F("ChannelManager::addDriver() - Engine has empty name (driver->getName() returned empty string)");
+        (void)addDriverSlow(priority, driver, &engineName, AddDriverSlowReason::EMPTY_NAME);
         return;
     }
 
-    // Check if driver with this name already exists
-    bool replacing = false;
+    // A duplicate name takes the uncommon replacement/idempotency path.
     for (const auto& entry : mDrivers) {
         if (entry.name == engineName) {
-            // True-duplicate fast path: same shared_ptr at same priority is
-            // a no-op (legacy clockless controllers may pre-bind the same
-            // driver singleton from many template instantiations). Skip the
-            // replace flow entirely so we don't waitForReady() or emit a
-            // spurious "Replacing" warning.
-            if (entry.driver == driver && entry.priority == priority) {
-                FL_DBG_F("ChannelManager::addDriver() - '%s' already registered at priority %s (idempotent no-op)", engineName.c_str(), priority);
+            if (!addDriverSlow(priority, driver, &engineName, AddDriverSlowReason::DUPLICATE_NAME)) {
                 return;
             }
-            replacing = true;
-            FL_WARN_F("ChannelManager::addDriver() - Replacing existing driver '%s'", engineName.c_str());
             break;
-        }
-    }
-
-    // If replacing, wait for all drivers to become READY
-    if (replacing) {
-        FL_DBG_F("ChannelManager: Waiting for all drivers to become READY before replacement");
-        waitForReady();
-
-        // Remove the old driver with matching name (shared_ptr may trigger deletion)
-        for (size_t i = 0; i < mDrivers.size(); ++i) {
-            if (mDrivers[i].name == engineName) {
-                FL_DBG_F("ChannelManager: Removing old driver '%s' (shared_ptr may delete)", engineName.c_str());
-                if (mDrivers[i].driver) {
-                    mDrivers[i].driver->setPollNeededCallback(IChannelDriver::PollNeededCallback());
-                }
-                mDrivers.erase(mDrivers.begin() + i);
-                break;
-            }
         }
     }
 

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -30,6 +30,7 @@
 #include "fl/stl/vector.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"
 #include "platforms/channel_poll_signal.h"
 
 namespace fl {
@@ -247,6 +248,20 @@ public:
     void reset() FL_NO_EXCEPT;
 
 private:
+    enum class AddDriverSlowReason : u8 {
+        NULL_DRIVER,
+        EMPTY_NAME,
+        DUPLICATE_NAME,
+    };
+
+    /// Handle validation failures and the uncommon replacement flow outside
+    /// the normal driver-registration path.
+    FL_NO_INLINE FL_COLD bool addDriverSlow(
+        int priority,
+        const fl::shared_ptr<IChannelDriver>& driver,
+        const fl::string* engineName,
+        AddDriverSlowReason reason) FL_NO_EXCEPT;
+
     /// @brief Wait until a condition is met, with check-pump-delay logic
     /// @param condition Function that returns true when waiting should stop
     /// @param timeoutMs Optional timeout in milliseconds (0 = no timeout)

--- a/src/fl/stl/compiler_control.h
+++ b/src/fl/stl/compiler_control.h
@@ -353,6 +353,14 @@
   #define FL_NO_INLINE
 #endif
 
+// Mark an error/recovery helper as cold so supported compilers optimize it for
+// size and keep it out of the normal instruction path.
+#if defined(FL_IS_GCC) || defined(FL_IS_CLANG)
+  #define FL_COLD __attribute__((cold))
+#else
+  #define FL_COLD
+#endif
+
 // Place a function in RAM instead of flash, so it executes with zero flash
 // wait states. On parts whose flash cannot be fetched at full core speed
 // (e.g. LPC845 @ 30 MHz, no flash accelerator), the cycle-counted WS2812 bit


### PR DESCRIPTION
## Summary
- move `ChannelManager::addDriver` validation, duplicate logging, wait, and replacement cleanup into a noinline cold helper
- keep the common registration path focused on name lookup, insertion, callback setup, exclusive-mode enablement, and sorting
- add a portable `FL_COLD` compiler-control macro
- remove duplicate log includes encountered in the implementation file

## Verification
- `bash test manager --unit`
- `bash test channel_manager --unit`
- `bash test fastled_core --unit`
- `bash test manager --unit --build-mode release`
- `bash lint`
- `git diff --check`
- clud-review: clean

## Measurement note
Both ESP32-S3 build routes stalled in first-use package/toolchain setup before compilation, so the requested ESP32-S3 symbol-size comparison could not be produced on this host. The structural gate is present: the slow helper is both `FL_NO_INLINE` and `FL_COLD`, and release-mode host compilation/tests pass.

Closes #2979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid, duplicate, and replacement driver registrations.
  * Ensured driver replacements correctly rescan available drivers after readiness checks.
  * Prevented stale driver entries from remaining after replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->