### PR TITLE
fix(examples): give AudioUrl's .lnk a verifiable digest

### DIFF
--- a/examples/AudioUrl/data/track.mp3.lnk
+++ b/examples/AudioUrl/data/track.mp3.lnk
@@ -1,6 +1,7 @@
-# .lnk asset link file — see FastLED issue #2284.
+# .lnk asset link file - see FastLED issue #2284.
 # The first non-comment line is the URL this asset resolves to.
 # Lines starting with '#' and blank lines are ignored.
-# Additional lines (metadata like sha256=, fallback=) are reserved for
-# future use and are ignored by the v1 parser.
-https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3
+# Mirrored into FastLED/assets so the digest below stays valid; pinning a
+# sha256 to a third-party host means an upstream re-encode breaks the build.
+https://raw.githubusercontent.com/FastLED/assets/main/examples/AudioUrl/track.mp3
+sha256=cadd2666c5571e12fafdb21697b26aef6f196a5a9c28e708129870167679991d

--- a/tests/fl/asset/asset.cpp
+++ b/tests/fl/asset/asset.cpp
@@ -102,10 +102,14 @@ FL_TEST_CASE("fl::resolve_asset - host fallback finds sibling .lnk") {
     // examples/AudioUrl/data/track.mp3.lnk exists in the repo; the raw
     // track.mp3 does NOT. Resolution must fall through to the .lnk and return
     // the URL declared inside.
+    //
+    // The .lnk stays in the TEXT format on purpose: fl::parse_lnk reads only
+    // that form, so a JSON .lnk here would resolve to "{" as the URL. fbuild
+    // accepts both since FastLED/fbuild#1362.
     asset_ref r = FL_ASSET("examples/AudioUrl/data/track.mp3");
     url resolved = fl::resolve_asset(r);
     FL_CHECK(resolved.isValid());
-    FL_CHECK_EQ(resolved.host(), string_view("www.soundhelix.com"));
+    FL_CHECK_EQ(resolved.host(), string_view("raw.githubusercontent.com"));
 }
 
 FL_TEST_CASE("fl::resolve_asset - unknown path returns invalid url") {


### PR DESCRIPTION
## Problem

`examples/AudioUrl/data/track.mp3.lnk` had no `sha256`. fbuild requires a digest on every `.lnk` — it caches by content, so without one the asset can be neither verified nor content-addressed (FastLED/fbuild#1357).

## Why the URL changed too

Adding a digest to the existing `soundhelix.com` URL would pin a hash to a third-party host. Any re-encode upstream then breaks the build, loudly and confusingly, for a reason nobody here controls.

The track is mirrored into `FastLED/assets` and the `.lnk` points there:

```
sha256 = cadd2666c5571e12fafdb21697b26aef6f196a5a9c28e708129870167679991d
size   = 8,945,229 bytes
```

Verified byte-identical against the origin before and after upload. (The `main`-branch raw URL 404'd immediately after the push — a negative CDN cache from my own pre-upload existence check — so I confirmed against the commit-pinned URL instead.)

## The format is text on purpose

I first converted this to fbuild's JSON schema. `fl_asset_asset` caught it:

```
tests/fl/asset/asset.cpp:108: { == www.soundhelix.com
```

The C++ runtime's `fl::parse_lnk` reads **only** the text form — first non-comment line is the URL — so it took `{` as the URL and resolution returned host `{`. That is exactly the format split documented in FastLED/fbuild#1357, and the reason fbuild learned to read *text* `.lnk` files in FastLED/fbuild#1362 rather than the other way round.

The test's host assertion moves with the URL and gains a comment explaining why the format cannot change here, so the next person tempted to tidy this into JSON meets the explanation before the failure.

## Validation

| Consumer | Result |
|---|---|
| C++ runtime (`fl::parse_lnk`) | `fl_asset_asset` passes |
| Python scanner (`asset_scanner`) | reads URL + sha256, zero warnings |
| fbuild | needs the next release — 2.5.20 predates #1362 |

`bash lint` clean, `bash test --cpp` passes, `bash compile wasm --examples AudioUrl` builds.

Refs FastLED/fbuild#1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the audio asset fallback to use a mirrored FastLED-hosted source.
  * Added integrity verification for the asset.
  * Updated fallback resolution tests to reflect the new source URL.
  * Clarified supported link-file formats for reliable asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->