### PR TITLE
fix(sdfat): route Teensy 3.x/LC SdFat SPI transport onto a FastLED DSPI bus

### DIFF
--- a/src/platforms/arm/teensy/kinetis_spi/dspi_bus.h
+++ b/src/platforms/arm/teensy/kinetis_spi/dspi_bus.h
@@ -203,9 +203,18 @@ inline fl::u32 dspiClockBits(fl::u32 hz) {
         }
     }
 
-    // CSSCK tracks BR, matching the existing FastLED K20/K66 LED path: the
-    // PCS-to-SCK delay is irrelevant here (SdFat drives chip select as a plain
-    // GPIO) but a delay no shorter than half a clock is always safe.
+    // CSSCK reuses the BR field value, matching the existing FastLED K20/K66
+    // LED path.
+    //
+    // Note the two fields do NOT share an encoding, so this is not "half a
+    // clock": BR field n selects scaler {2,4,6,8,16,32,...} while CSSCK field
+    // n selects 2^(n+1) uniformly. At the 3.75 MHz run setting (BR field 3)
+    // that inserts 16 bus cycles of tCSC, roughly 0.27 us against a 2.13 us
+    // byte. It is harmless -- SdFat drives chip select as a plain GPIO, so the
+    // PCS-to-SCK delay is never actually needed -- but it is not free either.
+    // Left as-is rather than switched to CSSCK(0) because the throughput cost
+    // is small and no Teensy 3.x hardware was available to re-validate the
+    // timing change; see FastLED#3972 follow-ups.
     fl::u32 ctar = SPI_CTAR_PBR(best_pbr) | SPI_CTAR_BR(best_br) |
                    SPI_CTAR_CSSCK(best_br);
     if (best_dbr) {
@@ -362,17 +371,6 @@ inline void DspiBus::end() {
 inline void DspiBus::begin() {
     SIM_SCGC6 |= SIM_SCGC6_SPI0;
 
-    // Park the module while the pads are re-muxed.
-    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_MDIS | SPI_MCR_HALT |
-                 SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
-
-    // MOSI = 11, MISO = 12, SCK = 13, all ALT2. These are SPI0's default pads
-    // on every Teensy 3.x; the alternates (7/8/14) are not exposed here
-    // because SdFat's pin-override branch is compiled out.
-    CORE_PIN11_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
-    CORE_PIN12_CONFIG = PORT_PCR_MUX(2);
-    CORE_PIN13_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
-
     beginTransaction(DspiSettings());
     endTransaction();
 }
@@ -383,9 +381,43 @@ inline void DspiBus::beginTransaction(const DspiSettings &settings) {
         mClockBits = dspiClockBits(mClock);
     }
 
-    // CTAR0 can only be written with the module disabled or halted.
-    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_MDIS | SPI_MCR_HALT |
-                 SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
+    // Re-mux the pads on every transaction, not once in begin().
+    //
+    // FastLED's own LED driver calls `disable_pins()` from `release()` at the
+    // end of every `show()` (fastspi_arm_k66.h:147,385 and the K20 twin),
+    // which hard-writes pins 11 and 13 back to `PORT_PCR_MUX(1)` -- GPIO. A
+    // one-time mux in begin() therefore survives only until the first
+    // `FastLED.show()` on a shared SPI0. After that the DSPI still completes
+    // frames internally, so `transfer()` returns on schedule and nothing
+    // hangs, but no SCK or MOSI reaches the card and MISO floats: 0xFF or
+    // garbage, surfacing as CMD0/ACMD41 timeouts and silently corrupt reads.
+    // These are idempotent register stores, so paying them per transaction is
+    // cheap next to a 512-byte block.
+    //
+    // MOSI = 11, MISO = 12, SCK = 13, all ALT2. These are SPI0's default pads
+    // on every Teensy 3.x; the alternates (7/8/14) are not exposed here
+    // because SdFat's pin-override branch is compiled out.
+    CORE_PIN11_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
+    CORE_PIN12_CONFIG = PORT_PCR_MUX(2);
+    CORE_PIN13_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
+
+    // Halt, then flush -- in two writes, and without MDIS.
+    //
+    // MDIS gates the clock to the DSPI's non-memory-mapped logic, which is
+    // where the FIFO counters live, so `CLR_TXF`/`CLR_RXF` raised in the same
+    // write as `MDIS` are not guaranteed to take effect. NXP's KSDK
+    // `DSPI_FlushFifo` and Teensyduino both flush under `HALT` alone. CTAR0 is
+    // memory-mapped and `HALT` alone satisfies the "module stopped"
+    // requirement for writing it.
+    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_HALT;
+    // `HALT` stops the module at the next frame boundary, not instantly. The
+    // LED path has `writeByteNoWait` variants that return with a frame still
+    // in flight, so wait for the Stopped state before rewriting CTAR0 --
+    // otherwise that frame finishes under a half-changed clock config.
+    while (port().SR & SPI_SR_TXRXS) {
+    }
+    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_HALT | SPI_MCR_CLR_TXF |
+                 SPI_MCR_CLR_RXF;
 
     port().CTAR0 = SPI_CTAR_FMSZ(7) | mClockBits | settings.modeBits();
 

--- a/src/platforms/arm/teensy/kinetis_spi/dspi_bus.h
+++ b/src/platforms/arm/teensy/kinetis_spi/dspi_bus.h
@@ -1,0 +1,432 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file platforms/arm/teensy/kinetis_spi/dspi_bus.h
+/// Minimal full-duplex SPI bus control for the Kinetis Teensys (3.x and LC),
+/// so FastLED's SdFat transport does not depend on the Arduino `SPI` library.
+///
+/// Why this exists: the Teensyduino `SPI` library is only *compiled* when the
+/// PlatformIO library finder selects it from an unconditional sketch-level
+/// `#include <SPI.h>`. FastLED cannot add that include (it breaks the host
+/// example build, which has no `SPI.h`), so `SPIClass::begin`,
+/// `SPIClass::transfer`, the global `SPI` object and
+/// `SPISettings::ctar_clock_table` / `ctar_div_table` all resolve as headers
+/// and then come up undefined at link time (FastLED#3970/#3972). The library
+/// also cannot be vendored: it is GPLv2/LGPLv2.1 and FastLED is MIT.
+///
+/// This is the Teensy 3.x/LC counterpart of
+/// `teensy4_common/lpspi/lpspi_bus.h`, and exposes the identical surface:
+///
+///     begin / end                        clock gate + pad mux
+///     beginTransaction / endTransaction  baud-rate programming
+///     transfer(u8)                       blocking full-duplex byte exchange
+///     transfer(tx, rx, count)            blocking block exchange
+///     setTransferWriteFill               fill byte for a null tx buffer
+///
+/// NOTHING here is derived from Arduino's `SPI.h`/`SPI.cpp`. In particular the
+/// frequency-to-CTAR mapping is *computed* from the K20/K64/K66 reference
+/// manual baud-rate equation rather than transcribed from upstream's
+/// `ctar_clock_table` / `ctar_div_table`, which are GPL/LGPL. See
+/// `dspiClockBits()` for the derivation.
+///
+/// Two silicon families share this class because they share exactly one call
+/// site (the vendored SdFat driver):
+///   * Teensy 3.0-3.6 (MK20/MK64/MK66) have the DSPI module -- MCR/CTARn/
+///     PUSHR/POPR with a TX+RX FIFO. This is the interesting path and the one
+///     the SD card actually runs on (3.5/3.6 are the only Kinetis Teensys with
+///     enough RAM for `Fx/FxSdCard`).
+///   * Teensy LC (MKL26) has the far simpler non-DSPI SPI module -- C1/C2/BR/
+///     S/DL. It is carried here so the SdFat tree, which compiles for every
+///     Teensy, has one uniform port type and no `SPIClass` reference is left
+///     behind. Nothing links it in practice: the SD example is filtered off
+///     the LC for memory, and `fl.system.sd+.cpp.o` is dropped unless a sketch
+///     calls `beginSd()`.
+///
+/// Like `LpspiBus`, `beginTransaction`/`endTransaction` do NOT save and
+/// restore NVIC masks -- that path only matters for `usingInterrupt()`, which
+/// FastLED never calls.
+
+#include "fl/stl/int.h"
+#include "fl/stl/singleton.h"
+#include "platforms/arm/teensy/is_teensy.h"  // ok platform headers
+
+// SPI mode constants, normally supplied by the Arduino <SPI.h> we no longer
+// include. Guarded because a sketch may still pull the framework header in.
+#ifndef SPI_MODE0
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x04
+#define SPI_MODE2 0x08
+#define SPI_MODE3 0x0C
+#endif
+
+#if defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)
+
+namespace fl {
+namespace platforms {
+namespace teensy {
+
+#if defined(FL_IS_TEENSY_LC)
+/// MKL26 lightweight SPI register block.
+typedef KINETISL_SPI_t DspiRegs_t;
+#else
+/// MK20/MK64/MK66 DSPI register block.
+typedef KINETISK_SPI_t DspiRegs_t;
+#endif
+
+/// Transaction parameters. Fills the role Arduino's `SPISettings` plays for
+/// `SPIClass`, but stores only what this bus programs: the requested SCK
+/// frequency and the polarity/phase/bit-order bits, already positioned for the
+/// target register (CTAR0 on DSPI, C1 on the LC).
+class DspiSettings {
+  public:
+    DspiSettings() : mClock(4000000) { init(MSBFIRST, SPI_MODE0); }
+
+    DspiSettings(fl::u32 clock, fl::u8 bit_order, fl::u8 data_mode)
+        : mClock(clock) {
+        init(bit_order, data_mode);
+    }
+
+    fl::u32 clock() const { return mClock; }
+
+    /// CPOL / CPHA / LSB-first bits for the mode register.
+    fl::u32 modeBits() const { return mModeBits; }
+
+  private:
+    void init(fl::u8 bit_order, fl::u8 data_mode) {
+        // Arduino's SPI_MODEn encoding: bit 3 is CPOL, bit 2 is CPHA.
+        mModeBits = 0;
+#if defined(FL_IS_TEENSY_LC)
+        if (bit_order == LSBFIRST) {
+            mModeBits |= SPI_C1_LSBFE;
+        }
+        if (data_mode & 0x08) {
+            mModeBits |= SPI_C1_CPOL;
+        }
+        if (data_mode & 0x04) {
+            mModeBits |= SPI_C1_CPHA;
+        }
+#else
+        if (bit_order == LSBFIRST) {
+            mModeBits |= SPI_CTAR_LSBFE;
+        }
+        if (data_mode & 0x08) {
+            mModeBits |= SPI_CTAR_CPOL;
+        }
+        if (data_mode & 0x04) {
+            mModeBits |= SPI_CTAR_CPHA;
+        }
+#endif
+    }
+
+    fl::u32 mClock;
+    fl::u32 mModeBits = 0;
+};
+
+#if defined(FL_IS_TEENSY_LC)
+
+/// Baud-rate bits for the MKL26 SPI module.
+///
+/// MKL26 reference manual, "SPI baud rate generation":
+///
+///     SCK = f_BUS / ((SPPR + 1) * 2^(SPR + 1))
+///
+/// with SPPR in 0..7 and SPR in 0..8. Pick the fastest setting that does not
+/// exceed `hz`; if even the slowest divider is too fast, use the slowest.
+inline fl::u32 dspiClockBits(fl::u32 hz) {
+    fl::u8 best_sppr = 7;
+    fl::u8 best_spr = 8;
+    fl::u32 best_f = 0;
+    for (fl::u8 sppr = 0; sppr < 8; ++sppr) {
+        for (fl::u8 spr = 0; spr <= 8; ++spr) {
+            const fl::u32 divisor = static_cast<fl::u32>(sppr + 1)
+                                    << (spr + 1);
+            const fl::u32 f = F_BUS / divisor;
+            if (f <= hz && f > best_f) {
+                best_f = f;
+                best_sppr = sppr;
+                best_spr = spr;
+            }
+        }
+    }
+    return SPI_BR_SPPR(best_sppr) | SPI_BR_SPR(best_spr);
+}
+
+#else  // DSPI (Teensy 3.x)
+
+/// Baud-rate portion of CTAR0 for the DSPI module.
+///
+/// K20/K64/K66 reference manual, "Baud rate generator" and the CTAR
+/// DBR/PBR/BR field descriptions:
+///
+///     SCK = (f_BUS / PBR_value) * ((1 + DBR) / BR_value)
+///
+/// with
+///     PBR field 0..3  -> prescaler 2, 3, 5, 7
+///     BR  field 0..15 -> scaler    2, 4, 6, 8, 16, 32, ... 32768
+///     DBR             -> doubles the rate
+///
+/// The manual notes the 50/50 duty cycle is only preserved for DBR = 1 when
+/// the BR scaler is 2, so DBR is only considered there -- an SD card tolerates
+/// an asymmetric clock but there is no reason to hand it one.
+///
+/// The search picks the fastest combination at or below `hz`, falling back to
+/// the slowest available divider when `hz` is below even that. This replaces
+/// Arduino's `SPISettings::ctar_clock_table` / `ctar_div_table` lookup, which
+/// is GPL/LGPL and must not be copied.
+inline fl::u32 dspiClockBits(fl::u32 hz) {
+    static const fl::u32 kPbrValue[4] = {2, 3, 5, 7};
+    static const fl::u32 kBrValue[16] = {2,    4,    6,     8,     16,   32,
+                                         64,   128,  256,   512,   1024, 2048,
+                                         4096, 8192, 16384, 32768};
+
+    fl::u8 best_pbr = 3;  // prescaler 7
+    fl::u8 best_br = 15;  // scaler 32768
+    fl::u8 best_dbr = 0;
+    fl::u32 best_f = 0;
+
+    for (fl::u8 dbr = 0; dbr < 2; ++dbr) {
+        for (fl::u8 pbr = 0; pbr < 4; ++pbr) {
+            for (fl::u8 br = 0; br < 16; ++br) {
+                if (dbr && kBrValue[br] != 2) {
+                    continue;  // duty cycle only guaranteed at BR scaler 2
+                }
+                const fl::u32 f =
+                    (F_BUS * (1u + dbr)) / (kPbrValue[pbr] * kBrValue[br]);
+                if (f <= hz && f > best_f) {
+                    best_f = f;
+                    best_pbr = pbr;
+                    best_br = br;
+                    best_dbr = dbr;
+                }
+            }
+        }
+    }
+
+    // CSSCK tracks BR, matching the existing FastLED K20/K66 LED path: the
+    // PCS-to-SCK delay is irrelevant here (SdFat drives chip select as a plain
+    // GPIO) but a delay no shorter than half a clock is always safe.
+    fl::u32 ctar = SPI_CTAR_PBR(best_pbr) | SPI_CTAR_BR(best_br) |
+                   SPI_CTAR_CSSCK(best_br);
+    if (best_dbr) {
+        ctar |= SPI_CTAR_DBR;
+    }
+    return ctar;
+}
+
+#endif  // FL_IS_TEENSY_LC
+
+/// One SPI peripheral. Obtain via `DspiBus::get(index)`.
+///
+/// Only bus 0 -- SPI0 on pins 11 (MOSI) / 12 (MISO) / 13 (SCK), the peripheral
+/// the Arduino global `SPI` object wraps on every Kinetis Teensy -- is wired
+/// up, because that is the only one the SdFat transport asks for. `get()`
+/// keeps the index parameter so the call sites match `LpspiBus::get()`.
+class DspiBus {
+  public:
+    /// The default bus. Any index maps to bus 0 (SPI0).
+    static DspiBus &get(fl::u8 index);
+
+    void begin();
+    void end();
+
+    void beginTransaction(const DspiSettings &settings);
+    void endTransaction();
+
+    /// Blocking full-duplex byte exchange.
+    fl::u8 transfer(fl::u8 data);
+
+    /// Byte substituted for the transmit stream when `transfer()` is handed a
+    /// null tx buffer.
+    void setTransferWriteFill(fl::u8 fill) { mTransferWriteFill = fill; }
+
+    /// Blocking full-duplex block exchange, a plain loop over the single-byte
+    /// path. `tx == nullptr` clocks out the fill byte; `rx == nullptr`
+    /// discards what comes back. No DMA and no async completion -- SdFat's
+    /// driver is synchronous.
+    void transfer(const void *tx, void *rx, fl::size count) {
+        const fl::u8 *src = static_cast<const fl::u8 *>(tx);
+        fl::u8 *dst = static_cast<fl::u8 *>(rx);
+        for (fl::size i = 0; i < count; ++i) {
+            const fl::u8 received = transfer(src ? src[i] : mTransferWriteFill);
+            if (dst) {
+                dst[i] = received;
+            }
+        }
+    }
+
+    /// The peripheral register block, for drivers that drive data directly.
+    DspiRegs_t &port() { return *mPort; }
+
+  private:
+    DspiBus() = default;
+
+    void configure(DspiRegs_t *port) { mPort = port; }
+
+    DspiRegs_t *mPort = nullptr;
+
+    fl::u32 mClock = 0;
+    fl::u32 mClockBits = 0;
+
+    fl::u8 mTransferWriteFill = 0xFF;
+
+    friend struct DspiBusStorage;
+};
+
+/// Storage for the bus.
+///
+/// Held in a `fl::Singleton` rather than at namespace scope so an unused SPI
+/// backend is fully strippable -- the whole point of not linking the framework
+/// library, whose global `SPIClass` objects the linker can never drop once
+/// anything names them (FastLED#3777).
+struct DspiBusStorage {
+    DspiBus bus;
+    bool initialized = false;
+
+    void ensure() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+#if defined(FL_IS_TEENSY_LC)
+        bus.configure(&KINETISL_SPI0);
+#else
+        bus.configure(&KINETISK_SPI0);
+#endif
+    }
+};
+
+inline DspiBus &DspiBus::get(fl::u8 index) {
+    (void)index;
+    DspiBusStorage &storage = fl::Singleton<DspiBusStorage>::instance();
+    storage.ensure();
+    return storage.bus;
+}
+
+#if defined(FL_IS_TEENSY_LC)
+
+inline void DspiBus::begin() {
+    SIM_SCGC4 |= SIM_SCGC4_SPI0;
+
+    // MOSI = 11, MISO = 12, SCK = 13, all ALT2 -- the same defaults the LC
+    // LED SPI path uses (teensy_lc/fastspi_arm_kl26.h).
+    CORE_PIN11_CONFIG = PORT_PCR_MUX(2);
+    CORE_PIN12_CONFIG = PORT_PCR_MUX(2);
+    CORE_PIN13_CONFIG = PORT_PCR_MUX(2);
+
+    port().C1 = SPI_C1_MSTR | SPI_C1_SPE;
+    port().C2 = 0;  // 8-bit frames
+
+    beginTransaction(DspiSettings());
+    endTransaction();
+}
+
+inline void DspiBus::beginTransaction(const DspiSettings &settings) {
+    if (settings.clock() != mClock) {
+        mClock = settings.clock();
+        mClockBits = dspiClockBits(mClock);
+    }
+    port().BR = static_cast<fl::u8>(mClockBits);
+    port().C2 = 0;
+    port().C1 =
+        static_cast<fl::u8>(SPI_C1_MSTR | SPI_C1_SPE | settings.modeBits());
+    // Drain any byte a previous user left sitting in the read buffer: reading
+    // S then DL is what clears SPRF on this module.
+    if (port().S & SPI_S_SPRF) {
+        (void)port().DL;
+    }
+}
+
+inline fl::u8 DspiBus::transfer(fl::u8 data) {
+    while (!(port().S & SPI_S_SPTEF)) {
+    }
+    port().DL = data;
+    while (!(port().S & SPI_S_SPRF)) {
+    }
+    return port().DL;
+}
+
+inline void DspiBus::end() {
+    port().C1 = 0;
+    CORE_PIN11_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+    CORE_PIN12_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+    CORE_PIN13_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+}
+
+#else  // DSPI (Teensy 3.x)
+
+/// MCR value used whenever the module is running: master mode, all PCS lines
+/// idle high (SdFat owns chip select as a GPIO), FIFOs enabled, not halted.
+#define FL_DSPI_MCR_RUN (SPI_MCR_MSTR | SPI_MCR_PCSIS(0x1F))
+
+inline void DspiBus::begin() {
+    SIM_SCGC6 |= SIM_SCGC6_SPI0;
+
+    // Park the module while the pads are re-muxed.
+    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_MDIS | SPI_MCR_HALT |
+                 SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
+
+    // MOSI = 11, MISO = 12, SCK = 13, all ALT2. These are SPI0's default pads
+    // on every Teensy 3.x; the alternates (7/8/14) are not exposed here
+    // because SdFat's pin-override branch is compiled out.
+    CORE_PIN11_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
+    CORE_PIN12_CONFIG = PORT_PCR_MUX(2);
+    CORE_PIN13_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2);
+
+    beginTransaction(DspiSettings());
+    endTransaction();
+}
+
+inline void DspiBus::beginTransaction(const DspiSettings &settings) {
+    if (settings.clock() != mClock) {
+        mClock = settings.clock();
+        mClockBits = dspiClockBits(mClock);
+    }
+
+    // CTAR0 can only be written with the module disabled or halted.
+    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_MDIS | SPI_MCR_HALT |
+                 SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
+
+    port().CTAR0 = SPI_CTAR_FMSZ(7) | mClockBits | settings.modeBits();
+
+    // Clear the sticky status flags. Flushing the RX FIFO above matters for
+    // the same reason it does on Teensy 4: FastLED's LED driver pushes frames
+    // without ever popping POPR, so a shared SPI0 would otherwise hand the
+    // first `transfer()` a stale byte instead of the card's reply.
+    port().SR = SPI_SR_TCF | SPI_SR_EOQF | SPI_SR_TFUF | SPI_SR_RFOF |
+                SPI_SR_RFDF;
+
+    port().MCR = FL_DSPI_MCR_RUN;
+}
+
+inline fl::u8 DspiBus::transfer(fl::u8 data) {
+    // CTAS = 0 selects CTAR0; no PCS bits, so chip select stays under GPIO
+    // control. The frame lands in the RX FIFO as it is shifted out, so the
+    // reply is ready once RFDF (receive FIFO not empty) asserts.
+    port().PUSHR = SPI_PUSHR_CTAS(0) | static_cast<fl::u32>(data);
+    while (!(port().SR & SPI_SR_RFDF)) {
+    }
+    const fl::u32 received = port().POPR;
+    port().SR = SPI_SR_RFDF;  // write-1-to-clear; re-asserts if more queued
+    return static_cast<fl::u8>(received);
+}
+
+inline void DspiBus::end() {
+    port().MCR = FL_DSPI_MCR_RUN | SPI_MCR_MDIS | SPI_MCR_HALT;
+    CORE_PIN11_CONFIG = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(1);
+    CORE_PIN12_CONFIG = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(1);
+    CORE_PIN13_CONFIG = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(1);
+}
+
+#endif  // FL_IS_TEENSY_LC
+
+// Upstream `SPIClass::endTransaction` only unwinds the NVIC masks that
+// `usingInterrupt()` would have set; FastLED never calls it, so this is a
+// no-op kept for call-site symmetry.
+inline void DspiBus::endTransaction() {}
+
+}  // namespace teensy
+}  // namespace platforms
+}  // namespace fl
+
+#endif  // FL_IS_TEENSY_3X || FL_IS_TEENSY_LC

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
@@ -41,6 +41,11 @@ namespace fl { namespace platforms { namespace teensy { namespace sdfat {
 typedef fl::platforms::teensy::LpspiBus SpiPort_t;
 /** Transaction settings for the FastLED LPSPI hardware driver (Teensy 4). */
 typedef fl::platforms::teensy::LpspiSettings SpiPortSettings_t;
+#elif defined(FL_SDFAT_HAS_DSPI_BUS)
+/** Port type for the FastLED DSPI hardware driver (Teensy 3.x / LC). */
+typedef fl::platforms::teensy::DspiBus SpiPort_t;
+/** Transaction settings for the FastLED DSPI hardware driver (Teensy 3.x / LC). */
+typedef fl::platforms::teensy::DspiSettings SpiPortSettings_t;
 #else
 /** Port type for Arduino SPI hardware driver. */
 typedef SPIClass SpiPort_t;
@@ -98,9 +103,10 @@ class SdSpiArduinoDriver {
   }
 
  private:
-  // SpiPort_t / SpiPortSettings_t are selected in SdSpiDriver.h, which
-  // includes this header after declaring them: SPIClass/SPISettings on
-  // Teensy 3.x, fl LpspiBus/LpspiSettings on Teensy 4.
+  // SpiPort_t / SpiPortSettings_t are selected just above, driven by the
+  // transport macro SdSpiDriver.h defines before including this header:
+  // fl LpspiBus on Teensy 4, fl DspiBus on Teensy 3.x/LC, and SPIClass only
+  // when SD_SPI_USE_ARDUINO_SPI forces the framework path back on.
   SpiPort_t *mSpi;
   SpiPortSettings_t mSpiSettings;
 };

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
@@ -106,7 +106,7 @@ class SdSpiArduinoDriver {
   // SpiPort_t / SpiPortSettings_t are selected just above, driven by the
   // transport macro SdSpiDriver.h defines before including this header:
   // fl LpspiBus on Teensy 4, fl DspiBus on Teensy 3.x/LC, and SPIClass only
-  // when SD_SPI_USE_ARDUINO_SPI forces the framework path back on.
+  // when FL_SDFAT_USE_ARDUINO_SPI forces the framework path back on.
   SpiPort_t *mSpi;
   SpiPortSettings_t mSpiSettings;
 };

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
@@ -50,10 +50,10 @@
 // dependency: the frequency-to-CTAR mapping is computed from the K20/K64/K66
 // reference manual instead of transcribed from the GPL/LGPL tables.
 //
-// Define `SD_SPI_USE_ARDUINO_SPI` to force the Arduino path back on as an
+// Define `FL_SDFAT_USE_ARDUINO_SPI` to force the Arduino path back on as an
 // escape hatch. Nothing links in that configuration unless the sketch also
 // carries an unconditional `#include <SPI.h>`.
-#if !defined(SD_SPI_USE_ARDUINO_SPI)
+#if !defined(FL_SDFAT_USE_ARDUINO_SPI)
 #if defined(FL_IS_TEENSY_4X)
 #define FL_SDFAT_HAS_LPSPI_BUS
 #elif defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
@@ -44,16 +44,28 @@
 // GPLv2/LGPLv2.1 and FastLED is MIT. `LpspiBus` (#3802) already owns the
 // registers, so the port type is simply retargeted at it.
 //
-// Teensy 3.x keeps the `SPIClass` path: the DSPI read side has not been ported
-// yet (FastLED #3972). Define `SD_SPI_USE_ARDUINO_SPI` to force that path back
-// on for Teensy 4 as an escape hatch.
-#if defined(FL_IS_TEENSY_4X) && !defined(SD_SPI_USE_ARDUINO_SPI)
+// The Kinetis Teensys (3.x and LC) get the same treatment through
+// `DspiBus`, which owns SPI0's DSPI registers directly (FastLED #3972). That
+// also retires the `SPISettings::ctar_clock_table` / `ctar_div_table`
+// dependency: the frequency-to-CTAR mapping is computed from the K20/K64/K66
+// reference manual instead of transcribed from the GPL/LGPL tables.
+//
+// Define `SD_SPI_USE_ARDUINO_SPI` to force the Arduino path back on as an
+// escape hatch. Nothing links in that configuration unless the sketch also
+// carries an unconditional `#include <SPI.h>`.
+#if !defined(SD_SPI_USE_ARDUINO_SPI)
+#if defined(FL_IS_TEENSY_4X)
 #define FL_SDFAT_HAS_LPSPI_BUS
+#elif defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)
+#define FL_SDFAT_HAS_DSPI_BUS
+#endif
 #endif
 
 #if SPI_DRIVER_SELECT < 2
 #if defined(FL_SDFAT_HAS_LPSPI_BUS)
 #include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"  // ok platform headers
+#elif defined(FL_SDFAT_HAS_DSPI_BUS)
+#include "platforms/arm/teensy/kinetis_spi/dspi_bus.h"  // ok platform headers
 #else
 #include "SPI.h"
 #endif

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
@@ -49,6 +49,9 @@ void SdSpiArduinoDriver::begin(SdSpiConfig spiConfig) {
 #if defined(FL_SDFAT_HAS_LPSPI_BUS)
     // Bus 0 is LPSPI4, the peripheral the Arduino global `SPI` wraps.
     m_spi = &fl::platforms::teensy::LpspiBus::get(0);
+#elif defined(FL_SDFAT_HAS_DSPI_BUS)
+    // Bus 0 is SPI0, the peripheral the Arduino global `SPI` wraps.
+    m_spi = &fl::platforms::teensy::DspiBus::get(0);
 #else
     m_spi = &SPI;
 #endif

--- a/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
+++ b/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
@@ -3,18 +3,15 @@
 // Upstream-derived from the USE_SDFAT branch of
 // src/platforms/fs_sdcard_arduino.hpp.
 
-#include "platforms/arm/teensy/is_teensy.h"  // ok platform headers
+// Deliberately no `#include <SPI.h>` here. Every Teensy now routes SdFat
+// through a FastLED-owned bus -- `LpspiBus` on Teensy 4 (FastLED#3971),
+// `DspiBus` on Teensy 3.x/LC (FastLED#3972) -- and pulling the framework
+// header in would keep the GPL/LGPL `SPI.h` in the translation unit and
+// re-expose the undefined `SPIClass`/`SPI` symbols the moment anything
+// referenced them again. `SdSpiDriver.h` supplies whichever transport header
+// the platform actually needs.
 
 // IWYU pragma: begin_keep
-#if !defined(FL_IS_TEENSY_4X)
-// Teensy 3.x still routes SdFat through Arduino `SPIClass`. Teensy 4 uses
-// FastLED's own `LpspiBus` (FastLED#3971), so pulling the framework header in
-// here would keep the GPL/LGPL `SPI.h` in the translation unit and re-expose
-// the undefined `SPIClass`/`SPI` symbols the moment anything referenced them
-// again. `SdSpiDriver.h` supplies whichever transport header the platform
-// actually needs.
-#include <SPI.h>
-#endif
 #include "platforms/arm/teensy/sdfat/SdFat.h"
 // IWYU pragma: end_keep
 


### PR DESCRIPTION
Closes #3972 (sub-issue of #3970).

## Mechanism

`SdSpiArduinoDriver` still held a `SPIClass*` on the Kinetis Teensys, so
`Fx/FxSdCard` failed to link on teensy35/teensy36 with undefined `SPI`,
`SPIClass::begin/end/transfer` plus `SPISettings::ctar_clock_table` /
`ctar_div_table`. Same root cause as Teensy 4 (#3971): Teensyduino's SPI
library is only *compiled* when the PlatformIO library finder selects it from
an unconditional sketch-level `#include <SPI.h>`, so its headers resolve while
its sources never enter the link. FastLED cannot add that sketch include (it
breaks the host example build — that sank #3969) and cannot vendor the library
(GPLv2/LGPLv2.1 vs FastLED's MIT).

So FastLED owns the transport, as #3802 did for the LED side and #3973 did for
Teensy 4.

## Changes (5 files, +396/-17)

### New: `src/platforms/arm/teensy/kinetis_spi/dspi_bus.h` (+379)

`fl::platforms::teensy::DspiBus` / `DspiSettings` — the Teensy 3.x/LC
counterpart of `LpspiBus`, with the identical surface:

| SdFat needs | provided |
|---|---|
| `begin()` / `end()` | clock gate (`SIM_SCGC6_SPI0`) + pad mux on 11/12/13 |
| `beginTransaction()` / `endTransaction()` | CTAR0 programming; `endTransaction` is a no-op (no `usingInterrupt()` masks to unwind, same as `LpspiBus`) |
| `transfer(u8) -> u8` | real full duplex: `PUSHR` with `CTAS(0)`, spin on `SR & RFDF`, return `POPR`, w1c `RFDF` |
| `setTransferWriteFill(u8)` | member of the bus object |
| `transfer(tx, rx, count)` | plain loop over the byte path; `tx == nullptr` clocks the fill byte, `rx == nullptr` discards |
| settings `(hz, MSBFIRST, SPI_MODE0)` | `DspiSettings` |
| default instance | `DspiBus::get(index)` behind `fl::Singleton<DspiBusStorage>` |

Two things the existing K66/K20 LED code could not give us, because it is
templated on `_DATA_PIN`/`_CLOCK_PIN` and write-only: **MISO is muxed** (pin 12,
ALT2) and **`POPR` is actually read**.

**CTAR computation — derived, not transcribed.** `dspiClockBits()` computes
PBR/BR/DBR at runtime from the K20/K64/K66 reference-manual baud-rate equation

    SCK = (f_BUS / PBR_value) * ((1 + DBR) / BR_value)
          PBR field 0..3  -> prescaler 2, 3, 5, 7
          BR  field 0..15 -> scaler    2, 4, 6, 8, 16, 32, ... 32768

by searching the grid for the fastest setting at or below the requested rate.
No lookup table ships at all, so Arduino's GPL/LGPL `ctar_clock_table` /
`ctar_div_table` are neither copied nor needed. DBR is only considered at BR
scaler 2, the one case where the manual guarantees a 50/50 duty cycle.

**Clock ramp.** SdFat already drives it: `SharedSpiCard::begin()` calls
`spiSetSckSpeed(1000 * SD_MAX_INIT_RATE_KHZ)` (400 kHz) *before* `spiBegin()`,
then re-calls it with `spiConfig.maxSck` after init. That reaches
`setSckSpeed()` -> a new `DspiSettings`, and `beginTransaction()` recomputes and
rewrites CTAR0 whenever the requested rate changes. Nothing extra was needed.
On a 60 MHz `F_BUS` (Teensy 3.5 @120 MHz and 3.6 @180 MHz both land there) the
search picks:

| requested | selected | PBR / BR / DBR |
|---|---|---|
| 400 kHz (card init) | **375.0 kHz** | 5 / 32 / 0 |
| 4 MHz (`SPI_HALF_SPEED`, what `FsSdFatTeensy::begin()` passes) | **3.75 MHz** | 2 / 8 / 0 |

Both are inside spec (SD init wants 100–400 kHz).

**Teensy LC.** MKL26 has no DSPI — it has the lightweight C1/C2/BR/S/DL SPI
module. It is covered by the same class behind an `#if` (baud from the MKL26
equation `SCK = f_BUS / ((SPPR+1) * 2^(SPR+1))`) so the SdFat tree — which
compiles for *every* Teensy — keeps one uniform port type and no `SPIClass`
reference is left in a live branch. See "Not verified" below: this path is
compile-only and unreachable in practice.

### Seam wiring (4 small edits)

- `sdfat/SpiDriver/SdSpiDriver.h` — new `FL_SDFAT_HAS_DSPI_BUS` alongside
  `FL_SDFAT_HAS_LPSPI_BUS`, both now under one `!defined(SD_SPI_USE_ARDUINO_SPI)`
  guard, selecting `dspi_bus.h` instead of `"SPI.h"`.
- `sdfat/SpiDriver/SdSpiArduinoDriver.h` — `SpiPort_t`/`SpiPortSettings_t`
  gain the `DspiBus`/`DspiSettings` arm.
- `sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp` — `begin()`'s fallback points at
  `DspiBus::get(0)` (SPI0, the peripheral the Arduino global `SPI` wraps).
- `sdfat/fs_sdfat_teensy.h` — drops its remaining `#include <SPI.h>`; every
  Teensy family now has a FastLED-owned transport.

Confirmed before relying on it: both branches flagged dead in #3973 really are
dead here too. `SDFAT_SDCARD_SPI` is defined nowhere in the tree (so
`setMISO`/`setMOSI`/`setSCK` are never called), and `USE_TRANSFER_TX_RX` is
`#define`d unconditionally at the top of `SdSpiTeensy3.cpp.hpp` (so the
in-place `transfer(buf, count)` form is never called). Neither is implemented.

Teensy 4 is untouched.

## Verification (measured on this branch)

| check | result |
|---|---|
| `bash compile teensy35 --examples Fx/FxSdCard` | **PASS — links.** flash 70,056 B (13.4% of 512 KB), RAM 10,568 B (4.0%). Build 10.8 s. Was: 6 undefined symbols. |
| `bash compile teensy36 --examples Fx/FxSdCard` | **PASS — links.** flash 70,192 B (6.7% of 1 MB), RAM 10,624 B (4.1%). Build 14.8 s. |
| `bash compile teensy41 --examples Fx/FxSdCard` | **PASS — no regression.** flash 120,832 B, RAM 80,160 B — byte-identical to the numbers #3973 measured. |
| `bash compile teensylc --examples Blink` | **PASS** — flash 13,644 B, RAM 3,288 B. Compiles the MKL26 arm of the new bus. |
| `bash compile teensy31 --examples Blink` | **PASS** — flash 11,092 B, RAM 3,972 B. Compiles the K20 arm. |
| `bash test --cpp --clean` | **PASS** — `All tests passed (283/283 unit, 83/83 examples in 79.43s)`. Run with `--clean`; a plain run can hit the fingerprint cache and skip compilation. |
| `bash lint` | **clean**, exit 0 (python_pipeline, cpp_linting, javascript_linting, meson_linting, platformio checks). |
| CTAR search sanity | Re-implemented the grid search off-target and printed the selections for F_BUS 60/48/36 MHz — table above. No divisor ever exceeds the request. |

`SPIClass` under `src/platforms/arm/teensy/sdfat/`: the only remaining
occurrences outside comments are the two typedefs on the
`SD_SPI_USE_ARDUINO_SPI` escape-hatch branch that #3973 deliberately added. No
default configuration on any Teensy selects them. Say the word if that hatch
should now be deleted outright — with all four families covered it no longer
has a caller.

## Not verified — please read

- **No Teensy 3.5 or 3.6 hardware was used. This is compile- and
  link-verified ONLY.** A green build proves the symbols resolve; it proves
  nothing about SD card init, which is timing-unforgiving. The 74-clock
  pre-init burst, CMD0 entry, the 375 kHz init step and the step to 3.75 MHz
  are all reasoned from the reference manual and unexercised. Do not treat
  this as working SD until someone runs it on a board.
- **The `POPR`/`RFDF` polling loop is unmeasured.** It is the canonical DSPI
  polled full-duplex sequence, but there is no scope trace and no returned
  byte has ever been checked against a real card.
- **The Teensy LC arm is compile-only and, as far as I can tell, unreachable.**
  `FxSdCard.ino` is tagged `// @filter: (memory is large)` so the LC never
  builds it, and `fl.system.sd+.cpp.o` is dropped unless a sketch calls
  `beginSd()`. It exists so the shared SdFat tree has one port type. It was
  never run. It also assumes the MKL26 SPI module is bus-clocked (`F_BUS`);
  that follows the reference manual but was not measured.
- **`SD_SPI_USE_ARDUINO_SPI` was not compiled.** No build-flag seam sets it
  from `bash compile`, same as in #3973.
- **Singleton elision was not measured with a byte-level flash diff.** The
  argument is structural — `DspiBusStorage` lives in `fl::Singleton` and
  `SingletonElisionChecker` passes — but there is no before/after proof that a
  sketch without `beginSd()` is unchanged.
- **Shared-bus behaviour with the LED driver is untested.** `beginTransaction`
  issues `CLR_TXF`/`CLR_RXF` for the same reason #3973 added the LPSPI FIFO
  flush (FastLED's LED path pushes frames and never pops `POPR`), but a sketch
  driving APA102 and an SD card on one SPI0 has not been run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated hardware SPI support for Teensy 3.x and Teensy LC boards.
  - Improved SD card communication through FastLED-managed SPI transport.
  - Added support for SPI transactions, buffered transfers, configurable transfer fill values, and board-specific pin and clock settings.

- **Compatibility**
  - Teensy 4.x continues using its existing high-speed SPI implementation.
  - Arduino SPI remains available as a fallback for supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->