### PR TITLE
fix(esp32): make FastPin toggle per-bit atomic

### DIFF
--- a/ci/tests/test_esp32_fastpin_atomic_toggle.py
+++ b/ci/tests/test_esp32_fastpin_atomic_toggle.py
@@ -1,0 +1,28 @@
+"""Regression contract for ESP32 FastPin atomic GPIO toggling."""
+
+from pathlib import Path
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "platforms"
+    / "esp"
+    / "32"
+    / "core"
+    / "fastpin_esp32.h"
+)
+
+
+def test_esp32_fastpin_toggle_never_rewrites_unrelated_gpio_bits() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    toggle = source[
+        source.index("inline static void toggle()") : source.index(
+            "inline static void hi(FASTLED_REGISTER"
+        )
+    ]
+
+    assert "*port() ^= MASK" not in toggle
+    assert "if (isset())" in toggle
+    assert "lo();" in toggle
+    assert "hi();" in toggle

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -58,7 +58,13 @@ public:
   inline static void strobe() __attribute__ ((always_inline)) { toggle(); toggle(); }
 
   inline static void toggle() FL_NO_EXCEPT __attribute__ ((always_inline)) {
-      *port() ^= MASK;
+      // Never read-modify-write GPIO_OUT: a concurrent GPIO update could be
+      // overwritten. Use the per-bit atomic set/clear registers instead.
+      if (isset()) {
+          lo();
+      } else {
+          hi();
+      }
   }
 
   inline static void hi(FASTLED_REGISTER port_ptr_t port) __attribute__ ((always_inline)) { hi(); }


### PR DESCRIPTION
## Summary
- replace ESP32 FastPin whole-register XOR with per-bit W1TS/W1TC writes
- preserve software-SPI clock toggling without overwriting concurrent GPIO changes
- add a regression contract for the atomic toggle implementation

## Validation
- `PYTEST_ADDOPTS='-k esp32_fastpin_atomic_toggle' bash test --py`
- `bash compile esp32dev --examples Apa102 --defines FASTLED_FORCE_SOFTWARE_SPI`
- `bash lint`
- `clud-review: clean`

Closes #1040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESP32 pin toggling to use atomic set/clear operations.
  - Prevented unintended whole-port updates during pin state changes.

- **Tests**
  - Added regression coverage to verify safe, atomic pin toggling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->