### PR TITLE
Scope ObjectFLED diagnostic global exemptions

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
+++ b/src/platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.cpp.hpp
@@ -1,6 +1,5 @@
 // IWYU pragma: private
 
-// FL_LINT_ALLOW_GLOBAL_FILE(Tier 1d: ObjectFLED diagnostic snapshot state (s_events / s_lastPins / s_busyState + counters) is used from 40+ sites in this TU. Mechanical migration to `fl::Singleton<DiagState>` is tracked in FastLED#3487 — kept as-is here to keep the linter-landing PR focused.)
 #include "platforms/arm/teensy/is_teensy.h"
 
 #if defined(FL_IS_TEENSY_4X) && defined(FASTLED_OBJECTFLED_DIAGNOSTICS) && FASTLED_OBJECTFLED_DIAGNOSTICS
@@ -133,13 +132,21 @@ struct SnapshotEvent {
     u32 rxStandardPsr = 0;
 };
 
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized, trivially destructible diagnostic snapshots; internal linkage and -fdata-sections already make them linker-elidable.)
 SnapshotEvent s_events[kMaxEvents];
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized counter paired with s_events; Singleton would add lazy-init overhead without improving elision.)
 u8 s_eventCount = 0;
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized overflow counter; kept direct for low-overhead diagnostic capture.)
 u32 s_overflowCount = 0;
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized pin snapshot; internal linkage and -fdata-sections already make it linker-elidable.)
 u8 s_lastPins[kMaxPins];
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized count paired with s_lastPins; Singleton would add an unnecessary indirection.)
 u8 s_lastPinCount = 0;
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized, trivially destructible busy snapshot; no dynamic initialization to elide.)
 BusyStateSnapshot s_busyState;
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized RX diagnostic flag; direct storage avoids a lazy Singleton check in capture paths.)
 bool s_rxPinValid = false;
+// FL_LINT_ALLOW_GLOBAL(Constant-initialized RX diagnostic pin; direct storage avoids a lazy Singleton check in capture paths.)
 u8 s_rxPin = 0;
 
 u32 ptrToU32(const volatile void* ptr) FL_NO_EXCEPT {


### PR DESCRIPTION
## Summary
- remove the broad file-wide SingletonElisionChecker waiver from ObjectFLED diagnostics
- document each of the eight existing diagnostic globals with a precise, declaration-scoped exemption
- preserve constant initialization, direct access, and linker garbage collection instead of adding a lazy Singleton pointer and null-check overhead

## Resolution
Issue #3487's maintainer audit established that these globals have static initialization, internal linkage, no non-trivial destruction, and are already eligible for --gc-sections. The originally requested Singleton migration would add storage and indirection without improving elision. This PR makes that audited decision enforceable while ensuring future globals are not silently masked by a file-wide waiver.

## Verification
- ash test tests/platforms/arm/teensy/teensy4_common/drivers/objectfled/channel_engine_objectfled.cpp`n- ash lint --cpp (this file absent from SingletonElisionChecker output)
- git diff --check`n- clud-review: clean after wording follow-up

Fixes #3487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved lint configuration for diagnostic state variables.
  * No changes to exported functionality or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->