### PR TITLE
feat(tm1812): add RGBCCT frame encoder

### DIFF
--- a/examples/RGBWW/RGBWW.ino
+++ b/examples/RGBWW/RGBWW.ino
@@ -45,9 +45,13 @@ void setup() {
         /* placement */   fl::EOrderWW::WwWcEnd     // RGB, then warm-W, cool-W
     );
 
-    auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
+    // For ordinary continuous 5-byte RGBWW chipsets:
+    auto chipset = fl::makeClockless<fl::TIMING_WS2812_800KHZ>(DATA_PIN);
+    // For TM1812 RGBCCT strips that pack two pixels into each 12-channel IC,
+    // use this instead (issue #995):
+    // auto chipset = fl::makeClockless<fl::TIMING_TM1812_RGBWW_800KHZ>(DATA_PIN);
     FastLED.add(fl::ChannelConfig(
-        DATA_PIN, timing,
+        chipset,
         fl::span<CRGB>(leds, NUM_LEDS),
         GRB,
         opts));

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -330,6 +330,9 @@ class TX1813N1 : public TM1829Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
 /// @brief TM1812 controller class.
 /// @copydetails TM1809Controller800Khz
+/// @note This legacy controller emits continuous RGB pixels. TM1812 RGBCCT
+/// strips with two 5-channel pixels per 12-channel IC use the Channels API
+/// with `fl::TIMING_TM1812_RGBWW_800KHZ`; see the RGBWW example.
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class TM1812 : public TM1809Controller800Khz<DATA_PIN, RGB_ORDER> {};
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -521,6 +521,9 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             case ClocklessEncoder::CLOCKLESS_ENCODER_WS2812:
                 pixelIterator.writeWS2812(&data);
                 break;
+            case ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW:
+                pixelIterator.writeTM1812RGBWW(&data);
+                break;
 #if !defined(FASTLED_DISABLE_UCS7604) || !FASTLED_DISABLE_UCS7604
             // Gated by FASTLED_DISABLE_UCS7604 (#2920). For WS2812-only
             // sketches the UCS7604 case is dead at runtime, but each

--- a/src/fl/chipsets/clockless_encoder.h
+++ b/src/fl/chipsets/clockless_encoder.h
@@ -22,7 +22,8 @@ enum class ClocklessEncoder : u8 {
     CLOCKLESS_ENCODER_WS2812 = 0,           ///< Default, no preamble (WS2812 and compatible)
     CLOCKLESS_ENCODER_UCS7604_8BIT,         ///< UCS7604 8-bit 800KHz
     CLOCKLESS_ENCODER_UCS7604_16BIT,        ///< UCS7604 16-bit 800KHz
-    CLOCKLESS_ENCODER_UCS7604_16BIT_1600    ///< UCS7604 16-bit 1600KHz
+    CLOCKLESS_ENCODER_UCS7604_16BIT_1600,   ///< UCS7604 16-bit 1600KHz
+    CLOCKLESS_ENCODER_TM1812_RGBWW          ///< TM1812: two 5-byte RGBWW pixels in each 12-byte IC frame
 };
 
 /// @brief SFINAE helpers for detecting a static ENCODER member on timing structs

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -14,6 +14,7 @@
 #include "fl/chipsets/encoders/ws2801.h"
 #include "fl/chipsets/encoders/ws2803.h"
 #include "fl/chipsets/encoders/ws2812.h"
+#include "fl/chipsets/encoders/tm1812.h"
 #include "fl/chipsets/encoders/apa102.h"
 #include "fl/chipsets/encoders/sk9822.h"
 #include "fl/chipsets/encoders/hd108.h"
@@ -213,6 +214,14 @@ class PixelIterator {
             auto range = makeScaledPixelRangeRGB(this);
             encodeWS2812_RGB(range.first, range.second, back_ins);
         }
+    }
+
+    /// @brief Encode RGBWW pixels into 12-channel TM1812 IC frames.
+    template <typename CONTAINER_UIN8_T>
+    void writeTM1812RGBWW(CONTAINER_UIN8_T* out) FL_NO_EXCEPT {
+        auto back_ins = fl::back_inserter(*out);
+        auto range = makeScaledPixelRangeRGBWW(this);
+        encodeTM1812_RGBWW(range.first, range.second, back_ins);
     }
 
     /// @brief Encode pixels in APA102/DOTSTAR format (zero allocation)

--- a/src/fl/chipsets/encoders/tm1812.h
+++ b/src/fl/chipsets/encoders/tm1812.h
@@ -1,0 +1,50 @@
+/// @file fl/chipsets/encoders/tm1812.h
+/// @brief TM1812 12-channel encoder for two RGBWW pixels per IC.
+
+#pragma once
+
+#include "fl/chipsets/encoders/encoder_constants.h"
+#include "fl/stl/array.h"
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+/// @brief Pack 5-channel RGBCCT pixels into TM1812 12-channel frames.
+///
+/// The TM1812 consumes four RGB groups (12 bytes / 96 bits) per IC. RGBCCT
+/// strips reported in issue #995 wire two logical 5-channel pixels to the
+/// first ten outputs and leave the final two outputs unused. Consequently,
+/// each IC frame is `pixel 0 (5) + pixel 1 (5) + zero padding (2)`.
+///
+/// An odd final logical pixel is followed by five zero bytes for the absent
+/// second pixel, then the normal two padding bytes. This preserves the 96-bit
+/// boundary so downstream TM1812 chips stay aligned.
+template <typename InputIterator, typename OutputIterator>
+void encodeTM1812_RGBWW(InputIterator first, InputIterator last,
+                        OutputIterator out) FL_NO_EXCEPT {
+    while (first != last) {
+        const fl::array<u8, BYTES_PER_PIXEL_RGBWW>& firstPixel = *first;
+        for (u8 byte : firstPixel) {
+            *out++ = byte;
+        }
+        ++first;
+
+        if (first != last) {
+            const fl::array<u8, BYTES_PER_PIXEL_RGBWW>& secondPixel = *first;
+            for (u8 byte : secondPixel) {
+                *out++ = byte;
+            }
+            ++first;
+        } else {
+            for (u8 i = 0; i < BYTES_PER_PIXEL_RGBWW; ++i) {
+                *out++ = 0;
+            }
+        }
+
+        *out++ = 0;
+        *out++ = 0;
+    }
+}
+
+} // namespace fl

--- a/src/fl/chipsets/led_timing.h
+++ b/src/fl/chipsets/led_timing.h
@@ -272,6 +272,23 @@ struct TIMING_TM1809_800KHZ {
     };
 };
 
+/// TM1812 RGBCCT controller @ 800 kHz (issue #995)
+///
+/// Unlike the legacy RGB alias, this trait selects the TM1812 byte encoder:
+/// two 5-channel RGBWW pixels occupy ten of each IC's twelve output bytes and
+/// the encoder pads the remaining two. Timing values are the TM1812 V1.4
+/// datasheet typicals: T0H=400ns, T1H=850ns, bit period=1.25us.
+struct TIMING_TM1812_RGBWW_800KHZ {
+    enum : u32 {
+        T1 = 400,
+        T2 = 450,
+        T3 = 400,
+        RESET = 24
+    };
+    static constexpr ClocklessEncoder ENCODER =
+        ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW;
+};
+
 /// TM1829 RGB controller @ 800 kHz
 /// Four-phase: TH0=340ns, TH1=680ns, TL0=890ns, TL1=550ns
 struct TIMING_TM1829_800KHZ {

--- a/tests/fl/chipsets/encoders.cpp
+++ b/tests/fl/chipsets/encoders.cpp
@@ -7,6 +7,7 @@
 #include "tests/fl/chipsets/encoders/p9813.hpp"
 #include "tests/fl/chipsets/encoders/sk9822.hpp"
 #include "tests/fl/chipsets/encoders/sm16716.hpp"
+#include "tests/fl/chipsets/encoders/tm1812.hpp"
 #include "tests/fl/chipsets/encoders/ws2801.hpp"
 #include "tests/fl/chipsets/encoders/ws2803.hpp"
 #include "tests/fl/chipsets/encoders/ws2812.hpp"

--- a/tests/fl/chipsets/encoders/tm1812.hpp
+++ b/tests/fl/chipsets/encoders/tm1812.hpp
@@ -1,0 +1,96 @@
+/// @file tm1812.hpp
+/// @brief Unit tests for the TM1812 RGBCCT byte-packing encoder.
+
+#include "fl/chipsets/encoders/tm1812.h"
+#include "fl/channels/config.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/array.h"
+#include "fl/stl/iterator.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+using namespace fl;
+
+namespace test_tm1812 {
+
+fl::array<u8, 5> makeRgbwwPixel(u8 r, u8 g, u8 b, u8 ww, u8 cw) {
+    return {r, g, b, ww, cw};
+}
+
+FL_TEST_CASE("TM1812 RGBWW - empty input emits no chip frames") {
+    fl::vector<fl::array<u8, 5>> pixels;
+    fl::vector<u8> output;
+
+    encodeTM1812_RGBWW(pixels.begin(), pixels.end(),
+                       fl::back_inserter(output));
+
+    FL_CHECK(output.empty());
+}
+
+FL_TEST_CASE("TM1812 RGBWW - timing trait selects the packing encoder") {
+    FL_CHECK_EQ(TIMING_TM1812_RGBWW_800KHZ::T1, 400);
+    FL_CHECK_EQ(TIMING_TM1812_RGBWW_800KHZ::T2, 450);
+    FL_CHECK_EQ(TIMING_TM1812_RGBWW_800KHZ::T3, 400);
+    FL_CHECK_EQ(TIMING_TM1812_RGBWW_800KHZ::RESET, 24);
+    FL_CHECK(encoder_for<TIMING_TM1812_RGBWW_800KHZ>() ==
+             ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW);
+
+    const auto chipset =
+        makeClockless<TIMING_TM1812_RGBWW_800KHZ>(3);
+    FL_CHECK(chipset.encoder ==
+             ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW);
+}
+
+FL_TEST_CASE("TM1812 RGBWW - two pixels fill ten channels and pad two") {
+    fl::vector<fl::array<u8, 5>> pixels;
+    pixels.push_back(makeRgbwwPixel(1, 2, 3, 4, 5));
+    pixels.push_back(makeRgbwwPixel(6, 7, 8, 9, 10));
+    fl::vector<u8> output;
+
+    encodeTM1812_RGBWW(pixels.begin(), pixels.end(),
+                       fl::back_inserter(output));
+
+    FL_REQUIRE_EQ(output.size(), 12);
+    for (fl::size i = 0; i < 10; ++i) {
+        FL_CHECK_EQ(output[i], static_cast<u8>(i + 1));
+    }
+    FL_CHECK_EQ(output[10], 0);
+    FL_CHECK_EQ(output[11], 0);
+}
+
+FL_TEST_CASE("TM1812 RGBWW - odd pixel count completes the final chip frame") {
+    fl::vector<fl::array<u8, 5>> pixels;
+    pixels.push_back(makeRgbwwPixel(11, 12, 13, 14, 15));
+    fl::vector<u8> output;
+
+    encodeTM1812_RGBWW(pixels.begin(), pixels.end(),
+                       fl::back_inserter(output));
+
+    FL_REQUIRE_EQ(output.size(), 12);
+    for (fl::size i = 0; i < 5; ++i) {
+        FL_CHECK_EQ(output[i], static_cast<u8>(i + 11));
+    }
+    for (fl::size i = 5; i < 12; ++i) {
+        FL_CHECK_EQ(output[i], 0);
+    }
+}
+
+FL_TEST_CASE("TM1812 RGBWW - chip framing repeats for later pixels") {
+    fl::vector<fl::array<u8, 5>> pixels;
+    pixels.push_back(makeRgbwwPixel(1, 2, 3, 4, 5));
+    pixels.push_back(makeRgbwwPixel(6, 7, 8, 9, 10));
+    pixels.push_back(makeRgbwwPixel(21, 22, 23, 24, 25));
+    fl::vector<u8> output;
+
+    encodeTM1812_RGBWW(pixels.begin(), pixels.end(),
+                       fl::back_inserter(output));
+
+    FL_REQUIRE_EQ(output.size(), 24);
+    FL_CHECK_EQ(output[12], 21);
+    FL_CHECK_EQ(output[16], 25);
+    for (fl::size i = 17; i < 24; ++i) {
+        FL_CHECK_EQ(output[i], 0);
+    }
+}
+
+} // namespace test_tm1812


### PR DESCRIPTION
## Summary

- add a TM1812 RGB+CCT encoder for the Channels API
- pack two logical five-byte RGBWW pixels into each 12-byte/96-bit IC frame, zero-filling the two unused channels
- add datasheet-backed 800 kHz timing and odd-pixel padding coverage
- document the Channels API path in the RGBWW example while preserving the legacy continuous-RGB `TM1812` controller

## Validation

- `bash test encoders`
- `bash compile wasm --examples RGBWW`
- `bash lint`
- `bash test` (279/279 C++ unit tests and 84/84 example tests; Python QEMU cold-timeout tracked separately in #3910, focused warm test passes with fbuild 2.5.17)

No physical TM1812 strip was available; protocol framing and timing were validated against the TM1812 V1.4 datasheet and unit tests.

Closes #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for TM1812 RGBWW/RGBCCT LED strips, including dedicated timing and pixel encoding.
  - Added a public timing configuration for TM1812 RGBWW controllers.
  - Updated the RGBWW example to demonstrate WS2812 configuration and document TM1812 alternatives.

- **Bug Fixes**
  - TM1812 RGBWW channels now correctly encode and transmit pixel data.

- **Tests**
  - Added coverage for empty inputs, pixel packing, padding, odd pixel counts, and repeated frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->