### PR TITLE
fix(net): stabilize RP2350W peer lifecycle

### DIFF
--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -463,16 +463,21 @@ async def run_net_peer_autoresearch(
     primary: RpcClient | None = None
     peer: RpcClient | None = None
 
-    def rpc_timeout() -> float:
+    def rpc_timeout(max_wait: float = 15.0) -> float:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise RpcTimeoutError("--net-peer deadline expired")
-        return min(15.0, remaining)
+        return min(max_wait, remaining)
 
     async def rpc_data(
-        client: RpcClient, method: str, params: dict[str, Any] | None = None
+        client: RpcClient,
+        method: str,
+        params: dict[str, Any] | None = None,
+        max_wait: float = 15.0,
     ) -> dict[str, Any]:
-        response = await client.send(method, params or {}, timeout=rpc_timeout())
+        response = await client.send(
+            method, params or {}, timeout=rpc_timeout(max_wait)
+        )
         if not isinstance(response.data, dict):
             raise RpcError(f"{method} returned a non-object response")
         return response.data
@@ -550,12 +555,18 @@ async def run_net_peer_autoresearch(
                 raise RpcError(f"RP2350W startNetServer failed: {rp_server}")
 
             rp_to_c6 = await rpc_data(
-                primary, "runNetClientTest", {"host_ip": c6_ip, "port": c6_port}
+                primary,
+                "runNetClientTest",
+                {"host_ip": c6_ip, "port": c6_port},
+                max_wait=30.0,
             )
             if not rp_to_c6.get("success"):
                 raise RpcError(f"RP2350W -> ESP32-C6 HTTP failed: {rp_to_c6}")
             c6_to_rp = await rpc_data(
-                peer, "runNetClientTest", {"host_ip": rp_ip, "port": rp_port}
+                peer,
+                "runNetClientTest",
+                {"host_ip": rp_ip, "port": rp_port},
+                max_wait=30.0,
             )
             if not c6_to_rp.get("success"):
                 raise RpcError(f"ESP32-C6 -> RP2350W HTTP failed: {c6_to_rp}")

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -26,9 +26,12 @@ def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:
     peer.close = AsyncMock()
     primary_methods: list[str] = []
     peer_methods: list[str] = []
+    client_test_timeouts: list[float] = []
 
     async def primary_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
         primary_methods.append(method)
+        if method == "runNetClientTest":
+            client_test_timeouts.append(_kwargs["timeout"])
         responses = {
             "status": {"platform": "Raspberry Pi Pico 2 W (RP2350)"},
             "wifiConnect": {"success": True},
@@ -42,6 +45,8 @@ def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:
 
     async def peer_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
         peer_methods.append(method)
+        if method == "runNetClientTest":
+            client_test_timeouts.append(_kwargs["timeout"])
         responses = {
             "status": {"platform": "ESP32-C6 (RISC-V)"},
             "startNetServer": {
@@ -78,6 +83,8 @@ def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:
     assert primary_methods.count("runNetClientTest") == 10
     assert primary_methods.count("stopNet") >= 11
     assert peer_methods.count("runNetClientTest") == 10
+    assert len(client_test_timeouts) == 20
+    assert all(call_timeout > 20.0 for call_timeout in client_test_timeouts)
     assert "ping" in peer_methods
     primary.close.assert_awaited_once()
     peer.close.assert_awaited_once()

--- a/ci/tests/test_fbuild_deploy_streaming.py
+++ b/ci/tests/test_fbuild_deploy_streaming.py
@@ -142,8 +142,9 @@ def test_deploy_output_is_visible_before_process_exits(
     assert "late-line" in result.output
 
 
+@pytest.mark.parametrize("port", ["COM42", "/dev/ttyACM0"])
 def test_deploy_parses_port_marker_from_streamed_output(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, port: str
 ) -> None:
     """FBUILD_DEPLOY_PORT= is still picked up when parsed line-by-line."""
     sink = _RecordingSink()
@@ -152,7 +153,7 @@ def test_deploy_parses_port_marker_from_streamed_output(
         tmp_path,
         script_body=(
             "print('starting', flush=True)\n"
-            "print('FBUILD_DEPLOY_PORT=COM42 extra', flush=True)\n"
+            f"print('FBUILD_DEPLOY_PORT={port} extra', flush=True)\n"
             "print('finished', flush=True)\n"
         ),
         sink=sink,
@@ -162,7 +163,30 @@ def test_deploy_parses_port_marker_from_streamed_output(
         build_dir=tmp_path, environment="esp32s3", timeout=60
     )
     assert result.success is True
-    assert result.port == "COM42"
+    assert result.port == port
+
+
+def test_deploy_ignores_empty_port_marker_before_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty marker must not turn the following semicolon into a port."""
+    sink = _RecordingSink()
+    _install_fake_fbuild(
+        monkeypatch,
+        tmp_path,
+        script_body=(
+            "print('deploy succeeded (full flash); FBUILD_DEPLOY_PORT=; "
+            "firmware flashed but runtime CDC did not recover', flush=True)\n"
+        ),
+        sink=sink,
+    )
+
+    result = fbuild_runner.run_fbuild_deploy(
+        build_dir=tmp_path, environment="rp2350w", timeout=60
+    )
+    assert result.success is True
+    assert result.port is None
+    assert "runtime CDC did not recover" in result.output
 
 
 def test_deploy_reports_failure_exit_code(

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -221,3 +221,10 @@ def test_rp2350w_autoresearch_exposes_the_cyw43_http_peer_surface() -> None:
     assert "fl::Singleton<RpPeerState>::instance()" in net_source
     assert "void pollNetServer()" in net_source
     assert "pollNetServer();" in sketch_source
+    assert "const uint32_t deadline_ms = millis() + 2000;" in net_source
+    assert "state.server->begin();" in net_source
+    assert "if (*state.server)" in net_source
+    assert "FastLED.watchdog().feed();" in net_source
+    assert "delay(10);" in net_source
+    assert "} while (static_cast<int32_t>(millis() - deadline_ms) < 0);" in net_source
+    assert 'response.set("error", "TCP server failed to listen")' in net_source

--- a/ci/util/fbuild_runner.py
+++ b/ci/util/fbuild_runner.py
@@ -788,7 +788,8 @@ def run_fbuild_deploy(
             # later times out or is interrupted mid-flight.
             if marker in line:
                 suffix = line.split(marker, 1)[1].strip()
-                candidate = suffix.split()[0] if suffix else ""
+                marker_value = suffix.partition(";")[0].strip()
+                candidate = marker_value.split()[0] if marker_value else ""
                 if candidate:
                     returned_port = candidate
 

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -994,8 +994,22 @@ fl::json startNetServer() {
     RpPeerState& state = rpPeerState();
     if (!state.server) {
         state.server = fl::make_unique<WiFiServer>(AUTORESEARCH_NET_SERVER_PORT);
-        state.server->begin();
-        state.server->setNoDelay(true);
+        const uint32_t deadline_ms = millis() + 2000;
+        do {
+            state.server->begin();
+            if (*state.server) {
+                state.server->setNoDelay(true);
+                break;
+            }
+            FastLED.watchdog().feed();
+            delay(10);
+        } while (static_cast<int32_t>(millis() - deadline_ms) < 0);
+        if (!*state.server) {
+            state.server.reset();
+            response.set("success", false);
+            response.set("error", "TCP server failed to listen");
+            return response;
+        }
     }
     getNetState().http_server_active = true;
     response.set("success", true);

--- a/src/fl/stl/asio/http/server.cpp.hpp
+++ b/src/fl/stl/asio/http/server.cpp.hpp
@@ -12,6 +12,7 @@
 // Common includes needed by both POSIX/Windows and ESP32 implementations
 #include "fl/stl/cctype.h"
 #include "fl/stl/cstring.h"
+#include "fl/stl/limits.h"
 #include "fl/stl/malloc.h"
 #include "fl/log/log.h"
 
@@ -978,6 +979,16 @@ bool Server::start(int port) {
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.server_port = static_cast<u16>(port);
+    if (mRoutes.size() > (fl::numeric_limits<u16>::max)()) {
+        mLastError = "Too many HTTP routes";
+        FL_WARN_F("%s", "[HTTP] Too many routes for ESP-IDF HTTP server");
+        task::Executor::instance().unregister_runner(mAsyncRunner.get());
+        mAsyncRunner.reset();
+        return false;
+    }
+    if (mRoutes.size() > config.max_uri_handlers) {
+        config.max_uri_handlers = static_cast<u16>(mRoutes.size());
+    }
     // Route handlers execute ON the httpd task and run full fl::json /
     // fl::string / Response machinery. The IDF default stack (4 KB) is
     // not enough for that: overflows landed in adjacent heap blocks and
@@ -991,6 +1002,8 @@ bool Server::start(int port) {
     if (err != ESP_OK) {
         mLastError = "httpd_start failed";
         FL_WARN_F("[HTTP] httpd_start failed: %s", esp_err_to_name(err));
+        task::Executor::instance().unregister_runner(mAsyncRunner.get());
+        mAsyncRunner.reset();
         return false;
     }
 
@@ -1006,7 +1019,15 @@ bool Server::start(int port) {
 
         esp_err_t reg_err = httpd_register_uri_handler(s_esp_httpd, &uri_handler);
         if (reg_err != ESP_OK) {
-            FL_WARN_F("[HTTP] Failed to register route %s", mRoutes[i].path.c_str());
+            mLastError = "Failed to register route " + mRoutes[i].path;
+            FL_WARN_F("[HTTP] Failed to register route %s: %s",
+                      mRoutes[i].path.c_str(), esp_err_to_name(reg_err));
+            httpd_stop(s_esp_httpd);
+            s_esp_httpd = nullptr;
+            s_esp_route_contexts.clear();
+            task::Executor::instance().unregister_runner(mAsyncRunner.get());
+            mAsyncRunner.reset();
+            return false;
         }
         s_esp_route_contexts.push_back(fl::move(ctx));
     }


### PR DESCRIPTION
## Summary

- size the ESP-IDF HTTP URI-handler table from the registered FastLED routes and roll back cleanly on start/registration failure
- give device-side network client checks a bounded 30-second RPC allowance and retry RP2350W listener startup until it is actually open
- treat an empty `FBUILD_DEPLOY_PORT=` marker as no port instead of parsing the following semicolon

Closes #3953
Progresses #3832

## Validation

- `bash lint`
- `bash lint ci/util/fbuild_runner.py ci/tests/test_fbuild_deploy_streaming.py`
- `bash lint ci/tests/test_rp2350w_board_config.py`
- focused Python AutoResearch network/RP2350W board tests
- focused empty-marker RED -> debug RED -> GREEN tests, including COM and POSIX port markers
- `bash test fl_stl_asio_http_server`
- `bash compile esp32c6 --examples AutoResearch`
- `bash compile rp2350w --examples AutoResearch`
- delegated pre-push review: clean

## Hardware evidence and caveat

Before the final RP listener retry, the two-board HIL completed one full RP2350W <-> ESP32-C6 HTTP/RPC/4KiB/serial-health cycle; the next cycle exposed Arduino-Pico `WiFiServer::begin()` silently failing to listen, which this patch now detects and retries.

The next PICOBOOT deployment flashed successfully but the RP2350W runtime CDC endpoint did not return. COM18 is now an exact-serial phantom and Windows reports code 43 at the same direct root port, so final ten-cycle HIL is physically blocked pending recovery. That fbuild regression is recorded and deferred with restart criteria at FastLED/fbuild#1331; no raw flasher, ambiguous PnP reset, or hub/controller reset was attempted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network testing reliability by allowing longer per-request wait times.
  - Enhanced deployment output parsing across Windows and Unix serial-port formats.
  - Empty port markers are now handled safely without losing diagnostic information.
  - Improved HTTP server startup and route-registration failure handling, including clearer error reporting.
  - RP2350W server startup now retries briefly, feeds the watchdog, and reports failures cleanly.
- **Tests**
  - Added coverage for extended network timeouts, port parsing, and RP2350W server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->