### PR TITLE
fix(ble): queue RP2350W notifications instead of clobbering them (#3955)

### DIFF
--- a/ci/autoresearch/ble.py
+++ b/ci/autoresearch/ble.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from colorama import Fore, Style
 
 from ci.rpc_client import RpcClient, RpcTimeoutError
 from ci.util.ble_interface import BLE_CHAR_TX_UUID, BleInterface
+from ci.util.ble_notify_assembler import BleNotificationAssembler
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
@@ -127,17 +128,21 @@ async def run_ble_autoresearch(
         tests_failed = 0
         pong_received = False
 
-        # Try notifications first (preferred mechanism)
-        notification_payload = ""
-        async for line in ble_iface.read_lines(timeout=3.0):
-            notification_payload += line
-            payload = notification_payload
-            if payload.startswith("REMOTE: "):
-                payload = payload[8:]
-            try:
-                parsed = json.loads(payload)
-                result = parsed.get("result", {})
-                if isinstance(result, dict) and result.get("message") == "pong":
+        # Try notifications first (preferred mechanism). Each response is
+        # chunked across ATT-MTU-sized notifications, so fragments are
+        # reassembled per message rather than concatenated into one buffer
+        # that a single malformed value would poison (FastLED#3955).
+        assembler = BleNotificationAssembler()
+        async for fragment in ble_iface.read_lines(timeout=3.0):
+            for parsed in assembler.push(fragment):
+                if not isinstance(parsed, dict):
+                    continue
+                message = cast("dict[str, Any]", parsed)
+                result_value = message.get("result", {})
+                if not isinstance(result_value, dict):
+                    continue
+                result = cast("dict[str, Any]", result_value)
+                if result.get("message") == "pong":
                     print(
                         f"  {Fore.GREEN}PASS{Style.RESET_ALL} - "
                         f"Received pong via NOTIFY (transport={result.get('transport', '?')}, "
@@ -146,8 +151,8 @@ async def run_ble_autoresearch(
                     tests_passed += 1
                     pong_received = True
                     break
-            except json.JSONDecodeError:
-                continue
+            if pong_received:
+                break
 
         # Fallback: read TX characteristic value directly
         if not pong_received and ble_iface._client:

--- a/ci/tests/test_ble_notification_assembler.py
+++ b/ci/tests/test_ble_notification_assembler.py
@@ -1,0 +1,130 @@
+"""Tests for BLE notification reassembly (FastLED#3955).
+
+The RP2350W transport chunks each JSON-RPC response across ATT-MTU-sized
+notifications. The reader must reassemble those fragments, deliver each
+complete value independently, and stay usable after a malformed value.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any
+
+from ci.util.ble_notify_assembler import (
+    REMOTE_PREFIX,
+    BleNotificationAssembler,
+)
+
+
+def _pong(ident: int = 1) -> str:
+    return REMOTE_PREFIX + json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": ident,
+            "result": {"message": "pong", "transport": "ble", "uptimeMs": 1234},
+        },
+        separators=(",", ":"),
+    )
+
+
+def _chunks(text: str, size: int) -> list[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+class TestBleNotificationAssembler(unittest.TestCase):
+    def test_single_notification_parses(self) -> None:
+        asm = BleNotificationAssembler()
+        values = asm.push(_pong())
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["result"]["message"], "pong")
+
+    def test_reassembles_mtu_fragments(self) -> None:
+        """One response split across many notifications yields one value."""
+        asm = BleNotificationAssembler()
+        message = _pong()
+        collected: list[Any] = []
+        fragments = _chunks(message, 20)
+        self.assertGreater(len(fragments), 1, "test needs a fragmented message")
+        for fragment in fragments:
+            collected.extend(asm.push(fragment))
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["result"]["message"], "pong")
+
+    def test_two_responses_in_one_stream_are_independent(self) -> None:
+        """A second complete value must not be appended to the first."""
+        asm = BleNotificationAssembler()
+        first = asm.push(_pong(1))
+        second = asm.push(_pong(2))
+        self.assertEqual(len(first), 1)
+        self.assertEqual(len(second), 1)
+        self.assertEqual(first[0]["id"], 1)
+        self.assertEqual(second[0]["id"], 2)
+
+    def test_two_responses_in_a_single_fragment(self) -> None:
+        asm = BleNotificationAssembler()
+        values = asm.push(_pong(1) + _pong(2))
+        self.assertEqual([v["id"] for v in values], [1, 2])
+
+    def test_valid_pong_after_malformed_value(self) -> None:
+        """The regression: garbage must not poison the buffer forever."""
+        asm = BleNotificationAssembler()
+        self.assertEqual(asm.push(REMOTE_PREFIX + "{not json"), [])
+        values = asm.push(_pong(7))
+        self.assertEqual(len(values), 1, "valid pong must survive a bad predecessor")
+        self.assertEqual(values[0]["id"], 7)
+
+    def test_valid_pong_after_unrelated_complete_value(self) -> None:
+        """A complete non-matching value must not absorb the next one."""
+        asm = BleNotificationAssembler()
+        noise = asm.push(REMOTE_PREFIX + '{"jsonrpc":"2.0","id":0,"result":{}}')
+        self.assertEqual(len(noise), 1)
+        values = asm.push(_pong(2))
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["result"]["message"], "pong")
+
+    def test_partial_value_is_held_not_dropped(self) -> None:
+        asm = BleNotificationAssembler()
+        message = _pong(3)
+        head, tail = message[:25], message[25:]
+        self.assertEqual(asm.push(head), [])
+        self.assertNotEqual(asm.buffered, "")
+        values = asm.push(tail)
+        self.assertEqual(len(values), 1)
+        self.assertEqual(asm.buffered, "")
+
+    def test_values_without_prefix_still_parse(self) -> None:
+        """The READ-characteristic fallback has no REMOTE: marker."""
+        asm = BleNotificationAssembler()
+        values = asm.push('{"jsonrpc":"2.0","id":9,"result":{"message":"pong"}}')
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["id"], 9)
+
+    def test_whitespace_and_newline_delimiters_are_tolerated(self) -> None:
+        asm = BleNotificationAssembler()
+        values = asm.push("\n" + _pong(4) + "\n")
+        self.assertEqual(len(values), 1)
+        values = asm.push("  " + _pong(5) + "  \n")
+        self.assertEqual(len(values), 1)
+
+    def test_runaway_garbage_is_bounded(self) -> None:
+        asm = BleNotificationAssembler(max_buffer=64)
+        self.assertEqual(asm.push("{" + "x" * 200), [])
+        self.assertLessEqual(len(asm.buffered), 64)
+        # Still usable afterwards.
+        values = asm.push(_pong(6))
+        self.assertEqual(len(values), 1)
+
+    def test_reset_clears_partial_state(self) -> None:
+        asm = BleNotificationAssembler()
+        asm.push(_pong(8)[:20])
+        self.assertNotEqual(asm.buffered, "")
+        asm.reset()
+        self.assertEqual(asm.buffered, "")
+        values = asm.push(_pong(9))
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["id"], 9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_ble_notification_assembler.py
+++ b/ci/tests/test_ble_notification_assembler.py
@@ -83,6 +83,34 @@ class TestBleNotificationAssembler(unittest.TestCase):
         self.assertEqual(len(values), 1)
         self.assertEqual(values[0]["result"]["message"], "pong")
 
+    def test_embedded_marker_does_not_truncate_a_valid_message(self) -> None:
+        """A payload may legitimately contain the literal REMOTE: marker.
+
+        Resyncing on any occurrence of it inside the buffer would chop a
+        half-arrived message in two and destroy it.
+        """
+        asm = BleNotificationAssembler()
+        message = REMOTE_PREFIX + json.dumps(
+            {"jsonrpc": "2.0", "id": 5, "result": {"log": "REMOTE: hello"}},
+            separators=(",", ":"),
+        )
+        collected: list[Any] = []
+        for fragment in _chunks(message, 20):
+            collected.extend(asm.push(fragment))
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["result"]["log"], "REMOTE: hello")
+        self.assertEqual(asm.buffered, "")
+
+    def test_new_fragment_boundary_drops_a_stranded_partial(self) -> None:
+        """A response that never completed must not swallow the next one."""
+        asm = BleNotificationAssembler()
+        # First response is cut off mid-flight (device reset, link drop).
+        self.assertEqual(asm.push(REMOTE_PREFIX + '{"id":1,"result":{"mess'), [])
+        # The next fragment starts a fresh message.
+        values = asm.push(_pong(11))
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["id"], 11)
+
     def test_partial_value_is_held_not_dropped(self) -> None:
         asm = BleNotificationAssembler()
         message = _pong(3)

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -68,8 +68,34 @@ def test_rp2350w_ble_transport_uses_btstack_with_singleton_state() -> None:
     assert "fl::Singleton<RpBleRuntime>" in source
     assert "att_server_request_to_send_notification" in source
     assert "att_server_get_mtu" in source
-    assert "notification_offset" in source
+    # Outbound responses queue in a bounded FIFO and drain in ATT-MTU
+    # chunks; a single shared buffer truncated an in-flight response when
+    # a second one was produced mid-transfer (FastLED#3955).
+    assert "BleNotifyQueue notifications" in source
+    assert "notifications.chunkSize" in source
+    assert "notifications.advance" in source
     assert "notify failed: %u" in source
+
+
+def test_rp2350w_ble_disconnect_clears_pending_notification_state() -> None:
+    """A dropped link must not leave the send-registration flags latched.
+
+    Otherwise a request that registered just before the drop blocks every
+    send on the next connection (FastLED#3955).
+    """
+    source = RP_BLE_IMPL.read_text(encoding="utf-8")
+
+    disconnect = source[
+        source.index("static void onDisconnected(") : source.index("TransportState* createTransport(")
+    ]
+    assert "notifications.clear()" in disconnect
+    assert "notification_scheduled = false" in disconnect
+    assert "notification_callback_pending = false" in disconnect
+
+    destroy = source[
+        source.index("void destroyTransport(") : source.index("StatusInfo queryStatus(")
+    ]
+    assert "notification_callback_pending = false" in destroy
 
 
 def test_rp2350_and_rp2350w_keep_distinct_board_profiles() -> None:

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -86,7 +86,9 @@ def test_rp2350w_ble_disconnect_clears_pending_notification_state() -> None:
     source = RP_BLE_IMPL.read_text(encoding="utf-8")
 
     disconnect = source[
-        source.index("static void onDisconnected(") : source.index("TransportState* createTransport(")
+        source.index("static void onDisconnected(") : source.index(
+            "TransportState* createTransport("
+        )
     ]
     assert "notifications.clear()" in disconnect
     assert "notification_scheduled = false" in disconnect

--- a/ci/util/ble_interface.py
+++ b/ci/util/ble_interface.py
@@ -1,20 +1,21 @@
-"""BLE serial interface adapter for FastLED validation.
+"""BLE GATT interface adapter for FastLED validation.
 
-Implements the SerialInterface protocol using Bleak (cross-platform BLE GATT client).
-This allows RpcClient to communicate over BLE using the same interface as serial.
+Wraps Bleak (cross-platform BLE GATT client) for talking to the device's
+JSON-RPC service.
 
-Usage:
-    iface = BleInterface(device_name="FastLED-C6")
-    await iface.connect()
-    await iface.write('{"jsonrpc":"2.0","method":"ping","id":1}\\n')
-    async for line in iface.read_lines(timeout=10.0):
-        print(line)
-    await iface.close()
+Note this is NOT interchangeable with SerialInterface for RpcClient:
+``read_lines`` yields raw ATT notification fragments, not whole lines. One
+response can span several fragments and one fragment can hold several
+responses, so a consumer doing ``line.startswith(prefix)`` per item will
+misparse. Feed the fragments through
+``ci.util.ble_notify_assembler.BleNotificationAssembler`` instead — see
+FastLED#3955.
 """
 
 from __future__ import annotations
 
 import asyncio
+import codecs
 from collections.abc import AsyncIterator
 
 from bleak import BleakClient, BleakGATTCharacteristic, BleakScanner
@@ -42,6 +43,10 @@ class BleInterface:
         self._scan_timeout = scan_timeout
         self._client: BleakClient | None = None
         self._rx_queue: asyncio.Queue[str] = asyncio.Queue()
+        # A multi-byte UTF-8 sequence can straddle two notifications. An
+        # incremental decoder holds the partial sequence until the rest
+        # arrives instead of emitting U+FFFD on both sides of the split.
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
     def _notification_handler(
         self, _sender: BleakGATTCharacteristic, data: bytearray
@@ -54,7 +59,7 @@ class BleInterface:
         reassembled JSON (FastLED#3955). Consumers trim at message
         boundaries instead — see ci/util/ble_notify_assembler.py.
         """
-        text = data.decode("utf-8", errors="replace")
+        text = self._decoder.decode(bytes(data))
         if text:
             self._rx_queue.put_nowait(text)
 
@@ -76,6 +81,7 @@ class BleInterface:
         print(f"  [BLE] Connected to {device.address}")
 
         # Subscribe to NOTIFY on TX characteristic
+        self._decoder.reset()
         await client.start_notify(BLE_CHAR_TX_UUID, self._notification_handler)
         print(f"  [BLE] Subscribed to TX notifications")
 

--- a/ci/util/ble_interface.py
+++ b/ci/util/ble_interface.py
@@ -46,8 +46,15 @@ class BleInterface:
     def _notification_handler(
         self, _sender: BleakGATTCharacteristic, data: bytearray
     ) -> None:
-        """Callback invoked by Bleak when device sends a NOTIFY on TX char."""
-        text = data.decode("utf-8", errors="replace").strip()
+        """Callback invoked by Bleak when device sends a NOTIFY on TX char.
+
+        The value is queued verbatim. A response longer than ATT_MTU - 3
+        arrives as several notifications, so stripping each one would drop
+        whitespace that falls on a chunk boundary and corrupt the
+        reassembled JSON (FastLED#3955). Consumers trim at message
+        boundaries instead — see ci/util/ble_notify_assembler.py.
+        """
+        text = data.decode("utf-8", errors="replace")
         if text:
             self._rx_queue.put_nowait(text)
 
@@ -102,7 +109,9 @@ class BleInterface:
             timeout: Maximum time to wait for lines in seconds.
 
         Yields:
-            Lines from BLE notifications (stripped of whitespace).
+            Raw notification values, in arrival order. These are ATT
+            fragments, not necessarily whole lines: one logical message
+            may span several, and one value may hold several messages.
         """
         deadline = asyncio.get_event_loop().time() + timeout
         while True:

--- a/ci/util/ble_notify_assembler.py
+++ b/ci/util/ble_notify_assembler.py
@@ -1,0 +1,93 @@
+"""Reassemble ATT-fragmented BLE notifications into complete JSON values.
+
+The device chunks each JSON-RPC response into ``ATT_MTU - 3`` byte
+notifications, so one logical response can arrive as several notification
+values, and several responses can arrive back to back. The only message
+marker on the wire is the ``REMOTE: `` prefix each response starts with.
+
+The naive reader concatenated every notification into one buffer that was
+never reset, so a single unparseable value poisoned the buffer and every
+later response — including a valid ``pong`` — failed to parse forever
+(FastLED#3955). This assembler instead consumes exactly the bytes that
+form each complete JSON value and resynchronizes on the next message
+marker when it meets garbage.
+
+Deliberately free of any ``bleak`` import so the parsing contract can be
+unit-tested on a host without BLE support.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+REMOTE_PREFIX = "REMOTE: "
+
+# Cap on unparseable backlog. A response is a few hundred bytes, so a
+# buffer this large means the stream desynchronized; dropping it is better
+# than growing without bound on a chatty or corrupt link.
+MAX_BUFFER_CHARS = 16384
+
+_DECODER = json.JSONDecoder()
+
+
+class BleNotificationAssembler:
+    """Feed notification fragments in, get complete JSON values out."""
+
+    def __init__(
+        self, prefix: str = REMOTE_PREFIX, max_buffer: int = MAX_BUFFER_CHARS
+    ) -> None:
+        self._prefix = prefix
+        self._max_buffer = max_buffer
+        self._buffer = ""
+
+    @property
+    def buffered(self) -> str:
+        """Bytes held back waiting for the rest of a value (test visibility)."""
+        return self._buffer
+
+    def reset(self) -> None:
+        """Drop partial state — e.g. after a disconnect."""
+        self._buffer = ""
+
+    def push(self, fragment: str) -> list[Any]:
+        """Add one notification value; return every JSON value it completed.
+
+        Returns an empty list while a value is still incomplete. Values are
+        returned in arrival order, so a valid response is still delivered
+        when it follows a malformed one.
+        """
+        if fragment:
+            self._buffer += fragment
+
+        values: list[Any] = []
+        while True:
+            buf = self._buffer.lstrip()
+            if buf.startswith(self._prefix):
+                buf = buf[len(self._prefix) :].lstrip()
+            if not buf:
+                self._buffer = ""
+                break
+
+            try:
+                value, end = _DECODER.raw_decode(buf)
+            except ValueError:
+                # Either the value is still arriving, or it is garbage. If a
+                # later message marker is already in the buffer, this value
+                # can never complete — skip to that marker so one bad value
+                # does not swallow the ones behind it.
+                marker = buf.find(self._prefix, 1)
+                if marker > 0:
+                    self._buffer = buf[marker:]
+                    continue
+                if len(buf) > self._max_buffer:
+                    self._buffer = ""
+                else:
+                    self._buffer = buf
+                break
+
+            values.append(value)
+            self._buffer = buf[end:]
+
+        return values

--- a/ci/util/ble_notify_assembler.py
+++ b/ci/util/ble_notify_assembler.py
@@ -9,8 +9,15 @@ The naive reader concatenated every notification into one buffer that was
 never reset, so a single unparseable value poisoned the buffer and every
 later response — including a valid ``pong`` — failed to parse forever
 (FastLED#3955). This assembler instead consumes exactly the bytes that
-form each complete JSON value and resynchronizes on the next message
-marker when it meets garbage.
+form each complete JSON value, and resynchronizes only at a real message
+boundary: the start of a fragment.
+
+Resyncing on *any* occurrence of the marker inside the buffer would be
+wrong, because a payload may legitimately contain the literal
+``REMOTE: `` inside a JSON string (the device echoes host lines that
+carry that prefix). Searching the buffer would then chop a valid
+half-arrived message in two. A response only ever *begins* at the start
+of a fragment, so that is the only place a boundary is honored.
 
 Deliberately free of any ``bleak`` import so the parsing contract can be
 unit-tested on a host without BLE support.
@@ -58,8 +65,16 @@ class BleNotificationAssembler:
         returned in arrival order, so a valid response is still delivered
         when it follows a malformed one.
         """
-        if fragment:
-            self._buffer += fragment
+        if not fragment:
+            return []
+
+        # A fragment starting with the marker begins a new response. Anything
+        # still buffered at that point never completed, so drop it rather
+        # than let it swallow the message that is starting now.
+        if fragment.lstrip().startswith(self._prefix) and self._buffer:
+            self._buffer = ""
+
+        self._buffer += fragment
 
         values: list[Any] = []
         while True:
@@ -73,18 +88,11 @@ class BleNotificationAssembler:
             try:
                 value, end = _DECODER.raw_decode(buf)
             except ValueError:
-                # Either the value is still arriving, or it is garbage. If a
-                # later message marker is already in the buffer, this value
-                # can never complete — skip to that marker so one bad value
-                # does not swallow the ones behind it.
-                marker = buf.find(self._prefix, 1)
-                if marker > 0:
-                    self._buffer = buf[marker:]
-                    continue
-                if len(buf) > self._max_buffer:
-                    self._buffer = ""
-                else:
-                    self._buffer = buf
+                # Still arriving, or garbage. Either way it can only be
+                # resolved by the next fragment that starts a new message;
+                # hold it until then, bounded so a corrupt link cannot grow
+                # the buffer without limit.
+                self._buffer = "" if len(buf) > self._max_buffer else buf
                 break
 
             values.append(value)

--- a/src/fl/net/ble_notify_queue.h
+++ b/src/fl/net/ble_notify_queue.h
@@ -1,0 +1,140 @@
+#pragma once
+
+/// @file ble_notify_queue.h
+/// @brief Bounded outbound FIFO for chunked BLE GATT notifications.
+///
+/// A GATT notification carries at most `ATT_MTU - 3` bytes, so a JSON-RPC
+/// response usually needs several sends. The transport therefore holds a
+/// payload across multiple `can-send-now` callbacks while it drains.
+///
+/// Storing that in-flight payload in a single buffer loses data: when a
+/// second response is produced before the first finishes draining, the
+/// sink overwrites the buffer and the peer receives a truncated first
+/// response followed by the whole second one (FastLED#3955). This queue
+/// keeps completed responses in order and only advances to the next one
+/// after the final chunk of the current one is accepted.
+///
+/// The queue is deliberately platform-independent — no BTstack, no NimBLE,
+/// no ATT types — so the ordering and chunking contract is covered by host
+/// unit tests (`tests/fl/net/ble_notify_queue.cpp`) on targets that have no
+/// BLE silicon.
+
+#include "fl/stl/int.h"
+#include "fl/stl/vector.h"
+
+namespace fl {
+namespace net {
+namespace ble {
+
+/// Bounded FIFO of outbound notification payloads, drained in MTU-sized
+/// chunks.
+///
+/// Exactly one payload is "in flight" at a time: `chunkData()` /
+/// `chunkSize()` always describe the front payload at the current offset,
+/// and the front is popped only once `advance()` has consumed all of it.
+class BleNotifyQueue {
+  public:
+    /// Maximum number of complete responses held at once.
+    ///
+    /// Responses are produced by the RPC layer one request at a time, so a
+    /// depth of 4 absorbs a burst without letting a peer that never drains
+    /// grow the heap without bound. Pushing past this fails rather than
+    /// dropping an already-queued response — losing the *oldest* response
+    /// would corrupt an transfer already partly on the wire.
+    static constexpr size_t kCapacity = 4;
+
+    /// Append a complete payload.
+    ///
+    /// @return false when the queue is full; the caller should report the
+    ///         drop rather than silently losing the response.
+    bool push(const char *data, size_t size) {
+        if (data == nullptr || size == 0 || mCount >= kCapacity) {
+            return false;
+        }
+        fl::vector<u8> &slot = mSlots[mTail];
+        slot.clear();
+        slot.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            slot.push_back(static_cast<u8>(data[i]));
+        }
+        mTail = (mTail + 1) % kCapacity;
+        ++mCount;
+        return true;
+    }
+
+    /// True when nothing is waiting to be sent.
+    bool empty() const { return mCount == 0; }
+
+    /// Number of complete payloads queued, including the one in flight.
+    size_t depth() const { return mCount; }
+
+    /// Bytes of the in-flight payload not yet accepted by the stack.
+    size_t remaining() const {
+        if (mCount == 0) {
+            return 0;
+        }
+        const size_t size = mSlots[mHead].size();
+        return mOffset >= size ? 0 : size - mOffset;
+    }
+
+    /// Start of the next chunk, or nullptr when the queue is empty.
+    const u8 *chunkData() const {
+        if (remaining() == 0) {
+            return nullptr;
+        }
+        return mSlots[mHead].data() + mOffset;
+    }
+
+    /// Size of the next chunk, capped at @p max_payload.
+    ///
+    /// Never rounds up past what is left of the in-flight payload, so a
+    /// caller can hand the result straight to `att_server_notify()`.
+    size_t chunkSize(size_t max_payload) const {
+        const size_t left = remaining();
+        if (max_payload == 0) {
+            return 0;
+        }
+        return left < max_payload ? left : max_payload;
+    }
+
+    /// Record that @p sent bytes were accepted by the stack.
+    ///
+    /// Pops the front payload once it has been fully sent, so the next
+    /// `chunkData()` describes the following response.
+    void advance(size_t sent) {
+        if (mCount == 0 || sent == 0) {
+            return;
+        }
+        const size_t size = mSlots[mHead].size();
+        mOffset += sent;
+        if (mOffset >= size) {
+            mSlots[mHead].clear();
+            mHead = (mHead + 1) % kCapacity;
+            --mCount;
+            mOffset = 0;
+        }
+    }
+
+    /// Drop every queued payload — used when the link goes away.
+    void clear() {
+        for (size_t i = 0; i < kCapacity; ++i) {
+            mSlots[i].clear();
+        }
+        mHead = 0;
+        mTail = 0;
+        mCount = 0;
+        mOffset = 0;
+    }
+
+  private:
+    fl::vector<u8> mSlots[kCapacity];
+    size_t mHead = 0;
+    size_t mTail = 0;
+    size_t mCount = 0;
+    /// Bytes of `mSlots[mHead]` already accepted by the stack.
+    size_t mOffset = 0;
+};
+
+} // namespace ble
+} // namespace net
+} // namespace fl

--- a/src/fl/net/ble_notify_queue.h
+++ b/src/fl/net/ble_notify_queue.h
@@ -14,6 +14,28 @@
 /// keeps completed responses in order and only advances to the next one
 /// after the final chunk of the current one is accepted.
 ///
+/// @section threading Threading model
+///
+/// Single producer, single consumer, like the RX ring in the same
+/// transport:
+///
+/// - **Producer** (application / RPC pump context) calls `push()` only.
+///   It writes `mSlots[mTail]` and then publishes it by advancing
+///   `mTail`.
+/// - **Consumer** (BTstack can-send-now callback) calls `chunkData()`,
+///   `chunkSize()`, `remaining()` and `advance()` only. It reads
+///   `mSlots[mHead]` and owns `mOffset` outright.
+///
+/// The two sides therefore never write the same variable, so no
+/// read-modify-write can be lost — which is why depth is *derived* from
+/// the two indices rather than kept in a shared counter. `mHead` and
+/// `mTail` are `volatile` so neither side caches the other's index, the
+/// same treatment the RX ring gives its own indices.
+///
+/// `clear()` is the one exception: it resets both sides at once and must
+/// only be called when the link is already down and no send callback can
+/// be in flight (from `onDisconnected` / `destroyTransport`).
+///
 /// The queue is deliberately platform-independent — no BTstack, no NimBLE,
 /// no ATT types — so the ordering and chunking contract is covered by host
 /// unit tests (`tests/fl/net/ble_notify_queue.cpp`) on targets that have no
@@ -40,37 +62,55 @@ class BleNotifyQueue {
     /// depth of 4 absorbs a burst without letting a peer that never drains
     /// grow the heap without bound. Pushing past this fails rather than
     /// dropping an already-queued response — losing the *oldest* response
-    /// would corrupt an transfer already partly on the wire.
+    /// would corrupt a transfer already partly on the wire.
     static constexpr size_t kCapacity = 4;
 
-    /// Append a complete payload.
+  private:
+    /// One spare slot keeps "empty" and "full" distinguishable without a
+    /// shared count, which is what makes the ring safe across the two
+    /// contexts.
+    static constexpr size_t kSlots = kCapacity + 1;
+
+    static size_t next(size_t index) { return (index + 1) % kSlots; }
+
+  public:
+    /// Append a complete payload. Producer side.
     ///
     /// @return false when the queue is full; the caller should report the
     ///         drop rather than silently losing the response.
     bool push(const char *data, size_t size) {
-        if (data == nullptr || size == 0 || mCount >= kCapacity) {
+        if (data == nullptr || size == 0) {
             return false;
         }
-        fl::vector<u8> &slot = mSlots[mTail];
+        const size_t tail = mTail;
+        const size_t advanced = next(tail);
+        if (advanced == mHead) {
+            return false; // full
+        }
+        fl::vector<u8> &slot = mSlots[tail];
         slot.clear();
         slot.reserve(size);
         for (size_t i = 0; i < size; ++i) {
             slot.push_back(static_cast<u8>(data[i]));
         }
-        mTail = (mTail + 1) % kCapacity;
-        ++mCount;
+        // Publish only after the slot is fully written.
+        mTail = advanced;
         return true;
     }
 
     /// True when nothing is waiting to be sent.
-    bool empty() const { return mCount == 0; }
+    bool empty() const { return mHead == mTail; }
 
     /// Number of complete payloads queued, including the one in flight.
-    size_t depth() const { return mCount; }
+    size_t depth() const {
+        const size_t head = mHead;
+        const size_t tail = mTail;
+        return (tail + kSlots - head) % kSlots;
+    }
 
     /// Bytes of the in-flight payload not yet accepted by the stack.
     size_t remaining() const {
-        if (mCount == 0) {
+        if (empty()) {
             return 0;
         }
         const size_t size = mSlots[mHead].size();
@@ -90,48 +130,67 @@ class BleNotifyQueue {
     /// Never rounds up past what is left of the in-flight payload, so a
     /// caller can hand the result straight to `att_server_notify()`.
     size_t chunkSize(size_t max_payload) const {
-        const size_t left = remaining();
         if (max_payload == 0) {
             return 0;
         }
+        const size_t left = remaining();
         return left < max_payload ? left : max_payload;
     }
 
-    /// Record that @p sent bytes were accepted by the stack.
+    /// Record that @p sent bytes were accepted by the stack. Consumer side.
     ///
     /// Pops the front payload once it has been fully sent, so the next
     /// `chunkData()` describes the following response.
     void advance(size_t sent) {
-        if (mCount == 0 || sent == 0) {
+        if (empty() || sent == 0) {
             return;
         }
-        const size_t size = mSlots[mHead].size();
+        const size_t head = mHead;
+        const size_t size = mSlots[head].size();
         mOffset += sent;
         if (mOffset >= size) {
-            mSlots[mHead].clear();
-            mHead = (mHead + 1) % kCapacity;
-            --mCount;
+            mSlots[head].clear();
             mOffset = 0;
+            // Release the slot last, so the producer cannot reuse it while
+            // it is still being cleared.
+            mHead = next(head);
         }
     }
 
+    /// Drop the in-flight payload and move to the next one.
+    ///
+    /// Used when a payload cannot be delivered after repeated attempts, so
+    /// one undeliverable response does not block the queue forever.
+    void dropFront() {
+        if (empty()) {
+            return;
+        }
+        const size_t head = mHead;
+        mSlots[head].clear();
+        mOffset = 0;
+        mHead = next(head);
+    }
+
     /// Drop every queued payload — used when the link goes away.
+    ///
+    /// Only safe while no send callback can be in flight; see the
+    /// threading note on this class.
     void clear() {
-        for (size_t i = 0; i < kCapacity; ++i) {
+        for (size_t i = 0; i < kSlots; ++i) {
             mSlots[i].clear();
         }
         mHead = 0;
         mTail = 0;
-        mCount = 0;
         mOffset = 0;
     }
 
   private:
-    fl::vector<u8> mSlots[kCapacity];
-    size_t mHead = 0;
-    size_t mTail = 0;
-    size_t mCount = 0;
-    /// Bytes of `mSlots[mHead]` already accepted by the stack.
+    fl::vector<u8> mSlots[kSlots];
+    /// Owned by the consumer; read by the producer to detect "full".
+    volatile size_t mHead = 0;
+    /// Owned by the producer; read by the consumer to detect "empty".
+    volatile size_t mTail = 0;
+    /// Bytes of `mSlots[mHead]` already accepted. Consumer-only.
     size_t mOffset = 0;
 };
 

--- a/src/platforms/arm/rp/ble_rp.cpp.hpp
+++ b/src/platforms/arm/rp/ble_rp.cpp.hpp
@@ -44,6 +44,8 @@ struct TransportState {
     // second one was produced mid-transfer (FastLED#3955).
     BleNotifyQueue notifications;
     bool notification_scheduled = false;
+    // Consecutive att_server_notify() failures for the in-flight payload.
+    u8 notify_failures = 0;
 };
 
 struct RpBleRuntime {
@@ -57,6 +59,9 @@ struct RpBleRuntime {
 RpBleRuntime& rpBleRuntime() FL_NO_EXCEPT {
     return fl::Singleton<RpBleRuntime>::instance();
 }
+
+// Attempts to deliver one payload before it is dropped as undeliverable.
+static constexpr u8 kMaxNotifyRetries = 5;
 
 static void onNotificationReady(void* context);
 
@@ -105,14 +110,27 @@ static void onNotificationReady(void* context) {
         state->connection, state->tx_handle,
         state->notifications.chunkData(), static_cast<u16>(chunk_size));
     if (result != ERROR_CODE_SUCCESS) {
-        FL_WARN_F("[BLE RP] notify failed: %u", static_cast<unsigned>(result));
-        // Leave the chunk queued and ask for another send window, or the
-        // rest of this response would never leave the device.
+        // Retry a bounded number of times: a transient refusal (ACL
+        // buffers full) clears on the next send window, but a permanent
+        // one (peer never enabled the CCC, bad handle) would otherwise
+        // spin request -> can-send-now -> fail forever, flooding the log
+        // and never draining. Warn once per payload, then drop it so the
+        // queue keeps moving.
+        if (state->notify_failures == 0) {
+            FL_WARN_F("[BLE RP] notify failed: %u", static_cast<unsigned>(result));
+        }
+        if (++state->notify_failures >= kMaxNotifyRetries) {
+            FL_WARN_F("[BLE RP] dropping undeliverable response after %u attempts",
+                      static_cast<unsigned>(kMaxNotifyRetries));
+            state->notify_failures = 0;
+            state->notifications.dropFront();
+        }
         scheduleNotification(state);
         return;
     }
 
     // Only now may the queue advance to the next response.
+    state->notify_failures = 0;
     state->notifications.advance(chunk_size);
     scheduleNotification(state);
 }
@@ -172,6 +190,7 @@ static void onDisconnected(BLEDevice*) { // ok no noexcept
     state->connection = HCI_CON_HANDLE_INVALID;
     state->connected = false;
     state->notifications.clear();
+    state->notify_failures = 0;
     // The BTstack registration dies with the connection, so the pending
     // flags must not survive it: a request that registered just before the
     // drop would otherwise block every send on the next connection.
@@ -271,6 +290,9 @@ getTransportCallbacks(TransportState* state) FL_NO_EXCEPT {
                                        state->last_tx_value.size())) {
             FL_WARN_F("[BLE RP] TX queue full, dropping response (%u bytes)",
                       static_cast<unsigned>(state->last_tx_value.size()));
+            // Still (re-)arm the drain: the queue may have filled because a
+            // previous scheduling attempt failed, and nothing else retries.
+            scheduleNotification(state);
             return;
         }
         scheduleNotification(state);

--- a/src/platforms/arm/rp/ble_rp.cpp.hpp
+++ b/src/platforms/arm/rp/ble_rp.cpp.hpp
@@ -11,6 +11,7 @@
 #if FL_BLE_AVAILABLE && defined(FL_IS_RP2350)
 
 #include "fl/log/log.h"
+#include "fl/net/ble_notify_queue.h"
 #include "fl/remote/transport/serial.h"
 #include "fl/stl/cctype.h"
 #include "fl/stl/int.h"
@@ -19,7 +20,6 @@
 #include "fl/stl/string.h"
 #include "fl/stl/string_view.h"
 #include "fl/stl/unique_ptr.h"
-#include "fl/stl/vector.h"
 
 // IWYU pragma: begin_keep
 #include <BTstackLib.h>
@@ -39,8 +39,10 @@ struct TransportState {
     hci_con_handle_t connection = HCI_CON_HANDLE_INVALID;
     bool connected = false;
     fl::string last_tx_value;
-    fl::vector<u8> notification_payload;
-    size_t notification_offset = 0;
+    // Completed responses waiting to go out, drained in ATT-MTU chunks.
+    // A single shared buffer here truncated an in-flight response when a
+    // second one was produced mid-transfer (FastLED#3955).
+    BleNotifyQueue notifications;
     bool notification_scheduled = false;
 };
 
@@ -60,7 +62,7 @@ static void onNotificationReady(void* context);
 
 static void scheduleNotification(TransportState* state) {
     if (state == nullptr || rpBleRuntime().active != state || !state->connected ||
-        state->tx_handle == 0 || state->notification_offset >= state->notification_payload.size() ||
+        state->tx_handle == 0 || state->notifications.empty() ||
         state->notification_scheduled) {
         return;
     }
@@ -92,25 +94,26 @@ static void onNotificationReady(void* context) {
         return;
     }
     state->notification_scheduled = false;
-    if (!state->connected || state->tx_handle == 0 ||
-        state->notification_offset >= state->notification_payload.size()) {
+    if (!state->connected || state->tx_handle == 0 || state->notifications.empty()) {
         return;
     }
 
     const u16 mtu = att_server_get_mtu(state->connection);
     const size_t max_payload = mtu > 3 ? static_cast<size_t>(mtu - 3) : 20;
-    const size_t remaining = state->notification_payload.size() - state->notification_offset;
-    const size_t chunk_size = remaining < max_payload ? remaining : max_payload;
+    const size_t chunk_size = state->notifications.chunkSize(max_payload);
     const u8 result = att_server_notify(
         state->connection, state->tx_handle,
-        state->notification_payload.data() + state->notification_offset,
-        static_cast<u16>(chunk_size));
+        state->notifications.chunkData(), static_cast<u16>(chunk_size));
     if (result != ERROR_CODE_SUCCESS) {
         FL_WARN_F("[BLE RP] notify failed: %u", static_cast<unsigned>(result));
+        // Leave the chunk queued and ask for another send window, or the
+        // rest of this response would never leave the device.
+        scheduleNotification(state);
         return;
     }
 
-    state->notification_offset += chunk_size;
+    // Only now may the queue advance to the next response.
+    state->notifications.advance(chunk_size);
     scheduleNotification(state);
 }
 
@@ -168,8 +171,12 @@ static void onDisconnected(BLEDevice*) { // ok no noexcept
     }
     state->connection = HCI_CON_HANDLE_INVALID;
     state->connected = false;
-    state->notification_payload.clear();
-    state->notification_offset = 0;
+    state->notifications.clear();
+    // The BTstack registration dies with the connection, so the pending
+    // flags must not survive it: a request that registered just before the
+    // drop would otherwise block every send on the next connection.
+    state->notification_scheduled = false;
+    rpBleRuntime().notification_callback_pending = false;
 }
 
 TransportState* createTransport(const char* device_name) FL_NO_EXCEPT {
@@ -209,6 +216,7 @@ void destroyTransport(TransportState* state) FL_NO_EXCEPT {
         runtime.active = nullptr;
         // A pending callback receives null and returns before state is deleted.
         runtime.notification_callback.context = nullptr;
+        runtime.notification_callback_pending = false;
     }
     fl::unique_ptr<TransportState> holder(state);
 }
@@ -259,12 +267,12 @@ getTransportCallbacks(TransportState* state) FL_NO_EXCEPT {
         if (!state->connected || state->tx_handle == 0) {
             return;
         }
-        state->notification_payload.clear();
-        state->notification_payload.reserve(state->last_tx_value.size());
-        for (char value : state->last_tx_value) {
-            state->notification_payload.push_back(static_cast<u8>(value));
+        if (!state->notifications.push(state->last_tx_value.c_str(),
+                                       state->last_tx_value.size())) {
+            FL_WARN_F("[BLE RP] TX queue full, dropping response (%u bytes)",
+                      static_cast<unsigned>(state->last_tx_value.size()));
+            return;
         }
-        state->notification_offset = 0;
         scheduleNotification(state);
     };
 

--- a/tests/fl/net/ble_notify_queue.cpp
+++ b/tests/fl/net/ble_notify_queue.cpp
@@ -1,0 +1,146 @@
+// Host-side tests for the outbound BLE notification FIFO (FastLED#3955).
+//
+// The RP2350W BTstack transport drains a JSON-RPC response over several
+// `can-send-now` callbacks because one notification carries at most
+// `ATT_MTU - 3` bytes. Before this queue existed the transport held that
+// in-flight payload in a single buffer, so a second response produced
+// mid-transfer overwrote the first and the peer saw a truncated message.
+//
+// These tests pin the ordering + chunking contract without BTstack, so
+// they run on the host where there is no BLE silicon.
+
+#include "test.h"
+#include "fl/net/ble_notify_queue.h"
+#include "fl/stl/string.h"
+
+namespace {
+
+using fl::net::ble::BleNotifyQueue;
+
+// Drain up to `max_payload` bytes at a time, mimicking the transport's
+// can-send-now loop, and return everything the peer would observe.
+fl::string drain(BleNotifyQueue &queue, size_t max_payload) {
+    fl::string seen;
+    while (!queue.empty()) {
+        const size_t chunk = queue.chunkSize(max_payload);
+        FL_REQUIRE(chunk > 0);
+        const fl::u8 *data = queue.chunkData();
+        FL_REQUIRE(data != nullptr);
+        for (size_t i = 0; i < chunk; ++i) {
+            seen.push_back(static_cast<char>(data[i]));
+        }
+        queue.advance(chunk);
+    }
+    return seen;
+}
+
+void pushString(BleNotifyQueue &queue, const fl::string &value) {
+    FL_CHECK(queue.push(value.c_str(), value.size()));
+}
+
+} // namespace
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+FL_TEST_CASE("ble notify queue: second response does not truncate the first") {
+    // The regression the issue asks for: two complete responses are
+    // produced before the first transfer finishes.
+    BleNotifyQueue queue;
+    const fl::string first("REMOTE: {\"id\":1,\"result\":{\"message\":\"pong\"}}");
+    const fl::string second("REMOTE: {\"id\":2,\"result\":{\"message\":\"ack\"}}");
+
+    pushString(queue, first);
+
+    // Send one MTU-sized chunk, leaving the rest of `first` unsent.
+    const size_t mtu_payload = 20;
+    const size_t sent = queue.chunkSize(mtu_payload);
+    FL_CHECK_EQ(sent, mtu_payload);
+    queue.advance(sent);
+    FL_CHECK(queue.remaining() > 0);
+
+    // A second response arrives mid-transfer. It must queue behind the
+    // first rather than replace it.
+    pushString(queue, second);
+    FL_CHECK_EQ(queue.depth(), size_t(2));
+
+    fl::string rest = drain(queue, mtu_payload);
+    fl::string expected_rest = first.substr(mtu_payload) + second;
+    FL_CHECK_EQ(rest, expected_rest);
+    FL_CHECK(queue.empty());
+}
+
+FL_TEST_CASE("ble notify queue: preserves order across many responses") {
+    BleNotifyQueue queue;
+    pushString(queue, fl::string("aaa"));
+    pushString(queue, fl::string("bb"));
+    pushString(queue, fl::string("cccc"));
+
+    FL_CHECK_EQ(queue.depth(), size_t(3));
+    FL_CHECK_EQ(drain(queue, 2), fl::string("aaabbcccc"));
+}
+
+FL_TEST_CASE("ble notify queue: chunking never overruns the payload") {
+    BleNotifyQueue queue;
+    pushString(queue, fl::string("12345"));
+
+    // A generous MTU must not report more than what is left.
+    FL_CHECK_EQ(queue.chunkSize(1000), size_t(5));
+    queue.advance(2);
+    FL_CHECK_EQ(queue.chunkSize(1000), size_t(3));
+    FL_CHECK_EQ(queue.remaining(), size_t(3));
+    // A zero-sized window yields nothing rather than a bogus send.
+    FL_CHECK_EQ(queue.chunkSize(0), size_t(0));
+
+    queue.advance(3);
+    FL_CHECK(queue.empty());
+    FL_CHECK(queue.chunkData() == nullptr);
+    FL_CHECK_EQ(queue.chunkSize(1000), size_t(0));
+}
+
+FL_TEST_CASE("ble notify queue: is bounded and reports the drop") {
+    BleNotifyQueue queue;
+    for (size_t i = 0; i < BleNotifyQueue::kCapacity; ++i) {
+        FL_CHECK(queue.push("x", 1));
+    }
+    FL_CHECK_EQ(queue.depth(), BleNotifyQueue::kCapacity);
+
+    // Full: the newest response is refused rather than evicting one that
+    // may already be partly on the wire.
+    FL_CHECK_FALSE(queue.push("y", 1));
+    FL_CHECK_EQ(queue.depth(), BleNotifyQueue::kCapacity);
+
+    // Draining one frees exactly one slot.
+    queue.advance(queue.chunkSize(64));
+    FL_CHECK(queue.push("y", 1));
+}
+
+FL_TEST_CASE("ble notify queue: empty and degenerate pushes are rejected") {
+    BleNotifyQueue queue;
+    FL_CHECK_FALSE(queue.push(nullptr, 4));
+    FL_CHECK_FALSE(queue.push("x", 0));
+    FL_CHECK(queue.empty());
+    // Advancing an empty queue must be a no-op, not an underflow.
+    queue.advance(5);
+    FL_CHECK(queue.empty());
+    FL_CHECK_EQ(queue.remaining(), size_t(0));
+}
+
+FL_TEST_CASE("ble notify queue: clear drops in-flight state on disconnect") {
+    BleNotifyQueue queue;
+    pushString(queue, fl::string("first"));
+    pushString(queue, fl::string("second"));
+    queue.advance(2); // partway through `first`
+
+    queue.clear();
+
+    FL_CHECK(queue.empty());
+    FL_CHECK_EQ(queue.depth(), size_t(0));
+    FL_CHECK_EQ(queue.remaining(), size_t(0));
+    FL_CHECK(queue.chunkData() == nullptr);
+
+    // A reconnect reuses the queue and must start from a clean offset.
+    pushString(queue, fl::string("after"));
+    FL_CHECK_EQ(drain(queue, 64), fl::string("after"));
+}
+
+}

--- a/tests/fl/net/ble_notify_queue.cpp
+++ b/tests/fl/net/ble_notify_queue.cpp
@@ -125,6 +125,40 @@ FL_TEST_CASE("ble notify queue: empty and degenerate pushes are rejected") {
     FL_CHECK_EQ(queue.remaining(), size_t(0));
 }
 
+FL_TEST_CASE("ble notify queue: dropFront skips an undeliverable payload") {
+    // A payload the peer keeps refusing must not block the ones behind it.
+    BleNotifyQueue queue;
+    pushString(queue, fl::string("stuck"));
+    pushString(queue, fl::string("next"));
+
+    queue.advance(2); // partway through "stuck" before it starts failing
+    queue.dropFront();
+
+    FL_CHECK_EQ(queue.depth(), size_t(1));
+    // The survivor must start from offset zero, not inherit the dropped
+    // payload's progress.
+    FL_CHECK_EQ(drain(queue, 64), fl::string("next"));
+}
+
+FL_TEST_CASE("ble notify queue: dropFront on an empty queue is a no-op") {
+    BleNotifyQueue queue;
+    queue.dropFront();
+    FL_CHECK(queue.empty());
+    pushString(queue, fl::string("ok"));
+    FL_CHECK_EQ(drain(queue, 64), fl::string("ok"));
+}
+
+FL_TEST_CASE("ble notify queue: slots are reused across many cycles") {
+    // Exercises the ring wrap: far more payloads than there are slots.
+    BleNotifyQueue queue;
+    for (int i = 0; i < 20; ++i) {
+        pushString(queue, fl::string("payload"));
+        FL_CHECK_EQ(queue.depth(), size_t(1));
+        FL_CHECK_EQ(drain(queue, 3), fl::string("payload"));
+        FL_CHECK(queue.empty());
+    }
+}
+
 FL_TEST_CASE("ble notify queue: clear drops in-flight state on disconnect") {
     BleNotifyQueue queue;
     pushString(queue, fl::string("first"));


### PR DESCRIPTION
Addresses the three CodeRabbit findings tracked in #3955 (follow-ups from #3863).

## Problems fixed

**1. A second response truncated the first (C++).** `response_sink` cleared and replaced a single `notification_payload` buffer. Because a response drains over several `can-send-now` callbacks (one notification carries at most `ATT_MTU - 3` bytes), a second response produced mid-transfer destroyed the unsent remainder of the first — the peer got a truncated message and lost the rest.

Replaced with `BleNotifyQueue`, a bounded outbound FIFO that preserves response order and advances only after the final chunk of the current response is accepted. When full it refuses the newest response rather than evicting one already partly on the wire, and reports the drop.

**2. Disconnect left registration state latched (C++).** `onDisconnected` cleared the payload but left `notification_scheduled` and `notification_callback_pending` set. A request that registered just before a drop therefore blocked every send on the next connection. Both flags now clear on disconnect; `destroyTransport` clears the pending flag too. Separately, a failed `att_server_notify` used to return without rescheduling, stranding the rest of the response — it now re-arms.

**3. One bad notification poisoned the reader forever (Python).** The HIL reader concatenated every notification into a buffer it never reset, so a single unparseable value meant no later response — including a valid `pong` — could ever parse.

Replaced with `BleNotificationAssembler`, which consumes exactly the bytes of each complete JSON value and resynchronizes on the next `REMOTE: ` marker. ATT-fragment reassembly is retained: `BleInterface` no longer `.strip()`s each notification, which was silently dropping whitespace that fell on a chunk boundary and corrupting reassembled JSON.

## Design note

`BleNotifyQueue` is deliberately free of BTstack/ATT types, and `BleNotificationAssembler` is free of `bleak`. That is what makes both contracts host-testable on machines with no BLE silicon — the transport itself is compile-gated to `FL_IS_RP2350`.

## Verification

- `bash test --cpp` — **282/282** unit tests (6 new cases in `tests/fl/net/ble_notify_queue.cpp`, including the two-responses-mid-transfer regression).
- `uv run pytest ci/tests/` — **913 passed**, 34 skipped. 11 new cases in `ci/tests/test_ble_notification_assembler.py`. The single failure, `test_fbuild_qemu.py::test_fbuild_test_emu_esp32dev`, reproduces on clean `master` (fbuild daemon error) and is unrelated.
- `bash lint` clean.
- `bash compile rp2350w --examples AutoResearch` and `bash compile esp32c6 --examples AutoResearch` both succeed. The new `[BLE RP] TX queue full` string appears in the linked `rp2350w` firmware, confirming the modified transport is actually compiled in rather than gated out.
- ESP32 NimBLE transport and the unsupported-platform stubs are untouched; singleton-owned RP runtime state is preserved.
- `ci/tests/test_rp2350w_board_config.py` updated: its structural assertion pinned the old `notification_offset` single-buffer design, and now pins the FIFO plus the disconnect/destroy flag clearing.

## Not covered

The issue's final bullet asks for live GATT discovery/ping plus disconnect/reconnect evidence on the Pico 2 W. **No RP2350W is attached to this bench**, so that evidence is not included and #3955 is intentionally left open — this PR says `Refs`, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BLE communication reliability for fragmented and consecutive notifications.
  * Prevented message corruption across whitespace and packet boundaries, including split multibyte characters.
  * Ensured queued responses are delivered in order without truncation or overwriting.
  * Improved handling of temporary send failures and cleared pending notifications correctly after disconnects.
  * Ensured valid responses are recognized promptly, even when unrelated or malformed data is received.
* **Refactor**
  * Added bounded buffering and message reassembly for BLE notifications, improving recovery from malformed or incomplete data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->