### PR TITLE
fix(sdfat): route Teensy 4 SdFat SPI transport onto LpspiBus

### DIFF
--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
@@ -36,7 +36,7 @@
 #define SD_USE_CUSTOM_SPI
 #endif  // SPI_DRIVER_SELECT == 0 && SD_HAS_CUSTOM_SPI
 namespace fl { namespace platforms { namespace teensy { namespace sdfat {
-#if defined(SD_SPI_USE_LPSPI_BUS)
+#if defined(FL_SDFAT_HAS_LPSPI_BUS)
 /** Port type for the FastLED LPSPI hardware driver (Teensy 4). */
 typedef fl::platforms::teensy::LpspiBus SpiPort_t;
 /** Transaction settings for the FastLED LPSPI hardware driver (Teensy 4). */

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
@@ -36,6 +36,17 @@
 #define SD_USE_CUSTOM_SPI
 #endif  // SPI_DRIVER_SELECT == 0 && SD_HAS_CUSTOM_SPI
 namespace fl { namespace platforms { namespace teensy { namespace sdfat {
+#if defined(SD_SPI_USE_LPSPI_BUS)
+/** Port type for the FastLED LPSPI hardware driver (Teensy 4). */
+typedef fl::platforms::teensy::LpspiBus SpiPort_t;
+/** Transaction settings for the FastLED LPSPI hardware driver (Teensy 4). */
+typedef fl::platforms::teensy::LpspiSettings SpiPortSettings_t;
+#else
+/** Port type for Arduino SPI hardware driver. */
+typedef SPIClass SpiPort_t;
+/** Transaction settings for Arduino SPI hardware driver. */
+typedef SPISettings SpiPortSettings_t;
+#endif
 class SdSpiConfig;
 /**
  * \class SdSpiArduinoDriver
@@ -83,12 +94,15 @@ class SdSpiArduinoDriver {
    * \param[in] maxSck Maximum SCK frequency.
    */
   void setSckSpeed(fl::u32 maxSck) {
-    mSpiSettings = SPISettings(maxSck, MSBFIRST, SPI_MODE0);
+    mSpiSettings = SpiPortSettings_t(maxSck, MSBFIRST, SPI_MODE0);
   }
 
  private:
-  SPIClass *mSpi;
-  SPISettings mSpiSettings;
+  // SpiPort_t / SpiPortSettings_t are selected in SdSpiDriver.h, which
+  // includes this header after declaring them: SPIClass/SPISettings on
+  // Teensy 3.x, fl LpspiBus/LpspiSettings on Teensy 4.
+  SpiPort_t *mSpi;
+  SpiPortSettings_t mSpiSettings;
 };
 // Keep the imported implementation's member spelling without changing it.
 #define m_spi mSpi

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
@@ -48,11 +48,11 @@
 // yet (FastLED #3972). Define `SD_SPI_USE_ARDUINO_SPI` to force that path back
 // on for Teensy 4 as an escape hatch.
 #if defined(FL_IS_TEENSY_4X) && !defined(SD_SPI_USE_ARDUINO_SPI)
-#define SD_SPI_USE_LPSPI_BUS 1
+#define FL_SDFAT_HAS_LPSPI_BUS
 #endif
 
 #if SPI_DRIVER_SELECT < 2
-#if defined(SD_SPI_USE_LPSPI_BUS)
+#if defined(FL_SDFAT_HAS_LPSPI_BUS)
 #include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"  // ok platform headers
 #else
 #include "SPI.h"

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
@@ -31,9 +31,37 @@
 #define SdSpiDriver_h
 #include "platforms/arm/teensy/sdfat/common/SysCall.h"
 #include "fl/stl/int.h"
+#include "platforms/arm/teensy/is_teensy.h"  // ok platform headers
+
+// Transport selection for the Arduino-shaped hardware driver.
+//
+// On Teensy 4 (IMXRT1062) SdFat's SPI port is FastLED's own `LpspiBus` rather
+// than the framework's `SPIClass`. This is not a preference: the Teensyduino
+// `SPI` library is only *compiled* when the library finder selects it from an
+// unconditional sketch-level `#include <SPI.h>`, so `SPIClass::begin`,
+// `SPIClass::transfer` and the global `SPI` object resolve as headers but
+// never link (FastLED #3970). The library also cannot be vendored -- it is
+// GPLv2/LGPLv2.1 and FastLED is MIT. `LpspiBus` (#3802) already owns the
+// registers, so the port type is simply retargeted at it.
+//
+// Teensy 3.x keeps the `SPIClass` path: the DSPI read side has not been ported
+// yet (FastLED #3972). Define `SD_SPI_USE_ARDUINO_SPI` to force that path back
+// on for Teensy 4 as an escape hatch.
+#if defined(FL_IS_TEENSY_4X) && !defined(SD_SPI_USE_ARDUINO_SPI)
+#define SD_SPI_USE_LPSPI_BUS 1
+#endif
+
 #if SPI_DRIVER_SELECT < 2
+#if defined(SD_SPI_USE_LPSPI_BUS)
+#include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"  // ok platform headers
+#else
 #include "SPI.h"
 #endif
+#endif
+
+// SpiPort_t / SpiPortSettings_t for SPI_DRIVER_SELECT < 2 are declared in
+// SdSpiArduinoDriver.h below, which is the only consumer and already opens
+// this namespace -- the include has to stay above any namespace here.
 #if SPI_DRIVER_SELECT == 0 && SD_HAS_CUSTOM_SPI
 #define SD_USE_CUSTOM_SPI
 #include "platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h"
@@ -94,10 +122,7 @@ inline bool spiOptionDedicated(fl::u8 opt) {(void)opt; return false;}
 /** Set SCK rate to 500 kHz for AVR. */
 #define SPI_SIXTEENTH_SPEED SD_SCK_HZ(500000)
 //------------------------------------------------------------------------------
-#if SPI_DRIVER_SELECT < 2
-/** Port type for Arduino SPI hardware driver. */
-typedef SPIClass SpiPort_t;
-#elif SPI_DRIVER_SELECT == 2
+#if SPI_DRIVER_SELECT == 2
 class SdSpiSoftDriver;
 /** Port type for software SPI driver. */
 typedef SdSpiSoftDriver SpiPort_t;
@@ -105,9 +130,9 @@ typedef SdSpiSoftDriver SpiPort_t;
 class SdSpiBaseClass;
 /** Port type for extrernal SPI driver. */
 typedef SdSpiBaseClass SpiPort_t;
-#else  // SPI_DRIVER_SELECT
+#elif SPI_DRIVER_SELECT >= 4
 typedef void*  SpiPort_t;
-#endif  // SPI_DRIVER_SELECT
+#endif  // SPI_DRIVER_SELECT (< 2 is handled above, next to its include)
 //------------------------------------------------------------------------------
 /**
  * \class SdSpiConfig

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
@@ -46,7 +46,12 @@ void SdSpiArduinoDriver::begin(SdSpiConfig spiConfig) {
     m_spi->setSCK(SDFAT_SDCARD_SCK_PIN);
 #endif  // defined(SDFAT_SDCARD_SPI) && defined(SDFAT_SDCARD_SS_PIN)
   } else {
+#if defined(SD_SPI_USE_LPSPI_BUS)
+    // Bus 0 is LPSPI4, the peripheral the Arduino global `SPI` wraps.
+    m_spi = &fl::platforms::teensy::LpspiBus::get(0);
+#else
     m_spi = &SPI;
+#endif
   }
   m_spi->begin();
 }

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
@@ -46,7 +46,7 @@ void SdSpiArduinoDriver::begin(SdSpiConfig spiConfig) {
     m_spi->setSCK(SDFAT_SDCARD_SCK_PIN);
 #endif  // defined(SDFAT_SDCARD_SPI) && defined(SDFAT_SDCARD_SS_PIN)
   } else {
-#if defined(SD_SPI_USE_LPSPI_BUS)
+#if defined(FL_SDFAT_HAS_LPSPI_BUS)
     // Bus 0 is LPSPI4, the peripheral the Arduino global `SPI` wraps.
     m_spi = &fl::platforms::teensy::LpspiBus::get(0);
 #else

--- a/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
+++ b/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
@@ -3,8 +3,18 @@
 // Upstream-derived from the USE_SDFAT branch of
 // src/platforms/fs_sdcard_arduino.hpp.
 
+#include "platforms/arm/teensy/is_teensy.h"  // ok platform headers
+
 // IWYU pragma: begin_keep
+#if !defined(FL_IS_TEENSY_4X)
+// Teensy 3.x still routes SdFat through Arduino `SPIClass`. Teensy 4 uses
+// FastLED's own `LpspiBus` (FastLED#3971), so pulling the framework header in
+// here would keep the GPL/LGPL `SPI.h` in the translation unit and re-expose
+// the undefined `SPIClass`/`SPI` symbols the moment anything referenced them
+// again. `SdSpiDriver.h` supplies whichever transport header the platform
+// actually needs.
 #include <SPI.h>
+#endif
 #include "platforms/arm/teensy/sdfat/SdFat.h"
 // IWYU pragma: end_keep
 

--- a/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
+++ b/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
@@ -327,6 +327,15 @@ inline void LpspiBus::beginTransaction(const LpspiSettings &settings) {
     }
 
     port().CR = 0;
+    // Flush both FIFOs before re-enabling. `CFGR1` leaves RX capture on, so
+    // every byte any driver clocks out also lands in the RX FIFO -- and the
+    // LED driver (spi_hw_4_mxrt1062.cpp.hpp) writes `TDR` in a loop without
+    // ever reading `RDR`. Sharing one `LpspiBus` between that driver and the
+    // SdFat transport would otherwise leave up to 16 stale bytes queued, and
+    // `transfer()` would return them instead of the card's reply -- silent
+    // data corruption rather than a failure. Clearing `MEN` alone does not
+    // flush; `RRF`/`RTF` do.
+    port().CR = LPSPI_CR_RRF | LPSPI_CR_RTF;
     port().CFGR1 = LPSPI_CFGR1_MASTER | LPSPI_CFGR1_SAMPLE;
     port().CCR = mCcr;
     port().TCR = settings.tcr();

--- a/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
+++ b/src/platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h
@@ -13,10 +13,15 @@
 ///     begin / end                  clock gate + pad drive strength
 ///     beginTransaction / endTransaction   CCR divisor + CR/CFGR1/TCR
 ///
-/// Everything else in upstream SPIClass -- transfer*, DMA, async, setCS,
-/// usingInterrupt, the deprecated setters -- is deliberately absent. FastLED
-/// drives the data path itself via direct register access (see
-/// spi_hw_4_mxrt1062.cpp.hpp's transmit loop polling LPSPI_SR_TDF).
+///     transfer                     blocking byte / block exchange
+///     setTransferWriteFill         fill byte for a null tx buffer
+///
+/// Everything else in upstream SPIClass -- DMA, async, setCS, usingInterrupt,
+/// the deprecated setters -- is deliberately absent. FastLED's LED drivers
+/// drive the data path themselves via direct register access (see
+/// spi_hw_4_mxrt1062.cpp.hpp's transmit loop polling LPSPI_SR_TDF); the
+/// blocking `transfer` overloads exist for the SdFat transport, which needs
+/// a real full-duplex read.
 ///
 /// One behavioural simplification vs upstream: `beginTransaction` /
 /// `endTransaction` do NOT save and restore the NVIC interrupt masks. That
@@ -107,6 +112,27 @@ class LpspiBus {
         }
     }
 
+    /// Byte substituted for the transmit stream when `transfer()` is handed a
+    /// null tx buffer. Mirrors upstream `SPIClass::setTransferWriteFill`.
+    void setTransferWriteFill(fl::u8 fill) { mTransferWriteFill = fill; }
+
+    /// Blocking full-duplex block exchange, a plain loop over the single-byte
+    /// path above. `tx == nullptr` clocks out the fill byte set by
+    /// `setTransferWriteFill()`; `rx == nullptr` discards what comes back.
+    /// Deliberately no DMA and no async completion -- SdFat's driver is
+    /// synchronous, and the FIFO-batched form can be added later if profiling
+    /// asks for it.
+    void transfer(const void *tx, void *rx, fl::size count) {
+        const fl::u8 *src = static_cast<const fl::u8 *>(tx);
+        fl::u8 *dst = static_cast<fl::u8 *>(rx);
+        for (fl::size i = 0; i < count; ++i) {
+            const fl::u8 received = transfer(src ? src[i] : mTransferWriteFill);
+            if (dst) {
+                dst[i] = received;
+            }
+        }
+    }
+
     /// The peripheral register block, for drivers that drive data directly.
     IMXRT_LPSPI_t &port() { return *mPort; }
 
@@ -129,6 +155,8 @@ class LpspiBus {
 
     fl::u32 mClock = 0;
     fl::u32 mCcr = 0;
+
+    fl::u8 mTransferWriteFill = 0xFF;
 
     friend struct LpspiBusStorage;
 };


### PR DESCRIPTION
Closes #3971 (sub-issue of #3970).

## Mechanism

`SdSpiArduinoDriver` held a `SPIClass*`. Teensyduino's SPI library is only
*compiled* when the PlatformIO library finder selects it from an unconditional
sketch-level `#include <SPI.h>` — so its headers always resolve while its
sources never link. FastLED cannot add that sketch include (it breaks the host
example build: the stub platform has no `SPI.h`, which is what sank #3969), and
cannot vendor the library either (GPLv2/LGPLv2.1 vs FastLED's MIT). Hence
`undefined reference to SPIClass::begin()` / `SPI` on every Teensy that builds
`Fx/FxSdCard`.

The fix is to own the transport, exactly as #3802 did for the LED side.

## Changes (4 files, +85/-13)

- **`teensy4_common/lpspi/lpspi_bus.h`** — `LpspiBus` gains
  `setTransferWriteFill(fl::u8)` and a blocking full-duplex
  `transfer(const void* tx, void* rx, fl::size count)`: a plain loop over the
  existing single-byte `transfer(u8)`. `tx == nullptr` clocks out the fill byte,
  `rx == nullptr` discards. No DMA, no async. Fill byte is a member of the
  existing bus object, so no new storage at namespace scope.
- **`sdfat/SpiDriver/SdSpiDriver.h`** — transport selection at the existing
  typedef seam. On `FL_IS_TEENSY_4X` (the macro `is_teensy.h` already defines),
  `#include "SPI.h"` is replaced by `lpspi_bus.h`. `SD_SPI_USE_ARDUINO_SPI`
  forces the Arduino path back on as an escape hatch.
- **`sdfat/SpiDriver/SdSpiArduinoDriver.h`** — members become
  `SpiPort_t* mSpi; SpiPortSettings_t mSpiSettings;`. The two typedefs are
  declared here rather than in `SdSpiDriver.h` because
  `IncludeAfterNamespaceChecker`/`NamespaceIncludesChecker` require every
  `#include` to precede any namespace, and this header is the only consumer.
- **`sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp`** — `begin()`'s fallback points at
  `LpspiBus::get(0)` (LPSPI4, the peripheral the Arduino global `SPI` wraps)
  instead of `&SPI`.

Teensy 3.x is untouched — `SpiPort_t` still resolves to `SPIClass` there. Its
DSPI read path is the sibling issue #3972.

Two branches in `SdSpiTeensy3.cpp.hpp` are dead (`SDFAT_SDCARD_SPI` is never
defined; `USE_TRANSFER_TX_RX` is always defined on Teensy), so `setMISO`/
`setMOSI`/`setSCK` and the in-place `transfer(buf, count)` form were not needed.

## Verification (measured on this branch)

| check | result |
|---|---|
| `bash compile teensy41 --examples Fx/FxSdCard` | **PASS** — links. flash 120832 B (1.5% of 7.75 MB), RAM 80160 B (15.3%). Re-run after the typedef relocation: still PASS, 17.8 s. |
| `bash compile teensy40 --examples Fx/FxSdCard` | **PASS** — links. flash 118784 B, RAM 79136 B. Build 272.5 s. |
| `bash test --cpp --clean` | **PASS** — `All tests passed (283/283 unit, 83/83 examples in 64.96s)`. Run with `--clean` because the first invocation hit a valid fingerprint cache and skipped. |
| `bash lint` | **clean**, exit 0 (python_pipeline, cpp_linting, javascript_linting, meson_linting, platformio checks). |
| `teensy35` unchanged | **confirmed** — still exits 1 with the identical pre-existing symbol set: `SPIClass::begin()`, `SPIClass::end()`, `SPIClass::transfer(void const*, void*, unsigned int)`, `SPI`, `SPISettings::ctar_clock_table`, `SPISettings::ctar_div_table`. Expected; that is #3972. |

## Not verified

- **No hardware.** Neither Teensy 4.0 nor 4.1 was flashed — an actual SD read
  over the new `transfer()` loop is unproven. Compile + link only.
- **The `SD_SPI_USE_ARDUINO_SPI` escape hatch was not compiled.** There is no
  build-flag seam wired up to set it from a `bash compile` invocation, so the
  path is reasoned-correct (it restores the exact prior preprocessor state) but
  untested.
- **Singleton elision** was not measured with a before/after flash diff. The
  argument is structural: the new fill byte is a member of the existing
  `LpspiBus`, which already lives in `fl::Singleton<LpspiBusStorage>`, and
  `SingletonElisionChecker` passes — but no byte-level proof that a sketch
  without `beginSd()` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teensy 4.x hardware SPI now uses the faster LPSPI transport by default, with an option to retain Arduino SPI.
  * Added blocking SPI transfers for transmit-only, receive-only, and simultaneous operations.
  * Added configurable SPI transfer fill bytes, defaulting to `0xFF`.

* **Improvements**
  * Teensy 3.x continues using the existing Arduino SPI path.
  * SPI transport is selected automatically for supported Teensy configurations.
  * Improved transaction handling by clearing pending transfer data when starting a new transaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->