### PR TITLE
fix(examples): declare the SPI dependency in FxSdCard — takes teensy to 8/8 green (#3838)

### DIFF
--- a/examples/Fx/FxSdCard/FxSdCard.ino
+++ b/examples/Fx/FxSdCard/FxSdCard.ino
@@ -27,8 +27,9 @@
 // a dependency finder will see it: fbuild selects a framework library solely
 // from unconditional top-level includes in the sketch, and the Teensy core
 // bundles SPI inside its own libraries/ folder, so the header resolves while
-// its sources are never compiled. Without this line every teensy board fails
-// to link with `undefined reference to SPIClass::*` (FastLED#3838). A guard
+// its sources are never compiled. Without this line the Teensy boards that
+// carry the SdFat/SPI path -- 3.5, 3.6, 4.0 and 4.1 -- fail to link with
+// `undefined reference to SPIClass::*` (FastLED#3838). A guard
 // does not work -- the finder skips conditional includes even when the
 // condition is true.
 #include <SPI.h>

--- a/examples/Fx/FxSdCard/FxSdCard.ino
+++ b/examples/Fx/FxSdCard/FxSdCard.ino
@@ -22,6 +22,16 @@
 ///   2. `cd` into this example dir
 ///   3. `fastled` at the repo root opens a browser-based runner.
 
+// This sketch reads its media from an SD card over SPI. The Arduino SPI
+// library is a real dependency of that path, and a sketch is the only place
+// a dependency finder will see it: fbuild selects a framework library solely
+// from unconditional top-level includes in the sketch, and the Teensy core
+// bundles SPI inside its own libraries/ folder, so the header resolves while
+// its sources are never compiled. Without this line every teensy board fails
+// to link with `undefined reference to SPIClass::*` (FastLED#3838). A guard
+// does not work -- the finder skips conditional includes even when the
+// condition is true.
+#include <SPI.h>
 #include "FastLED.h"
 #include "Arduino.h"
 


### PR DESCRIPTION
Closes the SPI half of #3838. With #3966 already on master, this should take the teensy board builds from **4/8 green to 8/8**.

## The remaining failure

After #3966, teensy35, teensy36, teensy40 and teensy41 each failed on **exactly one sketch** — `Fx/FxSdCard` — with zero Adafruit symbols left:

```
undefined reference to `SPIClass::begin()'
undefined reference to `SPI'
undefined reference to `SPIClass::transfer(void const*, void*, unsigned int)'
undefined reference to `SPIClass::end()'
```

## Why the include belongs in the sketch

`FxSdCard` drives an SD card over SPI, so the Arduino SPI library is a genuine dependency of the sketch — and the sketch is the only place a dependency finder will ever see it. fbuild selects a framework library **solely from unconditional top-level includes in the sketch** (FastLED/fbuild#1214, a deliberate tested invariant), while the Teensy core bundles SPI inside its own `libraries/` folder, so the header resolves everywhere and its sources are never compiled.

I measured the alternatives rather than assuming:

| approach | result |
|---|---|
| `#if FL_HAS_INCLUDE(<SPI.h>)` guard around the include | **fails** — the finder skips conditional includes even when the condition is true (measured on #3966) |
| `lib_deps=["SPI"]` on the board | **fails** — reaches the generated ini (`.build/pio/teensy35/platformio.ini:16`), link errors clear, then `build error: package error: library 'SPI' not found in registry`; fbuild resolves names against the PlatformIO registry and SPI ships inside the framework |
| gate the Teensy SdFat backend behind a new define | works, but silently removes SD from projects that get it today |
| **unconditional `#include <SPI.h>` in the sketch (this PR)** | works, no functional change for anyone |

## Scope

This is the stopgap, not the architectural fix. **#3777 remains the real answer** — the vendored SdFat (`sdfat/fs_sdfat_teensy.h:7`, `SpiDriver/SdSpiDriver.h:35,99`) should not depend on Arduino `SPIClass` at all. This line should be deleted when that lands, and the commit message says so.

I want to flag the tension honestly: #3838's acceptance criteria say the fix should not add "per-example include/link workarounds solely to appease the build scanner." I do not think this qualifies as *solely* that — an Arduino SD-over-SPI sketch including `<SPI.h>` is the standard idiom and declares a real dependency — but it is adjacent enough that a maintainer may prefer to hold out for #3777 and leave these four boards red. If so, close this and I will pick up #3777 instead.

## Verification (local, warm cache)

| board | before | after |
|---|---|---|
| teensy35 | link fails | ✅ flash 70604 B |
| teensy36 | link fails | ✅ flash 70772 B |
| teensy40 | link fails | ✅ flash 119808 B |
| teensy41 | link fails | ✅ flash 119808 B |
| esp32dev | builds | ✅ still builds |
| rp2040 | red: `SDFS` + `SPI` | red: `SDFS` only — pre-existing gap, SPI half improved |

`bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SD-card playback build failures on Teensy boards by ensuring required SPI support is included.
  * Clarified that SD-card playback is supported on Teensy 3.5, 3.6, 4.0, and 4.1 boards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->