### PR TITLE
[codex] fix(video): guard zero-sized pixel frames

### DIFF
--- a/src/fl/video/pixel_stream.cpp.hpp
+++ b/src/fl/video/pixel_stream.cpp.hpp
@@ -178,6 +178,9 @@ i32 PixelStream::framesDisplayed() const {
     if (mType == kStreaming) {
         return -1;
     }
+    if (mbytesPerFrame == 0) {
+        return 0;
+    }
     fl::size_t pos = mHandle->pos();
     if (pos < mPayloadOffset) return 0;
     return static_cast<i32>((pos - mPayloadOffset) / mbytesPerFrame);
@@ -192,6 +195,9 @@ i32 PixelStream::bytesRemaining() const {
 }
 
 i32 PixelStream::bytesRemainingInFrame() const {
+    if (mbytesPerFrame == 0) {
+        return 0;
+    }
     return bytesRemaining() % mbytesPerFrame;
 }
 

--- a/tests/fl/fx/video.cpp
+++ b/tests/fl/fx/video.cpp
@@ -19,6 +19,7 @@
 #include "fl/stl/move.h"
 #include "fl/stl/string.h"
 #include "fl/math/xymap.h"
+#include "fl/video/pixel_stream.h"
 #include "FastLED.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -80,6 +81,28 @@ class FakeFilebuf : public fl::filebuf {
     fl::vector<uint8_t> data;
     size_t mPos = 0;
 };
+
+FL_TEST_CASE("PixelStream zero frame size reports no displayed frames") {
+    FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+    const uint8_t byte = 0x42;
+    FL_REQUIRE_EQ(fileHandle->writeData(&byte, 1), 1);
+
+    fl::PixelStream stream(0);
+    FL_REQUIRE(stream.begin(fileHandle));
+    FL_CHECK_EQ(stream.framesDisplayed(), 0);
+    FL_CHECK_EQ(stream.bytesRemainingInFrame(), 0);
+}
+
+FL_TEST_CASE("PixelStream zero frame size preserves streaming semantics") {
+    fl::memorybufPtr memoryStream = fl::make_shared<fl::memorybuf>(3);
+    const CRGB pixel = CRGB::Red;
+    FL_REQUIRE_EQ(memoryStream->writeCRGB(&pixel, 1), 1);
+
+    fl::PixelStream stream(0);
+    FL_REQUIRE(stream.begin(memoryStream));
+    FL_CHECK_EQ(stream.getType(), fl::PixelStream::kStreaming);
+    FL_CHECK_EQ(stream.framesDisplayed(), -1);
+}
 
 FL_TEST_CASE("video with memory stream") {
     // fl::Video video(LEDS_PER_FRAME, FPS);


### PR DESCRIPTION
## Summary
- guard `PixelStream::framesDisplayed()` against division by a zero-sized frame
- guard `bytesRemainingInFrame()` against the matching modulo-by-zero case
- preserve the established `-1` result for non-seekable streaming sources
- add seekable and streaming regression coverage

## Validation
- `bash test video`
- `bash lint`
- clud-review: clean

Closes #3940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of video streams with zero-sized frames.
  * Prevented invalid calculations when tracking displayed frames and remaining bytes.
  * Preserved correct behavior for both file-backed and memory-backed video input.

* **Tests**
  * Added coverage for empty-frame tracking and streaming behavior with zero frame sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->