### PR TITLE
test(rp2350): enable RP2xxx driver validation

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -364,11 +364,25 @@ to validate a driver, subsystem, or special mode:
 - `--rmt` - Test RMT (Remote Control) driver
 - `--spi` - Test SPI driver
 - `--uart` - Test UART driver
+- `--rp-uart-index {0,1}` - Select the concrete RP2040/RP2350 UART engine
+  used by `--uart` (default `0`)
 - `--lcd` - Test LCD_CLOCKLESS driver (ESP32-S3 only)
 - `--lcd-spi` - Test LCD_SPI driver (ESP32-S3 only)
 - `--lcd-rgb` - Test LCD RGB driver (ESP32-P4 only)
 - `--object-fled` - Test ObjectFLED DMA driver (Teensy 4.x only)
-- `--flex-io` - Test FlexIO clockless driver (Teensy 4.x only)
+- `--flex-io` - Test FlexIO clockless on Teensy 4.x or PIO clockless on
+  RP2040/RP2350
+- `--rp-pio-index {0,1,2}` - Select the RP PIO engine used by `--flex-io`;
+  PIO2 requires RP2350
+- `--rp-pio-both` - Select RP PIO0 and PIO1 together; requires
+  `--flex-io --parallel`
+- `--rp-spi-loopback` / `--rp-spi-index {0,1}` - Run RP2040/RP2350
+  fixed-SPI DMA byte loopback on the selected SPI instance. The fixed pin
+  routes require GPIO3 MOSI to GPIO0 MISO for SPI0, or GPIO11 MOSI to GPIO8
+  MISO for SPI1; an arbitrary discovered TX/RX bridge does not replace that
+  wiring.
+- `--rp-spi-public-api` / `--rp-spi-chipset {apa102,sk9822}` - Verify
+  RP2040/RP2350 SPI1 output through the public `FastLED.addLeds()` API
 - `--flexio [0|1]` - Deprecated compatibility alias for `--flex-io`; default
   `0`, pass `1` to enable, emits a warning
 - `--lpuart` - Deprecated compatibility alias for `--uart`; emits a warning
@@ -386,6 +400,9 @@ bash autoresearch esp32s3 --parlio            # Specify esp32s3 environment
 bash autoresearch --rmt
 bash autoresearch --spi
 bash autoresearch --uart
+bash autoresearch rp2350w --uart --rp-uart-index 0
+bash autoresearch rp2350w --flex-io --rp-pio-index 2
+bash autoresearch rp2350w --rp-spi-loopback --rp-spi-index 0
 bash autoresearch esp32c6 --rmt --legacy --chipset ws2814 --strip-sizes 1,2,3,4
 bash autoresearch --lcd                       # ESP32-S3 LCD_CLOCKLESS
 bash autoresearch --lcd-rgb                   # ESP32-P4 only

--- a/autoresearch
+++ b/autoresearch
@@ -33,12 +33,20 @@ Driver Selection (optional - omit for GPIO-only mode):
   --rmt               Test RMT (Remote Control) driver
   --spi               Test SPI driver
   --uart              Test UART driver (LPC845: UART DMA clockless RX-DMA loopback)
+  --rp-uart-index N   RP2040/RP2350 UART engine for --uart: 0 or 1 (default: 0)
   --lpuart            Deprecated alias for --uart; emits a warning
   --lcd               Test LCD_CLOCKLESS driver (ESP32-S3 only)
   --lcd-spi           Test LCD_SPI driver (ESP32-S3 only)
   --lcd-rgb           Test LCD RGB driver (ESP32-P4 only)
   --object-fled       Test ObjectFLED DMA driver (Teensy 4.x only)
-  --flex-io           Test FlexIO clockless driver (Teensy 4.x only)
+  --flex-io           Test FlexIO (Teensy 4.x) or PIO (RP2040/RP2350) clockless driver
+  --rp-pio-index N    RP PIO engine for --flex-io: 0, 1, or RP2350-only 2
+  --rp-pio-both       RP: select PIO0 + PIO1 (requires --flex-io --parallel)
+  --rp-spi-loopback   RP2040/RP2350 fixed-SPI DMA byte loopback; requires
+                      GPIO3->GPIO0 (SPI0) or GPIO11->GPIO8 (SPI1)
+  --rp-spi-index N    RP fixed-SPI instance: 0 or 1 (default: 0)
+  --rp-spi-public-api RP2040/RP2350 SPI1 APA102/SK9822 public-API loopback
+  --rp-spi-chipset X  Chipset for --rp-spi-public-api: apa102 or sk9822
   --flexio [0|1]      Deprecated alias for --flex-io; default 0, 1 enables it
   --pwm-dma-cl        LPC845-only: channels-API SCT+DMA clockless
                       self-loopback (FastLED #3468). Jumper P0_10↔P0_11.
@@ -101,6 +109,9 @@ Examples:
   bash autoresearch --rmt --color-pattern ff00aa     # Test RMT with custom color (pink)
   bash autoresearch --parlio                         # Uses fbuild for compile/upload
   bash autoresearch --parlio --lcd-rgb --parallel --lanes 1  # Test PARLIO + LCD_RGB in parallel
+  bash autoresearch rp2350w --flex-io --rp-pio-index 2
+  bash autoresearch rp2350w --uart --rp-uart-index 0
+  bash autoresearch rp2350w --rp-spi-loopback --rp-spi-index 0
   bash autoresearch --net                             # ESP32 self-contained HTTP loopback test
   bash autoresearch --net-server                     # ESP32 WiFi AP + HTTP server autoresearch
   bash autoresearch --net-client                     # ESP32 WiFi AP + HTTP client autoresearch

--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -121,11 +121,13 @@ class Args:
     # exclusive with the other LPC DMA harnesses at the flash budget.
     dma_uart: bool
 
-    # RP2040 fixed-SPI DMA byte-loopback harness.
+    # RP2040/RP2350 fixed-SPI DMA byte-loopback harness.
     rp_spi_loopback: bool
     rp_spi_index: int
     rp_spi_public_api: bool
     rp_spi_chipset: str
+    # RP PL011 UART engine used by --uart on RP2040/RP2350.
+    rp_uart_index: int
     # RP PIO TX engine used by --flex-io on RP2040/RP2350.
     rp_pio_index: int
     # Select both PIO TX engines for a parallel RP run.
@@ -266,7 +268,7 @@ See Also:
         driver_group.add_argument(
             "--rp-spi-loopback",
             action="store_true",
-            help="RP2040-only: fixed SPI0/SPI1 DMA byte-loopback "
+            help="RP2040/RP2350: fixed SPI0/SPI1 DMA byte-loopback "
             + "through the channel engine; requires MOSI-to-MISO jumper.",
         )
         driver_group.add_argument(
@@ -279,7 +281,7 @@ See Also:
         driver_group.add_argument(
             "--rp-spi-public-api",
             action="store_true",
-            help="RP2040: verify APA102/SK9822 through FastLED.addLeds() on SPI1.",
+            help="RP2040/RP2350: verify APA102/SK9822 through FastLED.addLeds() on SPI1.",
         )
         driver_group.add_argument(
             "--rp-spi-chipset",
@@ -291,6 +293,13 @@ See Also:
             "--uart",
             action="store_true",
             help="Test only UART driver (LPC845: UART DMA clockless RX-DMA loopback)",
+        )
+        driver_group.add_argument(
+            "--rp-uart-index",
+            type=int,
+            choices=(0, 1),
+            default=0,
+            help="RP UART engine for --uart on RP2040/RP2350 (default: 0).",
         )
         driver_group.add_argument(
             "--lcd",
@@ -926,6 +935,7 @@ See Also:
             rp_spi_index=parsed.rp_spi_index,
             rp_spi_public_api=parsed.rp_spi_public_api,
             rp_spi_chipset=parsed.rp_spi_chipset,
+            rp_uart_index=parsed.rp_uart_index,
             rp_pio_index=parsed.rp_pio_index,
             rp_pio_both=parsed.rp_pio_both,
             test_fault_emit=parsed.test_fault_emit,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
 from colorama import Fore, Style
+from running_process import RunningProcess
 
 from ci.autoresearch.args import Args
 from ci.autoresearch.build_driver import DeployResult, select_build_driver
@@ -98,7 +99,10 @@ def _is_teensy4_environment(final_environment: str | None) -> bool:
 
 
 def _driver_name_for_environment(
-    driver: str, final_environment: str | None, rp_pio_index: int = 1
+    driver: str,
+    final_environment: str | None,
+    rp_pio_index: int = 1,
+    rp_uart_index: int = 0,
 ) -> str:
     if driver == "SPI" and _is_teensy4_environment(final_environment):
         return "SPI_UNIFIED"
@@ -110,7 +114,58 @@ def _driver_name_for_environment(
         # concrete names must remain distinct so a runtime-exclusive test can
         # select one physical PIO block without replacing the other.
         return f"PIO{rp_pio_index}"
+    if driver == "UART" and _active_rp2xxx_environment(final_environment) is not None:
+        # RP exposes two concrete PL011 engines. The portable "UART" bus name
+        # is not registered as a runtime driver on this platform.
+        return f"UART{rp_uart_index}"
     return driver
+
+
+def _replace_driver_selection(
+    ctx: RunContext, current: str, replacements: list[str]
+) -> None:
+    """Replace a deferred driver name in the inventory and generated RPCs."""
+    expanded_drivers: list[str] = []
+    for driver in ctx.drivers:
+        expanded_drivers.extend(replacements if driver == current else (driver,))
+    ctx.drivers = expanded_drivers
+
+    for command in ctx.json_rpc_commands:
+        params = command.get("params")
+        if not isinstance(params, dict):
+            continue
+        if params.get("driver") == current:
+            # Multi-target replacements are generated only for parallel mode.
+            params["driver"] = replacements[0]
+        driver_entries = params.get("drivers")
+        if not isinstance(driver_entries, list):
+            continue
+        expanded_entries: list[Any] = []
+        for entry in driver_entries:
+            if not isinstance(entry, dict) or entry.get("driver") != current:
+                expanded_entries.append(entry)
+                continue
+            for replacement in replacements:
+                replacement_entry = dict(entry)
+                replacement_entry["driver"] = replacement
+                expanded_entries.append(replacement_entry)
+        params["drivers"] = expanded_entries
+
+
+def _normalize_deferred_driver_names(ctx: RunContext) -> None:
+    """Apply platform-specific names after USB board auto-detection."""
+    environment = ctx.final_environment
+    args = ctx.args
+    if _active_rp2xxx_environment(environment) is not None:
+        _replace_driver_selection(ctx, "UART", [f"UART{args.rp_uart_index}"])
+        pio_names = (
+            ["PIO0", "PIO1"]
+            if args.rp_pio_both and args.flex_io
+            else [f"PIO{args.rp_pio_index}"]
+        )
+        _replace_driver_selection(ctx, "FLEX_IO", pio_names)
+    elif _is_teensy4_environment(environment):
+        _replace_driver_selection(ctx, "SPI", ["SPI_UNIFIED"])
 
 
 def _uses_teensy_flex_io_default_tx(
@@ -510,7 +565,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.spi:
             drivers.append(_driver_name_for_environment("SPI", final_environment))
         if args.uart:
-            drivers.append("UART")
+            drivers.append(
+                _driver_name_for_environment(
+                    "UART",
+                    final_environment,
+                    rp_uart_index=args.rp_uart_index,
+                )
+            )
         if args.lcd:
             drivers.append("LCD_CLOCKLESS")
         if args.lcd_spi:
@@ -1382,6 +1443,7 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
         print()
 
     ctx.final_environment = _canonical_board_environment(ctx.final_environment)
+    _normalize_deferred_driver_names(ctx)
 
     if args.use_root_platformio_ini and _reject_teensy_root_platformio_ini(
         ctx.final_environment
@@ -3460,9 +3522,11 @@ async def _run_lpc_dma_spi_tests(ctx: RunContext) -> int:
 async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
     """Run byte-exact loopback through the RP fixed-SPI channel engine."""
     final_environment = (ctx.final_environment or "").lower()
-    if final_environment != "rp2040":
-        print("--rp-spi-loopback is only supported on the rp2040 environment.")
+    active_environment = _active_rp2xxx_environment(final_environment)
+    if active_environment is None:
+        print("--rp-spi-loopback requires an RP2040 or RP2350 environment.")
         return 1
+    chip_name = "RP2350" if active_environment in RP2350_ENVIRONMENTS else "RP2040"
 
     upload_port = ctx.upload_port
     assert upload_port is not None
@@ -3474,7 +3538,7 @@ async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
     rx_pin = ctx.args.rx_pin if ctx.args.rx_pin is not None else default_rx_pin
     print()
     print("=" * 60)
-    print("RP2040 fixed-SPI DMA byte-loopback")
+    print(f"{chip_name} fixed-SPI DMA byte-loopback")
     print(
         f"   Wiring: GPIO{tx_pin} (SPI{spi_index} MOSI) -> GPIO{rx_pin} (SPI{spi_index} MISO)"
     )
@@ -3500,19 +3564,27 @@ async def _run_rp_spi_loopback_tests(ctx: RunContext) -> int:
         "--spi-index",
         str(spi_index),
     ]
-    result = subprocess.run(cmd)
+    result = RunningProcess.run(
+        cmd,
+        check=False,
+        timeout=ctx.remaining_seconds(),
+    )
     return 0 if result.returncode == 0 else 1
 
 
 async def _run_rp_spi_public_api_tests(ctx: RunContext) -> int:
     """Verify APA102/SK9822 framing through the RP SPI1 public API path."""
-    if (ctx.final_environment or "").lower() != "rp2040":
-        print("--rp-spi-public-api is only supported on the rp2040 environment.")
+    active_environment = _active_rp2xxx_environment(ctx.final_environment)
+    if active_environment is None:
+        print("--rp-spi-public-api requires an RP2040 or RP2350 environment.")
         return 1
+    chip_name = "RP2350" if active_environment in RP2350_ENVIRONMENTS else "RP2040"
     upload_port = ctx.upload_port
     assert upload_port is not None
-    print("RP2040 SPI1 public API loopback: GPIO11 MOSI -> GPIO8 MISO, GPIO10 SCK")
-    result = subprocess.run(
+    print(
+        f"{chip_name} SPI1 public API loopback: GPIO11 MOSI -> GPIO8 MISO, GPIO10 SCK"
+    )
+    result = RunningProcess.run(
         [
             "uv",
             "run",
@@ -3523,7 +3595,9 @@ async def _run_rp_spi_public_api_tests(ctx: RunContext) -> int:
             upload_port,
             "--chipset",
             ctx.args.rp_spi_chipset,
-        ]
+        ],
+        check=False,
+        timeout=ctx.remaining_seconds(),
     )
     return 0 if result.returncode == 0 else 1
 

--- a/ci/autoresearch/test_rp_spi_loopback.py
+++ b/ci/autoresearch/test_rp_spi_loopback.py
@@ -1,4 +1,4 @@
-"""Validate RP2040 fixed-SPI DMA loopback through ChannelEngineRpSpi.
+"""Validate RP2xxx fixed-SPI DMA loopback through ChannelEngineRpSpi.
 
 The companion AutoResearch RPC sends a fixed 32-byte pattern through
 ``BusTraits<Bus::SPI, N>``. RX DMA captures MISO while the engine waits for
@@ -90,7 +90,7 @@ def run_case(
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="RP2040 fixed-SPI DMA byte-loopback through ChannelEngineRpSpi"
+        description="RP2xxx fixed-SPI DMA byte-loopback through ChannelEngineRpSpi"
     )
     parser.add_argument("--port", default=DEFAULT_PORT)
     parser.add_argument("--spi-index", type=int, choices=(0, 1), default=0)
@@ -102,7 +102,7 @@ def main() -> int:
     mosi_pin = args.mosi_pin if args.mosi_pin is not None else default_pins.mosi
     miso_pin = args.miso_pin if args.miso_pin is not None else default_pins.miso
 
-    print(f"RP2040 SPI{args.spi_index} DMA byte-loopback — FastLED #3659")
+    print(f"RP2xxx SPI{args.spi_index} DMA byte-loopback - FastLED #3659")
     print(f"  Port: {args.port}")
     print(f"  Wiring: GPIO{mosi_pin} (MOSI) -> GPIO{miso_pin} (MISO)")
     print(f"  SCK: GPIO{sck_pin} (output only)")

--- a/ci/autoresearch/test_rp_spi_public_api.py
+++ b/ci/autoresearch/test_rp_spi_public_api.py
@@ -1,4 +1,4 @@
-"""Validate RP2040 SPI1 APA102/SK9822 output through FastLED's public API."""
+"""Validate RP2xxx SPI1 APA102/SK9822 output through FastLED's public API."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ def main() -> int:
     parser.add_argument("--port", required=True)
     parser.add_argument("--chipset", choices=("apa102", "sk9822"), required=True)
     args = parser.parse_args()
-    print(f"RP2040 SPI1 {args.chipset.upper()} public API loopback — FastLED #3660")
+    print(f"RP2xxx SPI1 {args.chipset.upper()} public API loopback - FastLED #3660")
     print("  Wiring: GPIO11 (MOSI) -> GPIO8 (MISO); GPIO10 is SCK output only")
     try:
         with RpcBench(args.port) as bench:
@@ -47,7 +47,7 @@ def main() -> int:
     except Exception as error:  # noqa: BLE001
         print(f"FAIL — unable to run RP SPI public API loopback: {error}")
         return 1
-    print(f"PASS — {args.chipset.upper()} public API framing is byte-exact on SPI1.")
+    print(f"PASS - {args.chipset.upper()} public API framing is byte-exact on SPI1.")
     return 0
 
 

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -25,6 +25,8 @@ from ci.autoresearch.phases import (
     _parse_args_and_build_commands,
     _resolve_port_and_environment,
     _run_build_deploy,
+    _run_rp_spi_loopback_tests,
+    _run_rp_spi_public_api_tests,
     _run_schema_and_pin_setup,
     _run_tests_or_special_mode,
     _run_watchdog_soak,
@@ -153,6 +155,7 @@ def _make_args(**overrides) -> Args:
         rp_spi_index=0,
         rp_spi_public_api=False,
         rp_spi_chipset="apa102",
+        rp_uart_index=0,
         rp_pio_index=1,
         rp_pio_both=False,
         test_fault_emit=False,
@@ -850,6 +853,40 @@ class TestParseArgsAndBuildCommands:
         assert result.drivers == ["PIO2"]
         assert result.json_rpc_commands[0]["params"]["driver"] == "PIO2"
 
+    @pytest.mark.parametrize(
+        ("environment", "uart_index", "driver"),
+        (
+            ("rp2040", 0, "UART0"),
+            ("rpipico", 1, "UART1"),
+            ("rp2350", 0, "UART0"),
+            ("rp2350w", 1, "UART1"),
+            ("rpipico2w", 0, "UART0"),
+        ),
+    )
+    def test_uart_selects_concrete_rp_uart_driver(
+        self,
+        fake_project_dir: Path,
+        environment: str,
+        uart_index: int,
+        driver: str,
+    ) -> None:
+        args = _make_args(
+            parlio=False,
+            uart=True,
+            rp_uart_index=uart_index,
+            environment_positional=environment,
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == [driver]
+        assert result.json_rpc_commands[0]["params"]["driver"] == driver
+
     def test_flex_io_rejects_pio2_on_rp2040(self, fake_project_dir: Path) -> None:
         args = _make_args(
             parlio=False,
@@ -1090,6 +1127,11 @@ class TestParseArgsAndBuildCommands:
         args = Args.parse_args(["--rp-spi-loopback", "--rp-spi-index", "1"])
         assert args.rp_spi_loopback is True
         assert args.rp_spi_index == 1
+
+    def test_rp_uart_index_flag_parses(self) -> None:
+        args = Args.parse_args(["--uart", "--rp-uart-index", "1"])
+        assert args.uart is True
+        assert args.rp_uart_index == 1
 
     def test_simd_mode(self, fake_project_dir: Path) -> None:
         args = _make_args(parlio=False, simd=True, project_dir=fake_project_dir)
@@ -1348,6 +1390,55 @@ class TestParseArgsAndBuildCommands:
 
 class TestResolvePortAndEnvironment:
     """Test _resolve_port_and_environment (mocks port detection)."""
+
+    def test_auto_detected_rp_normalizes_uart_driver_name(self, tmp_path: Path) -> None:
+        (tmp_path / "examples" / "AutoResearch").mkdir(parents=True)
+        staged_dir = tmp_path / ".build" / "pio" / "rp2350w"
+        staged_dir.mkdir(parents=True)
+        args = _make_args(
+            upload_port=None,
+            environment_positional=None,
+            parlio=False,
+            uart=True,
+            rp_uart_index=1,
+            project_dir=tmp_path,
+            use_root_platformio_ini=False,
+        )
+        ctx = _parse_args_and_build_commands(args)
+        assert isinstance(ctx, RunContext)
+        assert ctx.drivers == ["UART"]
+        assert ctx.json_rpc_commands[0]["params"]["driver"] == "UART"
+
+        port_result = MagicMock(ok=True, selected_port="COM17")
+        chip_result = MagicMock(
+            ok=True,
+            chip_type="RP2350",
+            environment="rp2350w",
+        )
+        with (
+            patch(
+                f"{_PATCH_MOD}.auto_detect_upload_port",
+                return_value=port_result,
+            ),
+            patch(
+                f"{_PATCH_MOD}.detect_attached_chip",
+                return_value=chip_result,
+            ),
+            patch(
+                "ci.autoresearch.staging.synthesise_autoresearch_project",
+                return_value=staged_dir,
+            ),
+            patch(
+                f"{_PATCH_MOD}.select_build_driver",
+                return_value=_make_mock_driver(),
+            ),
+        ):
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+
+        assert rc is None
+        assert ctx.final_environment == "rp2350w"
+        assert ctx.drivers == ["UART1"]
+        assert ctx.json_rpc_commands[0]["params"]["driver"] == "UART1"
 
     def test_auto_detect_port_success(self) -> None:
         ctx = _make_ctx(upload_port=None)
@@ -1949,8 +2040,11 @@ class TestRunBuildDeploy:
 
     @pytest.fixture(autouse=True)
     def disable_host_watchdog_for_unit_deploys(self):
-        """Direct phase tests do not own the runner watchdog lifecycle."""
-        with patch(f"{_PATCH_MOD}.start_autoresearch_watchdog"):
+        """Direct phase tests do not own host watchdog or USB inventory state."""
+        with (
+            patch(f"{_PATCH_MOD}.start_autoresearch_watchdog"),
+            patch(f"{_PATCH_MOD}.absent_port_error", return_value=None),
+        ):
             yield
 
     def test_build_deploy_success(self) -> None:
@@ -2378,6 +2472,42 @@ class TestRunTestsOrSpecialMode:
             rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
         assert rc == 0
         loopback.assert_awaited_once_with(ctx)
+
+    @pytest.mark.parametrize("environment", ("rp2350", "rp2350w", "rpipico2w"))
+    def test_rp_spi_loopback_runs_on_rp2350_aliases(self, environment: str) -> None:
+        ctx = _make_ctx(
+            args=_make_args(parlio=False, rp_spi_loopback=True),
+            drivers=[],
+            gpio_only_mode=False,
+            final_environment=environment,
+            upload_port="COM17",
+        )
+        completed = MagicMock(returncode=0)
+        with patch(f"{_PATCH_MOD}.RunningProcess.run", return_value=completed) as run:
+            rc = asyncio.run(_run_rp_spi_loopback_tests(ctx))
+        assert rc == 0
+        command = run.call_args.args[0]
+        assert command[:4] == ["uv", "run", "python", "-m"]
+        assert command[4] == "ci.autoresearch.test_rp_spi_loopback"
+        assert run.call_args.kwargs == {"check": False, "timeout": 60.0}
+
+    @pytest.mark.parametrize("environment", ("rp2350", "rp2350w", "rpipico2w"))
+    def test_rp_spi_public_api_runs_on_rp2350_aliases(self, environment: str) -> None:
+        ctx = _make_ctx(
+            args=_make_args(parlio=False, rp_spi_public_api=True),
+            drivers=[],
+            gpio_only_mode=False,
+            final_environment=environment,
+            upload_port="COM17",
+        )
+        completed = MagicMock(returncode=0)
+        with patch(f"{_PATCH_MOD}.RunningProcess.run", return_value=completed) as run:
+            rc = asyncio.run(_run_rp_spi_public_api_tests(ctx))
+        assert rc == 0
+        command = run.call_args.args[0]
+        assert command[:4] == ["uv", "run", "python", "-m"]
+        assert command[4] == "ci.autoresearch.test_rp_spi_public_api"
+        assert run.call_args.kwargs == {"check": False, "timeout": 60.0}
 
     def test_simd_mode_pass(self) -> None:
         ctx = _make_ctx(simd_test_mode=True)

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -25,6 +25,13 @@ RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
 RP_BLE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "ble_rp.cpp.hpp"
 AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
 AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
+AUTORESEARCH_TEST = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchTest.cpp"
+AUTORESEARCH_SYSTEM_METHODS = (
+    REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchRemoteSystemMethods.cpp"
+)
+AUTORESEARCH_PARALLEL = (
+    REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchRemoteRunParallelTest.cpp"
+)
 
 
 def test_rp2350w_selects_the_pico_2_w_board_profile() -> None:
@@ -84,6 +91,31 @@ def test_autoresearch_identity_prioritizes_pico_2_w() -> None:
     assert pico_2_w_branch < generic_rp2350_branch
     assert 'return "Raspberry Pi Pico 2 W (RP2350)";' in source
     assert 'return "RP2350";' in source
+
+
+def test_autoresearch_uses_uart_timing_for_both_rp_uart_engines() -> None:
+    source = AUTORESEARCH_TEST.read_text(encoding="utf-8")
+
+    assert 'fl::strcmp(driver_name, "UART0") == 0' in source
+    assert 'fl::strcmp(driver_name, "UART1") == 0' in source
+
+
+def test_autoresearch_reports_typed_device_info_for_both_rp_uart_engines() -> None:
+    source = AUTORESEARCH_SYSTEM_METHODS.read_text(encoding="utf-8")
+
+    assert 'name == "UART0"' in source
+    assert "deviceJson<fl::Bus::UART, 0>()" in source
+    assert 'name == "UART1"' in source
+    assert "deviceJson<fl::Bus::UART, 1>()" in source
+
+
+def test_autoresearch_parallel_mode_preserves_rp_uart_instance_affinity() -> None:
+    source = AUTORESEARCH_PARALLEL.read_text(encoding="utf-8")
+
+    assert 'n == "UART0"' in source
+    assert "opts.mBusWhich = 0" in source
+    assert 'n == "UART1"' in source
+    assert "opts.mBusWhich = 1" in source
 
 
 def test_rp_platform_dispatches_real_mutex_and_semaphore_backends() -> None:

--- a/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunParallelTest.cpp
@@ -233,6 +233,8 @@ fl::json AutoResearchRemoteControl::runParallelTestImpl(const fl::json& args) {
                 else if (n == "LCD_SPI")       opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "LCD_CLOCKLESS") opts.mBus = fl::Bus::FLEX_IO;
                 else if (n == "UART")          opts.mBus = fl::Bus::UART;
+                else if (n == "UART0")         { opts.mBus = fl::Bus::UART; opts.mBusWhich = 0; }
+                else if (n == "UART1")         { opts.mBus = fl::Bus::UART; opts.mBusWhich = 1; }
                 else if (n == "FLEX_IO")       { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }
                 else if (n == "PIO0")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 0; }
                 else if (n == "PIO1")          { opts.mBus = fl::Bus::FLEX_IO; opts.mBusWhich = 1; }

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -90,7 +90,10 @@ ParlioRawTestState& parlioRawTestState() {
 fl::json autoResearchDeviceJson(const fl::string& name) {
     if (name == "RMT") return fl::deviceJson<fl::Bus::RMT>();
     if (name == "SPI" || name == "SPI_UNIFIED") return fl::deviceJson<fl::Bus::SPI>();
-    if (name == "UART" || name == "LPUART") return fl::deviceJson<fl::Bus::UART>();
+    if (name == "UART" || name == "LPUART" || name == "UART0") {
+        return fl::deviceJson<fl::Bus::UART, 0>();
+    }
+    if (name == "UART1") return fl::deviceJson<fl::Bus::UART, 1>();
     if (name == "BIT_BANG" || name == "STUB") return fl::deviceJson<fl::Bus::BIT_BANG>();
 
     if (name == "FLEX_IO" || name == "LCD_RGB") {

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -453,7 +453,9 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     // Buffer size: 1 LED byte = 8 bits = 8 RMT symbols
     // UART with TX inversion produces standard WS2812 waveform, same symbol count
     bool is_uart_driver = (fl::strcmp(driver_name, "UART") == 0)
-                       || (fl::strcmp(driver_name, "LPUART") == 0);
+                       || (fl::strcmp(driver_name, "LPUART") == 0)
+                       || (fl::strcmp(driver_name, "UART0") == 0)
+                       || (fl::strcmp(driver_name, "UART1") == 0);
     bool is_object_fled_driver = (fl::strcmp(driver_name, "OBJECT_FLED") == 0);
     rx_config.edge_capacity = fl::validation::captureEdgeCapacity(
         rx_buffer.size(), expected_data_bytes, rx_channel->backend());

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -170,7 +170,7 @@ FastLED.addLeds<WS2812, 4, GRB, fl::Bus::RMT>(leds, 60);
 
 // SPI: use the platform's compile-time default bus.
 FastLED.addLeds<APA102, 23, 18, RGB, DATA_RATE_MHZ(12), fl::Bus::AUTO>(leds, 60);
-// Or name a bus supported by the target (for example, RP2040 hardware SPI).
+// Or name a bus supported by the target (for example, RP2xxx hardware SPI).
 FastLED.addLeds<APA102, 11, 10, RGB, DATA_RATE_MHZ(12), fl::Bus::SPI, 1>(leds, 60);
 ```
 

--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -215,11 +215,14 @@ inline const char* busDriverName(Bus b, fl::u8 which = 0, bool spi = false) FL_N
             return busName(b, which);
 #endif
         case Bus::UART:
-            (void)which;
             (void)spi;
-#if defined(FL_IS_TEENSY_4X)
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+            return which == 0 ? "UART0" : "UART1";
+#elif defined(FL_IS_TEENSY_4X)
+            (void)which;
             return "LPUART";
 #else
+            (void)which;
             return "UART";
 #endif
     }

--- a/src/fl/channels/bus_info.h
+++ b/src/fl/channels/bus_info.h
@@ -170,6 +170,18 @@ template<> struct DeviceInfoResolver<Bus::FLEX_IO, 1> {
     }
 };
 
+template<> struct DeviceInfoResolver<Bus::UART, 0> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::UART, 0, "PL011", "RP UART0");
+    }
+};
+
+template<> struct DeviceInfoResolver<Bus::UART, 1> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::UART, 1, "PL011", "RP UART1");
+    }
+};
+
 #if defined(FL_IS_RP2350)
 template<> struct DeviceInfoResolver<Bus::FLEX_IO, 2> {
     static inline DeviceInfo get() FL_NO_EXCEPT {

--- a/tests/fl/channels/bus_info.cpp
+++ b/tests/fl/channels/bus_info.cpp
@@ -35,6 +35,11 @@ FL_STATIC_ASSERT(fl::BusInstanceCount<fl::Bus::SPI>::value == 1,
                  "ESP32-C6 exposes one SPI entry");
 FL_STATIC_ASSERT(fl::BusInstanceCount<fl::Bus::UART>::value == 2,
                  "ESP32-C6 exposes two UART entries");
+#elif defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+FL_STATIC_ASSERT(fl::BusInstanceCount<fl::Bus::SPI>::value == 2,
+                 "RP2xxx exposes two SPI entries");
+FL_STATIC_ASSERT(fl::BusInstanceCount<fl::Bus::UART>::value == 2,
+                 "RP2xxx exposes two UART entries");
 #endif
 
 FL_TEST_CASE("deviceInfo reports BIT_BANG") {
@@ -52,6 +57,28 @@ FL_TEST_CASE("deviceInfo reports UART Which0") {
     FL_CHECK_EQ(info.which, 0);
     FL_CHECK_EQ(fl::string(info.bus_name), fl::string("UART"));
 }
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+FL_TEST_CASE("RP UART affinity names and device metadata preserve Which") {
+    FL_CHECK_EQ(fl::string(fl::busDriverName(fl::Bus::UART, 0)),
+                fl::string("UART0"));
+    FL_CHECK_EQ(fl::string(fl::busDriverName(fl::Bus::UART, 1)),
+                fl::string("UART1"));
+
+    auto uart0 = fl::deviceInfo<fl::Bus::UART, 0>();
+    auto uart1 = fl::deviceInfo<fl::Bus::UART, 1>();
+    FL_CHECK_EQ(uart0.which, 0);
+    FL_CHECK_EQ(uart1.which, 1);
+    FL_CHECK_FALSE(uart0.is_noop);
+    FL_CHECK_FALSE(uart1.is_noop);
+    FL_CHECK(uart0.runtime.available);
+    FL_CHECK(uart1.runtime.available);
+    FL_CHECK_EQ(fl::string(uart0.vendor_name), fl::string("PL011"));
+    FL_CHECK_EQ(fl::string(uart1.vendor_name), fl::string("PL011"));
+    FL_CHECK_EQ(fl::string(uart0.device_name), fl::string("RP UART0"));
+    FL_CHECK_EQ(fl::string(uart1.device_name), fl::string("RP UART1"));
+}
+#endif
 
 FL_TEST_CASE("deviceInfo reports SPI entries and out-of-range no-op") {
     auto spi0 = fl::deviceInfo<fl::Bus::SPI, 0>();


### PR DESCRIPTION
## Summary
- extend RP fixed-SPI loopback and public-API validation to RP2350/RP2350W
- add indexed RP UART selection with correct UART0/UART1 runtime affinity and typed PL011 metadata
- normalize deferred driver names after USB board auto-detection and document RP PIO/SPI/UART workflows

## Validation
- `uv run pytest --tb=short ci/tests/test_autoresearch_phases.py ci/tests/test_rp2350w_board_config.py` (186 passed)
- `bash test bus_info`
- `bash test channel_engine_rp_uart`
- `bash test channel_engine_rp_spi`
- `bash test channel_engine_rp_pio`
- `bash lint`
- `bash compile rp2350w --examples AutoResearch` (30.4% flash, 31.3% RAM)
- `/clud-review` clean

## Hardware status
The recorded RP2350 endpoint is currently a phantom Windows COM17 device and no RPI-RP2 BOOTSEL volume is present, so live bridge-pin discovery and HIL remain intentionally unclaimed.

Refs #3899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RP2040 and RP2350 support for selecting UART 0 or 1.
  - Added PIO engine selection, including dual-PIO configurations.
  - Added fixed-pin SPI DMA loopback and public API validation for RP2350.
  - Added clearer platform-specific handling and status reporting for RP UART and SPI testing.

- **Documentation**
  - Expanded command-line help and examples for RP2350 FlexIO/PIO, UART, and SPI workflows.
  - Updated hardware references to cover the broader RP2xxx family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->