### PR TITLE
fix(test): harden long-running Python supervision

### DIFF
--- a/ci/early_exit_cache.py
+++ b/ci/early_exit_cache.py
@@ -492,6 +492,11 @@ def check_single_test_cached(test_name_raw: str, build_dir: Path) -> bool:
     )
 
 
+def pytest_addopts_active() -> bool:
+    """Return whether external pytest options can change suite coverage."""
+    return bool(os.environ.get("PYTEST_ADDOPTS", "").strip())
+
+
 def argv_ultra_early_exit(start_time: float) -> None:
     """Check if test result is cached without running parse_args().
 
@@ -526,6 +531,9 @@ def argv_ultra_early_exit(start_time: float) -> None:
     Args:
         start_time: Time when test.py started (used for elapsed time reporting).
     """
+    if pytest_addopts_active():
+        return
+
     argv = sys.argv[1:]
 
     # --- CASE 0: No flags (bash test with no arguments) ---

--- a/ci/tests/test_fbuild_qemu.py
+++ b/ci/tests/test_fbuild_qemu.py
@@ -21,6 +21,11 @@ import pytest
 from running_process import RunningProcess
 
 from ci.stage_fbuild_project import _parse_args, stage_fbuild_project
+from ci.util.test_runner import (
+    _GLOBAL_TIMEOUT,
+    _TOP_LEVEL_TEST_TIMEOUT,
+    create_python_test_process,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -71,6 +76,27 @@ def test_fbuild_process_timeout_allows_daemon_diagnostic_grace() -> None:
         FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS
         > FBUILD_DAEMON_LONG_OPERATION_TIMEOUT_SECONDS
     )
+
+
+def test_python_worker_outlives_fbuild_process_timeout() -> None:
+    """The parent pytest worker must not mask the child fbuild result."""
+    worker = create_python_test_process(False)
+
+    assert worker.timeout is not None
+    assert worker.timeout > FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS
+
+
+def test_stuck_output_threshold_outlives_fbuild_process_timeout() -> None:
+    """A healthy quiet child must reach its explicit process deadline."""
+    assert _GLOBAL_TIMEOUT > FBUILD_TEST_EMU_PROCESS_TIMEOUT_SECONDS
+
+
+def test_top_level_watchdog_outlives_python_worker_and_deadman_grace() -> None:
+    """The outermost watchdog must not preempt the process-group result."""
+    worker = create_python_test_process(False)
+
+    assert worker.timeout is not None
+    assert _TOP_LEVEL_TEST_TIMEOUT > worker.timeout + 60
 
 
 @pytest.mark.skipif(

--- a/ci/tests/test_fingerprint_cache.py
+++ b/ci/tests/test_fingerprint_cache.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 from typing import Optional
 from unittest import TestCase
+from unittest.mock import patch
 
 # Import the fingerprint cache module
 from ci.fingerprint.core import (
@@ -831,6 +832,20 @@ class TestFingerprintCache(TestCase):
             result,
             "Directory should be older than future reference time in modtime_only mode",
         )
+
+
+class TestPytestFingerprintEligibility(TestCase):
+    def test_filtered_pytest_options_disable_full_suite_cache(self) -> None:
+        from ci.early_exit_cache import pytest_addopts_active
+
+        with patch.dict(os.environ, {"PYTEST_ADDOPTS": "-k focused"}):
+            self.assertTrue(pytest_addopts_active())
+
+    def test_whitespace_pytest_options_preserve_cache(self) -> None:
+        from ci.early_exit_cache import pytest_addopts_active
+
+        with patch.dict(os.environ, {"PYTEST_ADDOPTS": "  \t"}):
+            self.assertFalse(pytest_addopts_active())
 
 
 def run_all_tests() -> bool:

--- a/ci/tests/test_run_breakdown.py
+++ b/ci/tests/test_run_breakdown.py
@@ -24,6 +24,7 @@ from ci.early_exit_cache import _cpp_run_breakdown
 from ci.meson.streaming import StreamingResult, is_example_artifact
 from ci.meson.test_execution import MesonTestResult, examples_are_included
 from ci.util.fingerprint import FingerprintManager
+from ci.util.test_exceptions import TestFailureInfo as FailureInfo
 from ci.util.test_runner import _describe_cpp_counts
 from ci.util.test_types import (
     FingerprintResult,
@@ -325,6 +326,61 @@ class TestResultRowLabel(unittest.TestCase):
     def test_unattributed_row_admits_it(self) -> None:
         """The meson-test fallback cannot split its total; it must not imply one."""
         self.assertEqual(self._row(), "357/357 passed; unit/example split unrecorded")
+
+
+class TestProcessFailureGuidance(unittest.TestCase):
+    """Process-level failures need suite-aware names and rerun commands."""
+
+    def test_pytest_timeout_gets_python_guidance(self) -> None:
+        from ci.util.test_runner import _failed_test_entry
+
+        failure = FailureInfo(
+            test_name="run",
+            command="uv run pytest --tb=short ci/tests --durations=0",
+            return_code=1,
+            output="Process killed due to global timeout",
+            error_type="global_timeout",
+        )
+
+        entry = _failed_test_entry(failure)
+
+        self.assertEqual(entry.name, "python_tests")
+        self.assertEqual(entry.category, "python")
+        self.assertEqual(entry.rerun_cmd, "bash test --py")
+        self.assertEqual(entry.debug_cmd, "bash test --py --verbose")
+
+    def test_cpp_unit_guidance_is_unchanged(self) -> None:
+        from ci.util.test_runner import _failed_test_entry
+
+        failure = FailureInfo(
+            test_name="fl_stl_vector",
+            command=".build/meson/tests/fl_stl_vector.exe",
+            return_code=1,
+            output="failed",
+        )
+
+        entry = _failed_test_entry(failure)
+
+        self.assertEqual(entry.category, "unit")
+        self.assertEqual(entry.rerun_cmd, "bash test fl_stl_vector --cpp")
+        self.assertEqual(entry.debug_cmd, "bash test fl_stl_vector --debug")
+
+    def test_integration_failure_gets_full_suite_guidance(self) -> None:
+        from ci.util.test_runner import _failed_test_entry
+
+        failure = FailureInfo(
+            test_name="integration_tests",
+            command="uv run pytest -s ci/test_integration -xvs --durations=0",
+            return_code=1,
+            output="failed",
+        )
+
+        entry = _failed_test_entry(failure)
+
+        self.assertEqual(entry.name, "integration_tests")
+        self.assertEqual(entry.category, "integration")
+        self.assertEqual(entry.rerun_cmd, "bash test --full")
+        self.assertEqual(entry.debug_cmd, "bash test --full --verbose")
 
 
 class TestSuiteExclusionDetection(unittest.TestCase):

--- a/ci/tests/test_running_process.py
+++ b/ci/tests/test_running_process.py
@@ -8,11 +8,18 @@ This test executes a trivial Python command via `uv run python -c` and verifies:
 import subprocess
 import time
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from running_process import EndOfStream, RunningProcess
+
+from ci.util.running_process_group import (
+    ProcessExecutionConfig,
+    RunningProcessGroup,
+)
 
 
 @pytest.mark.serial
@@ -257,6 +264,28 @@ class TestRunningProcessAdditional(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "out")
         self.assertEqual(result.stderr, "err")
+
+
+class TestRunningProcessGroup(unittest.TestCase):
+    def test_verbose_poll_tolerates_quiet_process(self) -> None:
+        """No line in one poll interval is not a process failure."""
+
+        def quiet_lines() -> Any:
+            raise TimeoutError("No combined output available before timeout")
+            yield  # pragma: no cover - makes this an iterator
+
+        process = MagicMock()
+        process.line_iter.return_value = nullcontext(quiet_lines())
+        process.finished = False
+        group = RunningProcessGroup(
+            config=ProcessExecutionConfig(verbose=True, enable_stuck_detection=False)
+        )
+
+        activity = group._process_active_tests(
+            [process], [], [], [], stuck_monitor=None
+        )
+
+        self.assertFalse(activity)
 
 
 if __name__ == "__main__":

--- a/ci/util/running_process_group.py
+++ b/ci/util/running_process_group.py
@@ -33,7 +33,6 @@ from ci.util.test_runner import (
     ProcessStuckMonitor,
     ProcessTiming,
     StuckProcessSignal,
-    _extract_test_name,
     _get_friendly_test_name,
     _handle_stuck_processes,
     extract_error_snippet,
@@ -315,7 +314,7 @@ class RunningProcessGroup:
                         p.kill()
                         failures.append(
                             TestFailureInfo(
-                                test_name=_extract_test_name(p.command),
+                                test_name=_get_friendly_test_name(p.command),
                                 command=str(p.command),
                                 return_code=1,
                                 output="Process killed due to global timeout",
@@ -395,7 +394,7 @@ class RunningProcessGroup:
 
                 failures.append(
                     TestFailureInfo(
-                        test_name=_extract_test_name(proc.command),
+                        test_name=_get_friendly_test_name(proc.command),
                         command=str(proc.command),
                         return_code=exit_code,
                         output=error_snippet,
@@ -418,7 +417,7 @@ class RunningProcessGroup:
             for cmd in failed_processes:
                 failures.append(
                     TestFailureInfo(
-                        test_name=_extract_test_name(cmd),
+                        test_name=_get_friendly_test_name(cmd),
                         command=str(cmd),
                         return_code=1,
                         output="Process was killed due to timeout/stuck detection",
@@ -531,7 +530,7 @@ class RunningProcessGroup:
             error_snippet = extract_error_snippet(_get_output_lines(proc))
             failures.append(
                 TestFailureInfo(
-                    test_name=_extract_test_name(proc.command),
+                    test_name=_get_friendly_test_name(proc.command),
                     command=str(proc.command),
                     return_code=exit_code,
                     output=error_snippet,
@@ -546,7 +545,7 @@ class RunningProcessGroup:
                 cmd_str = str(cmd)
             failures.append(
                 TestFailureInfo(
-                    test_name=_extract_test_name(cmd_str),
+                    test_name=_get_friendly_test_name(cmd_str),
                     command=cmd_str,
                     return_code=1,
                     output="Process was killed due to timeout/stuck detection",
@@ -572,10 +571,15 @@ class RunningProcessGroup:
             proc = active_processes[i]
 
             if self.config.verbose:
-                with proc.line_iter(timeout=60) as line_iter:
-                    for line in line_iter:
-                        print(line)
-                        any_activity = True
+                try:
+                    with proc.line_iter(timeout=60) as line_iter:
+                        for line in line_iter:
+                            print(line)
+                            any_activity = True
+                except TimeoutError:
+                    # A quiet process is still active. Completion, stuck-output,
+                    # and explicit process deadlines are checked separately.
+                    pass
 
             # Check if process has finished
             if proc.finished:
@@ -661,7 +665,7 @@ class RunningProcessGroup:
                             _get_output_lines(process)
                         )
                         failure = TestFailureInfo(
-                            test_name=_extract_test_name(process.command),
+                            test_name=_get_friendly_test_name(process.command),
                             command=str(process.command),
                             return_code=exit_code,
                             output=error_snippet,
@@ -741,7 +745,7 @@ class RunningProcessGroup:
                             _get_output_lines(process)
                         )
                         failure = TestFailureInfo(
-                            test_name=_extract_test_name(process.command),
+                            test_name=_get_friendly_test_name(process.command),
                             command=str(process.command),
                             return_code=exit_code,
                             output=error_snippet,

--- a/ci/util/test_runner.py
+++ b/ci/util/test_runner.py
@@ -74,9 +74,12 @@ class TestCounts:
 
 _IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 _TIMEOUT = 600 if _IS_GITHUB_ACTIONS else 240
-_GLOBAL_TIMEOUT = (
-    600 if _IS_GITHUB_ACTIONS else 600
-)  # Increased to 600s for local uno compilation
+# The default Python suite includes the native fbuild QEMU smoke test. Its
+# bounded child process may run for 1,860 seconds on a cold cache, so the
+# parent pytest worker must leave additional time to return that result.
+_PYTHON_TEST_TIMEOUT = 35 * 60
+_GLOBAL_TIMEOUT = max(600, _PYTHON_TEST_TIMEOUT)
+_TOP_LEVEL_TEST_TIMEOUT = _PYTHON_TEST_TIMEOUT + 2 * 60
 
 # Abort threshold for total failures across all processes (unit + examples)
 MAX_FAILURES_BEFORE_ABORT = 3
@@ -654,7 +657,7 @@ def create_python_test_process(
     return RunningProcess(
         cmd_str,
         auto_run=False,  # Don't auto-start - will be started in parallel later
-        timeout=_TIMEOUT,  # 2 minute timeout for Python tests
+        timeout=_PYTHON_TEST_TIMEOUT,
         output_formatter=TimestampFormatter(),
     )
 
@@ -938,15 +941,40 @@ class FailedTestEntry:
 
     @property
     def rerun_cmd(self) -> str:
+        if self.category == "python":
+            return "bash test --py"
+        if self.category == "integration":
+            return "bash test --full"
         if self.category == "example":
             return f"bash test {self.clean_name} --examples"
         return f"bash test {self.clean_name} --cpp"
 
     @property
     def debug_cmd(self) -> str:
+        if self.category == "python":
+            return "bash test --py --verbose"
+        if self.category == "integration":
+            return "bash test --full --verbose"
         if self.category == "example":
             return f"bash test {self.clean_name} --examples --debug"
         return f"bash test {self.clean_name} --debug"
+
+
+def _failed_test_entry(failure: TestFailureInfo) -> FailedTestEntry:
+    """Map a process or test-case failure to actionable rerun guidance."""
+    command = failure.command
+    command_text = " ".join(command) if isinstance(command, list) else command
+    normalized_command = command_text.replace("\\", "/").lower()
+
+    if "pytest" in normalized_command and "ci/tests" in normalized_command:
+        return FailedTestEntry(name=_get_friendly_test_name(command), category="python")
+    if "pytest" in normalized_command and "ci/test_integration" in normalized_command:
+        return FailedTestEntry(
+            name=_get_friendly_test_name(command), category="integration"
+        )
+
+    category = "example" if "example" in failure.test_name.lower() else "unit"
+    return FailedTestEntry(name=failure.test_name, category=category)
 
 
 def _format_failure_summary(
@@ -990,15 +1018,23 @@ def _format_failure_summary(
 
     # Loud banner for debug re-run — this is critical for AI agents to notice
     max_debug_show = 3
+    has_cpp_failure = any(ft.category in ("unit", "example") for ft in failed_tests)
     lines.append("\033[93m" + "!" * 60 + "\033[0m")
-    lines.append(
-        "\033[93m!!  AGENT ACTION REQUIRED: RE-RUN FAILED TESTS IN DEBUG  !!\033[0m"
-    )
+    if has_cpp_failure:
+        lines.append(
+            "\033[93m!!  AGENT ACTION REQUIRED: RE-RUN FAILED TESTS IN DEBUG  !!\033[0m"
+        )
+    else:
+        lines.append(
+            "\033[93m!!  AGENT ACTION REQUIRED: RE-RUN FAILED PROCESS VERBOSE !!\033[0m"
+        )
     lines.append("\033[93m" + "!" * 60 + "\033[0m")
     lines.append("")
-    lines.append("Quick mode does NOT enable sanitizers (ASAN/LSAN/UBSAN).")
-    lines.append("You MUST re-run each failed test in --debug mode to get")
-    lines.append("full diagnostics (stack traces, memory errors, UB detection).")
+    if has_cpp_failure:
+        lines.append("Quick mode does NOT enable sanitizers (ASAN/LSAN/UBSAN).")
+        lines.append("Re-run C++ failures in --debug mode for sanitizer diagnostics.")
+    else:
+        lines.append("Re-run the failed process with verbose output for diagnostics.")
     lines.append("")
     lines.append("\033[93mRun these commands NOW:\033[0m")
     for ft in failed_tests[:max_debug_show]:
@@ -2029,15 +2065,7 @@ def runner(
     except (TestExecutionFailedException, TestTimeoutException) as e:
         # Print failure summary table from exception details
         if e.failures:
-            failed_tests: list[FailedTestEntry] = []
-            for failure in e.failures:
-                # Determine category from test name or command
-                category = (
-                    "example" if "example" in failure.test_name.lower() else "unit"
-                )
-                failed_tests.append(
-                    FailedTestEntry(name=failure.test_name, category=category)
-                )
+            failed_tests = [_failed_test_entry(failure) for failure in e.failures]
             if failed_tests:
                 summary = _format_failure_summary(failed_tests)
                 print(summary)

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1651,9 +1651,14 @@ public:
 
 	/// Update all our controllers with the current led colors, using the passed in brightness
 	/// @param scale the brightness value to use in place of the stored value
+	/// @warning This function is not interrupt-safe and must not be called from an
+	/// interrupt service routine (ISR). On ESP32, doing so can deadlock or trigger
+	/// an interrupt-watchdog panic. Have the ISR set a flag, then call show() from
+	/// loop() or a normal task after leaving the interrupt context.
 	void show(fl::u8 scale);
 
 	/// Update all our controllers with the current led colors
+	/// @warning This function is not interrupt-safe. See show(fl::u8).
 	void show() { show(mScale); }
 
 	// Called automatically at the end of show().

--- a/test.py
+++ b/test.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from ci.early_exit_cache import (
     argv_ultra_early_exit,
     check_single_test_cached,
+    pytest_addopts_active,
 )
 
 
@@ -95,6 +96,7 @@ from ci.util.test_env import (
     setup_environment,
     setup_force_exit,
 )
+from ci.util.test_runner import _TOP_LEVEL_TEST_TIMEOUT
 from ci.util.test_types import (
     process_test_flags,
 )
@@ -114,7 +116,7 @@ import threading  # noqa: PLC0415 - lazy import (not at top level to speed up ea
 
 _CANCEL_WATCHDOG = threading.Event()
 
-_TIMEOUT_EVERYTHING = 600
+_TIMEOUT_EVERYTHING = _TOP_LEVEL_TEST_TIMEOUT
 
 _GDB_CRASH_DIR = Path(".gdb_crash")
 _GDB_CRASH_SEEN = _GDB_CRASH_DIR / ".seen"
@@ -183,7 +185,7 @@ def _get_run_platform_backends() -> dict[str, list[str]]:
 
 
 if os.environ.get("GITHUB_ACTIONS"):
-    _TIMEOUT_EVERYTHING = 1200  # Extended timeout for GitHub CI builds
+    _TIMEOUT_EVERYTHING = max(_TIMEOUT_EVERYTHING, 1200)
     ts_print(
         f"GitHub Actions environment detected - using extended timeout: {_TIMEOUT_EVERYTHING} seconds"
     )
@@ -444,6 +446,7 @@ def main() -> None:
             args.build_mode if args.build_mode else ("debug" if args.debug else "quick")
         )
         fingerprint_manager = FingerprintManager(cache_dir, build_mode=build_mode)
+        pytest_options_active = pytest_addopts_active()
 
         # Calculate fingerprints
         # OPTIMIZATION: When --no-fingerprint is set, skip computing fingerprints entirely.
@@ -688,6 +691,7 @@ def main() -> None:
                 force_python_test_change = (
                     python_test_change
                     or (args.test is not None)
+                    or pytest_options_active
                     or rebuild_mode != RebuildMode.CACHED
                 )
                 force_wasm_change = wasm_change or rebuild_mode != RebuildMode.CACHED
@@ -733,6 +737,7 @@ def main() -> None:
                 args.test is None
                 and not running_specific_examples
                 and not args.no_fingerprint
+                and not pytest_options_active
             )
             if running_all_tests:
                 status = "success" if tests_passed else "failure"


### PR DESCRIPTION
## Summary
- document that `FastLED.show()` is blocking and must not be called from an ISR
- keep the Python worker, process-group timeout, and outer watchdog alive beyond the bounded fbuild QEMU smoke-test deadline
- tolerate quiet verbose subprocesses, emit suite-aware rerun guidance, and keep filtered pytest runs out of the full-suite fingerprint cache

## Validation
- `bash lint`
- `bash test --cpp` (279 unit tests and 84 examples passed)
- unfiltered `bash test --py --verbose` aggregate completed and wrote a success fingerprint after 919 tests were collected
- focused fbuild ESP32 QEMU smoke retry passed in 276.16s
- focused timeout, quiet-process, failure-guidance, and fingerprint-cache regressions passed
- `clud-review: clean` (`review agents launched: 1`)

Closes #999
Closes #3913
Closes #3914
Closes #3915
Closes #3916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution when custom pytest options are active by preventing incorrect cache reuse.
  * Improved monitoring of quiet processes during parallel test runs.
  * Updated timeout handling for Python and integration tests.
  * Added more specific rerun guidance for different test failure types.
  * Adjusted CI watchdog timeouts for more reliable test execution.

* **Documentation**
  * Added warnings that LED updates may not be interrupt-safe on ESP32 and could cause deadlocks or watchdog resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->