### PR TITLE
ci(esp32s3): shard full example sweep

### DIFF
--- a/.github/workflows/build_esp32s3.yml
+++ b/.github/workflows/build_esp32s3.yml
@@ -50,6 +50,13 @@ jobs:
     # `github.event.pull_request == null` lets push / workflow_dispatch / etc.
     # pass; the equality clause only matches when the PR head repo IS the base.
     if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
+    strategy:
+      fail-fast: false
+      # A serial esp32s3 all-example sweep takes several hours because each
+      # sketch rebuilds the framework sources. Keep full coverage while each
+      # reusable-workflow job remains below its 45-minute bound (#3791).
+      matrix:
+        shard_index: [0, 1, 2, 3, 4, 5, 6, 7]
     uses: ./.github/workflows/build_template.yml
     with:
-      args: esp32s3 all
+      args: esp32s3 all --shard-index ${{ matrix.shard_index }} --shard-count 8

--- a/ci/compiler/argument_parser.py
+++ b/ci/compiler/argument_parser.py
@@ -166,6 +166,18 @@ class CompilationArgumentParser:
             "--exclude-examples", type=str, help="Examples that should be excluded"
         )
         parser.add_argument(
+            "--shard-index",
+            type=int,
+            help="Zero-based shard index for an 'all' example build. "
+            "Requires --shard-count.",
+        )
+        parser.add_argument(
+            "--shard-count",
+            type=int,
+            help="Split an 'all' example build into this many deterministic shards. "
+            "Requires --shard-index.",
+        )
+        parser.add_argument(
             "--no-filter",
             action="store_true",
             help="Disable @filter directives (compile even if incompatible with board). "
@@ -373,7 +385,8 @@ class CompilationArgumentParser:
             examples = ["Blink"]
 
         # Check for special 'all' keyword
-        if "all" in examples:
+        requested_all = "all" in examples
+        if requested_all:
             # Remove 'all' keyword and discover all examples
             examples = self._discover_all_examples()
 
@@ -381,6 +394,25 @@ class CompilationArgumentParser:
         if hasattr(args, "exclude_examples") and args.exclude_examples:
             excludes = set(args.exclude_examples.split(","))
             examples = [ex for ex in examples if ex not in excludes]
+
+        # Large cross-platform sweeps can exceed a single CI job's timeout.
+        # Keep the selection derived from the sorted discovery result so every
+        # shard is deterministic, disjoint, and collectively exhaustive.
+        shard_index = getattr(args, "shard_index", None)
+        shard_count = getattr(args, "shard_count", None)
+        if (shard_index is None) != (shard_count is None):
+            raise ValueError("--shard-index and --shard-count must be used together")
+        if shard_index is not None and shard_count is not None:
+            if not requested_all:
+                raise ValueError("example sharding requires the 'all' keyword")
+            if shard_count <= 0:
+                raise ValueError("--shard-count must be a positive integer")
+            if shard_index < 0 or shard_index >= shard_count:
+                raise ValueError(
+                    "--shard-index must be in the range "
+                    f"0..{shard_count - 1}, got {shard_index}"
+                )
+            examples = examples[shard_index::shard_count]
 
         # Validate examples exist
         for example in examples:

--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from ci.compiler.argument_parser import CompilationArgumentParser
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
+    parser = CompilationArgumentParser(ROOT)
+    all_examples = parser._discover_all_examples()
+
+    shards = [
+        parser.parse(
+            [
+                "esp32s3",
+                "all",
+                "--shard-index",
+                str(index),
+                "--shard-count",
+                "8",
+            ]
+        ).examples
+        for index in range(8)
+    ]
+
+    flattened = [example for shard in shards for example in shard]
+    assert sorted(flattened) == all_examples
+    assert len(flattened) == len(set(flattened))
+    assert max(map(len, shards)) - min(map(len, shards)) <= 1
+
+
+@pytest.mark.parametrize(
+    "args, message",
+    [
+        (["esp32s3", "all", "--shard-count", "8"], "must be used together"),
+        (
+            ["esp32s3", "Blink", "--shard-index", "0", "--shard-count", "8"],
+            "requires the 'all' keyword",
+        ),
+        (
+            ["esp32s3", "all", "--shard-index", "0", "--shard-count", "0"],
+            "must be a positive integer",
+        ),
+        (
+            ["esp32s3", "all", "--shard-index", "8", "--shard-count", "8"],
+            "must be in the range 0..7",
+        ),
+    ],
+)
+def test_invalid_example_shards_are_rejected(args: list[str], message: str) -> None:
+    parser = CompilationArgumentParser(ROOT)
+
+    with pytest.raises(ValueError, match=message):
+        parser.parse(args)


### PR DESCRIPTION
Closes #3791.

## What changed

- adds deterministic zero-based `all`-example sharding to `ci-compile`
- runs the ESP32-S3 all-example workflow as eight reusable-workflow matrix jobs
- preserves full coverage while keeping each job below the shared 45-minute bound
- tests exhaustive/disjoint/balanced selection and invalid shard arguments

## Evidence

The current serial workflow is making progress rather than deadlocking: the sampled master job compiled examples successfully at roughly 2.5 minutes each, but timed out after reaching only `Blur2d`. ESP32-S3 filtering leaves 95 supported examples; the eight shards contain 10?13 supported examples each, projecting the largest job to roughly 33 minutes.

Validation:

- `bash lint ci/compiler/argument_parser.py ci/tests/test_compile_example_sharding.py .github/workflows/build_esp32s3.yml`
- `PYTEST_ADDOPTS='-k compile_example_sharding' bash test --py`
- sole `clud-review`: clean

A broader Python run reached 897 passed with the new tests green; its sole unrelated failure was the existing generated `tests/fbuild_qemu_smoke/.fbuild/` fixture linking without `setup()`/`loop()`. Generated QEMU artifacts were not modified or staged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Parallelized ESP32-S3 example builds across eight jobs, helping large builds complete within time limits.
  * Added deterministic sharding options for distributing examples across build jobs.

* **Bug Fixes**
  * Added validation for incomplete, invalid, or out-of-range sharding settings.

* **Tests**
  * Verified shards are balanced, non-overlapping, and collectively cover all examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->