### PR TITLE
fix(core): make FastLED wait unbounded

### DIFF
--- a/ci/tests/test_fastled_wait_completion.py
+++ b/ci/tests/test_fastled_wait_completion.py
@@ -1,0 +1,29 @@
+"""Regression contract for the public FastLED.wait() overloads."""
+
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[2] / "src" / "FastLED.cpp.hpp"
+
+
+def test_no_argument_wait_requests_unbounded_completion() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    no_argument_wait = source[
+        source.index("void CFastLED::wait()") : source.index(
+            "bool CFastLED::wait(fl::u32 timeout_ms)"
+        )
+    ]
+
+    assert "manager.waitForReady(0);" in no_argument_wait
+    assert "manager.waitForReady();" not in no_argument_wait
+
+
+def test_bounded_wait_forwards_the_callers_timeout() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+    bounded_wait = source[
+        source.index("bool CFastLED::wait(fl::u32 timeout_ms)") : source.index(
+            "// Tiered-wait spin-budget shims"
+        )
+    ]
+
+    assert "return manager.waitForReady(timeout_ms);" in bounded_wait

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -634,9 +634,9 @@ fl::span<const fl::DriverInfo> CFastLED::getDriverInfos() const {
 
 void CFastLED::wait() {
 	fl::ChannelManager& manager = fl::channelManager();
-	// Wait for all drivers to become READY
-	// Calls async_run() and uses time-based delays to avoid busy-waiting
-	manager.waitForReady();
+	// A zero timeout means wait indefinitely. The void API cannot report a
+	// timeout, so returning early would violate its completion contract.
+	manager.waitForReady(0);
 }
 
 bool CFastLED::wait(fl::u32 timeout_ms) {

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1499,11 +1499,11 @@ public:
 
 	/// @} Channel Bus Manager Controls
 
-	/// Wait for channel bus transmissions, up to the manager's default timeout.
+	/// Wait for all channel bus transmissions to complete.
 	/// @note Normal animation code does not need to call this after show(); the
 	/// next frame waits before reusing driver-owned data.
-	/// @note For completion-sensitive cleanup, prefer wait(timeout_ms) and check
-	/// its result. The no-argument completion contract is tracked in #3933.
+	/// @note This overload waits indefinitely while cooperatively running system
+	/// work. Use wait(timeout_ms) when the caller needs a bounded wait.
 	/// @note Safe to call on all platforms (no-op on platforms without channel bus).
 	void wait();
 


### PR DESCRIPTION
## Summary

- make no-argument `FastLED.wait()` use the channel manager's existing unbounded wait semantics
- keep the boolean timeout overload unchanged
- document the distinction between indefinite and bounded waits
- add a focused regression contract for both forwarding paths

## Validation

- `PYTEST_ADDOPTS='-k fastled_wait_completion' bash test --py`
- `bash test fastled_core`
- `git diff --check`
- `bash lint`
- `clud-review: clean`

Closes #3933