### PR TITLE
docs(ci): correct stale comments on board_partitions and filesystem_size

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -61,6 +61,9 @@ class Board:
     framework: str | None = None
     board_build_mcu: str | None = None
     board_build_core: str | None = None
+    # Size of the LittleFS/SPIFFS partition (e.g. "1.5m"), emitted as
+    # `board_build.filesystem_size`. Wired through both ini emitters; no board
+    # sets it yet.
     board_build_filesystem_size: str | None = None
     board_build_flash_size: str | None = (
         None  # Flash size for ESP32 boards (e.g., '4MB')
@@ -71,7 +74,10 @@ class Board:
     build_unflags: list[str] | None = None  # New: unflag options
     defines: list[str] | None = None
     customsdk: str | None = None
-    board_partitions: str | None = None  # Reserved for future use.
+    # ESP32 partition-table CSV name (e.g. "huge_app.csv"), emitted as
+    # `board_build.partitions`. Set by several boards whose app exceeds the
+    # default 1.25MB app partition.
+    board_partitions: str | None = None
     no_board_spec: bool = (
         False  # For platforms like 'native' that don't need a board specification
     )


### PR DESCRIPTION
## Problem

`ci/boards.py` documented `board_partitions` as "Reserved for future use":

```python
board_partitions: str | None = None  # Reserved for future use.
```

But **8 boards set it**, and the ini emitter consumes it:

```python
if self.board_partitions:
    lines.append(f"board_build.partitions = {self.board_partitions}")
```

The comment is simply wrong. It caused a concrete factual error during design work on filesystem-image support (FastLED/fbuild#1358), where the field was reported as unused based on reading the comment rather than the call sites.

## Fix

Both fields now describe what they actually do:

- `board_partitions` — ESP32 partition-table CSV name, emitted as `board_build.partitions`, set by boards whose app exceeds the default 1.25MB partition.
- `board_build_filesystem_size` — the sibling field, which genuinely *is* unset by every board today. Rather than leave it bare, its comment now says so explicitly, since it becomes relevant with filesystem-image support.

Comment-only change; no behavior difference.

`bash lint` clean.

Closes #3985

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the purpose and configuration output of filesystem size settings.
  * Documented how partition-table settings support boards requiring larger application partitions.
  * Removed outdated wording indicating partition settings were reserved for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->