### PR TITLE
fix(esp32): reject legacy RMT4 on IDF 5 with one accurate diagnostic (#3936)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -55,18 +55,24 @@
 #warning "-DFASTLED_ESP32_I2S is removed (FastLED#3526 Phase 2e). Drop the flag; the modern I2S engine is now on Bus::FLEX_IO, 0. Runtime select via FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>()."
 #endif
 
-// ESP32 RMT Driver conflict prevention
-// Arduino ESP32 Core 3.x (ESP-IDF 5.x+) includes a neopixelWrite() function that uses the RMT driver,
-// which conflicts with FastLED's legacy RMT4 driver (FASTLED_RMT5=0).
-// Disable Arduino's built-in RGB LED support to prevent the conflict.
-// This is only needed for ESP-IDF 5.x+ with legacy RMT4 driver, not earlier versions or RMT5 driver.
-// Only applies to platforms that actually have RMT hardware (excludes ESP32-C2 which lacks RMT).
-// Reference: https://github.com/espressif/arduino-esp32/issues/9866
+// Legacy RMT4 backend is ESP-IDF 4.x only.
+//
+// On IDF 5.x the legacy TX and RX implementations no longer build: RMTMEM is not
+// exposed by the public headers, and both engines predate the current
+// IChannelDriver / RmtRxChannel contracts. `-DFASTLED_RMT5=0` there produced a
+// wall of unrelated compiler errors, and the old guard sent users chasing
+// -DESP32_ARDUINO_NO_RGB_BUILTIN=1, which gets past the guard but not past the
+// build. Reject the combination up front with one accurate diagnostic instead.
+// RMT5 is already the IDF 5.x default, so nothing that builds today is lost.
+// See FastLED#3936.
+//
+// Note the version test: FASTLED_RMT5 also defaults to 0 on IDF 4.x, where RMT4
+// is the correct native backend and must keep building.
 #if defined(FL_IS_ESP32)
 #include "platforms/esp/esp_version.h"  // ok platform headers
 #include "platforms/esp/32/feature_flags/enabled.h"  // ok platform headers
-#if FASTLED_RMT5 == 0 && FASTLED_ESP32_HAS_RMT && !defined(ESP32_ARDUINO_NO_RGB_BUILTIN)
-#error "ESP-IDF 5.x+ with legacy RMT4 driver detected: Please define ESP32_ARDUINO_NO_RGB_BUILTIN=1 to prevent conflicts with Arduino's neopixelWrite() function. Add '-DESP32_ARDUINO_NO_RGB_BUILTIN=1' to your build flags or use '-DFASTLED_RMT5=1' to enable RMT5 driver."
+#if FASTLED_RMT5 == 0 && FASTLED_ESP32_HAS_RMT && ESP_IDF_VERSION_5_OR_HIGHER
+#error "FASTLED_RMT5=0 (legacy RMT4 backend) is not supported on ESP-IDF 5.x or newer. Remove -DFASTLED_RMT5=0 to use the RMT5 backend, which is the default on this IDF. RMT4 remains available only when building against ESP-IDF 4.x. See https://github.com/FastLED/FastLED/issues/3936"
 #endif
 #endif
 

--- a/src/platforms/esp/32/README.md
+++ b/src/platforms/esp/32/README.md
@@ -493,7 +493,8 @@ Quick PlatformIO examples
   compile time on IDF 5.x and newer:
   ```ini
   [env:esp32dev_rmt4]
-  platform = espressif32@<pin to an IDF 4.x release>
+  ; IDF 4.4 — the release FastLED's esp32dev_idf44 CI job builds against
+  platform = https://github.com/platformio/platform-espressif32/archive/refs/tags/v4.4.0.zip
   board = esp32dev
   framework = arduino
   build_flags =

--- a/src/platforms/esp/32/README.md
+++ b/src/platforms/esp/32/README.md
@@ -456,12 +456,20 @@ Two RMT implementations exist and are selected by IDF version unless you overrid
 
 Selection rules:
 - Default: `ESP_IDF_VERSION` decides. On IDF < 5, RMT5 is disabled; on IDF ≥ 5, RMT5 is enabled.
-- To force RMT4 on IDF5, set this build define (PlatformIO `platformio.ini`):
-  ```ini
-  build_flags =
-    -D FASTLED_RMT5=0
-  ```
-  This ensures only one RMT implementation is compiled. Do not link/use the IDF v5 `led_strip` driver in the same binary when forcing RMT4.
+- `-D FASTLED_RMT5=0` selects RMT4. **It is only supported on ESP‑IDF 4.x.**
+
+### RMT4 on IDF 5.x is not supported
+
+Forcing `-D FASTLED_RMT5=0` on ESP‑IDF 5.x or newer is rejected at compile time
+with a single diagnostic from `FastLED.h`. The legacy TX and RX engines do not
+build against IDF 5 headers: `RMTMEM` is no longer exposed publicly, and both
+engines predate the current `IChannelDriver` / `RmtRxChannel` contracts.
+
+Earlier releases suggested adding `-D ESP32_ARDUINO_NO_RGB_BUILTIN=1` to get past
+the guard. That define silences the guard but does not make the backend compile,
+so it is no longer recommended for this purpose. Use the RMT5 backend, which is
+already the IDF 5.x default — simply drop `-D FASTLED_RMT5=0`. If you need RMT4,
+build against ESP‑IDF 4.x. Tracking issue: FastLED#3936.
 
 Important compatibility note:
 - The RMT4 and RMT5 drivers cannot co‑exist in the same sketch/binary. Mixing both (e.g., using IDF v5 `led_strip` alongside FastLED’s RMT4) will trigger an Espressif runtime abort at startup.
@@ -481,10 +489,11 @@ Behavioral differences and practical guidance:
 
 Quick PlatformIO examples
 
-- Force RMT4 on IDF5 (legacy path):
+- Select RMT4 (legacy path) — requires an ESP‑IDF 4.x platform; rejected at
+  compile time on IDF 5.x and newer:
   ```ini
   [env:esp32dev_rmt4]
-  platform = espressif32
+  platform = espressif32@<pin to an IDF 4.x release>
   board = esp32dev
   framework = arduino
   build_flags =

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
@@ -176,6 +176,13 @@ All interrupt handlers are marked `IRAM_ATTR` to ensure flash-safe execution:
 - RMT5 driver used when `FASTLED_RMT5=1` (IDF 5.x with new RMT API)
 - Both drivers are mutually exclusive (compile-time selection)
 
+> **IDF 4.x only.** Setting `FASTLED_RMT5=0` on ESP‑IDF 5.x or newer is rejected
+> by `FastLED.h` with a compile-time diagnostic. This driver does not build
+> against IDF 5 headers — `RMTMEM` is not exposed publicly there, and the TX/RX
+> engines predate the current `IChannelDriver` / `RmtRxChannel` contracts. The
+> chip table above describes silicon capability, not IDF 5 build support. See
+> FastLED#3936.
+
 ---
 
 ## Configuration Macros

--- a/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
+++ b/src/platforms/esp/32/drivers/rmt/rmt_4/README.md
@@ -162,14 +162,21 @@ All interrupt handlers are marked `IRAM_ATTR` to ensure flash-safe execution:
 
 ## Platform Support
 
-| Platform | RMT Channels | Memory Blocks | IDF Version | Status |
+Channel and memory-block figures describe the silicon. This driver itself
+builds only on ESP-IDF 4.x — see the note under *Conditional Compilation*.
+
+| Platform | RMT Channels | Memory Blocks | RMT4 driver | Status |
 |----------|--------------|---------------|-------------|--------|
-| ESP32 (original) | 8 | 64 words/channel | IDF 4.x, 5.x | ✅ Tested |
-| ESP32-S2 | 4 | 64 words/channel | IDF 4.x, 5.x | ✅ Tested |
-| ESP32-S3 | 4 | 48 words/channel | IDF 4.x, 5.x | ✅ Tested |
-| ESP32-C3 | 2 | 48 words/channel | IDF 4.x, 5.x | ⚠️ Untested |
-| ESP32-C6 | 2 | 48 words/channel | IDF 5.x only | ⚠️ Untested |
-| ESP32-H2 | 2 | 48 words/channel | IDF 5.x only | ⚠️ Untested |
+| ESP32 (original) | 8 | 64 words/channel | ✅ IDF 4.x | ✅ Tested |
+| ESP32-S2 | 4 | 64 words/channel | ✅ IDF 4.x | ✅ Tested |
+| ESP32-S3 | 4 | 48 words/channel | ✅ IDF 4.x | ✅ Tested |
+| ESP32-C3 | 2 | 48 words/channel | ✅ IDF 4.x | ⚠️ Untested |
+| ESP32-C6 | 2 | 48 words/channel | ❌ RMT5-only silicon | n/a |
+| ESP32-H2 | 2 | 48 words/channel | ❌ RMT5-only silicon | n/a |
+
+ESP32-C6 and ESP32-H2 have a newer RMT architecture that the legacy driver does
+not target; `FASTLED_ESP32_RMT5_ONLY_PLATFORM` forces `FASTLED_RMT5=1` there
+regardless of IDF version.
 
 **Conditional Compilation:**
 - RMT4 driver used when `FASTLED_RMT5=0` (IDF 4.x default)
@@ -179,8 +186,7 @@ All interrupt handlers are marked `IRAM_ATTR` to ensure flash-safe execution:
 > **IDF 4.x only.** Setting `FASTLED_RMT5=0` on ESP‑IDF 5.x or newer is rejected
 > by `FastLED.h` with a compile-time diagnostic. This driver does not build
 > against IDF 5 headers — `RMTMEM` is not exposed publicly there, and the TX/RX
-> engines predate the current `IChannelDriver` / `RmtRxChannel` contracts. The
-> chip table above describes silicon capability, not IDF 5 build support. See
+> engines predate the current `IChannelDriver` / `RmtRxChannel` contracts. See
 > FastLED#3936.
 
 ---


### PR DESCRIPTION
Closes #3936.

## Problem

`-DFASTLED_RMT5=0` on ESP-IDF 5.x was documented as the way to select the legacy RMT4 backend, but it does not build. The legacy engines predate the current headers and contracts:

- **TX** — `RMTMEM` is not exposed by the IDF 5 public headers; `canHandle()` is defined in `channel_driver_rmt4.cpp.hpp` but not declared on `ChannelEngineRMT4Impl`; that class does not implement the now-pure `IChannelDriver::getCapabilities()`, so factory construction sees an abstract type.
- **RX** — `DecodeError::INVALID_SYMBOL` no longer exists, `RxConfig::hz` is optional and cannot be assigned to `u32`, and `RmtRxChannelImpl` lacks `getPin()` / `getResolutionHz()`.

The guard made it worse. It fired only when `ESP32_ARDUINO_NO_RGB_BUILTIN` was *un*defined, and told the user to define it. Defining it silences the guard but not the failure — so following FastLED's own advice traded one clear error for a wall of unrelated ones.

## Fix — policy 2 from the issue ("reject")

Reject the combination up front with one accurate diagnostic. Nothing that builds today is lost: RMT5 is already the IDF 5.x default, and the RMT4 path never compiled there.

The guard also gains the IDF version test its message always claimed. The old condition was `FASTLED_RMT5 == 0 && FASTLED_ESP32_HAS_RMT` — **no version check at all**, even though `FASTLED_RMT5` also defaults to 0 on IDF 4.x, where RMT4 is the correct native backend. The new condition is strictly narrower, so no build that passes today can start failing.

Docs updated to match: `src/platforms/esp/32/README.md` no longer presents "Force RMT4 on IDF5" as a supported configuration, and the RMT4 driver README notes that its chip table describes silicon capability, not IDF 5 build support.

## Verification

On `esp32dev` (pioarduino 53.03.10, IDF 5, fbuild 2.5.18):

| check | result |
|---|---|
| `--defines FASTLED_RMT5=0,ESP32_ARDUINO_NO_RGB_BUILTIN=1` | fails with **exactly one** diagnostic; 0 hits for RMTMEM/canHandle/getCapabilities/INVALID_SYMBOL/getResolutionHz |
| `bash compile esp32dev --examples Blink` (default) | succeeds, flash 335688 B / ram 27348 B |
| `bash test --cpp` | 283/283 unit, 83/83 examples |
| `bash lint` | clean |

The exact reproduction command from the issue now emits only:

```
lib/FastLED/FastLED.h:75:2: error: #error "FASTLED_RMT5=0 (legacy RMT4 backend) is not
supported on ESP-IDF 5.x or newer. Remove -DFASTLED_RMT5=0 to use the RMT5 backend,
which is the default on this IDF. RMT4 remains available only when building against
ESP-IDF 4.x. See https://github.com/FastLED/FastLED/issues/3936"
```

## Acceptance criteria

- [x] Policy documented in the ESP32 backend selection guide and the `FastLED.h` guard text
- [x] Compatibility removed → `FASTLED_RMT5=0` on IDF 5 fails immediately with one accurate diagnostic and does not suggest an ineffective second define
- [x] IDF 4 builds remain covered — condition is strictly narrower than before, and the existing `esp32dev_idf44` workflow still exercises the native legacy backend
- [ ] *(N/A — the "keep compatibility" branch of the criteria was not taken)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ESP32 projects using the legacy RMT4 backend now fail early with a clear diagnostic on ESP-IDF 5.x or newer.
  * Removed the need for an additional Arduino configuration workaround with supported RMT configurations.
  * RMT4 remains supported on ESP-IDF 4.x.

* **Documentation**
  * Clarified RMT4 compatibility requirements and migration options.
  * Documented that ESP32-C6 and ESP32-H2 require RMT5.
  * Updated PlatformIO guidance to use an ESP-IDF 4.x-compatible platform for RMT4 builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->