### PR TITLE
docs(channels): clarify release channel names

### DIFF
--- a/src/fl/channels/README.md
+++ b/src/fl/channels/README.md
@@ -448,6 +448,13 @@ config when building one from scratch).
 
 Register callbacks for channel lifecycle events:
 
+`IChannel::name()` is stable only when the channel configuration supplies a
+name. If `ChannelConfig::mName` is unset, FastLED generates `Channel_<id>` only
+when `FASTLED_LOG_RUNTIME_ENABLED` is enabled; builds that compile runtime
+logging out return an empty string instead. Event listeners, telemetry, and
+other code that requires a stable name should use the named `ChannelConfig`
+constructor shown below or assign `config.mName` explicitly.
+
 ```cpp
 #include "FastLED.h"
 #include "fl/channels/channel.h"
@@ -469,6 +476,8 @@ void setup() {
         Serial.printf("%s -> %s\n", ch.name().c_str(), driver.c_str());
     });
 
+    // The named constructor sets ChannelConfig::mName, so callbacks receive
+    // "my_strip" even when FASTLED_LOG_RUNTIME_ENABLED is disabled.
     // Create channel (triggers onChannelCreated)
     auto timing = fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>();
     fl::ChannelConfig config("my_strip", fl::ClocklessChipset(5, timing),


### PR DESCRIPTION
## Summary

- document that auto-generated Channel_<id> names exist only when FASTLED_LOG_RUNTIME_ENABLED is enabled
- explain that unnamed release channels return an empty name when runtime logging is compiled out
- show that callers needing stable event/telemetry names must provide ChannelConfig::mName

## Validation

- source contract checked in Channel::makeName()
- lifecycle example already uses the named ChannelConfig constructor and now explains why
- bash lint src/fl/channels/README.md completed successfully; the repository wrapper reports Markdown as an unconfigured/skipped file type
- git diff --check passes

Closes #3948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how channel names are generated and when they remain stable.
  - Documented that unnamed channels may return an empty name when runtime logging is disabled.
  - Added guidance for assigning explicit channel names when stable identifiers are needed.
  - Expanded the example to show how named channel configurations behave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->