### PR TITLE
docs(review): refresh the API-expansion rule after the fl/fs move

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -52,17 +52,21 @@ reviews:
         4. Does it scale? If the answer to "what happens when we add a third,
            and a tenth?" is a proportionally larger class, the shape is wrong.
 
-        WORKED EXAMPLE — `fl/system/file_system.h` (see FastLED #4003).
+        WORKED EXAMPLE - the filesystem subsystem (FastLED #4003, #4007, #4008).
 
-        `FileSystem` grew a member per backend (`beginSd`, `sd`) and a member
-        per format (`openVideo`, `openMpeg1Video`, `readText`, `readJson`,
-        `readScreenMaps`, `readScreenMap`, `loadJpeg`, `openMp3`, `loadFled`).
-        The header now re-exports `fl/fx/video.h` and `fl/codec/jpeg.h`, so
-        every sketch that opens a file also pulls in video and JPEG. It also
-        carries an inline `loadJpegFromSD()` body, which the API Object
-        Pattern says a wrapper header must not do.
+        This is history now, and useful precisely because the end state is in
+        the tree to compare against. `FileSystem` had grown a member per
+        backend (`beginSd`, `sd`) AND a member per format (`openVideo`,
+        `openMpeg1Video`, `readText`, `readJson`, `readScreenMaps`,
+        `readScreenMap`, `loadJpeg`, `openMp3`, `loadFled`), in a header that
+        re-exported `fl/fx/video.h` and `fl/codec/jpeg.h` so every sketch
+        opening a file compiled both, and that carried an inline
+        `loadJpegFromSD()` body the API Object Pattern forbids.
 
-        WRONG — adding a LittleFS backend by extending the class:
+        No single addition was wrong. That is the point: each was locally
+        reasonable, and nothing asked "what about the tenth one?"
+
+        WRONG - adding a backend by extending the class:
 
             class FileSystem {
               public:
@@ -72,22 +76,39 @@ reviews:
                 bool beginLittleFs(bool format_on_fail = false);          // NEW
             };
 
-        Two more members, and two more again for the next backend. Every
-        consumer of the header recompiles, and the class keeps accreting.
+        Two more members, two more again for the next backend.
 
-        RIGHT — a free factory paired with the seam that already exists:
+        ALSO WRONG - naming the technology, even as a free function:
 
-            // header: one free function, mirroring make_sdcard_filesystem
-            FsImplPtr make_littlefs_filesystem(bool format_on_fail = false) FL_NO_EXCEPT;
+            FsImplPtr make_littlefs_filesystem(bool format_on_fail = false);
 
-            // call site: uses FileSystem::begin(FsImplPtr), already public
+        This looks like an improvement and is not. Once "LittleFS" is public,
+        every platform must hold an opinion about it - including the host
+        stub, which just maps to a directory on disk. ESP32 can back flash
+        with LittleFS, SPIFFS or FatFS, so the name is wrong for its own
+        siblings and blocks changing the default later.
+
+        RIGHT - name the medium, and use the seam that already exists:
+
+            // fl/fs/embedded/embedded_fs.h - one free function
+            FsImplPtr getEmbeddedFs(bool format_on_fail = false) FL_NO_EXCEPT;
+
+            // call site: FileSystem::begin(FsImplPtr) was already public
             fl::FileSystem fs;
-            if (fs.begin(fl::make_littlefs_filesystem())) { ... }
+            if (fs.begin(fl::getEmbeddedFs())) { ... }
 
-        `FileSystem` is unchanged. The Nth backend costs one free function
-        and no class surface. Reference: `agents/docs/cpp-standards.md` →
-        "API Object Pattern" (rule 2: the API object wraps, it does not
-        implement) and FastLED #4003.
+        `FileSystem` is untouched. Compare `getSdFs(cs_pin)`, which names a
+        removable card rather than the SdFat library driving it. The Nth
+        backend costs one free function and no class surface.
+
+        The same shape applies to formats: `fl/fs/read.h` declares `readJpeg`,
+        `readVideo`, `readJson` and friends as free functions over a
+        `FileSystem&`, so adding a format costs one function there instead of
+        widening the class.
+
+        Reference: `agents/docs/cpp-standards.md` -> "API Object Pattern"
+        (rule 2: the API object wraps, it does not implement), and
+        FastLED #4003 / #4007 / #4008 for how this one was unwound.
 
         This is guidance, not a veto — widening a public class is sometimes
         right. Ask for the justification in the PR description; do not block


### PR DESCRIPTION
## Problem

The API-expansion rule added in #4005 taught a shape that no longer exists. Its worked example cited `make_littlefs_filesystem()` and `fl/system/file_system.h` — both superseded since: the former became `fl::getEmbeddedFs()` in #4006, the latter moved to `fl/fs/fs.h` in #4010.

Review instructions describing code nobody can find are worse than none.

## The sharper problem

The old rule's **"RIGHT"** example was itself the naming mistake #4007 exists to prevent:

```cpp
FsImplPtr make_littlefs_filesystem(bool format_on_fail = false);
```

A free factory *is* better than a class member — that part was right. But naming the technology forces every platform to hold an opinion about LittleFS, including the host stub that just maps to a directory on disk. So the rule was teaching reviewers to approve the exact thing another issue was filed to stop.

## Change

The example now shows **three** states instead of two:

1. **WRONG** — extend the class (`beginLittleFs`, `littleFs`)
2. **ALSO WRONG** — a free factory naming the technology. Called out explicitly because it *looks* like the fix, which makes it the more likely error.
3. **RIGHT** — name the medium: `getEmbeddedFs()`, beside `getSdFs(cs_pin)` which names a removable card rather than the SdFat library driving it.

It also points at `fl/fs/read.h` for the same shape applied to formats — `readJpeg`, `readVideo`, `readJson` as free functions over a `FileSystem&`, so adding a format costs one function rather than widening the class.

Recast as history, since the end state is now in the tree to compare against. And it keeps the observation that mattered most: **no single addition to `FileSystem` was wrong.** Each was locally reasonable; nothing asked "what about the tenth one?"

## Verified

- YAML parses (`yaml.safe_load`), 19 `path_instructions` intact
- No stale `fl/system/file_system.h` references remain
- The one surviving `make_littlefs_filesystem` mention is the deliberate counter-example
- The carve-out for the Public Settings Pattern — which requires the opposite on the same glob — still reads correctly
- `bash lint` clean

Closes #4009

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded public API guidance with a more comprehensive filesystem example.
  * Added examples for multiple backends and formats, header re-exports, and inline implementations.
  * Clarified naming recommendations for filesystem factories and format extensions.
  * Documented reuse of the existing filesystem initialization interface.
  * Added references to related FastLED issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->