### PR TITLE
docs(review): add a CodeRabbit rule on public API expansion

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,9 +37,14 @@ reviews:
         1. Does an existing generic entry point already do this? If a class
            has a `begin(Interface)` seam, a new backend needs a free factory,
            not a new `beginFoo()` member.
-        2. Could this be a free function instead of a member? Free functions
-           are found by ADL, do not enlarge the class, and do not force every
-           consumer of the header to recompile when they change.
+        2. Could this be a free function instead of a member? It does not
+           enlarge the class, so the class stays stable as backends
+           accumulate, and it can move to its own header later so consumers
+           that never call it stop paying for it. Two things it does NOT buy
+           on its own: a free function declared in the same public header
+           still churns every consumer when that header changes, and ADL
+           only applies when a parameter type lives in the namespace — a
+           `bool` does not, so callers still write `fl::make_x(...)`.
         3. Does the new symbol drag headers with it? A method whose signature
            names a codec/format type pulls that header into the include graph
            of everyone who includes this one — especially with

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,78 @@ reviews:
         peripherals — one engine for both clockless and SPI modes" and
         `agents/docs/cpp-standards.md` → "Parallel-IO Driver: Unified
         Clockless + SPI Engine".
+    - path: "src/fl/**/*.h"
+      instructions: |
+        Public API expansion. A public header is a permanent commitment —
+        every symbol added is one FastLED has to keep working. Flag any PR
+        that widens a public class or header without showing that the
+        existing surface could not carry the change.
+
+        Ask, in order:
+        1. Does an existing generic entry point already do this? If a class
+           has a `begin(Interface)` seam, a new backend needs a free factory,
+           not a new `beginFoo()` member.
+        2. Could this be a free function instead of a member? Free functions
+           are found by ADL, do not enlarge the class, and do not force every
+           consumer of the header to recompile when they change.
+        3. Does the new symbol drag headers with it? A method whose signature
+           names a codec/format type pulls that header into the include graph
+           of everyone who includes this one — especially with
+           `// IWYU pragma: export`.
+        4. Does it scale? If the answer to "what happens when we add a third,
+           and a tenth?" is a proportionally larger class, the shape is wrong.
+
+        WORKED EXAMPLE — `fl/system/file_system.h` (see FastLED #4003).
+
+        `FileSystem` grew a member per backend (`beginSd`, `sd`) and a member
+        per format (`openVideo`, `openMpeg1Video`, `readText`, `readJson`,
+        `readScreenMaps`, `readScreenMap`, `loadJpeg`, `openMp3`, `loadFled`).
+        The header now re-exports `fl/fx/video.h` and `fl/codec/jpeg.h`, so
+        every sketch that opens a file also pulls in video and JPEG. It also
+        carries an inline `loadJpegFromSD()` body, which the API Object
+        Pattern says a wrapper header must not do.
+
+        WRONG — adding a LittleFS backend by extending the class:
+
+            class FileSystem {
+              public:
+                static FileSystem sd(int cs_pin);
+                bool beginSd(int cs_pin);
+                static FileSystem littleFs(bool format_on_fail = false);  // NEW
+                bool beginLittleFs(bool format_on_fail = false);          // NEW
+            };
+
+        Two more members, and two more again for the next backend. Every
+        consumer of the header recompiles, and the class keeps accreting.
+
+        RIGHT — a free factory paired with the seam that already exists:
+
+            // header: one free function, mirroring make_sdcard_filesystem
+            FsImplPtr make_littlefs_filesystem(bool format_on_fail = false) FL_NO_EXCEPT;
+
+            // call site: uses FileSystem::begin(FsImplPtr), already public
+            fl::FileSystem fs;
+            if (fs.begin(fl::make_littlefs_filesystem())) { ... }
+
+        `FileSystem` is unchanged. The Nth backend costs one free function
+        and no class surface. Reference: `agents/docs/cpp-standards.md` →
+        "API Object Pattern" (rule 2: the API object wraps, it does not
+        implement) and FastLED #4003.
+
+        This is guidance, not a veto — widening a public class is sometimes
+        right. Ask for the justification in the PR description; do not block
+        a change that argues its case.
+
+        DOES NOT APPLY to the Public Settings Pattern, which is a deliberate
+        exception in the opposite direction: a new `fl::set_*` / `enable_*` /
+        `disable_*` / `use_*` global setter MUST gain a matching `CFastLED`
+        method in `src/FastLED.h`. That is required widening — do not flag it
+        under this rule. See the separate `src/fl/**/*.h` instruction covering
+        that pattern.
+
+        Also does not apply to: per-object configuration on the object's own
+        API, anything under `fl::detail::` or an anonymous namespace, or a
+        header that is not part of the public surface.
     - path: "src/platforms/**/drivers/**/*peripheral*mock*.{h,cpp.hpp}"
       instructions: |
         Peripheral-mock singleton rule. FastLED peripheral mocks


### PR DESCRIPTION
## Why

A public header is a permanent commitment — every symbol added is one FastLED has to keep working. `fl/system/file_system.h` shows what happens without a check on that (#4003): `FileSystem` grew a member per *backend* (`beginSd`, `sd`) **and** a member per *format* (`openVideo`, `openMpeg1Video`, `readText`, `readJson`, `readScreenMaps`, `readScreenMap`, `loadJpeg`, `openMp3`, `loadFled`), and the header now re-exports `fl/fx/video.h` and `fl/codec/jpeg.h` — so every sketch that opens a file also pulls in video and JPEG.

None of that was a bad decision in isolation. It is what a class looks like after a series of locally-reasonable additions with nothing asking "and what about the tenth one?"

## The rule

Four questions, in order:

1. Does an existing generic entry point already do this?
2. Could this be a free function instead of a member?
3. Does the new symbol drag headers with it (especially under `// IWYU pragma: export`)?
4. Does it scale to the tenth case?

## Worked example

The rule ships with the LittleFS backend as a concrete wrong-vs-right pair, because it is exactly the decision that surfaced #4003.

**Wrong** — extend the class:

```cpp
class FileSystem {
  public:
    static FileSystem sd(int cs_pin);
    bool beginSd(int cs_pin);
    static FileSystem littleFs(bool format_on_fail = false);  // NEW
    bool beginLittleFs(bool format_on_fail = false);          // NEW
};
```

Two more members, two more again for the next backend, and every consumer of the header recompiles.

**Right** — a free factory paired with the seam that already existed:

```cpp
FsImplPtr make_littlefs_filesystem(bool format_on_fail = false) FL_NO_EXCEPT;

fl::FileSystem fs;
if (fs.begin(fl::make_littlefs_filesystem())) { ... }
```

`FileSystem` is unchanged. The Nth backend costs one free function and no class surface.

## Scoping

Explicitly **does not apply** to the Public Settings Pattern, which lives on the same `src/fl/**/*.h` glob and requires the opposite — a new `fl::set_*` / `enable_*` / `disable_*` / `use_*` global setter MUST gain a matching `CFastLED` wrapper. That is required widening; without this carve-out the two rules would contradict each other on the same file.

Also excluded: per-object configuration on the object's own API, `fl::detail::` and anonymous namespaces, and non-public headers.

Stated as guidance, not a veto — widening a public class is sometimes correct. The rule asks for the justification in the PR description rather than blocking.

YAML validated with `yaml.safe_load`.

Refs #4003

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added code review guidance for changes affecting public APIs.
  * Documented preferred extension patterns, include-graph and scalability considerations, and approved exceptions for specialized implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->