### PR TITLE
Reduce RMT5 encoder logging bloat

### DIFF
--- a/src/fl/log/log.h
+++ b/src/fl/log/log.h
@@ -106,6 +106,11 @@
   #define FASTLED_LOG_RUNTIME_ENABLED 0
 #endif
 
+// Public resolved gate for FL_WARN call sites and their supporting helpers.
+// Prefer this over coupling callers to FASTLED_LOG_RUNTIME_ENABLED, which is
+// the shared implementation gate for several log severities.
+#define FL_HAS_WARN FASTLED_LOG_RUNTIME_ENABLED
+
 // Lite gate for FL_WARN_LIT / FL_LOG_LIT - string-literal-only macros that
 // route through fl::println without the sstream / operator<< / log_emit
 // chain. These are intentionally usable on Low-memory targets (LPC845,
@@ -315,7 +320,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #endif
 
 #ifndef FL_WARN
-#if FASTLED_LOG_RUNTIME_ENABLED
+#if FL_HAS_WARN
 // FL_WARN: unified entry point - accepts both `"foo " << x` and `"foo %d", x`
 // via macro-level argument-count dispatch. Single-arg -> stream form (legacy
 // compatible); two-or-more args -> printf form. See #3272.
@@ -341,7 +346,7 @@ void log_emit(log_kind kind, const char* file, int line, fl::sstream& body) FL_N
 #define FL_WARN_FMT(...) FL_WARN(__VA_ARGS__)
 #define FL_WARN_FMT_IF(COND, ...) FL_WARN_IF(COND, __VA_ARGS__)
 
-// FL_WARN_LIT: defined below outside the FASTLED_LOG_RUNTIME_ENABLED block -
+// FL_WARN_LIT: defined below outside the FL_HAS_WARN block -
 // gated on FASTLED_LOG_LITE_ENABLED so it stays available on Low-memory
 // targets. See "Lite-variant literal macros" section below.
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_5/rmt5_peripheral_esp.cpp.hpp
@@ -55,6 +55,18 @@ FL_EXTERN_C_END
 namespace fl {
 namespace detail {
 
+#if FL_HAS_WARN
+namespace {
+
+FL_NO_INLINE FL_COLD void emitRmt5EncoderCreateFailure(
+    const char* encoder_kind, esp_err_t error) FL_NO_EXCEPT {
+    FL_WARN_F("[RMT5_ENCODER] Failed to create %s encoder: %s",
+              encoder_kind, esp_err_to_name(error));
+}
+
+} // namespace
+#endif
+
 //=============================================================================
 // Encoder Implementation (forward declaration)
 //=============================================================================
@@ -679,10 +691,10 @@ private:
         mBit1LowTicks = static_cast<u32>((timing.T3 + half_ns_per_tick) / ns_per_tick);
         mResetTicks = static_cast<u32>((timing.RESET * 1000ULL + half_ns_per_tick) / ns_per_tick);
 
-        FL_WARN_F("[RMT5_ENCODER] Timing config: resolution=%sHz, ns_per_tick=%s", resolution_hz, ns_per_tick);
-        FL_WARN_F("[RMT5_ENCODER] Bit0: high=%s ticks, low=%s ticks", mBit0HighTicks, mBit0LowTicks);
-        FL_WARN_F("[RMT5_ENCODER] Bit1: high=%s ticks, low=%s ticks", mBit1HighTicks, mBit1LowTicks);
-        FL_WARN_F("[RMT5_ENCODER] Reset: %s ticks", mResetTicks);
+        FL_DBG_F("[RMT5_ENCODER] Timing config: resolution=%sHz, ns_per_tick=%s", resolution_hz, ns_per_tick);
+        FL_DBG_F("[RMT5_ENCODER] Bit0: high=%s ticks, low=%s ticks", mBit0HighTicks, mBit0LowTicks);
+        FL_DBG_F("[RMT5_ENCODER] Bit1: high=%s ticks, low=%s ticks", mBit1HighTicks, mBit1LowTicks);
+        FL_DBG_F("[RMT5_ENCODER] Reset: %s ticks", mResetTicks);
 
         rmt_bytes_encoder_config_t bytes_config = {};
         bytes_config.bit0.level0 = 1;
@@ -697,14 +709,18 @@ private:
 
         esp_err_t ret = rmt_new_bytes_encoder(&bytes_config, &mBytesEncoder);
         if (ret != ESP_OK) {
-            FL_WARN_F("[RMT5_ENCODER] Failed to create bytes encoder: %s", esp_err_to_name(ret));
+#if FL_HAS_WARN
+            emitRmt5EncoderCreateFailure("bytes", ret);
+#endif
             return ret;
         }
 
         rmt_copy_encoder_config_t copy_config = {};
         ret = rmt_new_copy_encoder(&copy_config, &mCopyEncoder);
         if (ret != ESP_OK) {
-            FL_WARN_F("[RMT5_ENCODER] Failed to create copy encoder: %s", esp_err_to_name(ret));
+#if FL_HAS_WARN
+            emitRmt5EncoderCreateFailure("copy", ret);
+#endif
             rmt_del_encoder(mBytesEncoder);
             mBytesEncoder = nullptr;
             return ret;
@@ -715,7 +731,7 @@ private:
         mResetCode.duration1 = 0;
         mResetCode.level1 = 0;
 
-        FL_WARN_F("[RMT5_ENCODER] Encoder created successfully");
+        FL_DBG_F("[RMT5_ENCODER] Encoder created successfully");
         return ESP_OK;
     }
 

--- a/tests/fl/log/log.hpp
+++ b/tests/fl/log/log.hpp
@@ -173,6 +173,14 @@ FL_TEST_CASE("debug macro configuration") {
 // ============================================================================
 
 FL_TEST_CASE("FL_WARN macros are defined") {
+    FL_SUBCASE("FL_HAS_WARN is a resolved boolean gate") {
+#if defined(FL_HAS_WARN)
+        FL_CHECK((FL_HAS_WARN == 0 || FL_HAS_WARN == 1));
+#else
+        FL_CHECK(false);
+#endif
+    }
+
     FL_SUBCASE("FL_WARN is defined") {
         #ifdef FL_WARN
         FL_CHECK(true);
@@ -544,4 +552,3 @@ FL_TEST_CASE("warning macro edge cases") {
         FL_CHECK(true);
     }
 }
-


### PR DESCRIPTION
## Summary
- demote RMT5 encoder timing and success diagnostics from warnings to debug logs
- consolidate bytes/copy encoder creation failures in one noinline cold formatter
- add the resolved `FL_HAS_WARN` gate so warning helpers compile out with `FL_WARN`

## Verification
- `bash test log`
- `bash test channel_driver_rmt`
- `bash lint --cpp`
- `git diff --check`
- `/clud-review` clean

## Verification gap
- `bash compile esp32s3 --examples Blink` was attempted three times. The first fbuild daemon disconnected while downloading `tool-esptoolpy`; subsequent cold dependency builds exceeded the 15-minute wrapper timeout without a FastLED source diagnostic.

Fixes #2977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the public `FL_HAS_WARN` logging availability flag.

- **Bug Fixes**
  - Improved RMT encoder failure reporting while reducing successful-operation messages to debug level.
  - Standardized warning behavior for encoder creation failures.

- **Tests**
  - Added validation ensuring the warning availability flag reports a boolean value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->