### PR TITLE
warn(teensy3): tell users pre-4.0 Teensy boards are EOL and unvalidated (#3987)

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -68,8 +68,8 @@
 // platforms/arm/teensy/is_teensy.h). Testing 3X alone would silently miss the
 // LC, which is the most end-of-life board of the set.
 #if (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) &&                  \
-    !defined(FASTLED_INTERNAL) && !defined(FASTLED_NO_TEENSY3_EOL_WARNING)
-#warning "This Teensy (pre-4.0) is out of production and FastLED no longer hardware-validates it. If you hit a problem, try FastLED 3.10.3, the last release verified against these boards, and please file a report at https://github.com/FastLED/FastLED/issues -- we do still fix these. Define FASTLED_NO_TEENSY3_EOL_WARNING to silence this."
+    !defined(FASTLED_INTERNAL) && !defined(FL_TEENSY_EOL_SUPPRESS_WARNING)
+#warning "This Teensy (pre-4.0) is out of production and FastLED no longer hardware-validates it. If you hit a problem, try FastLED 3.10.3, the last release verified against these boards, and please file a report at https://github.com/FastLED/FastLED/issues -- we do still fix these. Define FL_TEENSY_EOL_SUPPRESS_WARNING to silence this."
 #endif
 
 // Legacy RMT4 backend is ESP-IDF 4.x only.

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -55,6 +55,23 @@
 #warning "-DFASTLED_ESP32_I2S is removed (FastLED#3526 Phase 2e). Drop the flag; the modern I2S engine is now on Bus::FLEX_IO, 0. Runtime select via FastLED.setExclusiveDriver<fl::Bus::FLEX_IO, 0>()."
 #endif
 
+// Pre-4.0 Teensy boards are end-of-life.
+//
+// Teensy LC and 3.0-3.6 are discontinued. FastLED still compiles for them and
+// we still fix reported bugs, but they get no hardware validation -- see
+// FastLED#3983, where bench testing is scoped to Teensy 4.0/4.1 only. Users on
+// these boards should know they are on an unvalidated path before they debug
+// something we cannot reproduce.
+//
+// Note the guard covers BOTH umbrellas: `FL_IS_TEENSY_3X` is only 3.0-3.6, and
+// Teensy LC sits beside it rather than inside it (see
+// platforms/arm/teensy/is_teensy.h). Testing 3X alone would silently miss the
+// LC, which is the most end-of-life board of the set.
+#if (defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)) &&                  \
+    !defined(FASTLED_INTERNAL) && !defined(FASTLED_NO_TEENSY3_EOL_WARNING)
+#warning "This Teensy (pre-4.0) is out of production and FastLED no longer hardware-validates it. If you hit a problem, try FastLED 3.10.3, the last release verified against these boards, and please file a report at https://github.com/FastLED/FastLED/issues -- we do still fix these. Define FASTLED_NO_TEENSY3_EOL_WARNING to silence this."
+#endif
+
 // Legacy RMT4 backend is ESP-IDF 4.x only.
 //
 // On IDF 5.x the legacy TX and RX implementations no longer build: RMTMEM is not

--- a/src/fl/control/wled/adapter.cpp.hpp
+++ b/src/fl/control/wled/adapter.cpp.hpp
@@ -1,4 +1,12 @@
 // ok no header
+
+// This is FastLED's own translation unit, not user code. `FastLED.h` emits
+// user-facing `#warning`s (EOL boards, removed build flags) that are all
+// guarded on `!defined(FASTLED_INTERNAL)`, so without this the library warns
+// at itself and the user sees the same notice twice per build. Matches the
+// convention already used by bitswap/crgb/cled_controller/FastLED.cpp.hpp.
+#define FASTLED_INTERNAL
+
 #include "fl/fx/wled/adapter.h"
 #include "FastLED.h"  // ok include - WLED adapter needs global FastLED object
 #include "fl/stl/memory.h"


### PR DESCRIPTION
Closes #3987.

## What

A `#warning` on Teensy LC and 3.0–3.6 telling users the board is out of production, pointing at 3.10.3, and asking for bug reports here.

```
This Teensy (pre-4.0) is out of production and FastLED no longer
hardware-validates it. If you hit a problem, try FastLED 3.10.3, the last
release verified against these boards, and please file a report at
https://github.com/FastLED/FastLED/issues -- we do still fix these.
Define FASTLED_NO_TEENSY3_EOL_WARNING to silence this.
```

These boards still compile and we still fix reported bugs — but they get no hardware validation. #3983 scopes bench testing to Teensy 4.0/4.1 only, and the SdFat DSPI transport in #3972 shipped compile-verified with no board available. Right now a user on a 3.2 has no signal they are on an unvalidated path.

## Two things found while implementing

**The guard has a trap.** `FL_IS_TEENSY_3X` covers only 3.0–3.6 — Teensy LC sits *beside* it, not inside it:

```c
// is_teensy.h:73-76      3X = 30|31|32|35|36        (no LC)
// is_teensy.h:84-86      FL_IS_TEENSY = LC | 3X | 4X
```

so the condition tests both. `#if defined(FL_IS_TEENSY_3X)` alone would silently skip the LC, which is arguably the most end-of-life board of the set. Verified empirically rather than by reading: teensylc does warn.

**FastLED was warning at itself.** `fl/control/wled/adapter.cpp.hpp` includes `FastLED.h` but never defined `FASTLED_INTERNAL`, so the unity TU `fl.control+.cpp` tripped the guard as well and the user saw the notice **twice per build**. Added the define, matching the convention already used by `bitswap` / `crgb` / `cled_controller` / `FastLED.cpp.hpp`.

This is a pre-existing leak, not one I introduced — the `FASTLED_ESP32_I2S` warning directly above has the same shape and would double up too. It just rarely fires, because it needs a user define.

## Design choices

- **Silenceable** via `FASTLED_NO_TEENSY3_EOL_WARNING`. An unsuppressable warning on every build pushes someone maintaining a working 3.2 project to patch it out of a vendored copy — worse than an opt-out we control.
- **`#warning`, never `#error`.** We are not dropping these boards.
- **No `-Werror` risk**: CI uses only `-Werror=invalid-pch` and `-Werror=unused-variable`, so this cannot become a hard failure. Checked before writing it.

## Verification

Measured on **genuine rebuilds**, not cache hits — an early run reported 0 warnings purely because zccache returned cached objects and cached compiles do not replay warnings.

| check | files compiled | result |
|---|---|---|
| `teensy32` Blink | 29/29 | warns **once**, from the sketch TU only |
| `teensylc` Blink | 4/4 | **warns** — the case a naive guard misses |
| `teensy41` Blink | — | silent ✅ |
| `uno` Blink | — | silent ✅ |
| `teensy30` + `-DFASTLED_NO_TEENSY3_EOL_WARNING=1` | 29/29 | silent ✅ |
| `bash test --cpp` | — | 283/283 unit, 83/83 examples |
| `bash lint` | — | clean |

## Note on the version number

`library.json` is at 3.10.3 while `src/FastLED.h:37` has `FASTLED_VERSION 3010004`, i.e. master is 3.10.4-in-progress. The message therefore names the current *published* release. If that becomes stale, the wording is a one-line change — or it could be softened to "the latest 3.10.x release" to avoid the problem permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a compile-time warning for Teensy LC and Teensy 3.x boards, noting that they are no longer hardware-validated.
  * Included guidance on the last verified release, issue reporting, and suppressing the warning when needed.
  * Prevented internal library builds from displaying the end-of-life warning.
  * Updated the warning-suppression option to use the new configuration name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->