### PR TITLE
fix(esp8266): honor Arduino D-pin constants

### DIFF
--- a/src/platforms/esp/8266/README.md
+++ b/src/platforms/esp/8266/README.md
@@ -32,10 +32,9 @@ Notes:
 - **`FASTLED_INTERRUPT_RETRY_COUNT`**: Max retries when a frame aborts due to long ISRs/NMIs. Default `2` (see `fastled_config.h`). Used by both single-lane and block drivers.
 
 - **Pin order selection** (choose one before including `FastLED.h`):
-  - **`FASTLED_ESP8266_RAW_PIN_ORDER`**: Use raw GPIO numbering.
-  - **`FASTLED_ESP8266_NODEMCU_PIN_ORDER`**: Use NodeMCU D0/D1 labeling.
-  - **`FASTLED_ESP8266_D1_PIN_ORDER`**: Use Wemos D1-style mapping.
-  - If none are defined, the code defaults to NodeMCU on `ARDUINO_ESP8266_NODEMCU`, otherwise raw pin order.
+  - **`FASTLED_ESP8266_RAW_PIN_ORDER`**: Use raw GPIO numbering. This is the default. Arduino board constants such as NodeMCU `D5` already expand to raw GPIO numbers and work with this mode.
+  - **`FASTLED_ESP8266_NODEMCU_PIN_ORDER`**: Legacy NodeMCU board-label numbering for bare numeric pins (for example, `5` means D5/GPIO14). Do not use this mode with Arduino `Dn` constants, because they have already been mapped to GPIO numbers.
+  - **`FASTLED_ESP8266_D1_PIN_ORDER`**: Legacy Wemos D1-style mapping for bare numeric pins.
 
 - **SPI backend**
   - **`FASTLED_ALL_PINS_HARDWARE_SPI`**: Route clocked LED chipsets via the hardware SPI driver. See `fastspi_esp8266.h` notes.

--- a/src/platforms/esp/8266/led_sysdefs_esp8266.h
+++ b/src/platforms/esp/8266/led_sysdefs_esp8266.h
@@ -45,13 +45,13 @@ typedef fl::u32 prog_uint32_t;
 
 #define NEED_CXX_BITS
 
-// These can be overridden
+// Arduino ESP8266 board variants expose Dn constants as raw GPIO numbers (for
+// example, NodeMCU D5 is GPIO 14). Default to raw numbering so those constants
+// reach the intended GPIO instead of being remapped a second time. The legacy
+// board-label mappings remain available as explicit opt-ins.
 #if !defined(FASTLED_ESP8266_RAW_PIN_ORDER) && !defined(FASTLED_ESP8266_NODEMCU_PIN_ORDER) && !defined(FASTLED_ESP8266_D1_PIN_ORDER)
-# ifdef ARDUINO_ESP8266_NODEMCU
-#   define FASTLED_ESP8266_NODEMCU_PIN_ORDER
-# else
-#   define FASTLED_ESP8266_RAW_PIN_ORDER
-# endif
+# define FL_ESP8266_PIN_ORDER_DEFAULTED 1
+# define FASTLED_ESP8266_RAW_PIN_ORDER
 #endif
 
 // Platform-specific IRAM attribute for ISR handlers and interrupt-sensitive functions

--- a/src/platforms/esp/compile_test.hpp
+++ b/src/platforms/esp/compile_test.hpp
@@ -49,6 +49,20 @@ void esp8266_compile_tests() {
 #ifndef FASTLED_HAS_MILLIS
 #error "FASTLED_HAS_MILLIS should be defined for ESP8266"
 #endif
+
+// The Arduino NodeMCU variant defines D5 as the raw GPIO number 14. FastLED
+// must not select its legacy board-label mapping automatically, because that
+// mapping accepts only 0..10 and would reject D5 (and double-map D1..D4).
+#if defined(ARDUINO_ESP8266_NODEMCU) && defined(FL_ESP8266_PIN_ORDER_DEFAULTED)
+#ifndef FASTLED_ESP8266_RAW_PIN_ORDER
+#error "The default ESP8266 pin order must accept Arduino Dn constants as raw GPIO numbers"
+#endif
+#ifdef FASTLED_ESP8266_NODEMCU_PIN_ORDER
+#error "The legacy NodeMCU board-label mapping must remain opt-in"
+#endif
+    FL_STATIC_ASSERT(FastPin<14>::validpin(),
+                     "NodeMCU D5 (GPIO 14) must be a valid FastLED pin");
+#endif
 }
 #endif // FL_IS_ESP8266
 


### PR DESCRIPTION
## Summary
- default ESP8266 pin selection to raw GPIO numbering so Arduino `Dn` constants are not remapped twice
- keep legacy NodeMCU and Wemos board-label numbering available as explicit opt-ins
- add a compile-time NodeMCU `D5`/GPIO14 regression check and document the modes

## Root cause
Arduino's NodeMCU variant defines `D5` as raw GPIO 14. FastLED automatically selected its legacy logical D0-D10 mapping for that board, where template pin 14 is invalid and D1-D4 are interpreted a second time as board labels.

## Validation
- `bash compile esp8266 --examples Blink --defines ARDUINO_ESP8266_NODEMCU`
- `bash compile esp8266 --examples Blink --defines ARDUINO_ESP8266_NODEMCU,FASTLED_ESP8266_NODEMCU_PIN_ORDER`
- `bash lint`
- `git diff --check`
- `clud-review: clean`

Closes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ESP8266 pin numbering and the behavior of Arduino `Dn` constants.
  * Documented legacy NodeMCU and D1 mappings as explicit opt-in modes.

* **Bug Fixes**
  * ESP8266 now consistently defaults to raw GPIO pin numbering across boards.
  * Preserved compatibility with legacy pin mappings when explicitly selected.
  * Confirmed support for GPIO 14 (`D5`) in the default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->