### PR TITLE
docs: add random LED flash troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,32 @@ maintainer and include a minimal FastLED-only reproduction when possible.
 Messages such as `#pragma message: FastLED version ...` are informational build
 output, not warnings or errors.
 
+## Troubleshooting Random Flashes or Wrong Colors
+
+If a steady color produces random pixels, flashes, or resets, first rule out an
+electrical problem. Color-dependent failures are often load-dependent: lighting
+two channels draws more current than lighting one, so a marginal supply can fail
+only for particular RGB values.
+
+1. **Prove the power path.** Power the strip from a regulated 5 V supply sized
+   for the LED load; do not route strip current through a development board's
+   linear regulator. A regulator marked 5.0 V cannot produce regulated 5 V from
+   a 5 V USB input because it needs voltage headroom.
+2. **Use a common ground.** Connect the controller ground, LED ground, and
+   external-supply ground together with short, low-resistance wiring.
+3. **Stabilize the strip input.** Add bulk capacitance across 5 V and ground at
+   the strip, keep the data wire short, and place a 33–220 Ω resistor in series
+   with data near the controller.
+4. **Reduce the test load.** Start with one LED at low brightness and a fixed
+   solid color, then increase LED count and brightness. If corruption begins as
+   load rises, measure the 5 V rail at the strip while it is lit.
+5. **Check logic levels.** When a 3.3 V controller drives a 5 V strip, use a
+   74HCT-family level shifter if the strip does not reliably recognize the data
+   signal.
+
+Once the same minimal sketch and wiring work on a known-good controller and
+power supply, include that A/B result in a FastLED bug report.
+
 ## 🎮 Advanced Features
 
 ### Performance Leaders: Parallel Output Records


### PR DESCRIPTION
## Summary
- document why color-specific random flashes are commonly load-dependent electrical failures
- add power-path, regulator-headroom, grounding, capacitance, signal, and logic-level checks
- require a minimal known-good controller/power A/B result before treating the symptom as a library defect

The schematic in #1044 powers the strip from an AMS1117-5.0 whose input is the same nominal 5 V USB rail. That regulator has no voltage headroom, and the LED current also passes through it, so adding the red channel can push an already marginal rail into corruption.

## Validation
- `git diff --check`
- `bash lint`

Closes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide for LED strips experiencing random flashes, incorrect colors, or resets.
  * Covers power supply validation, grounding, signal stabilization, load reduction, and logic-level compatibility.
  * Includes guidance for preparing reproducible results when reporting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->