### PR TITLE
docs: clarify low-value HSV quantization

### DIFF
--- a/src/hsv2rgb.h
+++ b/src/hsv2rgb.h
@@ -49,6 +49,13 @@
 /// The colorspace conversions here try to keep the apparent brightness
 /// constant even as the hue varies.
 ///
+/// @note `CHSV::val` is part of this 8-bit colorspace conversion. Very low
+/// values necessarily quantize individual RGB channels and can make a mixed
+/// hue appear closer to a primary color. For sensor-controlled output
+/// brightness, keep the color at full value and use `FastLED.setBrightness()`
+/// so the output pipeline can preserve the channel ratios with temporal
+/// dithering.
+///
 /// Adafruit's "Wheel" function, discussed [here](http://forums.adafruit.com/viewtopic.php?f=47&t=22483)
 /// is also of the "constant apparent brightness" variety.
 ///

--- a/tests/fl/hsv2rgb_accuracy.cpp
+++ b/tests/fl/hsv2rgb_accuracy.cpp
@@ -261,6 +261,14 @@ FL_TEST_CASE("rgb2hsv_approximate - greys report zero saturation") {
     }
 }
 
+FL_TEST_CASE("hsv2rgb_rainbow keeps mixed hues at low CHSV values (issue #1016)") {
+    CRGB rgb = hsv2rgb_rainbow(CHSV(80, 255, 30));
+
+    FL_CHECK_GT(rgb.r, 0);
+    FL_CHECK_GT(rgb.g, 0);
+    FL_CHECK_EQ(rgb.b, 0);
+}
+
 FL_TEST_CASE("HSV to RGB Conversion - Specific Color Tests") {
     FL_WARN("=== Specific Color Conversion Tests ===");
     


### PR DESCRIPTION
## Summary

- document that low `CHSV::val` values quantize individual 8-bit RGB channels
- recommend `FastLED.setBrightness()` with temporal dithering for sensor-controlled output dimming
- add a focused regression proving `CHSV(80,255,30)` retains both red and green instead of becoming pure green

## Validation

- `bash test hsv2rgb_accuracy`
- `bash lint`
- `git diff --check`
- clud-review: clean

Closes #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how low color-value settings affect 8-bit RGB conversion and perceived hue.
  * Added guidance to use full color values with brightness controls for sensor-driven lighting.

* **Tests**
  * Added coverage to verify accurate low-brightness conversion for mixed hues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->