### PR TITLE
feat: serialize CRGB buffers as JSON

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -53,6 +53,7 @@ Copy-paste ready recipes for popular LED effects.
 - [Twinkle/Sparkle](recipes/twinkle.md)
 - [Breathing Effect](recipes/breathing.md)
 - [Wave Patterns](recipes/waves.md)
+- [Save and Restore a CRGB Array](recipes/persist-crgb.md)
 
 ### [Troubleshooting](troubleshooting/)
 Solve common problems and debug your LED setup.

--- a/cookbook/recipes/persist-crgb.md
+++ b/cookbook/recipes/persist-crgb.md
@@ -1,0 +1,72 @@
+# Save and restore a CRGB array
+
+FastLED can convert a pixel buffer to versioned JSON and validate it when
+loading. The storage operation itself is platform-specific: use LittleFS on an
+ESP32, an SD card, EEPROM, or another store appropriate for your board.
+
+```cpp
+#include <FastLED.h>
+#include <LittleFS.h>
+#include "fl/gfx/crgb_json.h"
+
+constexpr int NUM_LEDS = 60;
+CRGB leds[NUM_LEDS];
+
+bool savePixels() {
+    const fl::optional<fl::json> document = fl::crgbToJson(leds);
+    if (!document) {
+        return false;
+    }
+
+    const fl::string text = document->to_string();
+    CRGB verified[NUM_LEDS];
+    if (!fl::crgbFromJson(fl::json::parse(text), verified)) {
+        return false;
+    }
+
+    File file = LittleFS.open("/leds.json.tmp", "w");
+    if (!file) {
+        return false;
+    }
+
+    const size_t written = file.print(text.c_str());
+    file.close();
+    if (written != text.size()) {
+        LittleFS.remove("/leds.json.tmp");
+        return false;
+    }
+    if (!LittleFS.rename("/leds.json.tmp", "/leds.json")) {
+        LittleFS.remove("/leds.json.tmp");
+        return false;
+    }
+    return true;
+}
+
+bool loadPixels() {
+    File file = LittleFS.open("/leds.json", "r");
+    if (!file) {
+        return false;
+    }
+
+    fl::string text;
+    text.reserve(file.size());
+    while (file.available()) {
+        text.push_back(static_cast<char>(file.read()));
+    }
+    file.close();
+
+    return fl::crgbFromJson(fl::json::parse(text), leds);
+}
+```
+
+Mount LittleFS once during `setup()` before calling either function. The loader
+requires the saved pixel count to match `NUM_LEDS`, checks every RGB channel,
+and leaves `leds` unchanged if the file is malformed or incompatible. Saving
+also validates the serialized text before it writes a temporary file, then
+renames that complete file over the previous save.
+
+JSON is convenient and human-readable, but it is larger than the three raw
+bytes stored by each `CRGB`. For large installations, store the raw bytes with
+a small version/checksum header instead. Avoid writing from `loop()` on every
+frame; flash and EEPROM have finite write endurance, so save only when the
+pattern actually changes.

--- a/src/fl/gfx/_build.cpp.hpp
+++ b/src/fl/gfx/_build.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/gfx/colorutils.cpp.hpp"
 #include "fl/gfx/corkscrew.cpp.hpp"
 #include "fl/gfx/crgb_extra.cpp.hpp"
+#include "fl/gfx/crgb_json.cpp.hpp"
 #include "fl/gfx/downscale.cpp.hpp"
 #include "fl/gfx/fill.cpp.hpp"
 #include "fl/gfx/five_bit_hd_gamma.cpp.hpp"

--- a/src/fl/gfx/crgb_json.cpp.hpp
+++ b/src/fl/gfx/crgb_json.cpp.hpp
@@ -1,0 +1,130 @@
+#include "fl/gfx/crgb_json.h"
+
+namespace fl {
+
+namespace {
+
+optional<i64> crgbJsonChannel(const json& value) FL_NO_EXCEPT {
+    if (!value.is_int() || value.is_bool()) {
+        return fl::nullopt;
+    }
+    const optional<i64> channel = value.as<i64>();
+    if (!channel || *channel < 0 || *channel > 255) {
+        return fl::nullopt;
+    }
+    return channel;
+}
+
+optional<CRGB> crgbJsonPixel(const json& value) FL_NO_EXCEPT {
+    if (!value.is_array() || value.size() != 3) {
+        return fl::nullopt;
+    }
+
+    const optional<i64> red = crgbJsonChannel(value[0]);
+    const optional<i64> green = crgbJsonChannel(value[1]);
+    const optional<i64> blue = crgbJsonChannel(value[2]);
+    if (!red || !green || !blue) {
+        return fl::nullopt;
+    }
+
+    return CRGB(static_cast<u8>(*red), static_cast<u8>(*green),
+                static_cast<u8>(*blue));
+}
+
+bool crgbJsonMatches(const json& document,
+                     span<const CRGB> pixels) FL_NO_EXCEPT {
+    if (!document.is_object() || document.size() != 2) {
+        return false;
+    }
+
+    const json versionJson = document["version"];
+    const optional<i64> version = versionJson.as<i64>();
+    if (!versionJson.is_int() || versionJson.is_bool() || !version ||
+        *version != 1) {
+        return false;
+    }
+
+    const json encodedPixels = document["pixels"];
+    if (!encodedPixels.is_array() || encodedPixels.size() != pixels.size()) {
+        return false;
+    }
+
+    for (size i = 0; i < encodedPixels.size(); ++i) {
+        const optional<CRGB> decoded = crgbJsonPixel(encodedPixels[i]);
+        if (!decoded || *decoded != pixels[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+optional<json> crgbToJson(span<const CRGB> pixels) FL_NO_EXCEPT {
+    json encodedPixels = json::array();
+    if (!encodedPixels.is_array()) {
+        return fl::nullopt;
+    }
+
+    for (const CRGB& pixel : pixels) {
+        json encodedPixel = json::array();
+        if (!encodedPixel.is_array()) {
+            return fl::nullopt;
+        }
+
+        encodedPixel.push_back(json(static_cast<int>(pixel.r)));
+        encodedPixel.push_back(json(static_cast<int>(pixel.g)));
+        encodedPixel.push_back(json(static_cast<int>(pixel.b)));
+        if (encodedPixel.size() != 3 || !crgbJsonPixel(encodedPixel)) {
+            return fl::nullopt;
+        }
+
+        const size oldSize = encodedPixels.size();
+        encodedPixels.push_back(encodedPixel);
+        if (encodedPixels.size() != oldSize + 1) {
+            return fl::nullopt;
+        }
+    }
+
+    json document = json::object();
+    if (!document.is_object()) {
+        return fl::nullopt;
+    }
+    document.set("version", 1);
+    document.set("pixels", encodedPixels);
+    if (!crgbJsonMatches(document, pixels)) {
+        return fl::nullopt;
+    }
+    return document;
+}
+
+bool crgbFromJson(const json& document, span<CRGB> pixels) FL_NO_EXCEPT {
+    if (!document.is_object()) {
+        return false;
+    }
+
+    const json versionJson = document["version"];
+    const optional<i64> version = versionJson.as<i64>();
+    if (!versionJson.is_int() || versionJson.is_bool() || !version ||
+        *version != 1) {
+        return false;
+    }
+
+    const json encodedPixels = document["pixels"];
+    if (!encodedPixels.is_array() || encodedPixels.size() != pixels.size()) {
+        return false;
+    }
+
+    for (size i = 0; i < encodedPixels.size(); ++i) {
+        if (!crgbJsonPixel(encodedPixels[i])) {
+            return false;
+        }
+    }
+
+    for (size i = 0; i < encodedPixels.size(); ++i) {
+        pixels[i] = *crgbJsonPixel(encodedPixels[i]);
+    }
+    return true;
+}
+
+} // namespace fl

--- a/src/fl/gfx/crgb_json.h
+++ b/src/fl/gfx/crgb_json.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/// @file fl/gfx/crgb_json.h
+/// @brief JSON serialization helpers for CRGB pixel buffers.
+///
+/// The encoded schema is versioned so persisted data can be validated before
+/// it replaces a live pixel buffer:
+/// @code
+/// {"version":1,"pixels":[[255,0,0],[0,255,0],[0,0,255]]}
+/// @endcode
+///
+/// These helpers convert pixels to and from fl::json. Choosing and operating a
+/// persistent store (LittleFS, SD, EEPROM, and so on) remains platform-specific.
+
+#include "fl/gfx/crgb.h"
+#include "fl/stl/json.h"
+#include "fl/stl/optional.h"
+#include "fl/stl/span.h"
+
+namespace fl {
+
+/// @brief Encode a CRGB pixel buffer as a versioned JSON object.
+/// @param pixels Pixel buffer to encode.
+/// @return JSON object with `version` and `pixels` fields, or nullopt if the
+///         document could not be built (for example, due to allocation
+///         failure).
+optional<json> crgbToJson(span<const CRGB> pixels) FL_NO_EXCEPT;
+
+/// @brief Decode a versioned JSON object into an existing CRGB pixel buffer.
+///
+/// The document must use schema version 1 and contain exactly one RGB triplet
+/// per output pixel. Every channel must be an integer from 0 through 255. The
+/// complete document is validated before any output pixel is changed.
+///
+/// @param document JSON object produced by crgbToJson().
+/// @param pixels Destination pixel buffer.
+/// @return true on success; false if the document is invalid. On failure,
+///         `pixels` is left unchanged.
+bool crgbFromJson(const json& document, span<CRGB> pixels) FL_NO_EXCEPT;
+
+} // namespace fl

--- a/tests/fl/gfx/crgb_json.cpp
+++ b/tests/fl/gfx/crgb_json.cpp
@@ -1,0 +1,106 @@
+#include "test.h"
+
+#include "fl/gfx/crgb_json.h"
+#include "fl/stl/json.h"
+#include "fl/stl/span.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+FL_TEST_CASE("CRGB JSON round-trip preserves pixels") {
+    const CRGB source[] = {
+        CRGB(0, 1, 2),
+        CRGB(255, 128, 64),
+        CRGB::Blue,
+    };
+
+    const optional<json> encoded = crgbToJson(source);
+    FL_REQUIRE_TRUE(encoded);
+    FL_REQUIRE_TRUE(encoded->is_object());
+    FL_CHECK_EQ((*encoded)["version"] | 0, 1);
+    FL_REQUIRE_TRUE((*encoded)["pixels"].is_array());
+    FL_CHECK_EQ((*encoded)["pixels"].size(), 3);
+
+    const json parsed = json::parse(encoded->to_string());
+    CRGB restored[3] = {};
+    FL_REQUIRE_TRUE(crgbFromJson(parsed, restored));
+
+    for (size i = 0; i < 3; ++i) {
+        FL_CHECK_EQ(restored[i], source[i]);
+    }
+}
+
+FL_TEST_CASE("CRGB JSON rejects invalid input without partial writes") {
+    const CRGB sentinel(7, 8, 9);
+    CRGB output[] = {sentinel, sentinel};
+
+    FL_SUBCASE("wrong schema version") {
+        const json input = json::parse(
+            R"({"version":2,"pixels":[[1,2,3],[4,5,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("pixel count mismatch") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("invalid later pixel") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3],[4,999,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("wrong pixel shape") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3],[4,5]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("non-numeric channel") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3],[4,"5",6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("boolean schema version") {
+        const json input = json::parse(
+            R"({"version":true,"pixels":[[1,2,3],[4,5,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("boolean channel") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3],[4,true,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("schema version wider than int") {
+        const json input = json::parse(
+            R"({"version":2147483648,"pixels":[[1,2,3],[4,5,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_SUBCASE("channel wider than int") {
+        const json input = json::parse(
+            R"({"version":1,"pixels":[[1,2,3],[4,2147483648,6]]})");
+        FL_CHECK_FALSE(crgbFromJson(input, output));
+    }
+
+    FL_CHECK_EQ(output[0], sentinel);
+    FL_CHECK_EQ(output[1], sentinel);
+}
+
+FL_TEST_CASE("CRGB JSON supports an empty pixel span") {
+    const span<const CRGB> emptyInput;
+    const optional<json> encoded = crgbToJson(emptyInput);
+    FL_REQUIRE_TRUE(encoded);
+    FL_CHECK_EQ((*encoded)["pixels"].size(), 0);
+
+    span<CRGB> emptyOutput;
+    FL_CHECK_TRUE(crgbFromJson(*encoded, emptyOutput));
+}
+
+} // FL_TEST_FILE


### PR DESCRIPTION
Adds opt-in, versioned JSON persistence helpers for CRGB pixel buffers. Encoding is fallible and validates the completed document; decoding strictly validates version, count, channel types/ranges, and leaves the destination unchanged on failure. Includes focused tests and an ESP32 LittleFS cookbook recipe with validated temporary-file writes.

Validation:
- bash test crgb_json
- bash test crgb_json --debug
- bash test --clean --cpp (281/281 unit, 84/84 examples)
- bash lint
- clud-review: clean

Closes #1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON serialization and restoration for CRGB pixel arrays.
  * Added validation for data versions, pixel counts, RGB channels, and malformed input.
  * Added a cookbook recipe demonstrating safe save and restore workflows using LittleFS.

* **Documentation**
  * Added the pixel persistence recipe to the cookbook’s Common Recipes list.

* **Tests**
  * Added coverage for round trips, invalid data, empty arrays, and protection against partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->