### PR TITLE
docs: clarify third-party adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,12 @@ After installing the Arduino IDE, add FastLED through the Library Manager:
 
 **Need Help?** Visit [r/FastLED](https://reddit.com/r/FastLED) - thousands of knowledgeable users and extensive solution history!
 
+GitHub issues track behavior owned by FastLED. If a problem appears only when
+using an adapter library such as FastLED_NeoMatrix, report it to that adapter's
+maintainer and include a minimal FastLED-only reproduction when possible.
+Messages such as `#pragma message: FastLED version ...` are informational build
+output, not warnings or errors.
+
 ## 🎮 Advanced Features
 
 ### Performance Leaders: Parallel Output Records


### PR DESCRIPTION
Closes #994

Clarifies that FastLED GitHub issues cover FastLED-owned behavior, third-party adapter failures belong with their maintainers, and the FastLED version pragma is informational rather than a warning or error.

Validation: documentation-only change; lint, tests, and code review intentionally skipped per the quick-fix workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for distinguishing FastLED issues from adapter-library problems.
  * Clarified that adapter issues should include a minimal FastLED reproduction when possible.
  * Explained that version output from `#pragma message` is informational, not an error or warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->