### PR TITLE
fix(lint): preserve code around block comments

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/bare_legacy.rs
+++ b/ci/lint_cpp_rs/src/checkers/bare_legacy.rs
@@ -1,9 +1,8 @@
 // Single-line regex bans ported from the Python checker fleet
 // (FastLED #3297 follow-up to #3288). Each struct here mirrors its
 // Python counterpart's `should_process_file` + `check_file_content`
-// semantics. The block-comment state machine follows the Python
-// "enter only on /* without */, exit only when the next line has */"
-// rule — see the per-checker tests in ../lint_core/tests.rs.
+// semantics. Block comments are stripped before matching so visible code on
+// either side of a multiline comment boundary is still inspected.
 
 // --- BareNoInlineChecker -----------------------------------------------------
 //
@@ -46,10 +45,11 @@ impl FileContentChecker for BareNoInlineChecker {
         let mut violations = Vec::new();
         let mut in_block_comment = false;
         for (index, line) in file_content.lines.iter().enumerate() {
-            if !python_style_pass_through_line(line, &mut in_block_comment, SUPPRESS) {
+            let visible = strip_block_comments_from_line(line, &mut in_block_comment);
+            if visible.trim_start().starts_with("//") || visible.contains(SUPPRESS) {
                 continue;
             }
-            let code = split_line_comment(line);
+            let code = split_line_comment(&visible);
             if regex_bare_noinline().is_match(code) {
                 violations.push((index + 1, line.trim_end().to_string()));
             }
@@ -104,10 +104,11 @@ impl FileContentChecker for BareSnprintfChecker {
         let mut violations = Vec::new();
         let mut in_block_comment = false;
         for (index, line) in file_content.lines.iter().enumerate() {
-            if !python_style_pass_through_line(line, &mut in_block_comment, SUPPRESS) {
+            let visible = strip_block_comments_from_line(line, &mut in_block_comment);
+            if visible.trim_start().starts_with("//") || visible.contains(SUPPRESS) {
                 continue;
             }
-            let code = split_line_comment(line);
+            let code = split_line_comment(&visible);
             for mat in regex_bare_snprintf().find_iter(code) {
                 if printf_family_has_qualifier_prefix(code, mat.start()) {
                     continue;
@@ -176,10 +177,11 @@ impl FileContentChecker for BareLibmChecker {
         let mut violations = Vec::new();
         let mut in_block_comment = false;
         for (index, line) in file_content.lines.iter().enumerate() {
-            if !python_style_pass_through_line(line, &mut in_block_comment, SUPPRESS) {
+            let visible = strip_block_comments_from_line(line, &mut in_block_comment);
+            if visible.trim_start().starts_with("//") || visible.contains(SUPPRESS) {
                 continue;
             }
-            let code = split_line_comment(line);
+            let code = split_line_comment(&visible);
             for mat in regex_bare_libm().find_iter(code) {
                 if libm_has_qualifier_prefix(code, mat.start()) {
                     continue;
@@ -226,10 +228,11 @@ impl FileContentChecker for FlNoUnderscoreChecker {
         let mut violations = Vec::new();
         let mut in_block_comment = false;
         for (index, line) in file_content.lines.iter().enumerate() {
-            if !python_style_pass_through_line(line, &mut in_block_comment, SUPPRESS) {
+            let visible = strip_block_comments_from_line(line, &mut in_block_comment);
+            if visible.trim_start().starts_with("//") || visible.contains(SUPPRESS) {
                 continue;
             }
-            let code = split_line_comment(line);
+            let code = split_line_comment(&visible);
             for mat in regex_fl_no_underscore().find_iter(code) {
                 let token = mat.as_str();
                 if FL_NO_UNDERSCORE_WHITELIST.contains(&token) {
@@ -291,24 +294,14 @@ impl FileContentChecker for LegacyLogMacroChecker {
         let mut violations = Vec::new();
         let mut in_block_comment = false;
         for (index, line) in file_content.lines.iter().enumerate() {
-            // Same block-comment + // line skip as the others, but with an
-            // ADDITIONAL skip on `#define` lines (the original macro
-            // definitions). No `// ok legacy log` suppression by design.
-            let trimmed = line.trim();
-            if in_block_comment {
-                if line.contains("*/") {
-                    in_block_comment = false;
-                }
-                continue;
-            }
-            if line.contains("/*") && !line.contains("*/") {
-                in_block_comment = true;
-                continue;
-            }
+            // Skip line comments and the original macro definitions after
+            // removing block comments. No suppression exists by design.
+            let visible = strip_block_comments_from_line(line, &mut in_block_comment);
+            let trimmed = visible.trim();
             if trimmed.starts_with("//") || trimmed.starts_with("#define") {
                 continue;
             }
-            let code = split_line_comment(line);
+            let code = split_line_comment(&visible);
             let Some(captures) = regex_legacy_log_macro().captures(code) else {
                 continue;
             };
@@ -415,8 +408,8 @@ impl FileContentChecker for IwyuPragmaPrivateChecker {
 // becomes `'999'` + stray digits — fatal parse error. Keep src/ portable
 // across C++11/14/17 by spelling out the digits.
 //
-// Comments are stripped before matching (via the shared
-// `python_style_pass_through_line` helper) so doxygen comments that mention
+// Comments are stripped before matching (via the shared block-comment
+// stripper) so doxygen comments that mention
 // the formula in pseudocode (`// = (ns * hz + 999'999'999) / 1'000'000'000`)
 // stay legal — the compiler never sees them.
 //
@@ -509,36 +502,6 @@ fn strip_double_quoted_strings(code: &str) -> String {
         out.push(ch);
     }
     out
-}
-
-// --- Shared helpers ----------------------------------------------------------
-//
-// All five checkers share the same Python-style "skip line on block comment
-// open or // line comment or // <suppress>" idiom. Centralizing it here keeps
-// the per-checker bodies focused on the rule.
-
-fn python_style_pass_through_line(
-    line: &str,
-    in_block_comment: &mut bool,
-    suppress: &str,
-) -> bool {
-    if *in_block_comment {
-        if line.contains("*/") {
-            *in_block_comment = false;
-        }
-        return false;
-    }
-    if line.contains("/*") && !line.contains("*/") {
-        *in_block_comment = true;
-        return false;
-    }
-    if line.trim_start().starts_with("//") {
-        return false;
-    }
-    if line.contains(suppress) {
-        return false;
-    }
-    true
 }
 
 // `\b` in Rust regex covers identifier-char boundary, but it ALSO allows `:`

--- a/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
+++ b/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
@@ -942,27 +942,67 @@ fn split_line_comment(line: &str) -> &str {
 }
 
 fn strip_block_comments_from_line(line: &str, in_block_comment: &mut bool) -> String {
-    let mut visible = String::new();
-    let mut rest = line;
+    let bytes = line.as_bytes();
+    let mut visible = String::with_capacity(line.len());
+    let mut cursor = 0;
+    let mut visible_start = 0;
 
-    loop {
+    while cursor < bytes.len() {
         if *in_block_comment {
-            let Some(end) = rest.find("*/") else {
-                return visible;
-            };
-            rest = &rest[end + 2..];
-            *in_block_comment = false;
+            if bytes[cursor..].starts_with(b"*/") {
+                cursor += 2;
+                visible_start = cursor;
+                *in_block_comment = false;
+            } else {
+                cursor += 1;
+            }
             continue;
         }
 
-        let Some(start) = rest.find("/*") else {
-            visible.push_str(rest);
+        if bytes[cursor..].starts_with(b"//") {
+            visible.push_str(&line[visible_start..]);
             return visible;
-        };
-        visible.push_str(&rest[..start]);
-        rest = &rest[start + 2..];
-        *in_block_comment = true;
+        }
+        if bytes[cursor..].starts_with(b"/*") {
+            visible.push_str(&line[visible_start..cursor]);
+            cursor += 2;
+            *in_block_comment = true;
+            continue;
+        }
+        if bytes[cursor] == b'"'
+            || (bytes[cursor] == b'\'' && !is_digit_separator_quote(bytes, cursor))
+        {
+            cursor = quoted_literal_end(bytes, cursor, bytes[cursor]);
+            continue;
+        }
+        cursor += 1;
     }
+
+    if !*in_block_comment {
+        visible.push_str(&line[visible_start..]);
+    }
+    visible
+}
+
+fn quoted_literal_end(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor = (cursor + 2).min(bytes.len());
+        } else if bytes[cursor] == quote {
+            return cursor + 1;
+        } else {
+            cursor += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn is_digit_separator_quote(bytes: &[u8], cursor: usize) -> bool {
+    cursor > 0
+        && cursor + 1 < bytes.len()
+        && bytes[cursor - 1].is_ascii_hexdigit()
+        && bytes[cursor + 1].is_ascii_hexdigit()
 }
 
 fn strip_string_literals(code: &str) -> String {

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -645,6 +645,68 @@ constexpr int kX = 5;
         assert!(!checker.should_process_file(&header, &project_root));
     }
 
+    // ---- FastLED#3946: visible code around block comments ----
+
+    #[test]
+    fn bare_noinline_handles_block_comments() {
+        let checker = BareNoInlineChecker;
+        let hits = checker.check_file_content(&file(
+            "src/fl/example.cpp",
+            concat!(
+                "__attribute__((noinline)) void before(); /* comment starts\n",
+                "still commented __attribute__((noinline))\n",
+                "*/ __attribute__((noinline)) void after();\n",
+                "/* __attribute__((noinline)) void hidden(); */\n",
+                "__attribute__((noinline)) void suppressed(); // ok noinline\n",
+                "// documentation mentions /* without opening a comment\n",
+                "const char *marker = \"/*\";\n",
+                "__attribute__((noinline)) void after_literals();\n",
+            ),
+        ));
+        assert_eq!(
+            hits.iter().map(|hit| hit.0).collect::<Vec<_>>(),
+            vec![1, 3, 8]
+        );
+    }
+
+    #[test]
+    fn bare_snprintf_handles_block_comments() {
+        let checker = BareSnprintfChecker;
+        let hits = checker.check_file_content(&file(
+            "src/fl/example.cpp",
+            concat!(
+                "snprintf(buf, sizeof(buf), \"%d\", value); /* comment starts\n",
+                "still commented snprintf(buf, 1, \"x\");\n",
+                "*/ snprintf(buf, sizeof(buf), \"%d\", value);\n",
+                "/* snprintf(buf, sizeof(buf), \"%d\", value); */\n",
+                "snprintf(buf, sizeof(buf), \"%d\", value); // ok snprintf\n",
+            ),
+        ));
+        assert_eq!(
+            hits.iter().map(|hit| hit.0).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+    }
+
+    #[test]
+    fn legacy_log_macro_handles_block_comments() {
+        let checker = LegacyLogMacroChecker;
+        let hits = checker.check_file_content(&file(
+            "src/fl/example.cpp",
+            concat!(
+                "FL_WARN(\"before\"); /* comment starts\n",
+                "still commented FL_WARN(\"hidden\");\n",
+                "*/ FL_ERROR(\"after\");\n",
+                "/* FL_DBG(\"hidden\"); */\n",
+                "#define FL_WARN(...)\n",
+            ),
+        ));
+        assert_eq!(
+            hits.iter().map(|hit| hit.0).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+    }
+
     // ---- FastLED#3287: container raw-pointer checkers ----
 
     #[test]


### PR DESCRIPTION
## Summary
- inspect visible code before and after multiline block-comment boundaries
- ignore block-comment delimiters inside line comments and quoted literals
- preserve existing suppression and legacy `#define` behavior

## Tests
- focused Rust block-comment tests (3 passed)
- Rust formatting check
- `bash lint --cpp`

Closes #3946


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting accuracy for code containing multiline comments, inline comments, and quoted literals.
  * Prevented commented-out or string-contained text from being incorrectly flagged.
  * Preserved detection of valid code surrounding comments and suppression markers.

* **Tests**
  * Added regression coverage for comment and string-literal handling across multiple C++ lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->