### PR TITLE
Fix string destructor chain noexcept bloat

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/test_structure.rs
+++ b/ci/lint_cpp_rs/src/checkers/test_structure.rs
@@ -606,12 +606,19 @@ impl FileContentChecker for NoexceptSpecialMembersChecker {
             let Some((kind, open_paren)) = info else {
                 continue;
             };
-            if signature_has_noexcept(&file_content.lines, index, open_paren) {
+            if signature_has_noexcept(
+                &file_content.lines,
+                index,
+                open_paren,
+                kind == "destructor",
+            ) {
                 continue;
             }
             violations.push((
                 index + 1,
-                format!("Missing FL_NO_EXCEPT on {kind}: {stripped}"),
+                format!(
+                    "Missing FL_NO_EXCEPT (or FL_DTOR_NOEXCEPT for destructors) on {kind}: {stripped}"
+                ),
             ));
         }
 

--- a/ci/lint_cpp_rs/src/lint_core/analysis_helpers.rs
+++ b/ci/lint_cpp_rs/src/lint_core/analysis_helpers.rs
@@ -479,12 +479,22 @@ fn join_multiline_signature(lines: &[String], start: usize) -> Option<String> {
     None
 }
 
-fn signature_has_noexcept(lines: &[String], start: usize, open_paren: usize) -> bool {
+fn signature_has_noexcept(
+    lines: &[String],
+    start: usize,
+    open_paren: usize,
+    allow_destructor_marker: bool,
+) -> bool {
     let Some((close_line, close_col)) = find_close_paren_multiline(lines, start, open_paren) else {
         return false;
     };
     let tail = &lines[close_line][close_col + 1..];
-    if regex_has_noexcept_special().is_match(tail) {
+    let noexcept_regex = if allow_destructor_marker {
+        regex_has_destructor_noexcept_special()
+    } else {
+        regex_has_noexcept_special()
+    };
+    if noexcept_regex.is_match(tail) {
         return true;
     }
     for offset in 1..6 {
@@ -493,7 +503,7 @@ fn signature_has_noexcept(lines: &[String], start: usize, open_paren: usize) -> 
             break;
         }
         let next = lines[idx].trim();
-        if regex_has_noexcept_special().is_match(next) {
+        if noexcept_regex.is_match(next) {
             return true;
         }
         if next.starts_with('{') || next.ends_with('{') || next == "};" {
@@ -515,4 +525,3 @@ fn platform_trampoline_suggestion(include_path: &str) -> &'static str {
         .find_map(|(pattern, replacement)| include_path.contains(pattern).then_some(*replacement))
         .unwrap_or("platforms/*.h (appropriate trampoline)")
 }
-

--- a/ci/lint_cpp_rs/src/lint_core/regexes.rs
+++ b/ci/lint_cpp_rs/src/lint_core/regexes.rs
@@ -323,6 +323,13 @@ fn regex_has_noexcept_special() -> &'static Regex {
     VALUE.get_or_init(|| Regex::new(r"\b(?:FL_NO_EXCEPT|noexcept)\b").unwrap())
 }
 
+fn regex_has_destructor_noexcept_special() -> &'static Regex {
+    static VALUE: OnceLock<Regex> = OnceLock::new();
+    VALUE.get_or_init(|| {
+        Regex::new(r"\b(?:FL_NO_EXCEPT|FL_DTOR_NOEXCEPT|noexcept)\b").unwrap()
+    })
+}
+
 fn regex_destructor_decl() -> &'static Regex {
     static VALUE: OnceLock<Regex> = OnceLock::new();
     VALUE.get_or_init(|| Regex::new(r"~(\w+)\s*\(").unwrap())
@@ -689,4 +696,22 @@ fn regex_raw_array_declaration() -> &'static Regex {
         )
         .unwrap()
     })
+}
+
+#[cfg(test)]
+mod noexcept_special_regex_tests {
+    use super::{regex_has_destructor_noexcept_special, regex_has_noexcept_special};
+
+    #[test]
+    fn destructor_only_marker_is_not_a_general_noexcept_marker() {
+        assert!(regex_has_noexcept_special().is_match("Widget(Widget&&) FL_NO_EXCEPT;"));
+        assert!(regex_has_noexcept_special().is_match("Widget(Widget&&) noexcept;"));
+        assert!(!regex_has_noexcept_special().is_match("Widget(Widget&&) FL_DTOR_NOEXCEPT;"));
+
+        let destructor_regex = regex_has_destructor_noexcept_special();
+        assert!(destructor_regex.is_match("~Widget() FL_NO_EXCEPT;"));
+        assert!(destructor_regex.is_match("~Widget() FL_DTOR_NOEXCEPT;"));
+        assert!(destructor_regex.is_match("~Widget() noexcept;"));
+        assert!(!destructor_regex.is_match("~Widget();"));
+    }
 }

--- a/src/fl/stl/basic_string.cpp.hpp
+++ b/src/fl/stl/basic_string.cpp.hpp
@@ -17,7 +17,7 @@ basic_string::basic_string(fl::span<char, static_cast<fl::size>(-1)> storage) FL
 
 // ======= DESTRUCTOR =======
 
-basic_string::~basic_string() FL_NO_EXCEPT {}
+basic_string::~basic_string() FL_DTOR_NOEXCEPT {}
 
 // ======= string_view CONSTRUCTOR FROM basic_string =======
 // Defined here (in the same TU as basic_string itself) so

--- a/src/fl/stl/basic_string.h
+++ b/src/fl/stl/basic_string.h
@@ -436,7 +436,7 @@ class basic_string {
     // ======= DESTRUCTOR =======
     // Body in basic_string.cpp.hpp per the project's header-thin
     // convention (declarations in `*.h`, definitions in `*.cpp.hpp`).
-    ~basic_string() FL_NO_EXCEPT;
+    ~basic_string() FL_DTOR_NOEXCEPT;
 
     // ======= PUBLIC CONSTRUCTION =======
     // Construct a basic_string backed by a caller-provided buffer.

--- a/src/fl/stl/detail/string_holder.cpp.hpp
+++ b/src/fl/stl/detail/string_holder.cpp.hpp
@@ -59,7 +59,7 @@ StringHolder::StringHolder(const char *str, size length)
     mData[mLength] = '\0';
 }
 
-StringHolder::~StringHolder() FL_NO_EXCEPT {
+StringHolder::~StringHolder() FL_DTOR_NOEXCEPT {
     fl::free(mData); // Release the memory
 }
 

--- a/src/fl/stl/detail/string_holder.h
+++ b/src/fl/stl/detail/string_holder.h
@@ -15,7 +15,7 @@ class StringHolder {
     StringHolder(const char *str, size length) FL_NO_EXCEPT;
     StringHolder(const StringHolder &other) FL_NO_EXCEPT = delete;
     StringHolder &operator=(const StringHolder &other) FL_NO_EXCEPT = delete;
-    ~StringHolder() FL_NO_EXCEPT;
+    ~StringHolder() FL_DTOR_NOEXCEPT;
 
     void grow(size newLength) FL_NO_EXCEPT;
     bool hasCapacity(size newLength) const FL_NO_EXCEPT { return newLength + 1 <= mCapacity; }

--- a/src/fl/stl/noexcept.h
+++ b/src/fl/stl/noexcept.h
@@ -8,6 +8,13 @@
 #define FL_NO_EXCEPT
 #endif
 
+// Destructor-only exception specification. Destructors in ownership chains
+// that only release memory can opt in without re-enabling FL_NO_EXCEPT across
+// platforms for unrelated functions.
+#ifndef FL_DTOR_NOEXCEPT
+#define FL_DTOR_NOEXCEPT noexcept
+#endif
+
 // FL_HAS_NOEXCEPT: defined (as 1) when FL_NO_EXCEPT actually expands to the
 // real noexcept keyword.  Currently FL_NO_EXCEPT is always a noop, so
 // FL_HAS_NOEXCEPT is never defined.  Code that checks whether noexcept is

--- a/src/fl/stl/shared_ptr.cpp.hpp
+++ b/src/fl/stl/shared_ptr.cpp.hpp
@@ -22,7 +22,7 @@ namespace fl {
 namespace detail {
 
 // Out-of-line destructor definition to anchor the vtable to this translation unit.
-ControlBlockBase::~ControlBlockBase() FL_NO_EXCEPT = default;
+ControlBlockBase::~ControlBlockBase() FL_DTOR_NOEXCEPT = default;
 
 // Reference count increment - must be out-of-line to prevent cross-binary vtable issues.
 void ControlBlockBase::add_shared_ref() {

--- a/src/fl/stl/shared_ptr.h
+++ b/src/fl/stl/shared_ptr.h
@@ -36,7 +36,7 @@ struct ControlBlockBase {
         : shared_count(track ? 1 : NO_TRACKING_VALUE), weak_count(1) {}
     // Destructor defined out-of-line in shared_ptr.cpp.hpp to anchor vtable
     // to a single translation unit, preventing ODR violations when using shared libraries.
-    virtual ~ControlBlockBase() FL_NO_EXCEPT;
+    virtual ~ControlBlockBase() FL_DTOR_NOEXCEPT;
     virtual void destroy_object() FL_NO_EXCEPT = 0;
     virtual void destroy_control_block() FL_NO_EXCEPT = 0;
     
@@ -234,7 +234,7 @@ public:
     }
     
     // Destructor
-    ~shared_ptr() FL_NO_EXCEPT {
+    ~shared_ptr() FL_DTOR_NOEXCEPT {
         //FL_WARN("shared_ptr destructor called, mPtr=" << mPtr 
         //          << ", mControlBlock=" << mControlBlock);
         reset();

--- a/src/fl/stl/variant.h
+++ b/src/fl/stl/variant.h
@@ -145,7 +145,7 @@ class FL_ALIGN_AS_T(max_align<Types...>::value) variant {
         }
     }
 
-    ~variant() FL_NO_EXCEPT { reset(); }
+    ~variant() FL_DTOR_NOEXCEPT { reset(); }
 
     variant &operator=(const variant &other) FL_NO_EXCEPT {
         if (this != &other) {

--- a/tests/fl/stl/strstream.cpp
+++ b/tests/fl/stl/strstream.cpp
@@ -39,8 +39,30 @@
 #include "fl/math/fixed_point.h"
 #include "fl/stl/int.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/detail/string_holder.h"
 #include "fl/stl/ios.h"
+#include "fl/stl/shared_ptr.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/string.h"
+#include "fl/stl/variant.h"
+
+using NoexceptTestVariant = fl::variant<int, bool>;
+
+FL_STATIC_ASSERT(noexcept(static_cast<fl::StringHolder*>(nullptr)->~StringHolder()),
+                 "StringHolder destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<fl::detail::ControlBlockBase*>(nullptr)
+                              ->~ControlBlockBase()),
+                 "shared_ptr control-block destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<fl::shared_ptr<int>*>(nullptr)->~shared_ptr()),
+                 "shared_ptr destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<NoexceptTestVariant*>(nullptr)->~variant()),
+                 "variant destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<fl::basic_string*>(nullptr)->~basic_string()),
+                 "basic_string destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<fl::string*>(nullptr)->~string()),
+                 "string destruction must not throw");
+FL_STATIC_ASSERT(noexcept(static_cast<fl::sstream*>(nullptr)->~sstream()),
+                 "sstream destruction must not throw");
 
 FL_TEST_FILE(FL_FILEPATH) {
 


### PR DESCRIPTION
## Summary
- add a destructor-only FL_DTOR_NOEXCEPT gate without re-enabling the broad compatibility-disabled FL_NO_EXCEPT macro
- mark the complete asic_string ownership/destruction chain nonthrowing
- teach the noexcept lint checker to accept the new marker only on destructors and add compile-time coverage

## Verification
- ash test tests/fl/stl/strstream.cpp`n- ash test shared_ptr`n- ash test variant`n- focused Rust lint-regression test
- ash lint --cpp`n- ash compile uno --examples Blink (avr-gcc 7.3.0)
- git diff --check`n- clud-review: clean

Fixes #2975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated `FL_DTOR_NOEXCEPT` support for destructor exception specifications.
  * Updated library destructors to use the dedicated annotation.

* **Bug Fixes**
  * Improved linting to correctly recognize destructor-specific exception annotations and provide clearer guidance for missing annotations.

* **Tests**
  * Added compile-time checks confirming `noexcept` destruction across strings, smart pointers, variants, streams, and related types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->