### PR TITLE
fix(samd51): unbreak compilation broken since 3.10.4 + add SAMD build badges

### DIFF
--- a/.github/workflows/build_metro_m4.yml
+++ b/.github/workflows/build_metro_m4.yml
@@ -20,6 +20,21 @@ on:
       - 'library.properties'
       - 'pyproject.toml'
       - 'uv.lock'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_metro_m4.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_metro_m4.yml
+++ b/.github/workflows/build_metro_m4.yml
@@ -1,0 +1,27 @@
+name: metro_m4
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_metro_m4.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: metro_m4 --examples Blink,Apa102

--- a/.github/workflows/build_samd21.yml
+++ b/.github/workflows/build_samd21.yml
@@ -1,0 +1,27 @@
+name: samd21
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd21.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: samd21 --examples Blink,Apa102

--- a/.github/workflows/build_samd21.yml
+++ b/.github/workflows/build_samd21.yml
@@ -20,6 +20,21 @@ on:
       - 'library.properties'
       - 'pyproject.toml'
       - 'uv.lock'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd21.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_samd21_zero.yml
+++ b/.github/workflows/build_samd21_zero.yml
@@ -1,0 +1,42 @@
+name: samd21_zero
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd21_zero.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd21_zero.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: samd21_zero --examples Blink,Apa102

--- a/.github/workflows/build_samd51j.yml
+++ b/.github/workflows/build_samd51j.yml
@@ -20,6 +20,21 @@ on:
       - 'library.properties'
       - 'pyproject.toml'
       - 'uv.lock'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd51j.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
 jobs:
   build:
     uses: ./.github/workflows/build_template.yml

--- a/.github/workflows/build_samd51j.yml
+++ b/.github/workflows/build_samd51j.yml
@@ -1,0 +1,27 @@
+name: samd51j
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'ci/**'
+      - '.github/workflows/build_samd51j.yml'
+      - '.github/workflows/build_template.yml'
+      - 'CMakeLists.txt'
+      - 'platformio.ini'
+      - 'library.json'
+      - 'library.properties'
+      - 'pyproject.toml'
+      - 'uv.lock'
+jobs:
+  build:
+    uses: ./.github/workflows/build_template.yml
+    with:
+      args: samd51j --examples Blink,Apa102

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ while the smoke badge is green.
 
 **ARM Boards:** [![sam3x8e_due](https://github.com/FastLED/FastLED/actions/workflows/build_due.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_due.yml) [![ClearCore SAME53 compile](https://github.com/FastLED/FastLED/actions/workflows/build_clearcore.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_clearcore.yml)
 
-**Microchip SAMD (M0+/M4):** [![samd21](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml) [![samd51j](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml) [![metro_m4](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml)
+**Microchip SAMD (M0+/M4):** [![samd21](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml) [![samd21_zero](https://github.com/FastLED/FastLED/actions/workflows/build_samd21_zero.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd21_zero.yml) [![samd51j](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml) [![metro_m4](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml)
+
+*`samd21_zero` builds against Arduino's upstream SAMD core; the other three build against Adafruit's fork (the only one with SAMD51 support).*
 
 **Arduino Due (Digix):** [![digix](https://github.com/FastLED/FastLED/actions/workflows/build_digix.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_digix.yml)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ while the smoke badge is green.
 
 **ARM Boards:** [![sam3x8e_due](https://github.com/FastLED/FastLED/actions/workflows/build_due.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_due.yml) [![ClearCore SAME53 compile](https://github.com/FastLED/FastLED/actions/workflows/build_clearcore.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_clearcore.yml)
 
+**Microchip SAMD (M0+/M4):** [![samd21](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd21.yml) [![samd51j](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_samd51j.yml) [![metro_m4](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_metro_m4.yml)
+
 **Arduino Due (Digix):** [![digix](https://github.com/FastLED/FastLED/actions/workflows/build_digix.yml/badge.svg)](https://github.com/FastLED/FastLED/actions/workflows/build_digix.yml)
 
 *ClearCore coverage is a compile-only Blink build against the pinned Teknic Arduino core; it does not claim hardware timing validation.*

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1551,6 +1551,19 @@ SAMD51P20A_GRANDCENTRAL = Board(
     ],
 )
 
+# Builds with ADAFRUIT_METRO_M4_EXPRESS defined, which is the only SAMD51 board
+# define that exercises the Metro M4 Express branch of fastpin_arm_d51.h.
+SAMD51J19A_METRO_M4 = Board(
+    board_name="metro_m4",
+    real_board_name="adafruit_metro_m4",
+    platform="atmelsam",
+    framework="arduino",
+    lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
+    defines=[
+        "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
+    ],
+)
+
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).
 # This is an fbuild-native board; its vendor Arduino core is pinned by fbuild.
 CLEARCORE_SAME53 = Board(

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -93,8 +93,10 @@ _FL_DEFPIN(23, 23, 1); _FL_DEFPIN(24,  1, 0); _FL_DEFPIN(25,  0, 0);
 #define HAS_HARDWARE_PIN_SUPPORT 1
 
 // Actual pin definitions
-#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
+#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
 
+// The Metro M4 Express and the Metro M4 AirLift Lite share a pinout apart from
+// A3 (pin 17), so both boards use this table.
 #define MAX_PIN 20
 // D0-D13, including D6+D8 (DotStar CLK + DATA)
 _FL_DEFPIN( 0, 23, 0); _FL_DEFPIN( 1, 22, 0); _FL_DEFPIN( 2,  17, 1); _FL_DEFPIN( 3, 16, 1);
@@ -102,7 +104,13 @@ _FL_DEFPIN( 4, 13, 1); _FL_DEFPIN( 5, 14, 1); _FL_DEFPIN( 6,  15, 1); _FL_DEFPIN
 _FL_DEFPIN( 8,  21, 0); _FL_DEFPIN( 9, 20, 0); _FL_DEFPIN(10, 18, 0); _FL_DEFPIN(11, 19, 0);
 _FL_DEFPIN(12, 17, 0); _FL_DEFPIN(13, 16, 0);
 // A0-A5
-_FL_DEFPIN(14,  2, 0); _FL_DEFPIN(15,  5, 0); _FL_DEFPIN(16,  6, 0); _FL_DEFPIN(17,  0, 1);
+_FL_DEFPIN(14,  2, 0); _FL_DEFPIN(15,  5, 0); _FL_DEFPIN(16,  6, 0);
+// A3 is the one pin that differs between the two Metro M4 variants
+#if defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
+_FL_DEFPIN(17,  0, 1);  // PB00
+#else
+_FL_DEFPIN(17,  4, 0);  // PA04
+#endif
 _FL_DEFPIN(18,  8, 1); _FL_DEFPIN(19,  9, 1);
 // SDA/SCL
 _FL_DEFPIN(22, 2, 1); _FL_DEFPIN(23, 3, 1);

--- a/src/platforms/arm/samd/isr_samd.hpp
+++ b/src/platforms/arm/samd/isr_samd.hpp
@@ -84,20 +84,15 @@ constexpr u8 MAX_TIMER_INDEX = 5;
 
 constexpr u8 MAX_TIMER_INSTANCES = MAX_TIMER_INDEX - MIN_TIMER_INDEX + 1;
 
-// EIC configuration
-constexpr u8 MAX_EIC_CHANNELS = 16;
-
 // Error code for functionality that is not available on this SAMD variant.
 // Matches the value used by the other ARM ISR backends (see isr_sam.hpp).
 constexpr int ERR_NOT_IMPLEMENTED = -100;
 
 // Track allocated resources
 static bool timer_allocated[MAX_TIMER_INDEX + 1] = {};
-static bool eic_allocated[MAX_EIC_CHANNELS] = {};
 
 // Storage for handles (to allow ISR to find user handler)
 static samd_isr_handle_data* timer_handles[MAX_TIMER_INDEX + 1] = {};
-static samd_isr_handle_data* eic_handles[MAX_EIC_CHANNELS] = {};
 
 // =============================================================================
 // Helper Functions
@@ -191,39 +186,6 @@ static void free_timer(u8 timer_idx) FL_NO_EXCEPT {
         __disable_irq();
         timer_allocated[timer_idx] = false;
         timer_handles[timer_idx] = nullptr;
-        __enable_irq();
-    }
-}
-
-// Allocate a free EIC channel
-// SAMD21 only: the SAMD51 EIC path is not implemented (see attach_external_handler).
-#if defined(FL_IS_SAMD21)
-static bool allocate_eic_channel(u8& channel) FL_NO_EXCEPT {
-    // Critical section: prevent interrupt from modifying allocation state
-    __disable_irq();
-
-    bool found = false;
-    for (u8 i = 0; i < MAX_EIC_CHANNELS; i++) {
-        if (!eic_allocated[i]) {
-            eic_allocated[i] = true;
-            channel = i;
-            found = true;
-            break;
-        }
-    }
-
-    __enable_irq();
-    return found;
-}
-#endif  // FL_IS_SAMD21
-
-// Free an EIC channel
-static void free_eic_channel(u8 channel) FL_NO_EXCEPT {
-    if (channel < MAX_EIC_CHANNELS) {
-        // Critical section: prevent interrupt from accessing freed resources
-        __disable_irq();
-        eic_allocated[channel] = false;
-        eic_handles[channel] = nullptr;
         __enable_irq();
     }
 }
@@ -351,27 +313,6 @@ extern "C" {
     }
 #endif
 
-    // EIC (External Interrupt Controller) handler
-    // SAMD21 only: SAMD51 splits the EIC across EIC_0_Handler..EIC_15_Handler,
-    // which the Arduino SAMD core already defines. Defining EIC_Handler there
-    // would produce a symbol that is never wired into the vector table.
-#if defined(FL_IS_SAMD21)
-    void EIC_Handler(void) FL_NO_EXCEPT {
-        for (u8 ch = 0; ch < MAX_EIC_CHANNELS; ch++) {
-            u32 flag = 1UL << ch;
-
-            if (EIC->INTFLAG.reg & flag) {
-                // Clear the interrupt flag
-                EIC->INTFLAG.reg = flag;
-
-                samd_isr_handle_data* handle = eic_handles[ch];
-                if (handle && handle->user_handler) {
-                    handle->user_handler(handle->user_data);
-                }
-            }
-        }
-    }
-#endif  // FL_IS_SAMD21
 }
 
 // =============================================================================
@@ -535,130 +476,34 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 }
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NO_EXCEPT {
-#if defined(FL_IS_SAMD51)
-    // SAMD51 splits the EIC into 16 separate vectors (EIC_0_Handler..EIC_15_Handler)
-    // rather than the single EIC_Handler that SAMD21 uses. The Arduino SAMD core
-    // (WInterrupts.c) defines all 16 of those handlers strongly and enables their
-    // IRQs at init, so FastLED cannot claim them without a duplicate-symbol link
-    // error. Report "not implemented" instead of silently attaching to a vector
-    // that will never fire (see the Arduino Due path in isr_sam.hpp).
+    // External (pin) interrupts are not implemented on SAMD. The previous
+    // implementation could not work on either variant:
+    //
+    //   * It derived the pad as `pin / 32` / `pin % 32`, treating the Arduino pin
+    //     index as a raw PORT/bit index. Those only coincide by accident - e.g.
+    //     Arduino pin 5 is PB14 on a Metro M4 and PA15 on a Feather M0, not PA05 -
+    //     so it re-muxed an unrelated pad.
+    //   * It handed out EIC channels sequentially, but EXTINT lines are hardwired
+    //     per pad, so EIC->CONFIG/INTENSET were programmed for a channel the pin
+    //     is not on and the handler never fired.
+    //   * On SAMD21 it also needed a strong EIC_Handler, which collides with the
+    //     Arduino core's own strong definition in WInterrupts.c as soon as a
+    //     sketch calls attachInterrupt() (that pulls WInterrupts.o out of core.a;
+    //     the startup file's weak Dummy_Handler aliases and the static
+    //     __initialize() never do). SAMD51 splits the same vector across
+    //     EIC_0_Handler..EIC_15_Handler with the identical problem.
+    //
+    // Report the failure instead of mis-programming the peripheral, matching the
+    // Arduino Due backend in isr_sam.hpp. The collision-free implementation is to
+    // delegate to the core's attachInterrupt() and claim no vectors at all, using
+    // g_APinDescription[pin].ulExtInt for the channel; that is a larger change
+    // than this compile fix.
     (void)pin;
     (void)config;
     if (out_handle) {
         *out_handle = isr_handle_t();  // Invalid handle
     }
     return ERR_NOT_IMPLEMENTED;
-#else
-    if (!config.handler) {
-        FL_WARN_F("attachExternalHandler: handler is null");
-        return -1;  // Invalid parameter
-    }
-
-    // Allocate an EIC channel
-    u8 eic_ch = 0;
-    if (!allocate_eic_channel(eic_ch)) {
-        FL_WARN_F("attachExternalHandler: no free EIC channels");
-        return -3;  // Out of resources
-    }
-
-    // Allocate handle data
-    auto handle_owner = fl::make_unique<samd_isr_handle_data>();
-    auto* handle_data = handle_owner.get();
-    if (!handle_data) {
-        free_eic_channel(eic_ch);
-        FL_WARN_F("attachExternalHandler: failed to allocate handle data");
-        return -5;  // Out of memory
-    }
-
-    handle_data->is_timer = false;
-    handle_data->eic_channel = eic_ch;
-    handle_data->gpio_pin = pin;
-    handle_data->user_handler = config.handler;
-    handle_data->user_data = config.user_data;
-
-    // Store handle for ISR access
-    eic_handles[eic_ch] = handle_data;
-
-    // Enable EIC clock
-    GCLK->CLKCTRL.reg = (u16)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID_EIC);
-    while (GCLK->STATUS.bit.SYNCBUSY) {
-        // Wait for sync
-    }
-
-    // Configure GPIO pin for EIC function
-    // Note: Pin-to-EIC-channel mapping is board-specific
-    // For now, we use a simple mapping (this may need board-specific adjustments)
-    u8 port = pin / 32;
-    u8 pin_num = pin % 32;
-
-    PORT->Group[port].PINCFG[pin_num].reg |= PORT_PINCFG_PMUXEN;
-
-    // Select peripheral function A (EIC) for the pin. Function A is encoded as 0,
-    // so clear the pin's PMUX nibble rather than OR-ing a value in - an OR can
-    // never move the field away from a previously-selected peripheral.
-    if (pin_num & 1) {
-        PORT->Group[port].PMUX[pin_num >> 1].reg &= ~(u8)PORT_PMUX_PMUXO_Msk;
-    } else {
-        PORT->Group[port].PMUX[pin_num >> 1].reg &= ~(u8)PORT_PMUX_PMUXE_Msk;
-    }
-
-    // Enable EIC if not already enabled
-    // SAMD21 uses CTRL instead of CTRLA, and STATUS.SYNCBUSY instead of SYNCBUSY
-    if (!EIC->CTRL.bit.ENABLE) {
-        EIC->CTRL.bit.ENABLE = 0;
-        while (EIC->STATUS.bit.SYNCBUSY) {
-            // Wait for sync
-        }
-
-        // Configure EIC
-        EIC->CTRL.bit.ENABLE = 1;
-        while (EIC->STATUS.bit.SYNCBUSY) {
-            // Wait for sync
-        }
-    }
-
-    // Determine sense configuration from flags
-    u8 sense;
-    if (config.flags & ISR_FLAG_EDGE_RISING) {
-        sense = EIC_CONFIG_SENSE0_RISE_Val;
-    } else if (config.flags & ISR_FLAG_EDGE_FALLING) {
-        sense = EIC_CONFIG_SENSE0_FALL_Val;
-    } else {
-        sense = EIC_CONFIG_SENSE0_BOTH_Val;  // Default to both edges
-    }
-
-    // Configure EIC channel
-    u8 config_idx = eic_ch / 8;  // Each CONFIG register handles 8 channels
-    u8 sense_shift = (eic_ch % 8) * 4;  // 4 bits per channel
-
-    EIC->CONFIG[config_idx].reg &= ~(0xF << sense_shift);
-    EIC->CONFIG[config_idx].reg |= (sense << sense_shift);
-
-    // Enable interrupt for this channel
-    EIC->INTENSET.reg = (1UL << eic_ch);
-
-    // Configure NVIC
-    u8 nvic_priority = map_priority_to_nvic(config.priority);
-    NVIC_DisableIRQ(EIC_IRQn) FL_NO_EXCEPT;
-    NVIC_ClearPendingIRQ(EIC_IRQn) FL_NO_EXCEPT;
-    NVIC_SetPriority(EIC_IRQn, nvic_priority) FL_NO_EXCEPT;
-    NVIC_EnableIRQ(EIC_IRQn) FL_NO_EXCEPT;
-
-    FL_DBG_F("EIC interrupt attached on pin %s EIC channel %s", static_cast<int>(pin), static_cast<int>(eic_ch));
-
-    // Release ownership - pointer is now managed by the C API (eic_handles + out_handle)
-    handle_owner.release();
-
-    // Populate output handle
-    if (out_handle) {
-        out_handle->platform_handle = handle_data;
-        out_handle->handler = config.handler;
-        out_handle->user_data = config.user_data;
-        out_handle->platform_id = SAMD_PLATFORM_ID;
-    }
-
-    return 0;  // Success
-#endif  // FL_IS_SAMD51
 }
 
 int detach_handler(isr_handle_t& handle) FL_NO_EXCEPT {
@@ -683,12 +528,6 @@ int detach_handler(isr_handle_t& handle) FL_NO_EXCEPT {
 
             NVIC_DisableIRQ(handle_data->timer_irq);
             free_timer(handle_data->timer_index);
-        }
-    } else {
-        // Disable EIC interrupt
-        if (handle_data->eic_channel < MAX_EIC_CHANNELS) {
-            EIC->INTENCLR.reg = (1UL << handle_data->eic_channel);
-            free_eic_channel(handle_data->eic_channel);
         }
     }
 
@@ -720,8 +559,9 @@ int enable_handler(const isr_handle_t& handle) FL_NO_EXCEPT {
             handle_data->is_enabled = true;
         }
     } else {
-        EIC->INTENSET.reg = (1UL << handle_data->eic_channel);
-        handle_data->is_enabled = true;
+        // Only timer handles can exist; attach_external_handler never produces
+        // one. Do not poke EIC with the sentinel channel (1UL << 0xFF is UB).
+        return ERR_NOT_IMPLEMENTED;
     }
 
     return 0;  // Success
@@ -747,8 +587,8 @@ int disable_handler(const isr_handle_t& handle) FL_NO_EXCEPT {
             handle_data->is_enabled = false;
         }
     } else {
-        EIC->INTENCLR.reg = (1UL << handle_data->eic_channel);
-        handle_data->is_enabled = false;
+        // See enable_handler(): no external handles are ever created.
+        return ERR_NOT_IMPLEMENTED;
     }
 
     return 0;  // Success
@@ -775,6 +615,7 @@ const char* get_error_string(int error_code) FL_NO_EXCEPT {
         case -3: return "Out of resources";
         case -4: return "Internal error";
         case -5: return "Out of memory";
+        case ERR_NOT_IMPLEMENTED: return "Not implemented (SAMD external pin interrupts are not supported)";
         default: return "Unknown error";
     }
 }

--- a/src/platforms/arm/samd/isr_samd.hpp
+++ b/src/platforms/arm/samd/isr_samd.hpp
@@ -87,6 +87,10 @@ constexpr u8 MAX_TIMER_INSTANCES = MAX_TIMER_INDEX - MIN_TIMER_INDEX + 1;
 // EIC configuration
 constexpr u8 MAX_EIC_CHANNELS = 16;
 
+// Error code for functionality that is not available on this SAMD variant.
+// Matches the value used by the other ARM ISR backends (see isr_sam.hpp).
+constexpr int ERR_NOT_IMPLEMENTED = -100;
+
 // Track allocated resources
 static bool timer_allocated[MAX_TIMER_INDEX + 1] = {};
 static bool eic_allocated[MAX_EIC_CHANNELS] = {};
@@ -192,6 +196,8 @@ static void free_timer(u8 timer_idx) FL_NO_EXCEPT {
 }
 
 // Allocate a free EIC channel
+// SAMD21 only: the SAMD51 EIC path is not implemented (see attach_external_handler).
+#if defined(FL_IS_SAMD21)
 static bool allocate_eic_channel(u8& channel) FL_NO_EXCEPT {
     // Critical section: prevent interrupt from modifying allocation state
     __disable_irq();
@@ -209,6 +215,7 @@ static bool allocate_eic_channel(u8& channel) FL_NO_EXCEPT {
     __enable_irq();
     return found;
 }
+#endif  // FL_IS_SAMD21
 
 // Free an EIC channel
 static void free_eic_channel(u8 channel) FL_NO_EXCEPT {
@@ -345,6 +352,10 @@ extern "C" {
 #endif
 
     // EIC (External Interrupt Controller) handler
+    // SAMD21 only: SAMD51 splits the EIC across EIC_0_Handler..EIC_15_Handler,
+    // which the Arduino SAMD core already defines. Defining EIC_Handler there
+    // would produce a symbol that is never wired into the vector table.
+#if defined(FL_IS_SAMD21)
     void EIC_Handler(void) FL_NO_EXCEPT {
         for (u8 ch = 0; ch < MAX_EIC_CHANNELS; ch++) {
             u32 flag = 1UL << ch;
@@ -360,6 +371,7 @@ extern "C" {
             }
         }
     }
+#endif  // FL_IS_SAMD21
 }
 
 // =============================================================================
@@ -523,6 +535,20 @@ int attach_timer_handler(const isr_config_t& config, isr_handle_t* out_handle) F
 }
 
 int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* out_handle) FL_NO_EXCEPT {
+#if defined(FL_IS_SAMD51)
+    // SAMD51 splits the EIC into 16 separate vectors (EIC_0_Handler..EIC_15_Handler)
+    // rather than the single EIC_Handler that SAMD21 uses. The Arduino SAMD core
+    // (WInterrupts.c) defines all 16 of those handlers strongly and enables their
+    // IRQs at init, so FastLED cannot claim them without a duplicate-symbol link
+    // error. Report "not implemented" instead of silently attaching to a vector
+    // that will never fire (see the Arduino Due path in isr_sam.hpp).
+    (void)pin;
+    (void)config;
+    if (out_handle) {
+        *out_handle = isr_handle_t();  // Invalid handle
+    }
+    return ERR_NOT_IMPLEMENTED;
+#else
     if (!config.handler) {
         FL_WARN_F("attachExternalHandler: handler is null");
         return -1;  // Invalid parameter
@@ -554,17 +580,10 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     eic_handles[eic_ch] = handle_data;
 
     // Enable EIC clock
-#if defined(FL_IS_SAMD21)
     GCLK->CLKCTRL.reg = (u16)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 | GCLK_CLKCTRL_ID_EIC);
     while (GCLK->STATUS.bit.SYNCBUSY) {
         // Wait for sync
     }
-#elif defined(FL_IS_SAMD51)
-    GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0 | GCLK_PCHCTRL_CHEN;
-    while (!(GCLK->PCHCTRL[EIC_GCLK_ID].reg & GCLK_PCHCTRL_CHEN)) {
-        // Wait for enable
-    }
-#endif
 
     // Configure GPIO pin for EIC function
     // Note: Pin-to-EIC-channel mapping is board-specific
@@ -574,15 +593,16 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
 
     PORT->Group[port].PINCFG[pin_num].reg |= PORT_PINCFG_PMUXEN;
 
-    // Set PMUX to function A (EIC) for the pin
+    // Select peripheral function A (EIC) for the pin. Function A is encoded as 0,
+    // so clear the pin's PMUX nibble rather than OR-ing a value in - an OR can
+    // never move the field away from a previously-selected peripheral.
     if (pin_num & 1) {
-        PORT->Group[port].PMUX[pin_num >> 1].reg |= PORT_PMUX_PMUXO_A;
+        PORT->Group[port].PMUX[pin_num >> 1].reg &= ~(u8)PORT_PMUX_PMUXO_Msk;
     } else {
-        PORT->Group[port].PMUX[pin_num >> 1].reg |= PORT_PMUX_PMUXE_A;
+        PORT->Group[port].PMUX[pin_num >> 1].reg &= ~(u8)PORT_PMUX_PMUXE_Msk;
     }
 
     // Enable EIC if not already enabled
-#if defined(FL_IS_SAMD21)
     // SAMD21 uses CTRL instead of CTRLA, and STATUS.SYNCBUSY instead of SYNCBUSY
     if (!EIC->CTRL.bit.ENABLE) {
         EIC->CTRL.bit.ENABLE = 0;
@@ -596,21 +616,6 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
             // Wait for sync
         }
     }
-#elif defined(FL_IS_SAMD51)
-    // SAMD51 uses CTRLA and dedicated SYNCBUSY register
-    if (!EIC->CTRLA.bit.ENABLE) {
-        EIC->CTRLA.bit.ENABLE = 0;
-        while (EIC->SYNCBUSY.bit.ENABLE) {
-            // Wait for sync
-        }
-
-        // Configure EIC
-        EIC->CTRLA.bit.ENABLE = 1;
-        while (EIC->SYNCBUSY.bit.ENABLE) {
-            // Wait for sync
-        }
-    }
-#endif
 
     // Determine sense configuration from flags
     u8 sense;
@@ -653,6 +658,7 @@ int attach_external_handler(u8 pin, const isr_config_t& config, isr_handle_t* ou
     }
 
     return 0;  // Success
+#endif  // FL_IS_SAMD51
 }
 
 int detach_handler(isr_handle_t& handle) FL_NO_EXCEPT {


### PR DESCRIPTION
## Problem

Reported on the forum: an Adafruit Metro M4 (SAMD51) on FastLED 3.10.5 fails to compile with **nothing in the sketch but `#include <FastLED.h>`**:

```
isr_samd.hpp:579: error: 'PORT_PMUX_PMUXO_A' was not declared in this scope; did you mean 'PORT_PMUX_PMUXO'?
isr_samd.hpp:581: error: 'PORT_PMUX_PMUXE_A' was not declared in this scope; did you mean 'PORT_PMUX_PMUXE'?
isr_samd.hpp:637: error: 'EIC_IRQn' was not declared in this scope; did you mean 'ICM_IRQn'?
```

`isr_samd.hpp` is pulled into the unconditional `fl.stl+.cpp` unity TU, so this breaks **every** SAMD51 sketch, not just ones using interrupts.

## Regression window

| Version | `isr_samd.hpp` | SAMD51 |
|---|---|---|
| 3.10.0 – 3.10.3 | absent | ✅ |
| **3.10.4** | present | ❌ |
| **3.10.5** | present | ❌ |
| master | present | ❌ |

Introduced by the 3.10.4 ISR platform-dispatch work (`55a70c7755`). Its SAMD51 branch was written against SAMD21 CMSIS symbols. Verified against the real Adafruit CMSIS headers:

| symbol | SAMD21 | SAMD51 |
|---|---|---|
| `PORT_PMUX_PMUXO_A` / `PMUXE_A` | defined | **missing** |
| `PORT_PMUX_PMUXO_Msk` / `PMUXE_Msk` | defined | defined |
| `EIC_IRQn` | defined | **missing** (has `EIC_0_IRQn`..`EIC_15_IRQn`) |

**Workaround for affected users until this ships: pin FastLED 3.10.3.**

## Changes

**`src/platforms/arm/samd/isr_samd.hpp`**
- PMUX function A is encoded as `0`, so select it by *clearing* the pin's PMUX nibble instead of OR-ing a value in. Portable across both families, and fixes a real bug: the old `|=` could never move the field off a previously-selected peripheral.
- **External (pin) interrupts now return `ERR_NOT_IMPLEMENTED` on all SAMD, and `EIC_Handler` is gone.** The path never worked on either variant and was a link landmine:
  - The pad was derived as `pin / 32` / `pin % 32`, treating the *Arduino* pin index as a raw PORT/bit index. Arduino pin 5 is PB14 on a Metro M4 and PA15 on a Feather M0 — not PA05 — so it re-muxed an unrelated pad.
  - EIC channels were handed out sequentially, but EXTINT lines are hardwired per pad, so `EIC->CONFIG`/`INTENSET` armed a channel the pin isn't on and the handler never fired.
  - On SAMD21 it needed a strong `EIC_Handler`, which collides with the Arduino core's own strong definition in `WInterrupts.c`. **`WInterrupts.o` is pulled out of `core.a` only when a sketch references `attachInterrupt()`/`detachInterrupt()`** — `__initialize()` is `static` and the startup file's weak `Dummy_Handler` aliases satisfy the vector table locally, so neither drags the member in. The collision is therefore *conditional on the sketch using `attachInterrupt()`*, and the core does **not** enable the EIC IRQs at boot. (An earlier revision of this PR described it as unconditional and boot-time; that was wrong.) Net: FastLED + `attachInterrupt()` on SAMD21 was `multiple definition of 'EIC_Handler'`.

  Result is 159 lines deleted net, matching the Arduino Due backend. The collision-free design is to delegate to the core's `attachInterrupt()` using `g_APinDescription[pin].ulExtInt` and claim no vectors at all — left as follow-up.
- `get_error_string()` now maps `ERR_NOT_IMPLEMENTED`; it previously reported `"Unknown error"`.
- `enable_handler`/`disable_handler` took `1UL << eic_channel` in the non-timer branch — UB with the `0xFF` sentinel. Unreachable now, but replaced rather than left.
- Timer ISR path and the rest of the SAMD51 platform are untouched.

**`src/platforms/arm/d51/fastpin_arm_d51.h`**
- Add `ADAFRUIT_METRO_M4_EXPRESS`. Only A3 differs from the already-supported AirLift Lite variant (PA04 vs PB00), so both share one table. Fixes the reporter's second complaint, `#warning "No pin/port mappings found, pin access will be slightly slower."`

**CI / badges — root cause**
- **No SAMD board compiled in CI and no SAMD badge existed on the README**, which is how a total compile break shipped in 3.10.4 and again in 3.10.5 with nothing turning red. The ARM row only covered `sam3x8e_due` and ClearCore; ClearCore is SAME53 and takes the `FL_IS_SAME53` path, so it never touched the broken code.
- Add `samd21`, `samd51j`, `metro_m4` workflows (push **and** pull_request, mirroring `build_teensy41`).
- Add `ci/boards.py` `metro_m4` (`adafruit_metro_m4`) — the only board that compiles with `ADAFRUIT_METRO_M4_EXPRESS` defined, so it is what exercises the new fastpin branch.
- Add a **Microchip SAMD (M0+/M4)** badge row to the README.

## Verification

- ✅ Reproduced the reporter's three errors **byte-for-byte** (including the `did you mean` hints) by compiling the shipped expressions against the real Adafruit CMSIS `samd51/port.h` + `samd51j19a.h`; the fixed expressions compile clean on **both** SAMD21 and SAMD51.
- ✅ `bash lint` clean. (The one reported failure is in `ci/tests/build/test_error_reporting.py`, which is untracked and gitignored — a local artifact, not in this repo.)
- ⚠️ **Local device compile blocked**: `bash compile samd51j` could not complete — fbuild's arm-gcc 15.2 download restarts from zero on interruption (no resume) and never got past ~78/282MB across four attempts. That looks like an fbuild download-resume gap worth filing separately. **The CI jobs on this PR are the compile verification — please do not merge until `samd51j`, `metro_m4` and `samd21` are green.** My host-compiler probe validated the *expressions*; only CI validates the full TU (preprocessor balance across the gated regions, unused-symbol warnings, the whole unity build).

## Follow-ups found, deliberately not fixed here

1. `#ifdef TC0_IRQn` … `#ifdef TC7_IRQn` guards are **always false** — `TC*_IRQn` are `IRQn_Type` enumerators, not macros (zero `#define`s in either CMSIS header). So `get_timer_irq()` always returns `0` and FastLED's `TC*_Handler` bodies are never compiled. Two consequences: the SAMD **timer** ISR path is silently inert on both variants, and — contrary to what a review pass suggested — those handlers do *not* collide with the core's `Tone.cpp`. Fixing the guard would newly define `TC*_Handler` and create that collision, so it needs the delegation design, not a one-line guard change.
2. Implement SAMD external interrupts by delegating to the core's `attachInterrupt()` (16 static trampolines, since the core callback carries no `user_data`). Collision-free on both variants and uses the correct pad/EXTINT mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Adafruit Metro M4 Express board.
  * Added automated build coverage for SAMD21, SAMD51J, and Metro M4 targets.
  * Added build-status indicators for supported SAMD boards.

* **Bug Fixes**
  * Corrected Metro M4 Express hardware pin mappings.

* **Breaking Changes**
  * SAMD external interrupt handling is no longer supported; related operations now report “not implemented.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->