### PR TITLE
ci(qemu): install libslirp0 so Espressif QEMU can start

### DIFF
--- a/.github/workflows/qemu_template.yml
+++ b/.github/workflows/qemu_template.yml
@@ -42,12 +42,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install QEMU runtime libraries (libSDL2)
+      - name: Install QEMU runtime libraries (libSDL2, libslirp)
         # The Espressif QEMU binary that fbuild downloads is dynamically
-        # linked against libSDL2-2.0.so.0 on Linux.
+        # linked against libSDL2-2.0.so.0 and libslirp.so.0 on Linux.
+        # Neither is preinstalled on ubuntu-latest (24.04); without them
+        # qemu-system-xtensa / qemu-system-riscv32 fail at exec with
+        # "error while loading shared libraries".
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0
+          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libslirp0
 
       - name: Pin python version
         run: echo "3.11" > .python-version


### PR DESCRIPTION
## Problem

All three README QEMU badges (ESP32-DEV, ESP32-C3, ESP32-S3) are red. Every leg fails identically:

```
emulator error: package error: QEMU at .../qemu/bin/qemu-system-xtensa cannot start: a required shared library is missing.
.../qemu-system-xtensa: error while loading shared libraries: libslirp.so.0: cannot open shared object file: No such file or directory
```

The Espressif QEMU 9.2.2 binaries fbuild downloads are dynamically linked against `libslirp.so.0`, which `ubuntu-latest` (24.04) does not preinstall. Affects both `qemu-system-xtensa` (esp32dev, esp32s3) and `qemu-system-riscv32` (esp32c3).

This is **not** an fbuild version problem — the pin is current. fbuild's "The cached QEMU toolchain appears incomplete or corrupt / rm -rf ..." message is a misleading diagnostic: the download is intact, the host is missing a system library. Same class of failure as #2639 / #2640 (libSDL2).

## Fix

Add `libslirp0` next to the existing `libsdl2-2.0-0` in the shared `qemu_template.yml` apt step.

## Verification

`.github/workflows/qemu_template.yml` is in the `pull_request` path filter of all three QEMU workflows, so this PR triggers all of them — green here is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QEMU runtime setup by installing required SDL2 and SLIRP libraries.
  * Added documentation for shared libraries needed by downloaded Espressif QEMU binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->