### PR TITLE
ci(qemu): drop the apt step — fbuild provisions QEMU's libraries itself

### DIFF
--- a/.github/workflows/qemu_template.yml
+++ b/.github/workflows/qemu_template.yml
@@ -3,6 +3,13 @@ name: ESP32 QEMU Test Template (fbuild)
 # Reusable native-fbuild QEMU workflow. FastLED stages the selected example as
 # a project, then `fbuild test-emu` owns compilation, flash-image preparation,
 # emulator download, process supervision, and success/error matching.
+#
+# There is deliberately no apt-get step here. The Espressif QEMU binaries link
+# libslirp/libSDL2/libpixman, which ubuntu-latest does not ship, but fbuild
+# provisions them itself (FastLED/fbuild#1352): it probes the emulator and, on
+# a host that cannot start it, downloads its own runtime-library bundle and
+# puts it on LD_LIBRARY_PATH. Re-adding an apt step here would hide a
+# regression in that path.
 
 on:
   workflow_call:
@@ -41,16 +48,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Install QEMU runtime libraries (libSDL2, libslirp)
-        # The Espressif QEMU binary that fbuild downloads is dynamically
-        # linked against libSDL2-2.0.so.0 and libslirp.so.0 on Linux.
-        # Neither is preinstalled on ubuntu-latest (24.04); without them
-        # qemu-system-xtensa / qemu-system-riscv32 fail at exec with
-        # "error while loading shared libraries".
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libslirp0
 
       - name: Pin python version
         run: echo "3.11" > .python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,17 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.19. It carries hardened USB/deploy recovery, current
+    # Pin to fbuild 2.5.20. It carries hardened USB/deploy recovery, current
     # esptool probing, and the accumulated library/build fixes below.
     #
     # Pin history:
+    #   2.5.20 -- fbuild provisions the Linux shared libraries Espressif QEMU
+    #              needs (libslirp/libSDL2/libpixman) itself instead of
+    #              requiring an apt-get step from the caller: it probes the
+    #              emulator and, on a host that cannot start it, downloads a
+    #              sha256-pinned runtime bundle and exports it on
+    #              LD_LIBRARY_PATH. This is what lets qemu_template.yml drop
+    #              its apt step (FastLED/fbuild#1352/#1355).
     #   2.5.19 -- selects the exact runtime RP board profile from the verified
     #              FastLED/boards USB identity registry instead of a local
     #              VID/PID guess, and adds ClearCore SAME53 builds
@@ -201,7 +208,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.19",
+    "fbuild==2.5.20",
     # Decodes the FastLED/boards `usb-vids.proto.zstd` registry artifact in
     # ci/util/audit_usb_registry.py. Declared explicitly rather than relied on
     # transitively (clang-tool-chain-bins pulls it in today) so the documented


### PR DESCRIPTION
Completes the fix that #3964 stopgapped.

## Background

#3964 turned the QEMU badges green by `apt-get install`ing `libsdl2-2.0-0` + `libslirp0` on the runner. That worked, but it made QEMU emulation depend on a bootstrap step *outside* fbuild for something fbuild owns — and it would mask any future regression in the emulator-provisioning path.

## What changed upstream

fbuild 2.5.20 provisions the libraries itself (FastLED/fbuild#1352, FastLED/fbuild#1355):

- The Espressif QEMU tarballs ship **no** shared libraries and the binaries carry **no RPATH**; they link `libpixman-1`, `libgcrypt`, `libSDL2`, `libz` and `libslirp`, three of which `ubuntu-24.04` does not have.
- fbuild now probes the emulator with `--version` and, **only** when the host genuinely cannot start it, downloads a sha256-pinned bundle of the full non-glibc dependency closure (43 libraries, ~4 MB zstd, built on ubuntu:20.04 so it needs no more than `GLIBC_2.30` — the same floor the QEMU binaries themselves have) and exports it on `LD_LIBRARY_PATH` for the emulator spawn.
- Hosts that already carry the libraries download nothing and keep their own copies unshadowed.
- x86_64 and aarch64 bundles are both published and self-tested on native runners.

## This PR

- Deletes the apt step from `qemu_template.yml`, with a comment saying why it must not come back.
- Bumps the pin to `fbuild==2.5.20` with the reasoning in the pin history.

The QEMU workflows on this PR are the end-to-end proof: they run on a stock `ubuntu-latest` with no library preinstall of any kind. fbuild's own CI carries the same check (`qemu-linux-runtime.yml`) so a regression is caught upstream too.

Depends on FastLED/fbuild#1352 and FastLED/fbuild#1355 (both merged and released as 2.5.20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to version 2.5.20.
  * Improved QEMU runtime library provisioning during builds.
  * Removed redundant system package installation steps while retaining fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->