### PR TITLE
docs(esp32): clarify show and wait semantics

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1499,15 +1499,17 @@ public:
 
 	/// @} Channel Bus Manager Controls
 
-	/// Wait for all channel bus transmissions to complete
-	/// @note Polls the channel bus manager until it returns READY state
-	/// @note Uses delayMicroseconds(100) between polls to prevent watchdog timeout
-	/// @note Safe to call on all platforms (no-op on platforms without channel bus)
+	/// Wait for channel bus transmissions, up to the manager's default timeout.
+	/// @note Normal animation code does not need to call this after show(); the
+	/// next frame waits before reusing driver-owned data.
+	/// @note For completion-sensitive cleanup, prefer wait(timeout_ms) and check
+	/// its result. The no-argument completion contract is tracked in #3933.
+	/// @note Safe to call on all platforms (no-op on platforms without channel bus).
 	void wait();
 
-	/// Wait for all channel bus transmissions to complete with timeout
-	/// @param timeout_ms Maximum milliseconds to wait (0 = wait forever)
-	/// @return true if all engines became READY, false if timeout occurred
+	/// Wait for all channel bus transmissions to complete with timeout.
+	/// @param timeout_ms Maximum milliseconds to wait (0 = wait forever).
+	/// @return true if all drivers became READY, false if the timeout elapsed.
 	bool wait(fl::u32 timeout_ms);
 
 	/// Set the maximum power to be used, given in volts and milliamps.

--- a/src/platforms/esp/32/README.md
+++ b/src/platforms/esp/32/README.md
@@ -413,6 +413,40 @@ On ESP32, when using 9-16 lanes, the `SPIBusManager` automatically:
 3. Promotes to hexadeca-SPI mode
 4. Uses hardware-accelerated parallel transmission
 
+## `show()`, `wait()`, and FreeRTOS tasks
+
+Normal animation code should not add a fixed delay solely to make
+`FastLED.show()` work. The channel manager waits for the previous frame before
+it reuses driver-owned data for the next one, and the default ESP32 RMT path
+includes the minimum inter-frame latch fix from
+[PR #965](https://github.com/FastLED/FastLED/pull/965). A delay does not need to
+grow with LED count.
+
+`FastLED.delay(ms)` is an animation helper: it repeatedly calls `show()` while
+the interval elapses and yields between calls. Do not use it as a transmission-
+completion primitive in a FreeRTOS task.
+
+If a task must know that RMT, I2S, SPI, or another asynchronous backend has
+finished on the wire, use the explicit completion API:
+
+```cpp
+FastLED.show();
+if (!FastLED.wait(1000)) {
+    // A driver did not complete within one second.
+}
+```
+
+The wait cooperatively runs system work, so lower-priority and network tasks can
+continue. An application may still use `vTaskDelay()`, `fl::delay()`, or its own
+timer to set the animation frame rate; that is task scheduling, not an LED
+protocol requirement.
+
+Exact trait-based reset timing for the selectable IDF4 RMT and ESP32-S3 I2S
+channel backends is tracked in
+[issue #3932](https://github.com/FastLED/FastLED/issues/3932). If a problem is
+specific to one of those backends, an arbitrary application delay may hide the
+symptom, but fixing the backend timing is the correct solution.
+
 ## RMT backends (IDF4 vs IDF5) and how to select
 
 Two RMT implementations exist and are selected by IDF version unless you override it:


### PR DESCRIPTION
## Summary

- explain that `FastLED.delay()` is animation pacing, not an ESP32 transmission-completion primitive
- document checked `FastLED.wait(timeout)` for FreeRTOS tasks that require on-wire completion
- distinguish the default RMT latch fix from the newly tracked RMT4/I2S reset-timing gap
- clarify the current no-argument wait timeout behavior pending #3933

## Validation

- `git diff --check`
- `bash lint`
- `clud-review: clean`

Closes #1049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how `FastLED.wait()` behaves with default and explicit timeouts, including zero-millisecond waits.
  - Documented frame reuse and cleanup considerations when waiting for LED updates to complete.
  - Added FreeRTOS usage guidance for `FastLED.show()`, `FastLED.wait()`, and `FastLED.delay()`, including asynchronous completion and task scheduling considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->