### PR TITLE
fix(test): allow cold fbuild QEMU builds

### DIFF
--- a/ci/tests/test_fbuild_qemu.py
+++ b/ci/tests/test_fbuild_qemu.py
@@ -30,6 +30,12 @@ ERROR_PATTERN = (
     r"Guru Meditation|abort\(\)|Backtrace:|TEST_SUITE_COMPLETE: FAIL|"
     r"QEMU_LCD_CLOCKLESS_REGISTRATION: FAIL"
 )
+# fbuild 2.5.17 caps daemon-side long operations at 30 minutes. Keep the
+# process wrapper slightly longer so fbuild can return its structured result.
+FBUILD_DAEMON_LONG_OPERATION_TIMEOUT_SECONDS = 30 * 60
+FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS = (
+    FBUILD_DAEMON_LONG_OPERATION_TIMEOUT_SECONDS + 60
+)
 
 
 def test_stage_fbuild_argument_parser_accepts_explicit_argv() -> None:
@@ -57,6 +63,14 @@ def test_stage_fbuild_qemu_project_without_compiling(tmp_path: Path) -> None:
     assert (staged_dir / "src" / "sketch" / "Blink.ino").is_file()
     assert (staged_dir / "lib" / "FastLED" / "FastLED.h").is_file()
     assert not (staged_dir / ".fbuild" / "build").exists()
+
+
+def test_fbuild_process_timeout_allows_daemon_diagnostic_grace() -> None:
+    """The outer wrapper must not mask fbuild's own long-operation result."""
+    assert (
+        FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS
+        > FBUILD_DAEMON_LONG_OPERATION_TIMEOUT_SECONDS
+    )
 
 
 @pytest.mark.skipif(
@@ -94,7 +108,7 @@ def test_fbuild_test_emu_esp32dev() -> None:
         check=False,
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS,
     )
     output = proc.stdout or ""
     assert proc.returncode == 0, (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,16 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.14. It carries library-dependency fixes for Teensy/STM32,
-    # stale daemon/install-lock recovery, and hardened RP2350 UF2 deployment
-    # that binds picotool to the selected board rather than a USB enumeration.
+    # Pin to fbuild 2.5.17. It carries QEMU cache repair, complete Arduino-Pico
+    # board resolution, and the accumulated library/build fixes below.
     #
     # Pin history:
+    #   2.5.17 -- repairs partial QEMU toolchain caches, completes Arduino-Pico
+    #              board resolution, and corrects ESP32 flash/RAM size reporting
+    #              (FastLED/fbuild#1296/#1297/#1301).
+    #   2.5.16 -- restores cached size reports, fixes normalized project locks,
+    #              and completes build fast-path coverage across orchestrators
+    #              (FastLED/fbuild#1277/#1278/#1288).
     #   2.5.14 -- binds RP2040/RP2350 picotool deployment to the selected
     #              board and refuses Windows USB Code 43 devices
     #              (FastLED/fbuild#1260).


### PR DESCRIPTION
## Summary

- extend the FastLED-side `fbuild test-emu` process ceiling from 10 minutes to 31 minutes
- preserve fbuild's 10-second emulator runtime timeout while allowing its 30-minute daemon operation to return first
- add a focused regression assertion for the diagnostic grace period
- refresh the stale dependency commentary for the already-pinned fbuild 2.5.17 release

## RED → GREEN

- RED: a cold Windows focused run reached the old 600-second wrapper boundary while the fbuild daemon was still logging successful ESP32 compiler jobs; continuing outside the wrapper completed after another 190.4 seconds
- GREEN: focused fast tests passed (3/3), end-to-end QEMU smoke passed in 185.58 seconds, and `bash lint` passed

Closes #3910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build test reliability by allowing diagnostic time after long-running operations.
  * Updated QEMU smoke tests to use the appropriate operation timeout.

* **Chores**
  * Updated the pinned build tool version, including improvements to QEMU caching, Arduino-Pico board resolution, and general build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->