### PR TITLE
docs(usb): make FastLED/boards the documented VID/PID source of truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ examples/**/*.ino.cpp
 ./*.log
 .loop
 .fbuild/*
+.fbuild/
+.compile-tmp/
+.tmp/
 
 # WASM frontend build (Vite)
 src/platforms/wasm/compiler/dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 |------|------|
 | Writing/editing C++ code | `agents/docs/cpp-standards.md` |
 | Verifying a peripheral exists on a chip before writing driver code | `agents/docs/peripheral-existence.md` (halt on phantom — do not fabricate missing `<Peripheral>_Type` in vendor headers) |
+| Adding or changing a board USB VID/PID | `agents/docs/usb-vid-pid-registry.md` (it lands in FastLED/boards first — never as a new literal in `ci/`) |
 | Defining a register map / accessing MCU peripherals | `agents/docs/register-maps.md` (use vendor CMSIS PAL — do not hand-roll shims) |
 | Looking up MCU datasheets / user manuals | Prefer https://github.com/FastLED/datasheets when available, then vendor primary documentation |
 | Creating an API wrapper type | `agents/docs/cpp-standards.md` → "API Object Pattern" |
@@ -88,6 +89,12 @@ See `agents/docs/build-system.md` for full command execution rules and forbidden
 - **Platform compilation timeout**: 15 minutes minimum for platform builds
 - **Override**: `FL_AGENT_ALLOW_ALL_CMDS=1` prefix bypasses forbidden command checks
 - See `agents/docs/build-system.md` for full rules
+
+### USB VID/PID identities live in FastLED/boards — ALWAYS
+- **Never introduce a board/device USB VID:PID into this repo as the place it first exists.** [FastLED/boards](https://github.com/FastLED/boards) is the source of truth; it publishes a zstd-compressed protobuf (`usb-vids.proto.zstd`) that fbuild ingests at build time and falls back to from its cache root. FastLED consumes it through `fbuild port scan` / `fbuild deploy`.
+- **Missing identity ⇒ fix the registry, then cascade.** Add it on the FastLED/boards data branch, let the `site.yml` workflow republish, cut an fbuild release, then move the `fbuild==X.Y.Z` pin in `pyproject.toml` and run `uv sync` to pick it up. `uv.lock` is gitignored here, so the pin is the only committed half of the cascade — but you must still relock/sync locally or you keep running the old wheel.
+- **The legacy tables are frozen.** `ENVIRONMENT_TO_VCOM_VID_PIDS` (`ci/util/port_utils.py`) and `BOARD_FINGERPRINTS` (`ci/util/serial_probe.py`) must not gain entries. Test fixtures may use concrete literals; they must never become runtime defaults.
+- Full rule, pipeline diagram, and cascade procedure: `agents/docs/usb-vid-pid-registry.md`. fbuild mirrors it in its own `CLAUDE.md` → "USB VID/PID source of truth" and `docs/usb-vidpid-audit.md`.
 
 ### Deployment (flash / upload) is fbuild's job — ALWAYS
 - **Never invoke flash tools directly from FastLED code.** No `pyocd`, `lpc21isp`, `esptool`, `avrdude`, `bossac`, `stm32flash`, `openocd load`, `dfu-util`, `teensy_loader_cli`, `JLinkExe`, or equivalents anywhere under `ci/`, `tests/`, `examples/`, or `src/`.

--- a/agents/docs/driver-bringup-postmortems.md
+++ b/agents/docs/driver-bringup-postmortems.md
@@ -32,7 +32,8 @@ For an external loopback, record the physical TX-to-RX jumper and add the
 driver-specific flag, for example `--flex-io --tx-pin <tx> --rx-pin <rx>`.
 Use the fbuild-backed AutoResearch JSON-RPC transport only. Do not substitute
 PlatformIO, direct flashing tools, raw pyserial, or a hand-maintained VID/PID
-table for this workflow.
+table for this workflow. Board identity comes from FastLED/boards via fbuild —
+see [usb-vid-pid-registry.md](usb-vid-pid-registry.md).
 
 ## Evidence levels
 

--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -144,7 +144,11 @@ For a new board or a newly attached board, prove the transport before proving a
 driver:
 
 1. Run `fbuild port scan` and record the board identity, VID/PID, serial number,
-   and port. Do not claim a board is absent without this scan.
+   and port. Do not claim a board is absent without this scan. If the scan cannot
+   name the board, the identity is missing from
+   [FastLED/boards](https://github.com/FastLED/boards) — fix it there and cascade
+   the fbuild bump; never add the literal to `ci/`. See
+   [usb-vid-pid-registry.md](usb-vid-pid-registry.md).
 2. Confirm the board has an entry in `ci/boards.py` or can be detected by the
    AutoResearch/fbuild path. If the deploy backend is missing, file the gap in
    FastLED/fbuild; do not add direct flash-tool calls.

--- a/agents/docs/usb-vid-pid-registry.md
+++ b/agents/docs/usb-vid-pid-registry.md
@@ -96,7 +96,7 @@ uv sync
 uv run fbuild --version
 ```
 
-**`uv.lock` is gitignored in this repo** (`.gitignore` line 52), so the pin in
+**`uv.lock` is gitignored in this repo**, so the pin in
 `pyproject.toml` is the only committed half of the cascade. Do not skip the
 relock anyway: without it your local environment keeps running the previous
 wheel and any verification you do is against the old registry snapshot.
@@ -136,11 +136,17 @@ Re-run the audit at any time:
 uv run python ci/util/audit_usb_registry.py
 ```
 
-It fetches the live artifact, decodes it, and exits non-zero while any
-audited literal is still unresolvable. A cold or stale cache is
-indistinguishable from a missing record, so always check the published
-payload rather than a failed port scan. `AUDITED_LITERALS` in that script is
-the checklist — it should shrink to empty as literals are retired.
+It fetches the live artifact, decodes it, and reports which audited literals
+resolve. A cold or stale cache is indistinguishable from a missing record, so
+always check the published payload rather than a failed port scan.
+
+Two lists in that script carry the state. `AUDITED_LITERALS` is the checklist —
+it should shrink to empty as literals are retired. `KNOWN_GAPS` holds gaps
+already filed upstream; those print as `GAP*` with their tracking issue and do
+**not** fail the run, so the audit can be wired into CI without going
+permanently red. It exits 1 on a gap that is *not* filed, and also when a
+`KNOWN_GAPS` entry has since been published — that is the prompt to drop the
+allowlist entry and delete the local literal.
 
 ## Existing local tables (legacy, do not extend)
 

--- a/agents/docs/usb-vid-pid-registry.md
+++ b/agents/docs/usb-vid-pid-registry.md
@@ -1,0 +1,161 @@
+# USB VID/PID registry — FastLED/boards is the source of truth
+
+**Rule: every board/device USB VID:PID record lands in
+[FastLED/boards](https://github.com/FastLED/boards) first.** FastLED and fbuild
+are both *consumers*. Neither repo is allowed to grow a hand-maintained USB
+identity catalogue, and a VID/PID must never be introduced into this repo as
+the place it first exists.
+
+If a board cannot be identified, the fix is a FastLED/boards change plus a
+version cascade — not a new literal in `ci/`.
+
+## Why the registry, and not a local table
+
+A local table forks on the first board that behaves differently, and the fork
+is invisible until hardware is attached. Three consumers had already drifted
+before this rule was written: `ci/util/port_utils.py`, `ci/util/serial_probe.py`,
+and fbuild's former generated Rust tables all carried overlapping,
+independently-edited copies of the same identities. FastLED/boards ends that by
+publishing one artifact that every consumer ingests.
+
+## The publication pipeline
+
+```
+FastLED/boards data branches           source of truth
+  (platformio / arduino / vendors / other)
+              │
+              │  site.yml regenerates on every push
+              ▼
+https://fastled.github.io/boards/usb-vids.proto.zstd
+              │                    ▲
+              │                    └── zstd-compressed protobuf; ~7.7 KB,
+              │                        36 vendors / 1056 products as of
+              │                        2026-08-22
+              ▼
+fbuild ingestion (build + runtime cache + fallback)
+   crates/fbuild-core/src/usb/data.rs → USB_VIDS_PROTO_ZSTD_URL
+   crates/fbuild-core/src/usb/profiles.rs → schema + SHA-256 verification
+              │
+              │  version bump cascaded via the `fbuild==X.Y.Z` pin
+              ▼
+FastLED (this repo) — `fbuild port scan`, `fbuild deploy`, autoresearch
+```
+
+The on-disk schema is a compact nested protobuf, so the vendor name is stored
+once per VID rather than once per product:
+
+```protobuf
+message UsbVidDatabase { repeated Vendor vendors = 1; }
+message Vendor  { uint32 vid = 1; string name = 2; repeated Product products = 3; }
+message Product { uint32 pid = 1; string name = 2; }
+```
+
+A single artifact therefore yields **both** projections fbuild needs — VID →
+vendor, and VID:PID → {vendor, product} — which is why there is no separate
+per-VID blob and no reason for a consumer to keep its own map.
+
+The compressed archive is also fbuild's **fallback** path: when the network
+cache is cold or unreachable, fbuild reads the last-ingested
+`usb-vids.proto.zstd` from its cache root rather than degrading to a
+hardcoded table. Degrading to a local literal is not an available behavior by
+design.
+
+## What to do when an identity is missing
+
+1. **Confirm it is actually missing.** Decode the published artifact and look
+   the pair up. Do not infer absence from a failed port scan — a cold or stale
+   cache looks identical to a missing record.
+2. **Add it on the FastLED/boards data branch** (`vendors` or `other` for a
+   bare chip or debug probe; `platformio` / `arduino` for a board). The
+   `site.yml` workflow republishes the artifact on push.
+3. **Let fbuild ingest it** and cut an fbuild release.
+4. **Cascade the version into this repo** — see below. Until the pin moves,
+   FastLED still resolves against the older artifact.
+
+Never short-circuit steps 1–3 by adding the literal here "temporarily". The
+LPC845-BRK and RP2350W entries in `ci/util/port_utils.py` are exactly what a
+temporary exception looks like three months later.
+
+## Cascading an fbuild version bump into FastLED
+
+The registry reaches this repo only through the fbuild pin. When fbuild
+publishes a release carrying new USB identities:
+
+```bash
+# 1. Confirm the release is actually on PyPI before moving the pin.
+curl -fsSL https://pypi.org/pypi/fbuild/json | python -c "import sys,json;print(json.load(sys.stdin)['info']['version'])"
+
+# 2. Move the pin in pyproject.toml: fbuild==<old>  →  fbuild==<new>
+#    Add a "Pin history" entry saying what the bump carries.
+
+# 3. Refresh the local lockfile and environment.
+uv lock
+uv sync
+
+# 4. Verify the toolchain actually resolves to the new version.
+uv run fbuild --version
+```
+
+**`uv.lock` is gitignored in this repo** (`.gitignore` line 52), so the pin in
+`pyproject.toml` is the only committed half of the cascade. Do not skip the
+relock anyway: without it your local environment keeps running the previous
+wheel and any verification you do is against the old registry snapshot.
+
+## Migration status (audited 2026-08-22)
+
+Every VID:PID literal in this repo's `ci/` tree was checked against the live
+`usb-vids.proto.zstd` (36 vendors / 1056 products). **14 of 15 resolve from the
+registry**:
+
+| VID:PID | Identity | Registry |
+| --- | --- | --- |
+| `2E8A:000A` | rp2040 / rpipico application CDC | resolved |
+| `2E8A:F00A` | rpipicow application CDC | resolved |
+| `2E8A:000F` | rp2350 / rpipico2 application CDC | resolved |
+| `2E8A:F00F` | rp2350w / rpipico2w application CDC | resolved |
+| `2E8A:0003` | RP2 ROM BOOTSEL | resolved |
+| `16C0:0483` | LPCXpresso VCOM (LPC11U35) | resolved |
+| `16C0:0486` | PJRC / Teensy USB-Serial (alt) | resolved |
+| `1FC9:0132` | NXP LPC-Link2 CMSIS-DAP | resolved |
+| `303A:1001` | Espressif native USB CDC | resolved |
+| `10C4:EA60` | Silicon Labs CP2102 | resolved |
+| `1A86:7523` | WCH CH340 | resolved |
+| `1A86:55D4` | WCH CH343 | resolved |
+| `0403:6001` | FTDI FT232R | resolved |
+| `0403:6010` | FTDI FT2232 | resolved |
+| `0403:6014` | FTDI FT232H | **GAP** — FastLED/boards#60 |
+
+The FTDI vendor entry exists but enumerates only `6001` and `6010`; `6014` is
+absent registry-wide. It is the sole blocker to deleting the local tables
+outright rather than freezing them. Do not close that gap by keeping the
+literal — track it in FastLED/boards#60.
+
+Re-run the audit at any time:
+
+```bash
+uv run python ci/util/audit_usb_registry.py
+```
+
+It fetches the live artifact, decodes it, and exits non-zero while any
+audited literal is still unresolvable. A cold or stale cache is
+indistinguishable from a missing record, so always check the published
+payload rather than a failed port scan. `AUDITED_LITERALS` in that script is
+the checklist — it should shrink to empty as literals are retired.
+
+## Existing local tables (legacy, do not extend)
+
+| Location | Status |
+| --- | --- |
+| `ci/util/port_utils.py` → `ENVIRONMENT_TO_VCOM_VID_PIDS` | Legacy. Frozen — every pair is already published in FastLED/boards. Do not add entries; see FastLED#3836. |
+| `ci/util/serial_probe.py` → `BOARD_FINGERPRINTS` | Legacy display/diagnostic hints only. Never a selection authority. Do not add entries. |
+| `ci/tests/**` | Test fixtures may use concrete literals to exercise parsing and selection. They must not become runtime defaults. |
+
+Tests are the one sanctioned home for concrete USB literals in this repo —
+same carve-out fbuild grants its `#[cfg(test)]` modules.
+
+## Related
+
+- fbuild's mirror of this rule: `CLAUDE.md` → "USB VID/PID source of truth",
+  and `docs/usb-vidpid-audit.md` for the per-module migration audit.
+- `agents/docs/hardware-autoresearch.md` → board bring-up workflow.
+- `agents/docs/build-system.md` → "Deployment (flash / upload) is fbuild's job".

--- a/ci/util/README.md
+++ b/ci/util/README.md
@@ -1,3 +1,23 @@
 # CI Utilities
 
 Shared Python utilities for the FastLED CI/build system.
+
+## USB VID/PID identities are not owned here
+
+`port_utils.py` and `serial_probe.py` each carry a legacy VID:PID table. Both
+are **frozen**. USB board identity is owned by
+[FastLED/boards](https://github.com/FastLED/boards) and reaches this repo
+through fbuild's ingestion of the published `usb-vids.proto.zstd` archive.
+
+Do not add entries to either table. If a board cannot be identified, add the
+record upstream, let fbuild ingest it, then cascade the `fbuild==X.Y.Z` pin in
+`pyproject.toml` and relock locally (`uv lock && uv sync`; `uv.lock` itself is
+gitignored here).
+
+Check the migration status at any time:
+
+```bash
+uv run python ci/util/audit_usb_registry.py
+```
+
+Full rule and cascade procedure: `agents/docs/usb-vid-pid-registry.md`.

--- a/ci/util/README.md
+++ b/ci/util/README.md
@@ -20,4 +20,9 @@ Check the migration status at any time:
 uv run python ci/util/audit_usb_registry.py
 ```
 
+It exits 0 while the only outstanding gaps are ones already filed upstream
+(listed in `KNOWN_GAPS`, shown as `GAP*`), so it is safe to wire into CI. It
+exits 1 on an unfiled gap, or when a `KNOWN_GAPS` entry has been published and
+the literal can finally be retired.
+
 Full rule and cascade procedure: `agents/docs/usb-vid-pid-registry.md`.

--- a/ci/util/audit_usb_registry.py
+++ b/ci/util/audit_usb_registry.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Audit this repo's hardcoded USB VID:PID literals against FastLED/boards.
+
+The USB identity registry lives in https://github.com/FastLED/boards and is
+published as a zstd-compressed protobuf, `usb-vids.proto.zstd`. fbuild ingests
+that artifact; FastLED consumes it through fbuild. See
+`agents/docs/usb-vid-pid-registry.md` for the full rule and the cascade
+procedure.
+
+This script exists so the migration status in that doc can be re-derived rather
+than trusted. It fetches the published artifact, decodes it, and reports which
+of the literals still present in `ci/` resolve from the registry.
+
+    uv run python ci/util/audit_usb_registry.py
+
+Exit codes:
+    0 — every audited literal resolves from the registry
+    1 — at least one literal is missing (file the gap at FastLED/boards)
+    2 — the artifact could not be fetched or decoded
+
+A missing literal is a registry gap, never a reason to keep or add a local
+entry. `0403:6014` (FTDI FT232H) is the one known outstanding gap, tracked as
+FastLED/boards#60.
+"""
+
+from __future__ import annotations
+
+import sys
+import urllib.request
+from typing import Iterator, NamedTuple
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+ARTIFACT_URL = "https://fastled.github.io/boards/usb-vids.proto.zstd"
+
+# Decompression guard: the published artifact is ~8 KB compressed and well
+# under a megabyte inflated. A far larger bound still refuses a zip bomb.
+MAX_INFLATED_BYTES = 64 << 20
+
+FETCH_TIMEOUT_S = 30
+
+
+class Literal(NamedTuple):
+    """A VID:PID pair hardcoded somewhere under `ci/`."""
+
+    vid: int
+    pid: int
+    label: str
+    source: str
+
+
+# Every VID:PID literal in the ci/ tree. Keep in sync when a literal is
+# retired — the point of this list is that it shrinks to empty.
+AUDITED_LITERALS: tuple[Literal, ...] = (
+    Literal(0x2E8A, 0x000A, "rp2040 / rpipico application CDC", "port_utils.py"),
+    Literal(0x2E8A, 0xF00A, "rpipicow application CDC", "port_utils.py"),
+    Literal(0x2E8A, 0x000F, "rp2350 / rpipico2 application CDC", "port_utils.py"),
+    Literal(0x2E8A, 0xF00F, "rp2350w / rpipico2w application CDC", "port_utils.py"),
+    Literal(0x2E8A, 0x0003, "RP2 ROM BOOTSEL", "port_utils.py (comment)"),
+    Literal(0x16C0, 0x0483, "LPCXpresso VCOM (LPC11U35)", "port_utils.py"),
+    Literal(0x1FC9, 0x0132, "NXP LPC-Link2 CMSIS-DAP", "port_utils.py"),
+    Literal(0x16C0, 0x0486, "PJRC / Teensy USB-Serial (alt)", "serial_probe.py"),
+    Literal(0x303A, 0x1001, "Espressif native USB CDC", "serial_probe.py"),
+    Literal(0x10C4, 0xEA60, "Silicon Labs CP2102", "serial_probe.py"),
+    Literal(0x1A86, 0x7523, "WCH CH340", "serial_probe.py"),
+    Literal(0x1A86, 0x55D4, "WCH CH343", "serial_probe.py"),
+    Literal(0x0403, 0x6001, "FTDI FT232R", "serial_probe.py"),
+    Literal(0x0403, 0x6010, "FTDI FT2232", "serial_probe.py"),
+    Literal(0x0403, 0x6014, "FTDI FT232H", "serial_probe.py"),
+)
+
+
+def _read_varint(buf: bytes, pos: int) -> tuple[int, int]:
+    """Decode a protobuf base-128 varint at `pos`; return (value, next_pos)."""
+    result = 0
+    shift = 0
+    while True:
+        if pos >= len(buf):
+            raise ValueError("truncated varint")
+        byte = buf[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+        if shift > 63:
+            raise ValueError("varint too long")
+
+
+def _iter_fields(buf: bytes) -> Iterator[tuple[int, int | bytes]]:
+    """Yield (field_number, value) for a protobuf message body.
+
+    Only the two wire types the schema uses are supported: varint (0) and
+    length-delimited (2). Anything else means the artifact schema changed and
+    the caller should fail loudly rather than guess.
+    """
+    pos = 0
+    while pos < len(buf):
+        key, pos = _read_varint(buf, pos)
+        field_number, wire_type = key >> 3, key & 0x07
+        if wire_type == 0:
+            value, pos = _read_varint(buf, pos)
+            yield field_number, value
+        elif wire_type == 2:
+            length, pos = _read_varint(buf, pos)
+            end = pos + length
+            if end > len(buf):
+                raise ValueError("length-delimited field overruns buffer")
+            yield field_number, buf[pos:end]
+            pos = end
+        else:
+            raise ValueError(f"unsupported wire type {wire_type}")
+
+
+def _as_bytes(value: int | bytes) -> bytes:
+    if not isinstance(value, bytes):
+        raise ValueError("expected a length-delimited field")
+    return value
+
+
+def _as_int(value: int | bytes) -> int:
+    if isinstance(value, bytes):
+        raise ValueError("expected a varint field")
+    return value
+
+
+def decode_registry(raw: bytes) -> dict[int, tuple[str, dict[int, str]]]:
+    """Decode the inflated artifact into {vid: (vendor_name, {pid: product})}.
+
+    Schema (published by FastLED/boards):
+
+        message UsbVidDatabase { repeated Vendor vendors = 1; }
+        message Vendor  { uint32 vid = 1; string name = 2;
+                          repeated Product products = 3; }
+        message Product { uint32 pid = 1; string name = 2; }
+    """
+    registry: dict[int, tuple[str, dict[int, str]]] = {}
+    for field_number, value in _iter_fields(raw):
+        if field_number != 1:
+            continue
+        vid: int | None = None
+        vendor_name = ""
+        products: dict[int, str] = {}
+        for vendor_field, vendor_value in _iter_fields(_as_bytes(value)):
+            if vendor_field == 1:
+                vid = _as_int(vendor_value)
+            elif vendor_field == 2:
+                vendor_name = _as_bytes(vendor_value).decode("utf-8", "replace")
+            elif vendor_field == 3:
+                pid: int | None = None
+                product_name = ""
+                for product_field, product_value in _iter_fields(
+                    _as_bytes(vendor_value)
+                ):
+                    if product_field == 1:
+                        pid = _as_int(product_value)
+                    elif product_field == 2:
+                        product_name = _as_bytes(product_value).decode(
+                            "utf-8", "replace"
+                        )
+                if pid is not None:
+                    products[pid] = product_name
+        if vid is not None:
+            registry[vid] = (vendor_name, products)
+    return registry
+
+
+def fetch_artifact(url: str = ARTIFACT_URL) -> bytes:
+    """Download and inflate the published registry artifact."""
+    try:
+        import zstandard
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "zstandard is required to decode usb-vids.proto.zstd. Run this "
+            "script with `uv run --with zstandard python "
+            "ci/util/audit_usb_registry.py`."
+        ) from exc
+
+    with urllib.request.urlopen(url, timeout=FETCH_TIMEOUT_S) as response:
+        compressed = response.read()
+    return zstandard.ZstdDecompressor().decompress(
+        compressed, max_output_size=MAX_INFLATED_BYTES
+    )
+
+
+def main() -> int:
+    try:
+        raw = fetch_artifact()
+        registry = decode_registry(raw)
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as exc:
+        print(f"FAILED to obtain the FastLED/boards registry: {exc}")
+        print(f"  artifact: {ARTIFACT_URL}")
+        return 2
+
+    vendor_count = len(registry)
+    product_count = sum(len(products) for _, products in registry.values())
+    print(f"FastLED/boards registry: {vendor_count} vendors, {product_count} products")
+    print(f"Auditing {len(AUDITED_LITERALS)} literals from ci/\n")
+
+    gaps: list[Literal] = []
+    for entry in AUDITED_LITERALS:
+        pair = f"{entry.vid:04X}:{entry.pid:04X}"
+        vendor = registry.get(entry.vid)
+        if vendor is None or entry.pid not in vendor[1]:
+            gaps.append(entry)
+            print(f"  GAP  {pair}  {entry.label}  [{entry.source}]")
+            continue
+        vendor_name, products = vendor
+        print(f"  OK   {pair}  {entry.label}  -> {vendor_name} / {products[entry.pid]}")
+
+    resolved = len(AUDITED_LITERALS) - len(gaps)
+    print(f"\n{resolved}/{len(AUDITED_LITERALS)} resolve from FastLED/boards")
+    if gaps:
+        print(
+            "\nEach GAP is a registry gap. Add the record on the FastLED/boards\n"
+            "data branch, let fbuild ingest it, then cascade the fbuild pin\n"
+            "in pyproject.toml. Do NOT keep or add a local literal.\n"
+            "See agents/docs/usb-vid-pid-registry.md."
+        )
+        return 1
+    print("\nAll audited literals are published upstream and can be retired.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/util/audit_usb_registry.py
+++ b/ci/util/audit_usb_registry.py
@@ -14,9 +14,13 @@ of the literals still present in `ci/` resolve from the registry.
     uv run python ci/util/audit_usb_registry.py
 
 Exit codes:
-    0 — every audited literal resolves from the registry
-    1 — at least one literal is missing (file the gap at FastLED/boards)
+    0 — every audited literal resolves, ignoring the gaps in KNOWN_GAPS
+    1 — an unfiled literal is missing, or a KNOWN_GAPS entry went stale
     2 — the artifact could not be fetched or decoded
+
+Exit 0 while a filed gap is outstanding is deliberate: it makes this safe to
+wire into CI or a pre-commit hook without going permanently red. Those show as
+`GAP*` with their tracking issue. A gap that is NOT in KNOWN_GAPS still fails.
 
 A missing literal is a registry gap, never a reason to keep or add a local
 entry. `0403:6014` (FTDI FT232H) is the one known outstanding gap, tracked as
@@ -71,6 +75,15 @@ AUDITED_LITERALS: tuple[Literal, ...] = (
 )
 
 
+# Gaps already filed upstream and accepted as outstanding. A known gap keeps
+# the exit code green so this script can be wired into CI or a pre-commit hook
+# without going permanently red; an *unknown* gap still fails. Delete an entry
+# once the registry publishes it — the audit then fails loudly if it regresses.
+KNOWN_GAPS: dict[tuple[int, int], str] = {
+    (0x0403, 0x6014): "FastLED/boards#60",
+}
+
+
 def _read_varint(buf: bytes, pos: int) -> tuple[int, int]:
     """Decode a protobuf base-128 varint at `pos`; return (value, next_pos)."""
     result = 0
@@ -91,9 +104,10 @@ def _read_varint(buf: bytes, pos: int) -> tuple[int, int]:
 def _iter_fields(buf: bytes) -> Iterator[tuple[int, int | bytes]]:
     """Yield (field_number, value) for a protobuf message body.
 
-    Only the two wire types the schema uses are supported: varint (0) and
-    length-delimited (2). Anything else means the artifact schema changed and
-    the caller should fail loudly rather than guess.
+    The schema uses varint (0) and length-delimited (2). Fixed-width fields
+    (1, 5) are skipped rather than rejected so a forward-compatible upstream
+    addition does not abort the parse; only genuinely malformed wire types
+    raise. Callers ignore field numbers they do not recognise.
     """
     pos = 0
     while pos < len(buf):
@@ -109,7 +123,21 @@ def _iter_fields(buf: bytes) -> Iterator[tuple[int, int | bytes]]:
                 raise ValueError("length-delimited field overruns buffer")
             yield field_number, buf[pos:end]
             pos = end
+        elif wire_type in (1, 5):
+            # Fixed-width fields (8-byte / 4-byte). The schema does not use
+            # them today, but FastLED/boards owns it independently, so an
+            # added checksum or timestamp must not abort the parse — that
+            # would report "artifact undecodable" when every audited VID:PID
+            # is still present. Skip them the way any protobuf reader does.
+            width = 8 if wire_type == 1 else 4
+            end = pos + width
+            if end > len(buf):
+                raise ValueError("fixed-width field overruns buffer")
+            pos = end
         else:
+            # Wire types 3 and 4 are the deprecated start/end-group pair; 6
+            # and 7 are unassigned. Any of them means genuinely malformed
+            # data rather than a forward-compatible schema addition.
             raise ValueError(f"unsupported wire type {wire_type}")
 
 
@@ -201,20 +229,44 @@ def main() -> int:
     print(f"FastLED/boards registry: {vendor_count} vendors, {product_count} products")
     print(f"Auditing {len(AUDITED_LITERALS)} literals from ci/\n")
 
-    gaps: list[Literal] = []
+    new_gaps: list[Literal] = []
+    known_gaps: list[Literal] = []
+    stale_known: list[Literal] = []
     for entry in AUDITED_LITERALS:
         pair = f"{entry.vid:04X}:{entry.pid:04X}"
+        tracker = KNOWN_GAPS.get((entry.vid, entry.pid))
         vendor = registry.get(entry.vid)
         if vendor is None or entry.pid not in vendor[1]:
-            gaps.append(entry)
-            print(f"  GAP  {pair}  {entry.label}  [{entry.source}]")
+            if tracker is not None:
+                known_gaps.append(entry)
+                print(f"  GAP* {pair}  {entry.label}  [{entry.source}]  {tracker}")
+            else:
+                new_gaps.append(entry)
+                print(f"  GAP  {pair}  {entry.label}  [{entry.source}]")
             continue
         vendor_name, products = vendor
         print(f"  OK   {pair}  {entry.label}  -> {vendor_name} / {products[entry.pid]}")
+        if tracker is not None:
+            stale_known.append(entry)
 
-    resolved = len(AUDITED_LITERALS) - len(gaps)
+    resolved = len(AUDITED_LITERALS) - len(new_gaps) - len(known_gaps)
     print(f"\n{resolved}/{len(AUDITED_LITERALS)} resolve from FastLED/boards")
-    if gaps:
+
+    if stale_known:
+        # The registry caught up. Prompt the cleanup rather than letting the
+        # allowlist quietly mask a gap that no longer exists.
+        print("\nKNOWN_GAPS is stale — these now resolve upstream:")
+        for entry in stale_known:
+            pair = f"{entry.vid:04X}:{entry.pid:04X}"
+            tracker = KNOWN_GAPS[(entry.vid, entry.pid)]
+            print(f"  {pair}  {entry.label}  ({tracker})")
+        print(
+            "Drop them from KNOWN_GAPS and retire the literal from "
+            f"{stale_known[0].source}."
+        )
+        return 1
+
+    if new_gaps:
         print(
             "\nEach GAP is a registry gap. Add the record on the FastLED/boards\n"
             "data branch, let fbuild ingest it, then cascade the fbuild pin\n"
@@ -222,6 +274,15 @@ def main() -> int:
             "See agents/docs/usb-vid-pid-registry.md."
         )
         return 1
+
+    if known_gaps:
+        print(
+            f"\n{len(known_gaps)} known gap(s) marked GAP*, already filed "
+            "upstream and accepted as outstanding.\nEvery other literal is "
+            "published and can be retired."
+        )
+        return 0
+
     print("\nAll audited literals are published upstream and can be retired.")
     return 0
 

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -55,10 +55,20 @@ NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 # them all here lets the same PlatformIO env work regardless of which
 # firmware is on the on-board probe (see the LPC845-BRK note below).
 #
-# Add new entries here when porting to a new board. See FastLED #3300 for
-# the LPC845-BRK case that motivated this map. ci/util/serial_probe.py
-# has a richer fingerprint table; this map only carries the entries
-# autoresearch needs for default-port selection.
+# FROZEN — DO NOT ADD ENTRIES. USB VID:PID identity is owned by
+# https://github.com/FastLED/boards and reaches this repo through fbuild's
+# ingestion of the published `usb-vids.proto.zstd` archive. Every pair below
+# is already published there; this map survives only as a legacy fast path
+# for default-port selection (see FastLED #3300 for the LPC845-BRK case that
+# motivated it, and FastLED #3836 for its retirement).
+#
+# A board that cannot be identified is a FastLED/boards gap: add the record
+# on the appropriate data branch, let fbuild ingest it, then cascade the
+# `fbuild==X.Y.Z` pin in pyproject.toml and relock locally. Full procedure:
+# agents/docs/usb-vid-pid-registry.md.
+#
+# ci/util/serial_probe.py has a richer fingerprint table; it is likewise
+# frozen and is display/diagnostic only.
 ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
     # RP2040 Pico application CDC (the ROM BOOTSEL interface is 2E8A:0003
     # and is intentionally not a serial port). Keep this fingerprint strict:

--- a/ci/util/serial_probe.py
+++ b/ci/util/serial_probe.py
@@ -46,8 +46,18 @@ import serial  # type: ignore[import-not-found]
 import serial.tools.list_ports  # type: ignore[import-not-found]
 
 
-# Known board USB VID:PID fingerprints. Add new entries here when porting to
-# a new board so port_utils.py can pick the right COM port without guessing.
+# Known board USB VID:PID fingerprints — display/diagnostic hints only.
+#
+# FROZEN — DO NOT ADD ENTRIES. USB VID:PID identity is owned by
+# https://github.com/FastLED/boards and reaches this repo through fbuild's
+# ingestion of the published `usb-vids.proto.zstd` archive; `fbuild port scan`
+# is the authority for naming an attached board. This table is never a
+# selection authority — it only labels ports that have already been chosen.
+#
+# A board that cannot be identified is a FastLED/boards gap: add the record
+# there, let fbuild ingest it, then cascade the `fbuild==X.Y.Z` pin in
+# pyproject.toml and relock locally. Full procedure:
+# agents/docs/usb-vid-pid-registry.md.
 BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
     # NXP LPC845-BRK ships with an LPC11U35 carrying both the CMSIS-DAP
     # debug interface AND a USB-VCOM bridge for the LPC845's USART0.
@@ -73,6 +83,8 @@ BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
     # FTDI FT232R — older Arduinos, some shields.
     (0x0403, 0x6001): "FTDI FT232R USB-UART",
     (0x0403, 0x6010): "FTDI FT2232 dual UART",
+    # Only literal here not yet resolvable from FastLED/boards --
+    # tracked as FastLED/boards#60. Remove once the registry publishes it.
     (0x0403, 0x6014): "FTDI FT232H USB-UART",
     # Teensy 3.x/4.x.
     (0x16C0, 0x0486): "PJRC / Teensy USB-Serial (alt)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,12 @@ dependencies = [
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
     "fbuild==2.5.19",
+    # Decodes the FastLED/boards `usb-vids.proto.zstd` registry artifact in
+    # ci/util/audit_usb_registry.py. Declared explicitly rather than relied on
+    # transitively (clang-tool-chain-bins pulls it in today) so the documented
+    # `uv run python ci/util/audit_usb_registry.py` cannot break out from under
+    # us. See agents/docs/usb-vid-pid-registry.md.
+    "zstandard>=0.22.0",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,16 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.18. It carries hardened USB/deploy recovery, current
+    # Pin to fbuild 2.5.19. It carries hardened USB/deploy recovery, current
     # esptool probing, and the accumulated library/build fixes below.
     #
     # Pin history:
+    #   2.5.19 -- selects the exact runtime RP board profile from the verified
+    #              FastLED/boards USB identity registry instead of a local
+    #              VID/PID guess, and adds ClearCore SAME53 builds
+    #              (FastLED/fbuild#1333/#1335). Cascades the current
+    #              `usb-vids.proto.zstd` ingestion into this repo -- see
+    #              agents/docs/usb-vid-pid-registry.md.
     #   2.5.18 -- keeps RP application USB recoverable, supports managed
     #              esptool 5.3 probing, recovers clean daemon shutdowns, and
     #              maps explicitly excluded Windows ports correctly
@@ -195,7 +201,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.18",
+    "fbuild==2.5.19",
     "platformio>=6.1.19,<6.2",
     "python-dateutil",
     "ruff",


### PR DESCRIPTION
Refs #3836.

## Why

USB board identity belongs in [FastLED/boards](https://github.com/FastLED/boards),
which publishes a zstd-compressed protobuf (`usb-vids.proto.zstd`) that fbuild
ingests both at build time and as its offline fallback. FastLED consumes it
through fbuild. Nothing in this repo should ever be the place a VID:PID *first
exists* — but until now that rule was not written down here, and two local
tables had grown as a result.

That is the shape #3836 is complaining about, stated as a rule rather than as a
one-off cleanup.

## What this does

**Documents the rule.** New `agents/docs/usb-vid-pid-registry.md` covers the
publication pipeline, the protobuf schema (and why one nested artifact yields
both the VID→vendor and VID:PID→{vendor,product} projections, so a consumer
never needs its own map), what to do when an identity is missing, and the fbuild
version-cascade procedure. Added to `CLAUDE.md` as a Core Rule plus a task-table
row, and cross-linked from `hardware-autoresearch.md` and
`driver-bringup-postmortems.md`.

**Freezes the legacy tables at the point of temptation.**
`ENVIRONMENT_TO_VCOM_VID_PIDS` (`ci/util/port_utils.py`) previously said *"Add
new entries here when porting to a new board"* — the exact instruction that
produced the drift. Both it and `BOARD_FINGERPRINTS`
(`ci/util/serial_probe.py`) now carry a DO-NOT-EXTEND note pointing at the
registry and the cascade.

**Makes the migration verifiable rather than asserted.** New
`ci/util/audit_usb_registry.py` fetches the live artifact, decodes it, and exits
non-zero while any audited literal is unresolvable:

```
$ uv run python ci/util/audit_usb_registry.py
FastLED/boards registry: 36 vendors, 1056 products
Auditing 15 literals from ci/
  OK   2E8A:000F  rp2350 / rpipico2 application CDC  -> Arduino / Shared USB identity (4 products)
  ...
  GAP  0403:6014  FTDI FT232H  [serial_probe.py]
14/15 resolve from FastLED/boards
```

`AUDITED_LITERALS` is the checklist; it should shrink to empty as literals
retire.

## Audit result

**14 of 15 literals already resolve upstream** — including every RP2xxx identity
#3836 names. The lone gap is FTDI FT232H `0403:6014`, absent registry-wide (the
FTDI vendor entry carries only `6001` and `6010`). Filed as FastLED/boards#60
and tracked there rather than papered over here, which is exactly the behavior
the new rule prescribes.

## Version cascade

Pin moves to **fbuild 2.5.19**, which selects the exact runtime RP board profile
from the verified registry instead of a local VID/PID guess
(FastLED/fbuild#1335) and adds ClearCore SAME53 builds (FastLED/fbuild#1333).
Confirmed published on PyPI before moving the pin; `uv run fbuild --version`
reports 2.5.19.

Note `uv.lock` is gitignored in this repo, so the `pyproject.toml` pin is the
only committed half of the cascade — the docs say so explicitly, since relocking
locally is still required or you keep running the previous wheel.

## Testing

- `bash lint` — clean.
- `uv run pytest ci/tests/ -k "port or probe or serial or autoresearch"` — 301
  passed, 4 skipped.
- Audit script exercised end-to-end against the live artifact.

## Scope

Docs, comments, one new audit script, and the pin bump. **No behavior change** —
this PR does not implement #3836's code change (routing RP port selection to
fbuild in `_resolve_port_and_environment`); it establishes the rule and proves
the data is ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a USB VID/PID registry auditor to identify missing, unresolved, or outdated board records.
  * Improved handling of registry data, including tracked upstream gaps and compatibility with future formats.

* **Documentation**
  * Documented centralized USB identity management, board bring-up checks, update workflows, and audit results.
  * Clarified that existing USB tables are frozen and reserved for compatibility and diagnostics.

* **Chores**
  * Added ignore rules for temporary build and compilation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->