### PR TITLE
[codex] fix(esp32): honor chipset reset timing

### DIFF
--- a/ci/tests/test_esp32_rmt4_reset_timing.py
+++ b/ci/tests/test_esp32_rmt4_reset_timing.py
@@ -1,0 +1,45 @@
+"""Regression contract for ESP32 RMT4 reset/latch timing."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = (
+    ROOT
+    / "src"
+    / "platforms"
+    / "esp"
+    / "32"
+    / "drivers"
+    / "rmt"
+    / "rmt_4"
+    / "channel_driver_rmt4.h"
+)
+IMPLEMENTATION = HEADER.with_suffix(".cpp.hpp")
+CLOCKLESS = HEADER.parent / "idf4_clockless_rmt_esp32.h"
+
+
+def test_rmt4_keeps_idle_low_until_chipset_reset_time_elapses() -> None:
+    header = HEADER.read_text(encoding="utf-8")
+    implementation = IMPLEMENTATION.read_text(encoding="utf-8")
+    tx_done = header[
+        header.index("FL_NO_INLINE IRAM_ATTR void onTxDoneInterrupt") : header.index(
+            "FL_NO_INLINE IRAM_ATTR void fillNextBuffer"
+        )
+    ]
+
+    assert "resetStartTimeUs" in header
+    assert "resetDurationUs" in header
+    assert "fl::atomic_bool transmissionComplete" in header
+    assert "gpio_matrix_out" not in tx_done
+    assert "transmissionComplete.store(true, fl::memory_order_release)" in tx_done
+    assert "state->resetDurationUs = data->getTiming().reset_us;" in implementation
+    assert "transmissionComplete.load(fl::memory_order_acquire)" in implementation
+    assert "resetElapsedUs < state.resetDurationUs" in implementation
+
+
+def test_rmt4_legacy_wait_time_can_only_extend_trait_reset_time() -> None:
+    source = CLOCKLESS.read_text(encoding="utf-8")
+
+    assert "static_cast<u32>(WAIT_TIME) > timing.reset_us" in source
+    assert "timing.reset_us = static_cast<u32>(WAIT_TIME);" in source

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp.hpp
@@ -380,20 +380,31 @@ bool ChannelEngineI2S::beginTransmission(fl::span<const ChannelDataPtr> channelD
         // Each byte = 64 bits of output (8 Wave8Bit × 8 bits each)
         // Each bit output as one 16-bit word
         // Buffer size = numLeds * 3 * 64 * 2 bytes = numLeds * 384 bytes
-        // Plus padding for reset signal
-        size_t reset_words = 64;  // ~50µs reset at typical clock
-        size_t data_words = static_cast<size_t>(mNumLeds) * mNumComponents * 64;
-        size_t total_words = data_words + reset_words;
-        size_t data_size = total_words * sizeof(u16);
+        // Append a LOW tail long enough for this chipset's reset/latch time.
+        // One uint16_t output word is presented per LCD_CAM pixel clock.
+        const u64 data_words =
+            static_cast<u64>(mNumLeds) * mNumComponents * 64u;
+        size_t data_size = 0;
+        if (!detail::calculateI2sBufferSize(
+                data_words, timing.reset_us, mConfig.pclk_hz, data_size)) {
+            FL_WARN_F("ChannelEngineI2S: DMA buffer size overflow");
+            return false;
+        }
+        const size_t total_words = data_size / sizeof(u16);
         pconfig.max_transfer_bytes = data_size;
         mBufferSize = data_size;
 
         FL_DBG_F("ChannelEngineI2S: Wave8 buffer size = %s bytes (%s words) for %s LEDs", data_size, total_words, mNumLeds);
 #else
         // Legacy transpose encoding
-        size_t offset_start = 0;
-        size_t offset_end = 24 * 3 * 2 * 2 * 2 + 2;
-        size_t data_size = mNumComponents * mNumLeds * 8 * 3 * 2 + offset_start + offset_end;
+        const u64 data_words =
+            static_cast<u64>(mNumComponents) * mNumLeds * 8u * 3u;
+        size_t data_size = 0;
+        if (!detail::calculateI2sBufferSize(
+                data_words, timing.reset_us, mConfig.pclk_hz, data_size)) {
+            FL_WARN_F("ChannelEngineI2S: DMA buffer size overflow");
+            return false;
+        }
         pconfig.max_transfer_bytes = data_size;
         mBufferSize = data_size;
 #endif

--- a/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.h
+++ b/src/platforms/esp/32/drivers/i2s/channel_driver_i2s.h
@@ -65,12 +65,41 @@
 #include "fl/chipsets/led_timing.h"
 #include "fl/stl/span.h"
 #include "fl/stl/atomic.h"
+#include "fl/stl/limits.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/unique_ptr.h"
 #include "platforms/esp/32/drivers/i2s/ii2s_lcd_cam_peripheral.h"
 #include "crgb.h"
 
 namespace fl {
+
+namespace detail {
+
+/// Convert a chipset reset interval to LCD_CAM words, rounding up so the
+/// encoded LOW tail is never shorter than requested.
+inline u64 calculateI2sResetWords(u32 reset_us, u32 pclk_hz) FL_NO_EXCEPT {
+    const u64 clocks = static_cast<u64>(reset_us) * pclk_hz;
+    return (clocks + 999999u) / 1000000u;
+}
+
+/// Calculate the complete DMA buffer size without narrowing or wrapping.
+inline bool calculateI2sBufferSize(u64 data_words, u32 reset_us, u32 pclk_hz,
+                                   size_t& size_bytes) FL_NO_EXCEPT {
+    // allocateBuffer() rounds up to the 64-byte DMA alignment, so reserve the
+    // maximum 63-byte adjustment here as part of the same overflow check.
+    constexpr size_t kDmaAlignmentAdjustment = 63u;
+    const size_t max_buffer_bytes =
+        (fl::numeric_limits<size_t>::max)() - kDmaAlignmentAdjustment;
+    const u64 max_words = static_cast<u64>(max_buffer_bytes) / sizeof(u16);
+    const u64 reset_words = calculateI2sResetWords(reset_us, pclk_hz);
+    if (data_words > max_words || reset_words > max_words - data_words) {
+        return false;
+    }
+    size_bytes = static_cast<size_t>((data_words + reset_words) * sizeof(u16));
+    return true;
+}
+
+} // namespace detail
 
 /// @brief Internal configuration structure for the I2S channel driver
 struct I2sChannelEngineConfig {

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.cpp.hpp
@@ -207,7 +207,9 @@ ChannelEngineRMT4Impl::ChannelState *ChannelEngineRMT4Impl::acquireChannel(
             state.one = makeOneSymbol(timing);
 
             // Reset transmission state
-            state.transmissionComplete = false;
+            state.transmissionComplete.store(false, fl::memory_order_release);
+            state.resetWaitStarted = false;
+            state.resetStartTimeUs = 0;
             state.whichHalf = 0;
             state.pixelDataPos = 0;
             state.pixelData = nullptr;
@@ -252,7 +254,10 @@ ChannelEngineRMT4Impl::ChannelState *ChannelEngineRMT4Impl::acquireChannel(
     ChannelState newState;
     newState.channel = static_cast<rmt_channel_t>(mChannels.size());
     newState.inUse = true;
-    newState.transmissionComplete = false;
+    newState.transmissionComplete.store(false, fl::memory_order_release);
+    newState.resetWaitStarted = false;
+    newState.resetStartTimeUs = 0;
+    newState.resetDurationUs = 0;
     newState.whichHalf = 0;
     newState.memPtr = nullptr;
     newState.memStart = nullptr;
@@ -325,7 +330,10 @@ void ChannelEngineRMT4Impl::releaseChannel(ChannelState *state) FL_NO_EXCEPT {
 
     // Mark channel as idle (available for reuse)
     state->inUse = false;
-    state->transmissionComplete = false;
+    state->transmissionComplete.store(false, fl::memory_order_release);
+    state->resetWaitStarted = false;
+    state->resetStartTimeUs = 0;
+    state->resetDurationUs = 0;
 
     // Clear pixel data reference (buffer is owned by ChannelData)
     state->pixelData = nullptr;
@@ -365,7 +373,9 @@ bool ChannelEngineRMT4Impl::configureChannel(
     state->pin = pin;
     state->zero = makeZeroSymbol(timing);
     state->one = makeOneSymbol(timing);
-    state->transmissionComplete = false;
+    state->transmissionComplete.store(false, fl::memory_order_release);
+    state->resetWaitStarted = false;
+    state->resetStartTimeUs = 0;
     state->whichHalf = 0;
     state->pixelDataPos = 0;
 
@@ -528,7 +538,10 @@ void ChannelEngineRMT4Impl::startTransmission(
     state->pixelDataPos = 0;
     state->whichHalf = 0;
     state->memPtr = state->memStart;
-    state->transmissionComplete = false;
+    state->transmissionComplete.store(false, fl::memory_order_release);
+    state->resetWaitStarted = false;
+    state->resetStartTimeUs = 0;
+    state->resetDurationUs = data->getTiming().reset_us;
     state->lastFill = 0;
     state->transmissionStartTime = fl::millis(); // Start timeout timer
 
@@ -543,7 +556,7 @@ void ChannelEngineRMT4Impl::startTransmission(
         FL_WARN_F("startTransmission: setTxIntrEnable failed on channel %s",
                   state->channel);
         // Mark complete to trigger cleanup in poll()
-        state->transmissionComplete = true;
+        state->transmissionComplete.store(true, fl::memory_order_release);
         data->setInUse(false);
         return;
     }
@@ -610,7 +623,21 @@ IChannelDriver::DriverState ChannelEngineRMT4Impl::poll() FL_NO_EXCEPT {
             continue;
         }
 
-        if (state.transmissionComplete) {
+        if (state.transmissionComplete.load(fl::memory_order_acquire)) {
+            // TX-done leaves the RMT output connected in its configured LOW
+            // idle state. Start the conservative software latch interval on
+            // the first poll after completion; delaying the start can only
+            // lengthen, never shorten, the required LOW period.
+            if (!state.resetWaitStarted) {
+                state.resetWaitStarted = true;
+                state.resetStartTimeUs = fl::micros();
+            }
+            const u32 resetElapsedUs = fl::micros() - state.resetStartTimeUs;
+            if (resetElapsedUs < state.resetDurationUs) {
+                anyBusy = true;
+                continue;
+            }
+
             // Transmission complete - release channel and mark data available
             FL_WARN_F("poll: Channel %s completed", state.channel);
 

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/channel_driver_rmt4.h
@@ -31,6 +31,7 @@
 
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
+#include "fl/stl/atomic.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/shared_ptr.h"
@@ -253,6 +254,67 @@ class ChannelEngineRMT4Impl final : public ChannelEngineRMT4 {
     // Channel State Structure
     // ═══════════════════════════════════════════════════════════════════════════
     struct ChannelState {
+        ChannelState() FL_NO_EXCEPT
+            : channel(static_cast<rmt_channel_t>(0)),
+              pin(static_cast<gpio_num_t>(0)), inUse(false), zero{}, one{},
+              transmissionComplete(false), resetWaitStarted(false),
+              resetStartTimeUs(0), resetDurationUs(0), whichHalf(0),
+              memPtr(nullptr), memStart(nullptr), pixelData(nullptr),
+              pixelDataSize(0), pixelDataPos(0), cyclesPerFill(0),
+              maxCyclesPerFill(0), lastFill(0), transmissionStartTime(0),
+              sourceData() {}
+
+        ChannelState(const ChannelState& other) FL_NO_EXCEPT
+            : channel(other.channel), pin(other.pin), inUse(other.inUse),
+              zero(other.zero), one(other.one),
+              transmissionComplete(other.transmissionComplete.load(
+                  fl::memory_order_acquire)),
+              resetWaitStarted(other.resetWaitStarted),
+              resetStartTimeUs(other.resetStartTimeUs),
+              resetDurationUs(other.resetDurationUs), whichHalf(other.whichHalf),
+              memPtr(other.memPtr), memStart(other.memStart),
+              pixelData(other.pixelData), pixelDataSize(other.pixelDataSize),
+              pixelDataPos(other.pixelDataPos),
+              cyclesPerFill(other.cyclesPerFill),
+              maxCyclesPerFill(other.maxCyclesPerFill), lastFill(other.lastFill),
+              transmissionStartTime(other.transmissionStartTime),
+              sourceData(other.sourceData) {}
+
+        ChannelState& operator=(const ChannelState& other) FL_NO_EXCEPT {
+            if (this != &other) {
+                channel = other.channel;
+                pin = other.pin;
+                inUse = other.inUse;
+                zero = other.zero;
+                one = other.one;
+                transmissionComplete.store(
+                    other.transmissionComplete.load(fl::memory_order_acquire),
+                    fl::memory_order_release);
+                resetWaitStarted = other.resetWaitStarted;
+                resetStartTimeUs = other.resetStartTimeUs;
+                resetDurationUs = other.resetDurationUs;
+                whichHalf = other.whichHalf;
+                memPtr = other.memPtr;
+                memStart = other.memStart;
+                pixelData = other.pixelData;
+                pixelDataSize = other.pixelDataSize;
+                pixelDataPos = other.pixelDataPos;
+                cyclesPerFill = other.cyclesPerFill;
+                maxCyclesPerFill = other.maxCyclesPerFill;
+                lastFill = other.lastFill;
+                transmissionStartTime = other.transmissionStartTime;
+                sourceData = other.sourceData;
+            }
+            return *this;
+        }
+
+        ChannelState(ChannelState&& other) FL_NO_EXCEPT
+            : ChannelState(static_cast<const ChannelState&>(other)) {}
+
+        ChannelState& operator=(ChannelState&& other) FL_NO_EXCEPT {
+            return operator=(static_cast<const ChannelState&>(other));
+        }
+
         // Hardware Configuration
         rmt_channel_t channel;
         gpio_num_t pin;
@@ -263,7 +325,10 @@ class ChannelEngineRMT4Impl final : public ChannelEngineRMT4 {
         rmt_item32_t one;
 
         // Transmission State
-        volatile bool transmissionComplete;
+        fl::atomic_bool transmissionComplete;
+        bool resetWaitStarted;
+        u32 resetStartTimeUs;
+        u32 resetDurationUs;
 
         // Double-Buffer State
         int whichHalf;
@@ -375,9 +440,6 @@ class ChannelEngineRMT4Impl final : public ChannelEngineRMT4 {
             return;
         }
 
-        // Disconnect the GPIO from the RMT controller
-        gpio_matrix_out(state->pin, SIG_GPIO_OUT_IDX, 0, 0);
-
         // Disable TX interrupts for this channel (platform-specific)
 #if defined(FL_IS_ESP_32C3)
         RMT.int_ena.val &= ~(1 << channelNum);
@@ -395,8 +457,10 @@ class ChannelEngineRMT4Impl final : public ChannelEngineRMT4 {
 #error "Unknown ESP32 target for RMT interrupt disable"
 #endif
 
-        // Mark transmission as complete (checked by pollDerived())
-        state->transmissionComplete = true;
+        // Keep the RMT signal connected after TX-done. The channel is
+        // configured idle-low, so poll() can enforce the chipset reset time
+        // before disconnecting and releasing this hardware channel.
+        state->transmissionComplete.store(true, fl::memory_order_release);
     }
 
     FL_NO_INLINE IRAM_ATTR void fillNextBuffer(ChannelState *state,

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/idf4_clockless_rmt_esp32.h
@@ -68,6 +68,9 @@ public:
     {
         // Create channel data with pin and timing configuration
         ChipsetTimingConfig timing = makeTimingConfig<TIMING>();
+        if (WAIT_TIME > 0 && static_cast<u32>(WAIT_TIME) > timing.reset_us) {
+            timing.reset_us = static_cast<u32>(WAIT_TIME);
+        }
         mChannelData = ChannelData::create(DATA_PIN, timing);
     }
 

--- a/tests/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp
+++ b/tests/platforms/esp/32/drivers/i2s/channel_driver_i2s.cpp
@@ -125,6 +125,53 @@ FL_TEST_CASE("ChannelEngineI2S - initial state is READY") {
     FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
 }
 
+FL_TEST_CASE("ChannelEngineI2S - reset words round up to the requested interval") {
+    FL_CHECK_EQ(detail::calculateI2sResetWords(0, 5000000), 0u);
+    FL_CHECK_EQ(detail::calculateI2sResetWords(1, 2400001), 3u);
+    FL_CHECK_EQ(detail::calculateI2sResetWords(50, 5000000), 250u);
+    FL_CHECK_EQ(detail::calculateI2sResetWords(300, 5000000), 1500u);
+
+    size_t sizeBytes = 0;
+    const size_t maxBufferBytes =
+        (fl::numeric_limits<size_t>::max)() - 63u;
+    const u64 maxWords = static_cast<u64>(maxBufferBytes) / sizeof(u16);
+    FL_CHECK(
+        detail::calculateI2sBufferSize(maxWords, 0, 1000000, sizeBytes));
+    FL_CHECK_EQ(sizeBytes, static_cast<size_t>(maxWords * sizeof(u16)));
+    FL_CHECK_FALSE(
+        detail::calculateI2sBufferSize(maxWords, 1, 1000000, sizeBytes));
+}
+
+FL_TEST_CASE("ChannelEngineI2S - DMA buffer includes chipset reset tail") {
+    resetMockState();
+
+    auto peripheral = createMockPeripheral();
+    ChannelEngineI2S driver(peripheral);
+    ChipsetTimingConfig timing(350, 800, 450, 300, "LONG_RESET");
+    fl::vector_psram<uint8_t> data;
+    data.resize(3);
+    auto channelData = ChannelData::create(1, timing, fl::move(data));
+
+    driver.enqueue(channelData);
+    driver.show();
+
+    auto& mock = I2sLcdCamPeripheralMock::instance();
+    const auto& config = mock.getConfig();
+    const size_t dataWords = 3u * 64u;
+    const size_t resetWords =
+        detail::calculateI2sResetWords(timing.reset_us, config.pclk_hz);
+    FL_CHECK_EQ(config.max_transfer_bytes,
+                (dataWords + resetWords) * sizeof(u16));
+    const fl::span<const u16> transmitted = mock.getLastTransmitData();
+    FL_REQUIRE_EQ(transmitted.size(), dataWords + resetWords);
+    for (size_t i = dataWords; i < transmitted.size(); ++i) {
+        FL_CHECK_EQ(transmitted[i], 0u);
+    }
+
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
 //=============================================================================
 // Test Suite: Single Channel Transmission
 //=============================================================================


### PR DESCRIPTION
## Summary

- derive the ESP32-S3 LCD_CAM/I2S LOW reset tail from each chipset's `reset_us` and the actual pixel clock
- keep ESP-IDF 4 RMT output connected idle-LOW until a synchronized, rollover-safe reset interval has elapsed
- treat legacy `WAIT_TIME` as a lower bound, add overflow-safe DMA sizing, and verify the encoded tail is LOW

## Root cause and impact

The alternate ESP32 channel drivers used fixed or implicit reset tails instead of the timing carried by `ChipsetTimingConfig`. Back-to-back frames could therefore start before slower chipsets had latched, causing ignored or corrupted updates. RMT completion was also shared between ISR and task code through `volatile` rather than an atomic.

## Validation

- `PYTEST_ADDOPTS='-k esp32_rmt4_reset_timing' bash test --py`
- `bash test channel_driver_i2s`
- `bash lint`
- `bash compile esp32dev_idf44 --examples Blink` (linked `firmware.elf`/`.bin`; metadata query warned after the successful build)
- ESP32-S3 forced LCD_CAM/I2S build produced fresh linked firmware artifacts
- current IDF5 forced-RMT4 API incompatibilities are separately tracked and deferred in #3936

Closes #3932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESP32 RMT4 timing so channels remain safely idle until the configured chipset reset interval elapses.
  - Preserved the RMT signal connection through transmission completion for more reliable output.
  - Improved legacy wait-time handling without shortening required reset timing.
  - Added safer I2S buffer sizing, including reset-tail data and overflow detection.

- **Tests**
  - Added coverage for ESP32 RMT4 reset and latch timing.
  - Added I2S tests for buffer sizing, reset timing, overflow handling, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->