### PR TITLE
docs(asset): correct what actually emits the asset manifest

### DIFF
--- a/src/fl/asset/asset.h
+++ b/src/fl/asset/asset.h
@@ -10,8 +10,10 @@
 ///     fl::UIAudio audio("Audio", FL_ASSET("data/track.mp3"));
 /// @endcode
 ///
-/// At build time, fbuild scans `<sketch>/data/` for `*.lnk` files containing
-/// URLs and emits a manifest. At runtime:
+/// At build time, `ci/compiler/asset_scanner.py` scans `<sketch>/data/` for
+/// `*.lnk` files and emits `fastled_js/asset_manifest.json` (see
+/// `ci/wasm_build.py`). It accepts both `.lnk` spellings: the text form this
+/// runtime parses, and the JSON form `fbuild lnk add` writes. At runtime:
 ///  - On WASM, the manifest is consulted to turn the relative path into the
 ///    URL the browser should fetch.
 ///  - On host/stub, the asset resolves to the file on disk — or, if the raw


### PR DESCRIPTION
## Problem

`src/fl/asset/asset.h` documents the build-time half of the asset pipeline incorrectly:

> At build time, fbuild scans `<sketch>/data/` for `*.lnk` files containing URLs and emits a manifest.

fbuild does not do this. `ci/compiler/asset_scanner.py` does, driven from `ci/wasm_build.py`, writing `fastled_js/asset_manifest.json`.

## Why it is worth fixing rather than ignoring

The two tools read **different formats**. fbuild's `.lnk` parser was JSON-only until FastLED/fbuild#1362; the scanner reads the text form this runtime parses, and now the JSON form as well.

So someone debugging a missing asset, who believes fbuild produced the manifest, goes looking in the wrong tool — and if they then "fix" their `.lnk` into fbuild's JSON schema to match, they break runtime resolution, because `fl::parse_lnk` reads only the text form. That is not hypothetical: it happened in #4012, and `fl_asset_asset` caught it with `{ == www.soundhelix.com`.

## Change

Documentation only. Names the actual script, the actual output path, and the fact that it accepts both `.lnk` spellings.

`bash lint` clean, `bash test --cpp` passes.

This is the last plain factual item on FastLED/fbuild#1357. What remains there is the long-term format direction — whether the two `.lnk` roles should keep sharing an extension — which is a maintainer call, not a code fix.

Refs FastLED/fbuild#1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the build-time asset scanning process and generated manifest location.
  * Documented support for both text and JSON `.lnk` asset reference formats.
  * No runtime behavior or functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->