### PR TITLE
fix: avoid ESP32 ANALOG macro collision

### DIFF
--- a/examples/AnalogOutput/AnalogOutput.ino
+++ b/examples/AnalogOutput/AnalogOutput.ino
@@ -12,8 +12,8 @@
 //
 // This example is designed to control an "analog" RGB LED strip
 // (or a single RGB LED) being driven by Arduino PWM output pins.
-// FastLED's ANALOG controller applies brightness, color correction, and color
-// temperature before writing PWM duty cycles to the three output pins.
+// FastLED's ANALOG_RGB controller applies brightness, color correction, and
+// color temperature before writing PWM duty cycles to the three output pins.
 // 
 // In this example, the RGB values are output on three separate
 // 'analog' PWM pins, one for red, one for green, and one for blue.
@@ -55,7 +55,7 @@ void loop()
 
 
 void setup() {
-  FastLED.addLeds<ANALOG, REDPIN, GREENPIN, BLUEPIN>(leds, 1)
+  FastLED.addLeds<ANALOG_RGB, REDPIN, GREENPIN, BLUEPIN>(leds, 1)
     .setCorrection(TypicalLEDStrip)
     .setTemperature(DirectSunlight);
   FastLED.setBrightness(192);

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -940,7 +940,7 @@ public:
 	/// @param data pointer to one CRGB value for the complete analog output
 	/// @param nLedsOrOffset number of CRGB values, or offset with nLedsIfOffset
 	/// @param nLedsIfOffset number of CRGB values when an offset is supplied
-	/// @tparam CHIPSET three-pin controller template, normally ANALOG
+	/// @tparam CHIPSET three-pin controller template, normally ANALOG_RGB
 	/// @tparam RED_PIN PWM pin connected to the red channel
 	/// @tparam GREEN_PIN PWM pin connected to the green channel
 	/// @tparam BLUE_PIN PWM pin connected to the blue channel

--- a/src/fl/chipsets/analog.h
+++ b/src/fl/chipsets/analog.h
@@ -52,4 +52,5 @@ class AnalogRGBController : public CPixelLEDController<RGB> {
 /// FastLED chipset-style wrapper for three-pin PWM RGB output.
 /// @see fl::AnalogRGBController
 template <fl::u8 RED_PIN, fl::u8 GREEN_PIN, fl::u8 BLUE_PIN>
-class ANALOG : public fl::AnalogRGBController<RED_PIN, GREEN_PIN, BLUE_PIN> {};
+class ANALOG_RGB
+    : public fl::AnalogRGBController<RED_PIN, GREEN_PIN, BLUE_PIN> {};

--- a/tests/fl/chipsets/analog.cpp
+++ b/tests/fl/chipsets/analog.cpp
@@ -2,13 +2,14 @@
 /// @brief Tests for three-pin PWM analog RGB output.
 
 #include "FastLED.h"
+#include "fl/stl/scope_exit.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
 namespace {
 
-class RecordingAnalogController : public fl::AnalogRGBController<3, 5, 6> {
+class RecordingAnalogController : public ANALOG_RGB<3, 5, 6> {
   public:
     fl::u8 red = 0;
     fl::u8 green = 0;
@@ -33,6 +34,8 @@ FL_TEST_CASE("analog_rgb_applies_global_output_adjustments") {
     RecordingAnalogController controller;
 
     FastLED.addLeds(&controller, &led, 1);
+    auto cleanup = fl::make_scope_exit(
+        [&controller]() { controller.removeFromDrawList(); });
     controller.setDither(DISABLE_DITHER);
     FL_CHECK_EQ(fl::getPwmFrequency(RED_PIN), 500u);
     FL_CHECK_EQ(fl::getPwmFrequency(GREEN_PIN), 500u);


### PR DESCRIPTION
## Summary
- rename the new three-pin PWM wrapper from `ANALOG` to `ANALOG_RGB` so ESP32 Arduino's existing `ANALOG` macro remains untouched
- update the public API documentation and AnalogOutput example
- compile the public wrapper in the focused analog test and detach its stack controller during cleanup

## RED -> GREEN
- RED: `fbuild build tests/fbuild_qemu_smoke -e esp32dev` failed because ESP32 core 3.3.11 expands `class ANALOG` to `class 0xC0`
- GREEN: the same fbuild build succeeds, the QEMU smoke reaches `FBUILD-QEMU-TEST-OK`, and AnalogOutput compiles for esp32dev

## Validation
- `bash test analog` — 1/1
- `bash test analog --debug` — 1/1 with sanitizers
- `fbuild build tests/fbuild_qemu_smoke -e esp32dev`
- `fbuild test-emu tests/fbuild_qemu_smoke -e esp32dev ...` — `FBUILD-QEMU-TEST-OK`
- `bash compile esp32dev --examples AnalogOutput`
- `bash test --py` — complete suite green
- `bash lint`
- `clud-review: clean` (`review agents launched: 1`)

Closes #3924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analog RGB controller documentation and example configuration to use the clearer `ANALOG_RGB` name.
  * Clarified that color processing is applied before PWM output.

* **Bug Fixes**
  * Improved test cleanup to prevent analog controller state from affecting subsequent tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->