### PR TITLE
docs: link online FastLED playgrounds

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,8 @@ Tips:
 
 ### WASM (browser demos + JSON UI)
 
+- Try FastLED without hardware in the [FastLED Web Compiler](https://zackees.github.io/fastled-wasm/)
+- The [Wokwi FastLED playground](https://wokwi.com/playground/fastled) runs the `ColorPalette` example in an Arduino simulator
 - `examples/wasm/` and related WASM-focused examples run in the browser
 - The JSON UI system enables sliders, buttons, and other controls (see `src/platforms/wasm` and `src/fl/ui/ui.h`)
 - Typical flow: build to WebAssembly, serve the app, and interact via the browser UI


### PR DESCRIPTION
## Summary
- link the first-party FastLED Web Compiler from the examples guide
- link the original Wokwi ColorPalette simulator for hardware-free Arduino experimentation

## Validation
- `git diff --check`
- verified the FastLED Web Compiler returns HTTP 200
- verified the Wokwi playground redirects to its active ColorPalette project
- `clud-review`: clean

Closes #1004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to the FastLED Web Compiler and Wokwi FastLED playground in the WASM examples documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->