### PR TITLE
fix(ci): resolve nested examples in the WASM build path

### DIFF
--- a/ci/ci-compile.py
+++ b/ci/ci-compile.py
@@ -86,7 +86,9 @@ def _wasm_fast_path() -> int | None:
     # skipping both wasm_compile and argparse (~47ms saved)
     from pathlib import Path
 
-    output_dir = Path("examples") / example / "fastled_js"
+    from ci.wasm_build import resolve_example_dir
+
+    output_dir = resolve_example_dir(example) / "fastled_js"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_js = output_dir / "fastled.js"
 

--- a/ci/tests/test_wasm_example_resolution.py
+++ b/ci/tests/test_wasm_example_resolution.py
@@ -1,0 +1,57 @@
+"""Tests for resolving example names to sketch directories.
+
+Examples live either directly under `examples/` (`examples/Blink/`) or nested
+(`examples/Fx/FxCylon/`). The WASM build path previously assumed the flat
+layout, so every nested sketch failed with FileNotFoundError.
+"""
+
+import pytest
+
+from ci.wasm_build import PROJECT_ROOT, resolve_example_dir
+
+
+def test_resolves_a_flat_example() -> None:
+    assert resolve_example_dir("Blink") == PROJECT_ROOT / "examples" / "Blink"
+
+
+def test_resolves_a_nested_example_by_bare_name() -> None:
+    """The regression: `FxCylon` lives at examples/Fx/FxCylon/, not examples/FxCylon/."""
+    resolved = resolve_example_dir("FxCylon")
+
+    assert resolved == PROJECT_ROOT / "examples" / "Fx" / "FxCylon"
+    assert (resolved / "FxCylon.ino").is_file()
+
+
+def test_resolves_a_nested_example_by_relative_path() -> None:
+    assert (
+        resolve_example_dir("Fx/FxCylon")
+        == PROJECT_ROOT / "examples" / "Fx" / "FxCylon"
+    )
+
+
+def test_flat_lookup_wins_without_a_tree_walk() -> None:
+    """A directly-present example resolves without scanning, preserving old behavior."""
+    assert resolve_example_dir("Blink").parent == PROJECT_ROOT / "examples"
+
+
+def test_unknown_example_raises() -> None:
+    with pytest.raises(FileNotFoundError, match="Sketch not found"):
+        resolve_example_dir("NoSuchSketchAnywhere")
+
+
+def test_directory_without_matching_ino_is_not_resolved() -> None:
+    """examples/Fx/ exists but has no Fx.ino, so it must not resolve."""
+    with pytest.raises(FileNotFoundError):
+        resolve_example_dir("Fx")
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["FxCylon", "FxDemoReel100", "FxEngine", "FxFire2012", "FxNoiseRing"],
+)
+def test_every_nested_fx_example_resolves(name: str) -> None:
+    """All of examples/Fx/* were broken before this fix."""
+    resolved = resolve_example_dir(name)
+
+    assert resolved.is_dir()
+    assert (resolved / f"{name}.ino").is_file()

--- a/ci/tests/test_wasm_example_resolution.py
+++ b/ci/tests/test_wasm_example_resolution.py
@@ -55,3 +55,22 @@ def test_every_nested_fx_example_resolves(name: str) -> None:
 
     assert resolved.is_dir()
     assert (resolved / f"{name}.ino").is_file()
+
+
+def test_relative_path_resolves_to_same_dir_as_bare_name() -> None:
+    """`Fx/FxCylon` and `FxCylon` must resolve identically.
+
+    Guards the wasm_compile path, which now forwards the full relative sketch
+    path so two sketches sharing a basename stay distinguishable.
+    """
+    assert resolve_example_dir("Fx/FxCylon") == resolve_example_dir("FxCylon")
+
+
+def test_resolved_dir_name_is_always_the_bare_sketch_name() -> None:
+    """Generated filenames derive from this, so it must never contain a separator.
+
+    Deriving from the caller's string instead would turn "Fx/FxCylon" into a
+    nested wrapper path (sketch_cache_dir/Fx/FxCylon_wrapper.cpp).
+    """
+    for name in ("FxCylon", "Fx/FxCylon"):
+        assert resolve_example_dir(name).name == "FxCylon"

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -53,11 +53,30 @@ def get_build_dir(mode: str) -> Path:
     return BUILD_DIR_PREFIX / f"meson-wasm-{mode}"
 
 
+def resolve_example_dir(example_name: str) -> Path:
+    """Resolve an example name to its directory.
+
+    Examples live either directly under examples/ (e.g. examples/Blink/) or
+    nested one or more levels deep (e.g. examples/Fx/FxCylon/). Accepts a bare
+    name ("FxCylon") or a relative path ("Fx/FxCylon").
+    """
+    examples_root = PROJECT_ROOT / "examples"
+    name = Path(example_name).name
+
+    direct = examples_root / example_name
+    if (direct / f"{name}.ino").exists():
+        return direct
+
+    for ino in examples_root.rglob(f"{name}.ino"):
+        if ino.parent.name == name:
+            return ino.parent
+
+    raise FileNotFoundError(f"Sketch not found: {examples_root / example_name}")
+
+
 def get_sketch_cache_dir(example_name: str) -> Path:
     """Get per-sketch cache directory next to the .ino file: <sketch_dir>/.build/wasm/."""
-    ino_file = PROJECT_ROOT / "examples" / example_name / f"{example_name}.ino"
-    if not ino_file.exists():
-        raise FileNotFoundError(f"Sketch not found: {ino_file}")
+    ino_file = resolve_example_dir(example_name) / f"{Path(example_name).name}.ino"
     d = ino_file.parent / ".build" / "wasm"
     d.mkdir(parents=True, exist_ok=True)
     return d
@@ -821,8 +840,8 @@ def create_wrapper(example_name: str, sketch_cache_dir: Path) -> Path:
 
     Returns path to the wrapper file.
     """
-    example_dir = PROJECT_ROOT / "examples" / example_name
-    ino_file = example_dir / f"{example_name}.ino"
+    example_dir = resolve_example_dir(example_name)
+    ino_file = example_dir / f"{Path(example_name).name}.ino"
 
     if not ino_file.exists():
         raise FileNotFoundError(f"Example not found: {ino_file}")
@@ -1135,8 +1154,8 @@ def compile_sketch(
     library_archive = build_dir / "ci" / "meson" / "wasm" / "libfastled.a"
     # Find the .ino file that the wrapper #includes
     example_name = wrapper_path.stem.replace("_wrapper", "")
-    example_dir = PROJECT_ROOT / "examples" / example_name
-    ino_file = example_dir / f"{example_name}.ino"
+    example_dir = resolve_example_dir(example_name)
+    ino_file = example_dir / f"{Path(example_name).name}.ino"
     if object_path.exists():
         object_mtime = object_path.stat().st_mtime
         wrapper_mtime = wrapper_path.stat().st_mtime
@@ -1645,7 +1664,7 @@ def copy_templates(output_dir: Path) -> None:
 
 def generate_manifest(example_name: str, output_dir: Path) -> None:
     """Generate files.json manifest for data files."""
-    example_dir = PROJECT_ROOT / "examples" / example_name
+    example_dir = resolve_example_dir(example_name)
     data_extensions = frozenset(
         (".json", ".csv", ".txt", ".cfg", ".bin", ".dat", ".mp3", ".wav")
     )
@@ -1711,7 +1730,7 @@ def generate_asset_manifest(example_name: str, output_dir: Path) -> None:
     """
     from ci.compiler.asset_scanner import scan_sketch_assets, write_manifest_json
 
-    sketch_dir = PROJECT_ROOT / "examples" / example_name
+    sketch_dir = resolve_example_dir(example_name)
     scan = scan_sketch_assets(sketch_dir)
     for warning in scan.warnings:
         print(f"[WASM] {warning}", file=sys.stderr)

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -841,7 +841,11 @@ def create_wrapper(example_name: str, sketch_cache_dir: Path) -> Path:
     Returns path to the wrapper file.
     """
     example_dir = resolve_example_dir(example_name)
-    ino_file = example_dir / f"{Path(example_name).name}.ino"
+    # Derive filenames from the resolved directory, not the caller's string: a
+    # relative form like "Fx/FxCylon" would otherwise produce a nested wrapper
+    # path (sketch_cache_dir/Fx/FxCylon_wrapper.cpp) instead of a flat one.
+    sketch_name = example_dir.name
+    ino_file = example_dir / f"{sketch_name}.ino"
 
     if not ino_file.exists():
         raise FileNotFoundError(f"Example not found: {ino_file}")
@@ -855,9 +859,9 @@ def create_wrapper(example_name: str, sketch_cache_dir: Path) -> Path:
         and all(part not in excluded_dirs for part in f.parts)
     )
 
-    wrapper_path = sketch_cache_dir / f"{example_name}_wrapper.cpp"
+    wrapper_path = sketch_cache_dir / f"{sketch_name}_wrapper.cpp"
     lines = [
-        f"// Auto-generated wrapper for {example_name}.ino",
+        f"// Auto-generated wrapper for {sketch_name}.ino",
         "// C++20 header unit import — ~2x faster than PCH for sketch compilation.",
         '// The .ino\'s #include "FastLED.h" is a harmless no-op after this import.',
         'import "wasm_pch.h";',

--- a/ci/wasm_compile.py
+++ b/ci/wasm_compile.py
@@ -94,7 +94,9 @@ def main() -> int:
     # Output to examples/<name>/fastled_js/fastled.js to match expected location
     from pathlib import Path
 
-    output_dir = Path("examples") / example_name / "fastled_js"
+    from ci.wasm_build import resolve_example_dir
+
+    output_dir = resolve_example_dir(example_name) / "fastled_js"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     output_js = output_dir / "fastled.js"

--- a/ci/wasm_compile.py
+++ b/ci/wasm_compile.py
@@ -42,8 +42,14 @@ def parse_args() -> tuple:
 def main() -> int:
     args, unknown_args = parse_args()
 
-    # Extract example name from sketch_dir (e.g., "examples/Blink" -> "Blink")
-    example_name = args.sketch_dir.split("/")[-1]
+    # Keep the sketch path relative to examples/ (e.g. "examples/Fx/FxCylon"
+    # -> "Fx/FxCylon") so resolution stays unambiguous when two sketches share
+    # a basename in different directories. `example_name` is the bare name and
+    # is used only for display and board filtering.
+    sketch_rel = args.sketch_dir.replace("\\", "/").strip("/")
+    if sketch_rel.startswith("examples/"):
+        sketch_rel = sketch_rel[len("examples/") :]
+    example_name = sketch_rel.split("/")[-1]
 
     # Check if sketch is filtered out for WASM platform
     try:
@@ -96,7 +102,7 @@ def main() -> int:
 
     from ci.wasm_build import resolve_example_dir
 
-    output_dir = resolve_example_dir(example_name) / "fastled_js"
+    output_dir = resolve_example_dir(sketch_rel) / "fastled_js"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     output_js = output_dir / "fastled.js"
@@ -108,7 +114,7 @@ def main() -> int:
     sys.argv = [
         "ci.wasm_build",
         "--example",
-        example_name,
+        sketch_rel,
         "-o",
         str(output_js),
     ] + unknown_args


### PR DESCRIPTION
## Problem

`bash compile wasm --examples <Name>` failed for every sketch not sitting directly under `examples/`:

```
$ bash compile wasm --examples FxCylon
[WASM] Build failed: Sketch not found: .../examples/FxCylon/FxCylon.ino
FileNotFoundError: Sketch not found: .../examples/FxCylon/FxCylon.ino
```

The sketch actually lives at `examples/Fx/FxCylon/FxCylon.ino`. All of `examples/Fx/*` (~10 sketches) were affected.

## Root cause

Five call sites in `ci/wasm_build.py` built the sketch path assuming a flat layout:

```python
ino_file = PROJECT_ROOT / "examples" / example_name / f"{example_name}.ino"
```

plus the output-directory construction in `ci/ci-compile.py` and `ci/wasm_compile.py`.

Example *discovery* already handles nesting via `examples_dir.rglob("*.ino")` (`ci/compiler/board_example_utils.py`), so nested sketches were found and then failed to build — the WASM path helpers were the only place assuming flat.

## Fix

Adds `resolve_example_dir()` and routes all seven sites through it. The direct path is checked first, which preserves existing behavior for flat examples and avoids an `rglob` on the common path. Accepts a bare name (`"FxCylon"`) or a relative path (`"Fx/FxCylon"`).

## Verification

End-to-end build now succeeds:

```
$ bash compile wasm --examples FxCylon
[WASM] Output: .../examples/Fx/FxCylon/fastled_js/fastled.js
[WASM] Build successful!
  Library:  27.61s   Sketch: 0.90s   Linking: 3.50s   Total: 61.93s
WASM compilation successful
```

Artifacts land in the correct nested directory (`examples/Fx/FxCylon/fastled_js/`).

- 11 new tests in `ci/tests/test_wasm_example_resolution.py` — flat resolution, nested-by-bare-name, nested-by-relative-path, unknown-name raises, a directory without a matching `.ino` does not resolve, and a parametrized sweep over five `examples/Fx/*` sketches
- `bash lint` clean

Closes #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM builds for examples stored in nested directories.
  * Added support for resolving examples by name or relative path.
  * Ensured compilation outputs and generated assets use the correct example location.
  * Added clearer handling for unknown or invalid example paths.

* **Tests**
  * Added regression coverage for flat examples, nested examples, direct paths, and nested Fx examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->