### PR TITLE
[codex] fix(avr): allow ATmega8A compile tests

### DIFF
--- a/src/platforms/avr/compile_test.hpp
+++ b/src/platforms/avr/compile_test.hpp
@@ -46,11 +46,5 @@ void avr_compile_tests() {
 #ifndef QADD8_AVRASM
 #warning "AVR assembly optimizations may not be enabled"
 #endif
-
-// Arduino's analogReference API depends on this core constant remaining
-// visible after FastLED's platform headers are included.
-#ifndef DEFAULT
-#error "DEFAULT should be defined after including FastLED.h on AVR"
-#endif
 }
 }  // namespace fl


### PR DESCRIPTION
## Summary
- remove an AVR compile-time invariant that incorrectly required every core to expose `DEFAULT`
- restore ATmega8A builds after #3889 moved the old public-header check into an internal implementation translation unit
- leave the actual AVR pin implementation's local analog-reference fallback unchanged

## RED → GREEN
- RED: `bash compile atmega8a --examples Blink` failed in `platforms/avr/compile_test.hpp` because `DEFAULT` was not defined
- GREEN: the same command succeeds (4.62 KB flash, 538 B RAM)

## Validation
- `bash compile atmega8a --examples Blink`
- `bash compile atmega8a all` progressed through and produced fresh metadata for all 24 filtered examples; the command wrapper timed out before returning the aggregate summary, while the compile process then completed without failure logs
- `bash lint`
- clud-review: clean

This repairs the last currently-red workflow tracked by #2779; the other 11 were verified green during triage.

Closes #2779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an AVR compilation issue caused by an overly restrictive compile-time check when including the FastLED library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->