### PR TITLE
fix(task): wire frame tasks to render lifecycle

### DIFF
--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -2,6 +2,28 @@
 
 <!-- Add tasks here as checkable items -->
 
+## Frame-task lifecycle (#3896)
+
+- [x] Reproduce the missing production dispatch and contradictory one-shot semantics.
+- [x] Compare repair, removal, and contract-narrowing strategies.
+- [x] Add failing lifecycle tests for automatic before/after dispatch and recurrence.
+- [x] Implement the selected engine-event integration and recurring semantics.
+- [x] Correct the frame-task and executor documentation.
+- [x] Run focused tests, lint, the C++ suite, and the pre-push review gate.
+- [ ] Push a PR, drive checks/reviews to green, merge it, and verify master.
+
+### Review
+
+- Selected automatic recurring frame tasks over removal (source-breaking) and
+  one-shot contract narrowing (inconsistent with the documented per-frame API).
+- Frame callbacks now use a lazy low-memory-safe engine hook, stable per-phase
+  snapshots, same-phase reentrancy guards, cancellation cleanup, and deferred
+  registration semantics.
+- RED reproduced missing dispatch in quick and sanitizer builds. GREEN evidence:
+  focused quick + sanitizer tests pass; all 279 C++ tests and 84 host examples
+  pass; full lint passes; the pre-push review is clean after fixing its scheduler
+  mutation finding.
+
 ## QEMU build badges
 
 - [x] Inventory the ESP32-DEV, ESP32-C3, and ESP32-S3 badge failures from current GitHub Actions logs.

--- a/examples/AutoResearch/AutoResearchAsync.h
+++ b/examples/AutoResearch/AutoResearchAsync.h
@@ -63,9 +63,7 @@ inline void maybeRegisterStubAutorun(
         AutoResearchRemoteControl& /*remote*/,
         fl::shared_ptr<AutoResearchState> state) {
 #ifdef FL_IS_STUB
-    // Register a task that runs on the next async_run() cycle (during loop())
-    // Note: every_ms(0) fires immediately; after_frame() requires frame-task
-    // dispatch which isn't wired up in the stub example runner.
+    // Register a task that runs on the next async_run() cycle (during loop()).
     fl::task::every_ms(0, FL_TRACE).then([state]() {
         if (!state || state->drivers_available.empty()) {
             FL_ERROR("[STUB CLIENT] No drivers discovered — autoresearch cannot run");

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -334,9 +334,7 @@ FL_KEEP_ALIVE void CFastLED::show(fl::u8 scale) {
 }
 
 void CFastLED::onEndFrame() {
-	#if FASTLED_HAS_ENGINE_EVENTS
 	fl::EngineEvents::onEndFrame();
-	#endif
 }
 
 int CFastLED::count() {
@@ -362,6 +360,7 @@ CLEDController & CFastLED::operator[](int x) {
 }
 
 void CFastLED::showColor(const CRGB & color, fl::u8 scale) {
+	onBeginFrame();
 	throttleToMaxRefreshRate(mNMinMicros);
 	lastshow = fl::micros();
 
@@ -402,6 +401,7 @@ void CFastLED::showColor(const CRGB & color, fl::u8 scale) {
 	}
 	countFPS();
 	onEndFrame();
+	onEndShowLeds();
 }
 
 void CFastLED::clear(bool writeData) {
@@ -766,9 +766,7 @@ namespace __cxxabiv1
 
 
 void CFastLED::onBeginFrame() {
-	#if FASTLED_HAS_ENGINE_EVENTS
 	fl::EngineEvents::onBeginFrame();
-	#endif
 }
 
 

--- a/src/fl/README.md
+++ b/src/fl/README.md
@@ -833,8 +833,6 @@ This section explains how the major graphics utilities fit together and how to u
 
     ```cpp
     #include <FastLED.h>
-    #include "fl/task.h"
-    #include "fl/async.h"
     #include "fl/math/corkscrew.h"
     #include "fl/grid.h"
 
@@ -863,13 +861,11 @@ This section explains how the major graphics utilities fit together and how to u
     void loop() {
         // The before_frame task is invoked automatically at the right time
         FastLED.show();
-        // Optionally pump other async work
-        fl::async_yield();
     }
     ```
 
     - The manual approach gives explicit control each frame.
-    - The `task::before_frame()` approach schedules work just‑in‑time before rendering without manual event wiring. Use `task::after_frame()` for post‑render work.
+    - The `task::before_frame()` approach schedules recurring work just‑in‑time before rendering without manual event wiring. Use `task::after_frame()` for recurring post‑render work; keep the returned handle and call `.cancel()` to stop either task.
 
 - **High‑definition HSV16**
   - Headers: `hsv16.h`, implementation in `hsv16.cpp`

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -179,14 +179,12 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NO_EXCEPT {
-#if FASTLED_HAS_ENGINE_EVENTS
         fl::EngineEvents::onBeginFrame();
-#endif
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);
         endShowLeds(data);
-#if FASTLED_HAS_ENGINE_EVENTS
         fl::EngineEvents::onEndFrame();
+#if FASTLED_HAS_ENGINE_EVENTS
         fl::EngineEvents::onEndShowLeds();
 #endif
     }

--- a/src/fl/system/engine_events.cpp.hpp
+++ b/src/fl/system/engine_events.cpp.hpp
@@ -8,6 +8,11 @@
 
 namespace fl {
 
+namespace {
+// FL_LINT_ALLOW_GLOBAL(frame-task callback registry backing)
+EngineEvents::Listener *gFrameTaskListener = nullptr;
+}
+
 // Explicitly define constructor and destructor
 EngineEvents::EngineEvents() = default;
 EngineEvents::~EngineEvents() FL_NO_EXCEPT = default;
@@ -28,6 +33,28 @@ EngineEvents::Listener::~Listener() FL_NO_EXCEPT {
         ptr->_removeListener(this);
     }
 #endif
+}
+
+void EngineEvents::setFrameTaskListener(Listener *listener) FL_NO_EXCEPT {
+    gFrameTaskListener = listener;
+}
+
+void EngineEvents::onBeginFrame() FL_NO_EXCEPT {
+#if FASTLED_HAS_ENGINE_EVENTS
+    EngineEvents::getInstance()->_onBeginFrame();
+#endif
+    if (gFrameTaskListener) {
+        gFrameTaskListener->onBeginFrame();
+    }
+}
+
+void EngineEvents::onEndFrame() FL_NO_EXCEPT {
+#if FASTLED_HAS_ENGINE_EVENTS
+    EngineEvents::getInstance()->_onEndFrame();
+#endif
+    if (gFrameTaskListener) {
+        gFrameTaskListener->onEndFrame();
+    }
 }
 
 #if FASTLED_HAS_ENGINE_EVENTS

--- a/src/fl/system/engine_events.h
+++ b/src/fl/system/engine_events.h
@@ -17,6 +17,9 @@
 namespace fl {
 
 class CLEDController;  // forward declaration
+namespace task {
+class Scheduler;
+}
 
 class EngineEvents {
   public:
@@ -71,11 +74,7 @@ class EngineEvents {
 #endif
     }
 
-    static void onBeginFrame() FL_NO_EXCEPT {
-#if FASTLED_HAS_ENGINE_EVENTS
-        EngineEvents::getInstance()->_onBeginFrame();
-#endif
-    }
+    static void onBeginFrame() FL_NO_EXCEPT;
 
     static void onEndShowLeds() FL_NO_EXCEPT {
 #if FASTLED_HAS_ENGINE_EVENTS
@@ -83,11 +82,7 @@ class EngineEvents {
 #endif
     }
 
-    static void onEndFrame() FL_NO_EXCEPT {
-#if FASTLED_HAS_ENGINE_EVENTS
-        EngineEvents::getInstance()->_onEndFrame();
-#endif
-    }
+    static void onEndFrame() FL_NO_EXCEPT;
 
     static void onStripAdded(CLEDController *strip, fl::u32 num_leds) FL_NO_EXCEPT {
 #if FASTLED_HAS_ENGINE_EVENTS
@@ -124,6 +119,10 @@ class EngineEvents {
     ~EngineEvents() FL_NO_EXCEPT;
 
   private:
+    // Frame tasks use one dedicated final listener so they remain available
+    // when the general listener list is disabled on low-memory platforms.
+    static void setFrameTaskListener(Listener *listener) FL_NO_EXCEPT;
+
     // Safe to add a listeners during a callback.
     void _addListener(Listener *listener, int priority) FL_NO_EXCEPT;
     // Safe to remove self during a callback.
@@ -153,6 +152,7 @@ class EngineEvents {
 
     friend class fl::Singleton<EngineEvents>;
 #endif  // FASTLED_HAS_ENGINE_EVENTS
+    friend class task::Scheduler;
 };
 
 } // namespace fl

--- a/src/fl/task/README.md
+++ b/src/fl/task/README.md
@@ -62,8 +62,9 @@ Nothing above it changes.
 
 ## `fl::task::run()` — the pump
 
-**`run()` must be called from `loop()`.** Nothing pumps the scheduler behind your back; if
-you never call it, your tasks never fire.
+**`run()` must be called from `loop()` for time-based tasks.** Frame tasks are the exception:
+`before_frame()` and `after_frame()` are pumped automatically by the FastLED frame lifecycle.
+If you never call `run()`, `every_ms()` and `at_framerate()` tasks never fire.
 
 ```cpp
 void loop() {
@@ -98,6 +99,8 @@ The 1 ms default yield is what keeps a busy render loop from starving the networ
 |---------|-------|
 | `fl::task::every_ms(int interval_ms)` | Every `interval_ms`, forever |
 | `fl::task::at_framerate(int fps)` | `fps` times a second, forever |
+| `fl::task::before_frame()` | Before every FastLED render, until canceled |
+| `fl::task::after_frame()` | After every FastLED render, until canceled |
 | `fl::task::coroutine(const CoroutineConfig&)` | Once, on its own OS task (see below) |
 
 Each builder has an overload taking a `TracePoint` — pass the `FL_TRACE` macro and the
@@ -132,10 +135,13 @@ blink.set_interval_ms(100);   // speed it up
 blink.cancel();               // stop it
 ```
 
-`every_ms` and `at_framerate` tasks recur until cancelled. Coroutines run once.
+`every_ms`, `at_framerate`, `before_frame`, and `after_frame` tasks recur until canceled.
+Coroutines run once. Frame tasks do not require `run()`; engine frame events dispatch them
+automatically.
 
-Callbacks run on whichever thread called `run()` and are not preempted — keep each one
-short. A callback that blocks for 200 ms delays every other task by 200 ms.
+Callbacks run on whichever thread called `run()` or initiated the frame and are not
+preempted — keep each one short. A callback that blocks for 200 ms delays every other
+task by 200 ms.
 
 ## Promises
 
@@ -238,7 +244,7 @@ Code using coroutines still compiles everywhere; where there is no support,
 
 ## Gotchas
 
-- **No `run()`, no tasks.** The single most common mistake.
+- **No `run()`, no time-based tasks.** Frame tasks follow FastLED frame events instead.
 - **`.then()` is what registers.** A handle with only `.catch_()` is inert.
 - **Don't block in a callback.** Everything else waits behind it. Long or blocking work
   belongs in a coroutine.

--- a/src/fl/task/executor.h
+++ b/src/fl/task/executor.h
@@ -6,8 +6,8 @@
 /// This module provides a unified system for managing background operations
 /// across FastLED, including HTTP requests, timers, and other background tasks.
 ///
-/// The executor integrates with FastLED's engine events and can be pumped
-/// during delay() calls on WASM platforms for optimal responsiveness.
+/// The executor is pumped by fl::task::run(). Platform code may also call
+/// run() while yielding, but FastLED.show() does not update registered runners.
 ///
 /// @section Usage
 /// @code
@@ -35,10 +35,8 @@
 ///     MyRunner* runner = new MyRunner();
 ///     fl::task::Executor::instance().register_runner(runner);
 ///
-///     // Now your tasks will be automatically updated during:
-///     // - FastLED.show() calls (via engine events)
-///     // - delay() calls on WASM platforms
-///     // - Manual fl::task::run() calls
+///     // Pump registered runners from loop().
+///     fl::task::run();
 /// }
 /// @endcode
 
@@ -308,4 +306,3 @@ inline PromiseResult<T> await(Promise<T> p) {
 
 } // namespace task
 } // namespace fl
-

--- a/src/fl/task/scheduler.cpp.hpp
+++ b/src/fl/task/scheduler.cpp.hpp
@@ -6,6 +6,21 @@
 namespace fl {
 namespace task {
 
+Scheduler::Scheduler() FL_NO_EXCEPT
+    : mTasks(), mBeforeFrameSnapshot(), mAfterFrameSnapshot(), mNextTaskId(1) {}
+
+Scheduler::~Scheduler() FL_NO_EXCEPT {
+    if (mFrameListenerRegistered) {
+        EngineEvents::setFrameTaskListener(nullptr);
+    }
+}
+
+void Scheduler::onBeginFrame() FL_NO_EXCEPT {
+    update_before_frame_tasks();
+}
+
+void Scheduler::onEndFrame() FL_NO_EXCEPT { update_after_frame_tasks(); }
+
 // Scheduler implementation
 Scheduler& Scheduler::instance() {
     return fl::Singleton<Scheduler>::instance();
@@ -13,12 +28,35 @@ Scheduler& Scheduler::instance() {
 
 int Scheduler::add_task(Handle t) {
     if (t.is_valid()) {
+        for (const Handle& existing : mTasks) {
+            if (existing.mImpl == t.mImpl) {
+                return existing._id();
+            }
+        }
         int task_id = mNextTaskId.fetch_add(1);
         t._set_id(task_id);
+        const bool is_frame_task = t._type() == TaskType::kBeforeFrame ||
+                                   t._type() == TaskType::kAfterFrame;
         mTasks.push_back(fl::move(t));
+        if (is_frame_task && !mFrameListenerRegistered) {
+            // The dedicated final listener works even where the general
+            // EngineEvents listener list is disabled for memory reasons.
+            EngineEvents::setFrameTaskListener(this);
+            mFrameListenerRegistered = true;
+        }
         return task_id;
     }
     return 0; // Invalid task
+}
+
+void Scheduler::clear_all_tasks() FL_NO_EXCEPT {
+    mTasks.clear();
+    mNextTaskId.store(1);
+    ++mClearGeneration;
+    if (mFrameListenerRegistered) {
+        EngineEvents::setFrameTaskListener(nullptr);
+        mFrameListenerRegistered = false;
+    }
 }
 
 void Scheduler::update() {
@@ -61,52 +99,91 @@ void Scheduler::update() {
             }
         }
     }
+    update_frame_listener_registration();
 }
 
 void Scheduler::update_before_frame_tasks() {
+    if (mUpdatingBeforeFrameTasks) {
+        return;
+    }
+    mUpdatingBeforeFrameTasks = true;
     update_tasks_of_type(TaskType::kBeforeFrame);
+    mUpdatingBeforeFrameTasks = false;
 }
 
 void Scheduler::update_after_frame_tasks() {
+    if (mUpdatingAfterFrameTasks) {
+        return;
+    }
+    mUpdatingAfterFrameTasks = true;
     update_tasks_of_type(TaskType::kAfterFrame);
+    mUpdatingAfterFrameTasks = false;
 }
 
 void Scheduler::update_tasks_of_type(TaskType task_type) {
     u32 current_time = fl::millis();
 
-    // Use index-based iteration to avoid iterator invalidation issues
-    for (fl::size i = 0; i < mTasks.size();) {
-        Handle& t = mTasks[i];
+    remove_inactive_tasks();
 
-        if (!t.is_valid() || t._is_canceled()) {
-            // erase() returns bool in fl::vector, not iterator
-            mTasks.erase(mTasks.begin() + i);
-            // Don't increment i since we just removed an element
-        } else if (t._type() == task_type) {
-            // This is a frame task of the type we're looking for
-            bool should_run = t._ready_to_run_frame_task(current_time);
-
-            if (should_run) {
-                // Update last run time for frame tasks (though they don't use it)
-                t._set_last_run_time(current_time);
-
-                // Execute the task
-                if (t._has_then()) {
-                    t._execute_then();
-                } else {
-                    warn_no_then(t._id(), t._trace_label());
-                }
-
-                // Frame tasks are always one-shot, so remove them after execution
-                mTasks.erase(mTasks.begin() + i);
-                // Don't increment i since we just removed an element
-            } else {
-                ++i;
-            }
-        } else {
-            ++i; // Not the task type we're looking for
+    // Stable handles isolate dispatch from callbacks that mutate mTasks.
+    // Separate reusable buffers preserve before/after nesting without a heap
+    // allocation on every frame after each buffer reaches its high-water mark.
+    fl::vector<Handle>& snapshot = task_type == TaskType::kBeforeFrame
+                                       ? mBeforeFrameSnapshot
+                                       : mAfterFrameSnapshot;
+    snapshot.clear();
+    for (const Handle& task : mTasks) {
+        if (task._type() == task_type &&
+            task._ready_to_run_frame_task(current_time)) {
+            snapshot.push_back(task);
         }
     }
+
+    const u32 clear_generation = mClearGeneration;
+    for (Handle& task : snapshot) {
+        if (mClearGeneration != clear_generation) {
+            break;
+        }
+        if (!task.is_valid() || task._is_canceled()) {
+            continue;
+        }
+
+        task._set_last_run_time(current_time);
+        if (task._has_then()) {
+            task._execute_then();
+        } else {
+            warn_no_then(task._id(), task._trace_label());
+        }
+    }
+    snapshot.clear();
+    remove_inactive_tasks();
+    update_frame_listener_registration();
+}
+
+void Scheduler::remove_inactive_tasks() FL_NO_EXCEPT {
+    for (fl::size i = 0; i < mTasks.size();) {
+        if (!mTasks[i].is_valid() || mTasks[i]._is_canceled()) {
+            mTasks.erase(mTasks.begin() + i);
+        } else {
+            ++i;
+        }
+    }
+}
+
+void Scheduler::update_frame_listener_registration() FL_NO_EXCEPT {
+    if (!mFrameListenerRegistered) {
+        return;
+    }
+    for (const Handle& task : mTasks) {
+        const TaskType type = task._type();
+        const bool is_frame_task = type == TaskType::kBeforeFrame ||
+                                   type == TaskType::kAfterFrame;
+        if (task.is_valid() && !task._is_canceled() && is_frame_task) {
+            return;
+        }
+    }
+    EngineEvents::setFrameTaskListener(nullptr);
+    mFrameListenerRegistered = false;
 }
 
 void Scheduler::warn_no_then(int task_id, const fl::string& trace_label) {

--- a/src/fl/task/scheduler.h
+++ b/src/fl/task/scheduler.h
@@ -4,6 +4,7 @@
 /// @brief Task scheduler — manages timer and frame-based tasks
 
 #include "fl/task/task.h"
+#include "fl/system/engine_events.h"
 #include "fl/stl/singleton.h"
 #include "fl/stl/atomic.h"
 #include "fl/stl/vector.h"
@@ -12,32 +13,44 @@
 namespace fl {
 namespace task {
 
-class Scheduler {
+class Scheduler : private EngineEvents::Listener {
 public:
     static Scheduler& instance();
 
     int add_task(Handle t);
     void update();
 
-    // New methods for frame task handling
+    // Dispatch the callbacks registered for one frame phase.
     void update_before_frame_tasks();
     void update_after_frame_tasks();
 
     // For testing: clear all tasks
-    void clear_all_tasks() { mTasks.clear(); mNextTaskId.store(1); }
+    void clear_all_tasks() FL_NO_EXCEPT;
 
 private:
     friend class fl::Singleton<Scheduler>;
-    Scheduler() FL_NO_EXCEPT : mTasks(), mNextTaskId(1) {}
+    Scheduler() FL_NO_EXCEPT;
+    ~Scheduler() FL_NO_EXCEPT override;
+
+    void onBeginFrame() FL_NO_EXCEPT override;
+    void onEndFrame() FL_NO_EXCEPT override;
 
     void warn_no_then(int task_id, const fl::string& trace_label);
     void warn_no_catch(int task_id, const fl::string& trace_label, const Error& error);
 
     // Helper method for running specific task types
     void update_tasks_of_type(TaskType task_type);
+    void remove_inactive_tasks() FL_NO_EXCEPT;
+    void update_frame_listener_registration() FL_NO_EXCEPT;
 
     fl::vector<Handle> mTasks;
+    fl::vector<Handle> mBeforeFrameSnapshot;
+    fl::vector<Handle> mAfterFrameSnapshot;
     fl::atomic<int> mNextTaskId;
+    u32 mClearGeneration = 0;
+    bool mUpdatingBeforeFrameTasks = false;
+    bool mUpdatingAfterFrameTasks = false;
+    bool mFrameListenerRegistered = false;
 };
 
 } // namespace task

--- a/src/fl/task/task.h
+++ b/src/fl/task/task.h
@@ -201,17 +201,17 @@ Handle every_ms(int interval_ms, const TracePoint& trace) FL_NO_EXCEPT;
 Handle at_framerate(int fps) FL_NO_EXCEPT;
 Handle at_framerate(int fps, const TracePoint& trace) FL_NO_EXCEPT;
 
-// For most cases you want after_frame() instead of before_frame(), unless you
-// are doing operations that need to happen right before the frame is rendered.
-// Most of the time for ui stuff (button clicks, etc) you want after_frame(), so it
-// can be available for the next iteration of loop().
+// Frame tasks run at every matching FastLED frame boundary until canceled.
+// Prefer after_frame() unless work must happen immediately before rendering.
+// UI work usually belongs after_frame() so it is ready for the next loop.
 Handle before_frame() FL_NO_EXCEPT;
 Handle before_frame(const TracePoint& trace) FL_NO_EXCEPT;
 
-// Example: auto t = fl::task::after_frame().then([]() {...}
+// Keep the returned handle when the task will need to be canceled.
+// Example: auto t = fl::task::after_frame().then([]() {...});
 Handle after_frame() FL_NO_EXCEPT;
 Handle after_frame(const TracePoint& trace) FL_NO_EXCEPT;
-// Example: auto t = fl::task::after_frame([]() {...}
+// Example: auto t = fl::task::after_frame([]() {...});
 Handle after_frame(function<void()> on_then) FL_NO_EXCEPT;
 Handle after_frame(function<void()> on_then, const TracePoint& trace) FL_NO_EXCEPT;
 Handle coroutine(const CoroutineConfig& config) FL_NO_EXCEPT;

--- a/tests/fl/task/task.cpp
+++ b/tests/fl/task/task.cpp
@@ -1,6 +1,7 @@
 
 
 #include "test.h"
+#include "FastLED.h"
 #include "fl/task/task.h"
 #include "fl/task/executor.h"
 #include "fl/system/engine_events.h"
@@ -14,30 +15,6 @@ FL_TEST_FILE(FL_FILEPATH) {
 
 
 
-
-namespace {
-
-// Helper class to track frame events for testing
-class TestFrameListener : public fl::EngineEvents::Listener {
-public:
-    TestFrameListener() {
-        fl::EngineEvents::addListener(this);
-    }
-    
-    ~TestFrameListener() {
-        fl::EngineEvents::removeListener(this);
-    }
-    
-    void onEndFrame() override {
-        frame_count++;
-        // Pump the scheduler to execute after_frame tasks specifically
-        fl::task::Scheduler::instance().update_after_frame_tasks();
-    }
-    
-    int frame_count = 0;
-};
-
-} // anonymous namespace
 
 FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
     
@@ -58,7 +35,6 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         }
         
         // Simulate frame end event
-        TestFrameListener listener;
         fl::EngineEvents::onEndFrame();
         
         // Task should now execute due to auto-registration
@@ -81,7 +57,6 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         // Entire chain destructs here, but task was auto-registered
         
         // Simulate frame end event  
-        TestFrameListener listener;
         fl::EngineEvents::onEndFrame();
         
         // Task should execute
@@ -107,7 +82,6 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         }
         
         // Simulate frame end event
-        TestFrameListener listener;
         fl::EngineEvents::onEndFrame();
         
         // All 3 tasks should execute
@@ -121,23 +95,22 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         // Clear any leftover tasks from previous tests
         fl::task::Scheduler::instance().clear_all_tasks();
         
-        bool task_executed = false;
+        int execution_count = 0;
         
         // Old style should still work
         auto task = fl::task::after_frame()
-            .then([&task_executed]() {
-                task_executed = true;
+            .then([&execution_count]() {
+                ++execution_count;
             });
         
         // Manual add should work (though now redundant since auto-registration already happened)
         fl::task::Scheduler::instance().add_task(task);
         
         // Simulate frame end event
-        TestFrameListener listener;
         fl::EngineEvents::onEndFrame();
         
         // Task should execute (only once, not twice)
-        FL_CHECK(task_executed);
+        FL_CHECK_EQ(execution_count, 1);
         
         // Clean up
         fl::task::Scheduler::instance().clear_all_tasks();
@@ -160,7 +133,6 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         task.cancel();
         
         // Simulate frame end event
-        TestFrameListener listener;
         fl::EngineEvents::onEndFrame();
         
         // Task should NOT execute due to cancellation
@@ -255,29 +227,107 @@ FL_TEST_CASE("Task self-registration and destruction behavior [task]") {
         FL_CHECK_EQ(execution_count, 0); // Still 0
 
         
-        // Create a frame listener for this specific test
-        TestFrameListener listener;
-        
-        // Instead of calling FastLED.show(), directly trigger the driver events
-        // This tests the task system without requiring LED hardware setup
-        fl::EngineEvents::onEndFrame();
+        // No controller is required to exercise the real FastLED frame path.
+        FastLED.show();
         
         // The after_frame task should have executed
         FL_CHECK_EQ(execution_count, 1);
         
-        // Calling onEndFrame() again should execute the task again (it's been removed as one-shot)
-        // But since it's already removed, create another task to test
-        auto task2 = fl::task::after_frame()
-            .then([&execution_count]() {
-                execution_count++;
-            });
-        
-        fl::EngineEvents::onEndFrame();
+        // Frame tasks recur at every matching boundary until canceled.
+        FastLED.show();
+        FL_CHECK_EQ(execution_count, 2);
+
+        task.cancel();
+        FastLED.show();
         FL_CHECK_EQ(execution_count, 2);
         
         // Clean up
         fl::task::Scheduler::instance().clear_all_tasks();
     }
-} 
+}
+
+FL_TEST_CASE("before_frame and after_frame follow the engine lifecycle [task]") {
+    auto& scheduler = fl::task::Scheduler::instance();
+    scheduler.clear_all_tasks();
+
+    fl::vector<int> order;
+    auto before = fl::task::before_frame().then([&order]() {
+        order.push_back(1);
+    });
+    auto after = fl::task::after_frame().then([&order]() {
+        order.push_back(2);
+    });
+
+    FastLED.show();
+    FastLED.show();
+    FastLED.showColor(CRGB::Black);
+
+    FL_REQUIRE_EQ(order.size(), 6);
+    FL_CHECK_EQ(order[0], 1);
+    FL_CHECK_EQ(order[1], 2);
+    FL_CHECK_EQ(order[2], 1);
+    FL_CHECK_EQ(order[3], 2);
+    FL_CHECK_EQ(order[4], 1);
+    FL_CHECK_EQ(order[5], 2);
+
+    before.cancel();
+    after.cancel();
+    FastLED.show();
+    FL_CHECK_EQ(order.size(), 6);
+
+    scheduler.clear_all_tasks();
+}
+
+FL_TEST_CASE("frame task dispatch is deferred and non-reentrant [task]") {
+    auto& scheduler = fl::task::Scheduler::instance();
+    scheduler.clear_all_tasks();
+
+    int outer_count = 0;
+    int deferred_count = 0;
+    fl::task::Handle deferred;
+    auto outer = fl::task::before_frame().then([&]() {
+        ++outer_count;
+        if (outer_count == 1) {
+            deferred = fl::task::before_frame().then([&deferred_count]() {
+                ++deferred_count;
+            });
+            FastLED.onBeginFrame();
+        }
+    });
+
+    FastLED.onBeginFrame();
+    FL_CHECK_EQ(outer_count, 1);
+    FL_CHECK_EQ(deferred_count, 0);
+
+    FastLED.onBeginFrame();
+    FL_CHECK_EQ(outer_count, 2);
+    FL_CHECK_EQ(deferred_count, 1);
+
+    outer.cancel();
+    deferred.cancel();
+    scheduler.clear_all_tasks();
+}
+
+FL_TEST_CASE("frame task dispatch tolerates scheduler mutation [task]") {
+    auto& scheduler = fl::task::Scheduler::instance();
+    scheduler.clear_all_tasks();
+
+    auto timer = fl::task::every_ms(1000).then([]() {});
+    int second_count = 0;
+    auto first = fl::task::before_frame().then([&timer]() {
+        timer.cancel();
+        fl::task::run(0, fl::task::ExecFlags::TASKS);
+    });
+    auto second = fl::task::before_frame().then([&second_count]() {
+        ++second_count;
+    });
+
+    FastLED.onBeginFrame();
+    FL_CHECK_EQ(second_count, 1);
+
+    first.cancel();
+    second.cancel();
+    scheduler.clear_all_tasks();
+}
 
 } // FL_TEST_FILE


### PR DESCRIPTION
## Summary

- wire `fl::task::before_frame()` and `after_frame()` into real FastLED frame boundaries
- make frame callbacks recur until canceled, matching the documented per-frame contract
- keep dispatch stable across scheduler mutation, defer tasks registered mid-phase, and prevent same-phase recursive dispatch
- correct the broken README includes/`async_yield()` call and the stale executor auto-pump documentation

## Strategy

Three approaches were evaluated:

1. Remove the frame-task API. Rejected because the builders, task types, and manual pumps are shipped public API.
2. Preserve one-shot behavior and narrow the docs. Rejected because it conflicts with the intended per-frame use and makes the API substantially less useful.
3. Repair automatic recurring dispatch. Selected because it preserves source compatibility and fulfills the public rendering-lifecycle contract.

The scheduler installs a dedicated final frame listener only while live frame tasks exist. This keeps ordinary time-task and low-memory paths lightweight, while ensuring frame callbacks run after ordinary begin/end listeners. Dispatch uses reusable stable-handle snapshots, so callbacks may add/cancel tasks or call `fl::task::run()` without invalidating traversal.

## Validation

- RED: focused quick and sanitizer tests failed on missing frame dispatch before implementation
- GREEN: `bash test fl_task_task --debug`
- `bash test --cpp` — 279 unit tests and 84 host examples passed
- `bash lint`
- pre-push `/clud-review` — clean after fixing its scheduler-mutation finding

Fixes #3896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recurring tasks that run before or after each LED frame.
  * Added support for cancelling frame tasks and safely handling task changes during execution.
  * Frame-task scheduling now integrates directly with LED rendering events.

* **Documentation**
  * Clarified frame-task behavior, callback timing, cancellation, and manual task execution requirements.
  * Updated examples to demonstrate the streamlined frame-task workflow.

* **Tests**
  * Added coverage for recurring execution, cancellation, ordering, deferred dispatch, and scheduler changes during frame processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->