### PR TITLE
docs: explain runtime LED configuration

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -734,7 +734,8 @@ public:
 	/// @brief Add LED channel with runtime configuration (from ChannelConfig)
 	///
 	/// Creates and registers a Channel-based LED controller with runtime-configurable timing.
-	/// Returns a shared_ptr for lifetime control - controller auto-removes on destruction.
+	/// Returns a shared_ptr handle for later inspection, reconfiguration, or removal.
+	/// FastLED retains its own reference until remove(channel) is called.
 	///
 	/// @param config Channel configuration (pin, timing, leds, rgb order, settings)
 	/// @returns Shared pointer to Channel (extends CLEDController), or nullptr if unsupported
@@ -747,14 +748,15 @@ public:
 	/// auto channel = FastLED.add(config);
 	/// fill_solid(leds, NUM_LEDS, CRGB::Red);
 	/// FastLED.show();
-	/// channel.reset();  // Destroy controller
+	/// FastLED.remove(channel);  // Unregister and release FastLED's reference
 	/// @endcode
 	static fl::ChannelPtr add(const fl::ChannelConfig& config);
 
 	/// @brief Add multiple LED channels from a config array
 	///
 	/// Creates and registers multiple Channel-based LED controllers from an array of configurations.
-	/// Returns a vector of shared_ptrs for lifetime control.
+	/// Returns handles for later inspection, reconfiguration, or removal.
+	/// FastLED retains its own references until remove(channel) is called for each channel.
 	///
 	/// @param configs Span of ChannelConfig objects
 	/// @returns Vector of ChannelPtrs (one per config), or empty elements if unsupported
@@ -774,7 +776,8 @@ public:
 	/// @brief Add multiple LED channels from an initializer list
 	///
 	/// Creates and registers multiple Channel-based LED controllers from a brace-enclosed list.
-	/// Returns a vector of shared_ptrs for lifetime control.
+	/// Returns handles for later inspection, reconfiguration, or removal.
+	/// FastLED retains its own references until remove(channel) is called for each channel.
 	///
 	/// @param configs Initializer list of ChannelConfig objects
 	/// @returns Vector of ChannelPtrs (one per config)
@@ -792,7 +795,8 @@ public:
 	/// @brief Add multiple LED channels from a MultiChannelConfig
 	///
 	/// Creates and registers multiple Channel-based LED controllers from a MultiChannelConfig.
-	/// Returns a vector of shared_ptrs for lifetime control.
+	/// Returns handles for later inspection, reconfiguration, or removal.
+	/// FastLED retains its own references until remove(channel) is called for each channel.
 	///
 	/// @param multiConfig MultiChannelConfig containing multiple channel configurations
 	/// @returns Vector of ChannelPtrs (one per config), or empty elements if unsupported

--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -101,6 +101,50 @@ void loop() {
 
 Every `addLeds<>` variant also accepts an optional trailing `fl::Bus B = fl::Bus::AUTO` template parameter — see "Compile-Time Bus Selection" below for how to pin the driver from the call site.
 
+### Select a strip configuration at runtime
+
+The template arguments to `addLeds<>` must be known at compile time, so the
+template itself cannot be stored in a variable. Use the non-template Channel
+API when a saved setting or user input selects the chipset, pins, or color
+order during `setup()`:
+
+```cpp
+#include "FastLED.h"
+#include "fl/channels/config.h"
+
+constexpr int NUM_LEDS = 60;
+CRGB leds[NUM_LEDS];
+
+uint8_t readStripSetting() {
+    return 0;  // Replace with an EEPROM, file, web UI, or other saved setting.
+}
+
+void setup() {
+    const fl::ChannelConfig options[] = {
+        fl::ChannelConfig(fl::makeClockless<fl::TIMING_WS2813>(4),
+                          fl::span<CRGB>(leds, NUM_LEDS), GRB),
+        fl::ChannelConfig(fl::makeClockless<fl::TIMING_WS2812_800KHZ>(5),
+                          fl::span<CRGB>(leds, NUM_LEDS), RGB),
+        fl::ChannelConfig(fl::makeClockless<fl::TIMING_WS2811_400KHZ>(6),
+                          fl::span<CRGB>(leds, NUM_LEDS), BRG),
+    };
+
+    const uint8_t selected = readStripSetting();
+    if (selected < sizeof(options) / sizeof(options[0])) {
+        FastLED.add(options[selected]);
+    }
+}
+
+void loop() {
+    fill_rainbow(leds, NUM_LEDS, millis() / 16, 7);
+    FastLED.show();
+}
+```
+
+`makeClockless<>()` builds each supported timing value into the firmware. The
+resulting `ChannelConfig` objects are ordinary values, so the final selection
+can be made at runtime without a chipset switch statement.
+
 ### Compile-Time Bus Selection (`fl::Bus`)
 
 The `fl::Bus` enum (in `fl/channels/bus.h`) is the portable identifier that flows through both the templated APIs and the runtime registry overrides. Some portable values map to different concrete vendor drivers on different chips; `deviceInfo<Bus, Which>()` reports the concrete `vendor_name` and `device_name`.


### PR DESCRIPTION
## Summary
- document how to select clockless chipset timing, pin, and RGB order from a `ChannelConfig` array at runtime
- clarify that `addLeds<>` template arguments remain compile-time values
- correct Channel API ownership docs: FastLED retains registered channels until `FastLED.remove(channel)`

## Validation
- ownership source-contract RED: found stale `auto-removes` and `channel.reset()` claims
- ownership source-contract GREEN: stale claims removed
- `bash test fastled_core` (1/1 passed)
- `bash lint`
- `git diff --check`
- `clud-review`: clean

Closes #1007
Closes #3920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Channel API handle lifetime and removal behavior.
  * Updated examples to use explicit channel removal.
  * Added guidance for selecting strip configurations at runtime.
  * Documented support for saved settings and user-selected timing and color-order options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->