### PR TITLE
fix(rp): keep AutoResearch USB recovery available

### DIFF
--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -75,6 +75,12 @@ def synthesise_autoresearch_project(
     # monkeypatch bridge that lived here is obsolete — autoresearch's
     # fbuild path no longer reads root platformio.ini regardless.
     defines = ["FASTLED_OBJECTFLED_DIAGNOSTICS=1"]
+    # AutoResearch's managed RP2350W fixture must remain recoverable when the
+    # CDC endpoint is wedged or cannot be opened. Arduino-Pico exposes the
+    # Pico SDK's target-bound USB reset interface behind this opt-in define;
+    # keep it scoped to the HIL fixture instead of changing normal RP builds.
+    if board_name == "rp2350w":
+        defines.append("ENABLE_PICOTOOL_USB=1")
     if extra_defines:
         defines.extend(extra_defines)
 

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -75,11 +75,13 @@ def synthesise_autoresearch_project(
     # monkeypatch bridge that lived here is obsolete — autoresearch's
     # fbuild path no longer reads root platformio.ini regardless.
     defines = ["FASTLED_OBJECTFLED_DIAGNOSTICS=1"]
-    # AutoResearch's managed RP2350W fixture must remain recoverable when the
-    # CDC endpoint is wedged or cannot be opened. Arduino-Pico exposes the
-    # Pico SDK's target-bound USB reset interface behind this opt-in define;
-    # keep it scoped to the HIL fixture instead of changing normal RP builds.
-    if board_name == "rp2350w":
+    # AutoResearch's managed RP2350-family fixtures must remain recoverable
+    # when the CDC endpoint is wedged or cannot be opened. Arduino-Pico exposes
+    # the Pico SDK's target-bound USB reset interface behind this opt-in
+    # define; keep it scoped to AutoResearch instead of changing normal RP
+    # builds. Use the resolved board name so PlatformIO aliases (rpipico2 and
+    # rpipico2w) receive the same recovery interface as the canonical names.
+    if board.board_name in {"rp2350", "rp2350w"}:
         defines.append("ENABLE_PICOTOOL_USB=1")
     if extra_defines:
         defines.extend(extra_defines)

--- a/ci/tests/test_autoresearch_staging.py
+++ b/ci/tests/test_autoresearch_staging.py
@@ -20,3 +20,35 @@ def test_autoresearch_staging_enables_objectfled_diagnostics(
     assert build_dir == tmp_path / ".build" / "pio" / "teensy41"
     _, kwargs = mock_init.call_args
     assert kwargs["additional_defines"] == ["FASTLED_OBJECTFLED_DIAGNOSTICS=1"]
+
+
+def test_rp2350w_autoresearch_enables_target_bound_picotool_reset(
+    tmp_path: Path,
+) -> None:
+    with patch("ci.compiler.pio._init_platformio_build") as mock_init:
+        mock_init.return_value = SimpleNamespace(success=True, output="")
+
+        synthesise_autoresearch_project(
+            "rp2350w",
+            project_root=tmp_path,
+            verbose=False,
+        )
+
+    _, kwargs = mock_init.call_args
+    assert "ENABLE_PICOTOOL_USB=1" in kwargs["additional_defines"]
+
+
+def test_unrelated_rp_autoresearch_does_not_enable_picotool_reset(
+    tmp_path: Path,
+) -> None:
+    with patch("ci.compiler.pio._init_platformio_build") as mock_init:
+        mock_init.return_value = SimpleNamespace(success=True, output="")
+
+        synthesise_autoresearch_project(
+            "rp2350",
+            project_root=tmp_path,
+            verbose=False,
+        )
+
+    _, kwargs = mock_init.call_args
+    assert "ENABLE_PICOTOOL_USB=1" not in kwargs["additional_defines"]

--- a/ci/tests/test_autoresearch_staging.py
+++ b/ci/tests/test_autoresearch_staging.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from ci.autoresearch.staging import synthesise_autoresearch_project
 
 
@@ -22,14 +24,15 @@ def test_autoresearch_staging_enables_objectfled_diagnostics(
     assert kwargs["additional_defines"] == ["FASTLED_OBJECTFLED_DIAGNOSTICS=1"]
 
 
-def test_rp2350w_autoresearch_enables_target_bound_picotool_reset(
-    tmp_path: Path,
+@pytest.mark.parametrize("environment", ("rp2350", "rpipico2", "rp2350w", "rpipico2w"))
+def test_rp2350_family_autoresearch_enables_target_bound_picotool_reset(
+    tmp_path: Path, environment: str
 ) -> None:
     with patch("ci.compiler.pio._init_platformio_build") as mock_init:
         mock_init.return_value = SimpleNamespace(success=True, output="")
 
         synthesise_autoresearch_project(
-            "rp2350w",
+            environment,
             project_root=tmp_path,
             verbose=False,
         )
@@ -38,14 +41,14 @@ def test_rp2350w_autoresearch_enables_target_bound_picotool_reset(
     assert "ENABLE_PICOTOOL_USB=1" in kwargs["additional_defines"]
 
 
-def test_unrelated_rp_autoresearch_does_not_enable_picotool_reset(
+def test_rp2040_autoresearch_does_not_enable_picotool_reset(
     tmp_path: Path,
 ) -> None:
     with patch("ci.compiler.pio._init_platformio_build") as mock_init:
         mock_init.return_value = SimpleNamespace(success=True, output="")
 
         synthesise_autoresearch_project(
-            "rp2350",
+            "rp2040",
             project_root=tmp_path,
             verbose=False,
         )

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -22,6 +22,9 @@ ESP_WIFI_IMPL = (
     REPO_ROOT / "src" / "platforms" / "esp" / "32" / "net" / "wifi_esp32.cpp.hpp"
 )
 RP_BUILD = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "_build.cpp.hpp"
+RP_WATCHDOG_IMPL = (
+    REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "watchdog_rp.impl.hpp"
+)
 RP_BLE_IMPL = REPO_ROOT / "src" / "platforms" / "arm" / "rp" / "ble_rp.cpp.hpp"
 AUTORESEARCH_NET = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchNet.cpp"
 AUTORESEARCH_SKETCH = REPO_ROOT / "examples" / "AutoResearch" / "AutoResearch.ino"
@@ -31,6 +34,9 @@ AUTORESEARCH_SYSTEM_METHODS = (
 )
 AUTORESEARCH_PARALLEL = (
     REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchRemoteRunParallelTest.cpp"
+)
+AUTORESEARCH_RP_CONCURRENCY = (
+    REPO_ROOT / "examples" / "AutoResearch" / "AutoResearchRpConcurrency.cpp"
 )
 
 
@@ -82,6 +88,43 @@ def test_autoresearch_filter_admits_both_rp2350_profiles() -> None:
     for environment in ("rp2350", "rp2350w"):
         skip, reason = should_skip_sketch(create_board(environment), sketch_filter)
         assert skip is False, reason
+
+
+def test_rp_autoresearch_does_not_block_rpc_on_usb_dtr() -> None:
+    source = AUTORESEARCH_INO.read_text(encoding="utf-8")
+    wait_policy = source[
+        source.index("#if defined(FL_IS_ESP_32S3)") : source.index(
+            "const fl::RxBackend RX_BACKEND"
+        )
+    ]
+
+    assert "defined(FL_IS_RP)" in wait_policy
+
+
+def test_rp_bootloader_reboot_is_not_counted_as_a_watchdog_crash() -> None:
+    source = RP_WATCHDOG_IMPL.read_text(encoding="utf-8")
+
+    assert "#include <pico/version.h>" in source
+    assert "PICO_SDK_VERSION_MINOR >= 3" in source
+    assert "FL_RP_WATCHDOG_HAS_ENABLE_MARKER" in source
+    assert "FL_RP_WATCHDOG_HAS_DISABLE_API" in source
+    assert "if (watchdog_enable_caused_reboot()) return ResetCause::WATCHDOG;" in source
+    assert "if (watchdog_caused_reboot()) return ResetCause::WATCHDOG;" in source
+    assert "hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);" in source
+    assert "if (watchdog_hw->reason) return ResetCause::SOFTWARE;" in source
+
+    begin_body = source[
+        source.index("void Watchdog::begin") : source.index("void Watchdog::feed")
+    ]
+    assert begin_body.index("(void)lastResetCause();") < begin_body.index(
+        "watchdog_enable(timeout_ms, true);"
+    )
+
+
+def test_rp_concurrency_probe_uses_a_separate_core1_stack() -> None:
+    source = AUTORESEARCH_RP_CONCURRENCY.read_text(encoding="utf-8")
+
+    assert "bool core1_separate_stack = true;" in source
 
 
 def test_autoresearch_identity_prioritizes_pico_2_w() -> None:

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -106,8 +106,8 @@ def test_rp_bootloader_reboot_is_not_counted_as_a_watchdog_crash() -> None:
 
     assert "#include <pico/version.h>" in source
     assert "PICO_SDK_VERSION_MINOR >= 3" in source
-    assert "FL_RP_WATCHDOG_HAS_ENABLE_MARKER" in source
-    assert "FL_RP_WATCHDOG_HAS_DISABLE_API" in source
+    assert "FL_WATCHDOG_HAS_RP_ENABLE_MARKER" in source
+    assert "FL_WATCHDOG_HAS_RP_DISABLE_API" in source
     assert "if (watchdog_enable_caused_reboot()) return ResetCause::WATCHDOG;" in source
     assert "if (watchdog_caused_reboot()) return ResetCause::WATCHDOG;" in source
     assert "hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);" in source

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -262,7 +262,9 @@ SET_LOOP_TASK_STACK_SIZE(16 * 1024);
 
 // Serial port timeout (milliseconds) - wait for serial monitor to attach
 static constexpr uint32_t SERIAL_TIMEOUT_MS = 120000;  // 120 seconds
-#if defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) || defined(CONFIG_IDF_TARGET_ESP32P4)
+#if defined(FL_IS_ESP_32S3) || defined(FL_IS_ESP_32C3) ||                  \
+    defined(FL_IS_ESP_32C6) || defined(FL_IS_ESP_32H2) ||                 \
+    defined(CONFIG_IDF_TARGET_ESP32P4) || defined(FL_IS_RP)
 static constexpr uint32_t AUTORESEARCH_SERIAL_WAIT_MS = 2000;
 #else
 static constexpr uint32_t AUTORESEARCH_SERIAL_WAIT_MS = SERIAL_TIMEOUT_MS;

--- a/examples/AutoResearch/AutoResearchRpConcurrency.cpp
+++ b/examples/AutoResearch/AutoResearchRpConcurrency.cpp
@@ -11,6 +11,11 @@
 #include "fl/stl/semaphore.h"
 #include "fl/stl/static_assert.h"
 
+// Arduino-Pico otherwise splits one 8 KB stack into two 4 KB halves when
+// setup1()/loop1() are present. The RPC/JSON call chain on core 0 can exceed
+// its half and overwrite core 1 while this diagnostic is running.
+bool core1_separate_stack = true;
+
 namespace {
 
 constexpr int kRpConcurrencyIterations = 100;

--- a/src/platforms/arm/rp/watchdog_rp.impl.hpp
+++ b/src/platforms/arm/rp/watchdog_rp.impl.hpp
@@ -3,9 +3,10 @@
 /// @file platforms/arm/rp/watchdog_rp.impl.hpp
 /// @brief RP2040 / RP2350 watchdog implementation.
 ///
-/// Pico SDK `hardware/watchdog.h` for begin/feed/disable. Reset cause via
-/// `watchdog_caused_reboot()` (+ `VREG_AND_CHIP_RESET` on RP2040,
-/// `POWMAN.CHIP_RESET` on RP2350 for richer cause detection).
+/// Pico SDK `hardware/watchdog.h` for begin/feed/disable. A timer expiry is
+/// distinguished from the SDK/bootrom's intentional watchdog-based reboot
+/// path with `watchdog_enable_caused_reboot()` on Pico SDK 1.3+. Older Pico
+/// SDKs fall back to `watchdog_caused_reboot()`.
 ///
 /// **Persist storage** uses the low 14 bytes of `watchdog_hw->scratch[0..3]`.
 /// The upper two bytes of `scratch[3]` hold FastLED's consecutive watchdog
@@ -25,11 +26,22 @@
 #include <hardware/watchdog.h>   // ok include — Pico SDK
 #include <hardware/structs/watchdog.h>  // ok include — scratch[0..7]
 #include <pico/bootrom.h>        // ok include — reset_usb_boot()
+#include <pico/version.h>        // ok include — watchdog API capability guard
 // IWYU pragma: end_keep
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 14   // scratch[0..2] + low half of scratch[3]
 #define FL_WATCHDOG_HAS_BOOTLOADER_REBOOT
+
+#if defined(PICO_SDK_VERSION_MAJOR) && defined(PICO_SDK_VERSION_MINOR) \
+    && (PICO_SDK_VERSION_MAJOR > 1 \
+        || (PICO_SDK_VERSION_MAJOR == 1 && PICO_SDK_VERSION_MINOR >= 3))
+#define FL_RP_WATCHDOG_HAS_ENABLE_MARKER
+#endif
+
+#if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
+#define FL_RP_WATCHDOG_HAS_DISABLE_API
+#endif
 
 #if defined(FL_IS_RP2350)
 #define FL_WATCHDOG_MAX_TIMEOUT_MS 16777u
@@ -61,10 +73,25 @@ inline void rpSetCrashCount(fl::u16 count) {
 }
 
 inline ResetCause rpDetectResetCause() {
+    // reset_usb_boot(), watchdog_reboot(), and UF2 flashing also use the
+    // watchdog reset hardware. The SDK's enable marker survives only a real
+    // timeout after watchdog_enable(); intentional bootloader/deploy resets
+    // clear it. Counting every watchdog-caused reboot as a crash makes a few
+    // normal deploys trip the retained safe-mode threshold and strand USB RPC.
+#if defined(FL_RP_WATCHDOG_HAS_ENABLE_MARKER)
+    if (watchdog_enable_caused_reboot()) return ResetCause::WATCHDOG;
+    // On RP2350 the SDK deliberately makes watchdog_caused_reboot() false
+    // for non-normal boot types, including reset_usb_boot(). The raw reason
+    // bit is still set, and the missing enable marker above proves this was
+    // an intentional watchdog-backed software reset rather than our timeout.
+    if (watchdog_hw->reason) return ResetCause::SOFTWARE;
+#else
+    // Pico SDK 1.x (used by Arduino Mbed RP2040) predates the enable-marker
+    // API. Preserve its supported watchdog detection even though that SDK
+    // cannot distinguish a timeout from an intentional watchdog-backed reset.
     if (watchdog_caused_reboot()) return ResetCause::WATCHDOG;
-    // RP2040 / RP2350 chip reset register read; the SDK exposes
-    // `watchdog_enable_caused_reboot()` to distinguish but we already
-    // covered the WDT case. Default to POWER_ON for first-boot heuristics.
+#endif
+    // Default to POWER_ON for first-boot heuristics.
     return ResetCause::POWER_ON;
 }
 
@@ -76,6 +103,10 @@ Watchdog& Watchdog::instance() FL_NO_EXCEPT {
 }
 
 void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
+    // Capture the previous boot's marker before watchdog_enable() writes the
+    // current boot's enable marker into scratch[4]. Reading it afterward
+    // makes every intentional SDK/bootrom reset look like a timer expiry.
+    (void)lastResetCause();
     if (timeout_ms == 0) timeout_ms = 1000;
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
     // Second arg `pause_on_debug` defaults to true — useful in dev so a
@@ -92,7 +123,13 @@ void Watchdog::disable() FL_NO_EXCEPT {
     // Pico SDK's `watchdog_disable()` clears WATCHDOG_CTRL_ENABLE_BITS, which
     // halts the counter. Subsequent `feed()` calls are still safe (they only
     // write LOAD).
+#if defined(FL_RP_WATCHDOG_HAS_DISABLE_API)
     watchdog_disable();
+#else
+    // Pico SDK 1.x has no watchdog_disable() helper. Its hardware struct and
+    // atomic register helper expose the same operation used by the 2.x API.
+    hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+#endif
     platforms::rpWatchdogState().armed = false;
 }
 
@@ -172,3 +209,6 @@ WatchdogCrashReport Watchdog::readCrashReport() const FL_NO_EXCEPT {
 void Watchdog::clearCrashReport() FL_NO_EXCEPT {}
 
 } // namespace fl
+
+#undef FL_RP_WATCHDOG_HAS_ENABLE_MARKER
+#undef FL_RP_WATCHDOG_HAS_DISABLE_API

--- a/src/platforms/arm/rp/watchdog_rp.impl.hpp
+++ b/src/platforms/arm/rp/watchdog_rp.impl.hpp
@@ -36,11 +36,11 @@
 #if defined(PICO_SDK_VERSION_MAJOR) && defined(PICO_SDK_VERSION_MINOR) \
     && (PICO_SDK_VERSION_MAJOR > 1 \
         || (PICO_SDK_VERSION_MAJOR == 1 && PICO_SDK_VERSION_MINOR >= 3))
-#define FL_RP_WATCHDOG_HAS_ENABLE_MARKER
+#define FL_WATCHDOG_HAS_RP_ENABLE_MARKER
 #endif
 
 #if defined(PICO_SDK_VERSION_MAJOR) && PICO_SDK_VERSION_MAJOR >= 2
-#define FL_RP_WATCHDOG_HAS_DISABLE_API
+#define FL_WATCHDOG_HAS_RP_DISABLE_API
 #endif
 
 #if defined(FL_IS_RP2350)
@@ -78,7 +78,7 @@ inline ResetCause rpDetectResetCause() {
     // timeout after watchdog_enable(); intentional bootloader/deploy resets
     // clear it. Counting every watchdog-caused reboot as a crash makes a few
     // normal deploys trip the retained safe-mode threshold and strand USB RPC.
-#if defined(FL_RP_WATCHDOG_HAS_ENABLE_MARKER)
+#if defined(FL_WATCHDOG_HAS_RP_ENABLE_MARKER)
     if (watchdog_enable_caused_reboot()) return ResetCause::WATCHDOG;
     // On RP2350 the SDK deliberately makes watchdog_caused_reboot() false
     // for non-normal boot types, including reset_usb_boot(). The raw reason
@@ -123,7 +123,7 @@ void Watchdog::disable() FL_NO_EXCEPT {
     // Pico SDK's `watchdog_disable()` clears WATCHDOG_CTRL_ENABLE_BITS, which
     // halts the counter. Subsequent `feed()` calls are still safe (they only
     // write LOAD).
-#if defined(FL_RP_WATCHDOG_HAS_DISABLE_API)
+#if defined(FL_WATCHDOG_HAS_RP_DISABLE_API)
     watchdog_disable();
 #else
     // Pico SDK 1.x has no watchdog_disable() helper. Its hardware struct and
@@ -210,5 +210,5 @@ void Watchdog::clearCrashReport() FL_NO_EXCEPT {}
 
 } // namespace fl
 
-#undef FL_RP_WATCHDOG_HAS_ENABLE_MARKER
-#undef FL_RP_WATCHDOG_HAS_DISABLE_API
+#undef FL_WATCHDOG_HAS_RP_ENABLE_MARKER
+#undef FL_WATCHDOG_HAS_RP_DISABLE_API


### PR DESCRIPTION
Depends on FastLED/fbuild#1304

Companion firmware support for FastLED/fbuild#1303.

- Enables ENABLE_PICOTOOL_USB for every RP2350-family AutoResearch staging environment (Pico 2 and Pico 2 W, including PlatformIO aliases) so firmware exposes Arduino-Pico's dedicated application Reset interface.
- Replaces the RP native-USB 120-second DTR wait with a bounded two-second startup wait so automation cannot strand the firmware.
- Gives RP2350 AutoResearch core 1 a separate stack.
- Captures reset cause before enabling the watchdog, distinguishes watchdog timeouts from intentional software/BOOTSEL resets, and retains compatibility with Pico SDK 1.0-1.2 watchdog APIs.

Validation:

- 202 RP2350-family configuration, staging, and AutoResearch phase tests passed
- Comprehensive FastLED lint and forced C++ lint passed
- Pico 2 / RP2350 AutoResearch firmware compiled and linked successfully through fbuild with the recovery interface enabled
- Isolated Nano RP2040 Connect build linked successfully through fbuild's compatibility backend against the forced Pico SDK 1.0.1 capability branch
- Independent pre-push review findings resolved

Hardware-in-the-loop (RP2350W serial 2DCB876B587EA334, COM18):

- Exact reset-interface-only recovery and production RPC smoke passed without a replug
- 50/50 repeated no-replug deploy/RPC cycles passed
- Final watchdog soak passed in 61.1 seconds
- Live ping reported lastResetCause=WATCHDOG and lastResetWasWatchdog=true
- CDC, composite USB, and Reset WinUSB nodes all remained Status=OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RP2350 and RP2350W builds, including supported board aliases, now enable Picotool USB support automatically.
  - AutoResearch on RP platforms now starts after a shorter serial wait, improving startup responsiveness.
  - RP concurrency examples use a dedicated Core 1 stack for improved stability.

- **Bug Fixes**
  - Improved watchdog reset handling to distinguish intentional bootloader resets from genuine watchdog failures.
  - Prevented RP AutoResearch from blocking RPC communication while waiting for USB serial control signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->