### PR TITLE
[codex] test(esp32): prove 16-lane I2S SPI output

### DIFF
--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -300,6 +300,13 @@ void setup() {
 
 Including the matching per-driver `bus_traits.h` is the explicit opt-in that makes the `BusTraits<Bus::X>` specialization visible at the call site — without that include the call fails to link and `--gc-sections` stays free to drop the driver TU.
 
+For parallel clocked-SPI output on the original ESP32, include
+`platforms/esp/32/drivers/i2s_spi/bus_traits.h` instead. Register one APA102,
+SK9822, or other clocked-SPI controller per data pin, give every controller the
+same clock pin, and select `Bus::FLEX_IO, 0` before registration as above. The
+I2S-SPI engine batches up to 16 data lanes into one transmission. ESP32-S3 uses
+the shown `lcd_spi/bus_traits.h` include with the same public API.
+
 ---
 
 ## Hardware Engine Selection

--- a/tests/platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp
+++ b/tests/platforms/esp/32/drivers/i2s_spi/channel_driver_i2s_spi.cpp
@@ -276,6 +276,47 @@ FL_TEST_CASE("ChannelDriverI2sSpi - multi-channel transmission") {
     FL_CHECK(history[0].size_bytes == 48 * 3);
 }
 
+FL_TEST_CASE("ChannelDriverI2sSpi - full 16-lane transmission") {
+    resetMockState();
+    auto peripheral = createMockPeripheral();
+    ChannelDriverI2sSpi driver(peripheral);
+    SpiEncoder encoder = SpiEncoder::apa102();
+
+    constexpr size_t kLaneCount = 16;
+    constexpr int kClockPin = 18;
+    for (size_t lane = 0; lane < kLaneCount; ++lane) {
+        SpiChipsetConfig config{static_cast<int>(lane), kClockPin, encoder};
+        fl::vector_psram<u8> data;
+        data.resize(2);
+        data[0] = static_cast<u8>(0xA0 + lane);
+        data[1] = static_cast<u8>(0x10 + lane);
+        driver.enqueue(ChannelData::create(config, fl::move(data)));
+    }
+
+    driver.show();
+
+    auto &mock = I2sSpiPeripheralMock::instance();
+    const I2sSpiConfig &config = mock.getConfig();
+    FL_CHECK_EQ(config.num_lanes, static_cast<int>(kLaneCount));
+    FL_CHECK_EQ(config.clock_gpio, kClockPin);
+    FL_CHECK_EQ(config.max_transfer_bytes, 2 * kLaneCount);
+    for (size_t lane = 0; lane < kLaneCount; ++lane) {
+        FL_CHECK_EQ(config.data_gpios[lane], static_cast<int>(lane));
+    }
+
+    fl::span<const u8> tx = mock.getLastTransmitData();
+    FL_REQUIRE_EQ(tx.size(), 2 * kLaneCount);
+    for (size_t lane = 0; lane < kLaneCount; ++lane) {
+        FL_CHECK_EQ(tx[lane], static_cast<u8>(0xA0 + lane));
+        FL_CHECK_EQ(tx[kLaneCount + lane], static_cast<u8>(0x10 + lane));
+    }
+
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::DRAINING);
+    FL_CHECK(mock.isBusy());
+    mock.simulateTransmitComplete();
+    FL_CHECK(driver.poll() == IChannelDriver::DriverState::READY);
+}
+
 //=============================================================================
 // Interleave Data Correctness
 //=============================================================================


### PR DESCRIPTION
## Summary
- add a full 16-lane regression for the ESP32 I2S parallel-SPI driver
- verify every data GPIO, the shared clock, transfer geometry, exact interleave, and asynchronous lifecycle
- document how original ESP32 and ESP32-S3 sketches select the parallel clocked-SPI path

The I2S_SPI implementation landed on master in 61898e066c; this PR supplies the missing boundary proof and user-facing closeout for the original request.

## Validation
- `bash test channel_driver_i2s_spi`
- `bash lint`
- `clud-review` clean after follow-up

Closes #2130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring parallel clocked-SPI output on the original ESP32.
  * Clarified setup requirements for data lanes, shared clock pins, controller selection, and 16-lane batching.
  * Documented the corresponding ESP32-S3 configuration path.

* **Tests**
  * Added coverage for transmitting data across all 16 I2S-SPI lanes.
  * Verified lane mapping, transmitted data ordering, peripheral configuration, and asynchronous transfer completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->