### PR TITLE
fix(ci): skip oversized analog example on ATmega8

### DIFF
--- a/ci/tests/test_sketch_filter.py
+++ b/ci/tests/test_sketch_filter.py
@@ -645,6 +645,36 @@ class TestPintestFilter:
         assert "atmega8" in reason.lower() or "board" in reason.lower()
 
 
+class TestAnalogOutputFilter:
+    """AnalogOutput needs more flash than the ATmega8A provides."""
+
+    def test_analog_output_skips_atmega8a(self) -> None:
+        from pathlib import Path
+
+        from ci.boards import ATMEGA8A, UNO
+
+        analog_output_path = (
+            Path(__file__).parent.parent.parent
+            / "examples"
+            / "AnalogOutput"
+            / "AnalogOutput.ino"
+        )
+        sketch_filter = parse_filter_from_sketch(analog_output_path)
+
+        assert sketch_filter is not None, "AnalogOutput should have a @filter directive"
+        should_skip, reason = should_skip_sketch(ATMEGA8A, sketch_filter)
+
+        assert should_skip is True, (
+            f"atmega8a should be skipped for AnalogOutput (reason: {reason})"
+        )
+        assert "atmega8" in reason.lower() or "board" in reason.lower()
+
+        should_skip, reason = should_skip_sketch(UNO, sketch_filter)
+        assert should_skip is False, (
+            f"uno should compile AnalogOutput (reason: {reason})"
+        )
+
+
 class TestAudioInputFilter:
     """Test AudioInput example filter behavior."""
 

--- a/examples/AnalogOutput/AnalogOutput.ino
+++ b/examples/AnalogOutput/AnalogOutput.ino
@@ -1,3 +1,4 @@
+// @filter: (board is not atmega8*)
 /// @file    AnalogOutput.ino
 /// @brief   Demonstrates how to use FastLED color functions even without a "pixel-addressible" smart LED strip.
 /// @example AnalogOutput.ino


### PR DESCRIPTION
## Summary
- exclude AnalogOutput from atmega8-class boards whose 8 KiB flash cannot hold the 21 KiB controller example
- preserve AnalogOutput on Uno and other capable AVR boards
- add focused ATmega8A/Uno filter regression

## Validation
- focused pytest regression: RED before the filter, GREEN after
- bash compile atmega8a AnalogOutput (filtered successfully)
- bash compile uno AnalogOutput (21.19 KiB, succeeds)
- bash lint examples/AnalogOutput/AnalogOutput.ino ci/tests/test_sketch_filter.py
- clud-review clean

Closes #2779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted the AnalogOutput example to compatible boards, excluding ATmega8A-based boards.
* **Tests**
  * Added automated coverage to verify that the example is skipped for ATmega8A and remains available for UNO boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->