### PR TITLE
fix(samd): detect SAMD from part macros, not ARDUINO_ARCH_SAMD

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1525,9 +1525,6 @@ SAMD21G18A_FEATHER = Board(
     real_board_name="adafruit_feather_m0",
     platform="atmelsam",
     framework="arduino",
-    # SAMD routes into platforms/arm/sam/fastspi_arm_sam.h, which includes
-    # <SPI.h> under FL_IS_SAMD21/FL_IS_SAMD51. See #4011.
-    lib_deps=["SPI"],
 )
 
 SAMD21G18A_ZERO = Board(
@@ -1535,7 +1532,6 @@ SAMD21G18A_ZERO = Board(
     real_board_name="zeroUSB",
     platform="atmelsam",
     framework="arduino",
-    lib_deps=["SPI"],  # see samd21
 )
 
 # SAMD51 boards (Cortex-M4F @ 120 MHz)
@@ -1548,7 +1544,6 @@ SAMD51J19A_FEATHER_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
-    lib_deps=["SPI"],  # see samd21
 )
 
 SAMD51P20A_GRANDCENTRAL = Board(
@@ -1573,7 +1568,6 @@ SAMD51J19A_METRO_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
-    lib_deps=["SPI"],  # see samd21
 )
 
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1548,6 +1548,8 @@ SAMD51J19A_FEATHER_M4 = Board(
         # #ifndef, so a board define is the sanctioned override. Pin 6 is
         # defined for this board.
         "PIN_DATA=6",
+        # Apa102 defaults its clock to pin 2, which this board also lacks.
+        "STRIP_CLOCK_PIN=4",
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
 )

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1542,14 +1542,6 @@ SAMD51J19A_FEATHER_M4 = Board(
     framework="arduino",
     lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
     defines=[
-        # Feather M4 has no pin 3 -- fastpin_arm_d51.h says so outright
-        # ("no pins 2 3"), and Blink defaults to PIN_DATA 3, tripping the
-        # FastPin<3>::validpin() static assert. Blink guards the default with
-        # #ifndef, so a board define is the sanctioned override. Pin 6 is
-        # defined for this board.
-        "PIN_DATA=6",
-        # Apa102 defaults its clock to pin 2, which this board also lacks.
-        "STRIP_CLOCK_PIN=4",
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
 )

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1525,6 +1525,13 @@ SAMD21G18A_FEATHER = Board(
     real_board_name="adafruit_feather_m0",
     platform="atmelsam",
     framework="arduino",
+    # fbuild does not implement lib_ldf_mode and its chain scan reaches
+    # neither the #if 0 LDF hint in platforms/arm/samd/ldf_headers.h nor the
+    # real conditional include in fastspi_arm_sam.h, so the SAMD SPI backend
+    # needs SPI declared here too. fbuild calls lib_deps "the escape hatch
+    # for a dependency the finder scan never reaches". See #4011, #4016,
+    # FastLED/fbuild#1371. The src/ hint stays for PlatformIO consumers.
+    lib_deps=["SPI"],
 )
 
 SAMD21G18A_ZERO = Board(
@@ -1532,6 +1539,7 @@ SAMD21G18A_ZERO = Board(
     real_board_name="zeroUSB",
     platform="atmelsam",
     framework="arduino",
+    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 # SAMD51 boards (Cortex-M4F @ 120 MHz)
@@ -1544,6 +1552,7 @@ SAMD51J19A_FEATHER_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
+    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 SAMD51P20A_GRANDCENTRAL = Board(
@@ -1568,6 +1577,7 @@ SAMD51J19A_METRO_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
+    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1525,6 +1525,9 @@ SAMD21G18A_FEATHER = Board(
     real_board_name="adafruit_feather_m0",
     platform="atmelsam",
     framework="arduino",
+    # SAMD routes into platforms/arm/sam/fastspi_arm_sam.h, which includes
+    # <SPI.h> under FL_IS_SAMD21/FL_IS_SAMD51. See #4011.
+    lib_deps=["SPI"],
 )
 
 SAMD21G18A_ZERO = Board(
@@ -1532,6 +1535,7 @@ SAMD21G18A_ZERO = Board(
     real_board_name="zeroUSB",
     platform="atmelsam",
     framework="arduino",
+    lib_deps=["SPI"],  # see samd21
 )
 
 # SAMD51 boards (Cortex-M4F @ 120 MHz)
@@ -1544,6 +1548,7 @@ SAMD51J19A_FEATHER_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
+    lib_deps=["SPI"],  # see samd21
 )
 
 SAMD51P20A_GRANDCENTRAL = Board(
@@ -1568,6 +1573,7 @@ SAMD51J19A_METRO_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
+    lib_deps=["SPI"],  # see samd21
 )
 
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1525,13 +1525,6 @@ SAMD21G18A_FEATHER = Board(
     real_board_name="adafruit_feather_m0",
     platform="atmelsam",
     framework="arduino",
-    # fbuild does not implement lib_ldf_mode and its chain scan reaches
-    # neither the #if 0 LDF hint in platforms/arm/samd/ldf_headers.h nor the
-    # real conditional include in fastspi_arm_sam.h, so the SAMD SPI backend
-    # needs SPI declared here too. fbuild calls lib_deps "the escape hatch
-    # for a dependency the finder scan never reaches". See #4011, #4016,
-    # FastLED/fbuild#1371. The src/ hint stays for PlatformIO consumers.
-    lib_deps=["SPI"],
 )
 
 SAMD21G18A_ZERO = Board(
@@ -1539,7 +1532,6 @@ SAMD21G18A_ZERO = Board(
     real_board_name="zeroUSB",
     platform="atmelsam",
     framework="arduino",
-    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 # SAMD51 boards (Cortex-M4F @ 120 MHz)
@@ -1552,7 +1544,6 @@ SAMD51J19A_FEATHER_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
-    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 SAMD51P20A_GRANDCENTRAL = Board(
@@ -1577,7 +1568,6 @@ SAMD51J19A_METRO_M4 = Board(
     defines=[
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
-    lib_deps=["SPI"],  # see samd21 / #4016
 )
 
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1542,6 +1542,12 @@ SAMD51J19A_FEATHER_M4 = Board(
     framework="arduino",
     lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
     defines=[
+        # Feather M4 has no pin 3 -- fastpin_arm_d51.h says so outright
+        # ("no pins 2 3"), and Blink defaults to PIN_DATA 3, tripping the
+        # FastPin<3>::validpin() static assert. Blink guards the default with
+        # #ifndef, so a board define is the sanctioned override. Pin 6 is
+        # defined for this board.
+        "PIN_DATA=6",
         "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
     ],
 )

--- a/ci/tests/test_samd_default_pins.py
+++ b/ci/tests/test_samd_default_pins.py
@@ -7,8 +7,8 @@ assertion whose message talks about ground and read-only and noisy pins. That
 sends you looking at wiring rather than at a pin table. It went unnoticed
 because SAMD had never built at all (#4011).
 
-The examples now default to `CLOCKLESS_PIN_1` / `SPI_PIN_DATA_1` /
-`SPI_PIN_CLOCK_1`, which a board may define beside its `_FL_DEFPIN` table.
+The examples now default to `FL_PIN_CLOCKLESS_1` / `FL_PIN_SPI_DATA_1` /
+`FL_PIN_SPI_CLOCK_1`, which a board may define beside its `_FL_DEFPIN` table.
 These tests check the resulting value is in that table, for every SAMD board --
 not only the four that CI compiles.
 
@@ -34,14 +34,14 @@ FASTPIN_HEADERS = (
 )
 
 # Fallbacks in platforms/default_pins.h, used when a board defines no override.
-FALLBACKS = {"CLOCKLESS_PIN_1": 3, "SPI_PIN_DATA_1": 1, "SPI_PIN_CLOCK_1": 2}
+FALLBACKS = {"FL_PIN_CLOCKLESS_1": 3, "FL_PIN_SPI_DATA_1": 1, "FL_PIN_SPI_CLOCK_1": 2}
 
 _OPEN = re.compile(r"^\s*#\s*(if|ifdef|ifndef)\b")
 _CLOSE = re.compile(r"^\s*#\s*endif\b")
 _BRANCH = re.compile(r"^\s*#\s*(?:el)?if\s+defined\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)")
 _DEFPIN = re.compile(r"_FL_DEFPIN\(\s*(\d+)")
 _DEFAULT = re.compile(
-    r"^\s*#\s*define\s+(CLOCKLESS_PIN_1|SPI_PIN_DATA_1|SPI_PIN_CLOCK_1)\s+(\d+)"
+    r"^\s*#\s*define\s+(FL_PIN_CLOCKLESS_1|FL_PIN_SPI_DATA_1|FL_PIN_SPI_CLOCK_1)\s+(\d+)"
 )
 
 

--- a/ci/tests/test_samd_default_pins.py
+++ b/ci/tests/test_samd_default_pins.py
@@ -1,0 +1,143 @@
+"""Every SAMD board's default example pins must be pins that board actually has.
+
+`Blink` and `Apa102` used to hardcode pins 3, and 1/2. Adafruit Feather M4 has
+none of 2 or 3 -- `fastpin_arm_d51.h` says so in a comment, "no pins 2 3" -- so
+both examples failed to compile for it, with a `FastPin<3>::validpin()` static
+assertion whose message talks about ground and read-only and noisy pins. That
+sends you looking at wiring rather than at a pin table. It went unnoticed
+because SAMD had never built at all (#4011).
+
+The examples now default to `CLOCKLESS_PIN_1` / `SPI_PIN_DATA_1` /
+`SPI_PIN_CLOCK_1`, which a board may define beside its `_FL_DEFPIN` table.
+These tests check the resulting value is in that table, for every SAMD board --
+not only the four that CI compiles.
+
+Parser limitation, stated rather than hidden: pins are collected across a
+board's nested conditionals, so the set is a superset for boards that vary
+their table by sub-variant. That still catches "this pin exists nowhere for
+this board", which is the failure that occurred; it would not catch a pin valid
+only for a sibling sub-variant.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC = REPO_ROOT / "src"
+
+FASTPIN_HEADERS = (
+    SRC / "platforms" / "arm" / "d21" / "fastpin_arm_d21.h",
+    SRC / "platforms" / "arm" / "d51" / "fastpin_arm_d51.h",
+)
+
+# Fallbacks in platforms/default_pins.h, used when a board defines no override.
+FALLBACKS = {"CLOCKLESS_PIN_1": 3, "SPI_PIN_DATA_1": 1, "SPI_PIN_CLOCK_1": 2}
+
+_OPEN = re.compile(r"^\s*#\s*(if|ifdef|ifndef)\b")
+_CLOSE = re.compile(r"^\s*#\s*endif\b")
+_BRANCH = re.compile(r"^\s*#\s*(?:el)?if\s+defined\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)")
+_DEFPIN = re.compile(r"_FL_DEFPIN\(\s*(\d+)")
+_DEFAULT = re.compile(
+    r"^\s*#\s*define\s+(CLOCKLESS_PIN_1|SPI_PIN_DATA_1|SPI_PIN_CLOCK_1)\s+(\d+)"
+)
+
+
+def _board_blocks(header: Path) -> dict[str, dict]:
+    """Map each top-level board branch to its pins and default-pin overrides.
+
+    Board branches sit one level inside the file's
+    `#if defined(FASTLED_FORCE_SOFTWARE_PINS) / #else` wrapper. That wrapper's
+    own depth is derived rather than assumed -- these headers sit inside include
+    guards, so it is not at depth zero.
+    """
+    boards: dict[str, dict] = {}
+    depth = 0
+    wrapper_depth: int | None = None
+    board_depth: int | None = None
+    current: str | None = None
+
+    for line in header.read_text(encoding="utf-8").splitlines():
+        if _CLOSE.match(line):
+            depth -= 1
+            if board_depth is not None and depth < board_depth:
+                current = None
+            continue
+
+        opening = bool(_OPEN.match(line))
+        if opening:
+            depth += 1
+        m = _BRANCH.match(line)
+
+        if wrapper_depth is None:
+            if m and "FASTLED_FORCE_SOFTWARE_PINS" in line:
+                wrapper_depth = depth
+                board_depth = depth + 1
+            continue
+
+        if m and depth == board_depth:
+            current = m.group(1)
+            boards.setdefault(current, {"pins": set(), "defaults": {}})
+            continue
+
+        if current is None:
+            continue
+        for pm in _DEFPIN.finditer(line):
+            boards[current]["pins"].add(int(pm.group(1)))
+        dm = _DEFAULT.match(line)
+        if dm:
+            boards[current]["defaults"][dm.group(1)] = int(dm.group(2))
+
+    return {name: b for name, b in boards.items() if b["pins"]}
+
+
+def _all_boards() -> list[tuple[str, str, dict]]:
+    out = []
+    for header in FASTPIN_HEADERS:
+        for name, block in _board_blocks(header).items():
+            out.append((header.name, name, block))
+    return out
+
+
+BOARDS = _all_boards()
+
+
+def test_the_parser_found_boards() -> None:
+    """Guard against the parser silently matching nothing and passing."""
+    assert len(BOARDS) >= 15, f"only found {len(BOARDS)} boards; parser likely broken"
+    names = {n for _, n, _ in BOARDS}
+    assert "ADAFRUIT_FEATHER_M4_EXPRESS" in names
+    assert "ADAFRUIT_ITSYBITSY_M0" in names
+
+
+@pytest.mark.parametrize(
+    "header,board,block",
+    [(h, b, blk) for h, b, blk in BOARDS],
+    ids=[f"{h.split('_')[-1].rstrip('.h')}:{b}" for h, b, _ in BOARDS],
+)
+@pytest.mark.parametrize("macro", sorted(FALLBACKS))
+def test_default_pin_exists_on_this_board(
+    header: str, board: str, block: dict, macro: str
+) -> None:
+    effective = block["defaults"].get(macro, FALLBACKS[macro])
+    assert effective in block["pins"], (
+        f"{header}: {board} resolves {macro} to pin {effective}, which it does not "
+        f"define. FastPin<{effective}>::validpin() will fail and any example using "
+        f"this default will not compile. Define {macro} in this board's branch "
+        f"(see platforms/default_pins.h). Pins available: "
+        f"{sorted(block['pins'])[:20]}"
+    )
+
+
+def test_feather_m4_regression() -> None:
+    """The board that started this: it must not resolve to pin 2 or 3."""
+    blocks = _board_blocks(SRC / "platforms" / "arm" / "d51" / "fastpin_arm_d51.h")
+    for board in ("ADAFRUIT_FEATHER_M4_EXPRESS", "ADAFRUIT_FEATHER_M4_CAN"):
+        block = blocks[board]
+        assert 2 not in block["pins"] and 3 not in block["pins"], (
+            f"{board} now defines pin 2 or 3; this test's premise changed"
+        )
+        for macro in FALLBACKS:
+            assert block["defaults"].get(macro, FALLBACKS[macro]) not in (2, 3)

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -93,11 +93,14 @@ def _defined_macros(flags: list[str], header: str) -> set[str]:
         timeout=120,
     )
     assert proc.returncode == 0, f"preprocessing failed:\n{proc.stderr}"
-    return {
-        line.split()[1]
-        for line in proc.stdout.splitlines()
-        if line.startswith("#define") and len(line.split()) > 1
-    }
+    macros: set[str] = set()
+    for line in proc.stdout.splitlines():
+        if not line.startswith("#define"):
+            continue
+        parts = line.split()
+        if len(parts) > 1:
+            macros.add(parts[1])
+    return macros
 
 
 HEADER = "platforms/arm/samd/is_samd.h"

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -53,6 +53,13 @@ BOARD_MANIFEST_FLAGS = {
         "-D__SAMD51__",
         "-DARM_MATH_CM4",
     ],
+    "metro_m4 (adafruit_metro_m4)": [
+        "-DARDUINO_METRO_M4",
+        "-DADAFRUIT_METRO_M4_EXPRESS",
+        "-D__SAMD51J19A__",
+        "-D__SAMD51__",
+        "-DARM_MATH_CM4",
+    ],
 }
 
 

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -153,30 +153,24 @@ def test_non_samd_build_is_not_detected_as_samd() -> None:
     assert "FL_IS_SAMD51" not in macros
 
 
-def test_samd_ldf_hint_declares_spi() -> None:
-    """The SAMD SPI backend needs <SPI.h>, so the LDF hint must declare it.
+def test_samd_does_not_route_into_the_arduino_spi_backend() -> None:
+    """SAMD must not claim platforms/arm/sam/ hardware SPI while #4016 is open.
 
-    This guards the trap that caused #4011 to take two rounds to fix. Both
-    ``platforms/arm/samd/ldf_headers.h`` and the FL_IS_SAMD gate in
-    ``platforms/ldf_headers.h`` that reaches it were unreachable while
-    detection was broken, so the file's "no additional LDF hints needed
-    currently" comment looked true and was not. Fixing detection made the
-    SPI include live and the build failed on a missing SPI.h.
+    That backend does `#include <SPI.h>`, and nothing available can supply it
+    under fbuild: lib_ldf_mode is unimplemented, the scan reaches neither an
+    `#if 0` LDF hint nor a conditional include, and `lib_deps = SPI` fails with
+    "library 'SPI' not found in registry" because framework-bundled libraries
+    are not registry packages (FastLED/fbuild#1371).
 
-    Tracked for a proper fix in #4016 -- until then the dependency is real and
-    must stay declared.
+    It also had never compiled on any board -- FL_IS_SAMD21/FL_IS_SAMD51 never
+    evaluated true until #4011 -- so routing SAMD to bit-bang SPI preserves the
+    behaviour every SAMD build has actually had, rather than switching on
+    untested code. #4016 tracks a real SERCOM backend.
     """
-    backend = (SRC / "platforms" / "arm" / "sam" / "fastspi_arm_sam.h").read_text(
-        encoding="utf-8"
-    )
-    if "#include <SPI.h>" not in backend:
-        pytest.skip("SAMD SPI backend no longer includes <SPI.h>; see #4016")
-
-    hint = (SRC / "platforms" / "arm" / "samd" / "ldf_headers.h").read_text(
-        encoding="utf-8"
-    )
-    assert "#include <SPI.h>" in hint, (
-        "platforms/arm/sam/fastspi_arm_sam.h includes <SPI.h> for SAMD, so "
-        "platforms/arm/samd/ldf_headers.h must hint it or SAMD builds fail "
-        "with 'SPI.h: No such file or directory'. See #4011 and #4016."
-    )
+    for name in ("spi_device_proxy.h", "spi_output_template.h"):
+        text = (SRC / "platforms" / name).read_text(encoding="utf-8")
+        assert "defined(FL_IS_SAM) || defined(FL_IS_SAMD)" not in text, (
+            f"platforms/{name} routes SAMD into platforms/arm/sam/, whose SPI "
+            "backend needs Arduino <SPI.h>. SAMD builds fail with 'SPI.h: No "
+            "such file or directory'. See #4011, #4016, FastLED/fbuild#1371."
+        )

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -1,0 +1,146 @@
+"""Regression contracts for SAMD platform detection (FastLED #4011).
+
+The SAMD CI workflows failed on every board with::
+
+    platforms/pin.h:56:6: error: "Platform-specific pin implementation not
+      defined for this Arduino variant."
+
+even though ``platforms/pin.h`` has an ``#elif defined(FL_IS_SAMD)`` branch and
+``platforms/arm/samd/pin_samd.hpp`` exists.
+
+The cause was in ``is_samd.h``: the family gates required ``ARDUINO_ARCH_SAMD``
+*and* a CPU macro. PlatformIO's Arduino builder script injects
+``ARDUINO_ARCH_<ARCH>``; the board manifest does not. A build system that reads
+the manifest directly -- fbuild, which is what ``bash compile samd21`` now uses
+-- therefore never defines it, and detection threw away the unambiguous part
+macro the manifest *did* supply.
+
+These are preprocessor tests: they run the host compiler over the real header
+with the exact ``-D`` flags a board manifest provides, so they need no SAMD
+toolchain. A C++ unit test cannot cover this -- ``tests/test_pch.h`` force-
+includes ``FastLED.h``, so ``is_samd.h`` is always already included (it is
+``#pragma once``) before any test TU gets to set up its macros.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from running_process import RunningProcess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC = REPO_ROOT / "src"
+
+# Exactly what the PlatformIO board manifests for the three CI boards define.
+# Fetched from platformio/platform-atmelsam -> boards/*.json "build.extra_flags".
+# Note the absence of ARDUINO_ARCH_SAMD in every one of them.
+BOARD_MANIFEST_FLAGS = {
+    "samd21 (adafruit_feather_m0)": [
+        "-DARDUINO_SAMD_ZERO",
+        "-DARDUINO_SAMD_FEATHER_M0",
+        "-DARM_MATH_CM0PLUS",
+        "-D__SAMD21G18A__",
+    ],
+    "samd21_zero (zeroUSB)": [
+        "-DARDUINO_SAMD_ZERO",
+        "-D__SAMD21G18A__",
+    ],
+    "samd51j (adafruit_feather_m4)": [
+        "-DARDUINO_FEATHER_M4",
+        "-DADAFRUIT_FEATHER_M4_EXPRESS",
+        "-D__SAMD51J19A__",
+        "-D__SAMD51__",
+        "-DARM_MATH_CM4",
+    ],
+}
+
+
+def _compiler() -> str:
+    for name in ("clang++", "clang", "g++", "gcc"):
+        found = shutil.which(name)
+        if found:
+            return found
+    pytest.skip("no host compiler available to run the preprocessor")
+
+
+def _defined_macros(flags: list[str], header: str) -> set[str]:
+    """Return every macro defined after preprocessing ``header`` with ``flags``."""
+    cmd = [
+        _compiler(),
+        "-E",
+        "-dM",
+        "-x",
+        "c++",
+        f"-I{SRC}",
+        *flags,
+        "-",
+    ]
+    proc = RunningProcess.run(
+        cmd,
+        input=f'#include "{header}"\n',
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+    )
+    assert proc.returncode == 0, f"preprocessing failed:\n{proc.stderr}"
+    return {
+        line.split()[1]
+        for line in proc.stdout.splitlines()
+        if line.startswith("#define") and len(line.split()) > 1
+    }
+
+
+HEADER = "platforms/arm/samd/is_samd.h"
+
+
+@pytest.mark.parametrize("board", sorted(BOARD_MANIFEST_FLAGS))
+def test_board_manifest_flags_alone_define_fl_is_samd(board: str) -> None:
+    """#4011: the part macro must be sufficient, with no ARDUINO_ARCH_SAMD.
+
+    This is the exact failure. Every SAMD board manifest names its part; none
+    names its arch. If FL_IS_SAMD is not set here, platforms/pin.h falls
+    through to its #error and the board cannot build.
+    """
+    flags = BOARD_MANIFEST_FLAGS[board]
+    assert not any("ARDUINO_ARCH_SAMD" in f for f in flags), (
+        "test premise: no SAMD board manifest defines ARDUINO_ARCH_SAMD"
+    )
+
+    macros = _defined_macros(flags, HEADER)
+
+    assert "FL_IS_SAMD" in macros, (
+        f"{board}: FL_IS_SAMD not defined from manifest flags {flags}. "
+        "platforms/pin.h will fall through to its #error."
+    )
+
+
+def test_part_macros_select_the_right_family() -> None:
+    """FL_IS_SAMD21 and FL_IS_SAMD51 must be distinguished, and not both set."""
+    samd21 = _defined_macros(["-D__SAMD21G18A__"], HEADER)
+    assert "FL_IS_SAMD21" in samd21
+    assert "FL_IS_SAMD51" not in samd21
+
+    samd51 = _defined_macros(["-D__SAMD51J19A__"], HEADER)
+    assert "FL_IS_SAMD51" in samd51
+    assert "FL_IS_SAMD21" not in samd51
+
+
+def test_arduino_arch_samd_still_recognized_on_its_own() -> None:
+    """Kept as an alternative, so PlatformIO-driven builds are unaffected.
+
+    Matches is_nrf52.h and is_apollo3.h, which also treat ARDUINO_ARCH_* as one
+    alternative among several rather than a requirement.
+    """
+    macros = _defined_macros(["-DARDUINO_ARCH_SAMD"], HEADER)
+    assert "FL_IS_SAMD" in macros
+
+
+def test_non_samd_build_is_not_detected_as_samd() -> None:
+    """Negative control -- detection must not fire on an unrelated target."""
+    macros = _defined_macros([], HEADER)
+    assert "FL_IS_SAMD" not in macros
+    assert "FL_IS_SAMD21" not in macros
+    assert "FL_IS_SAMD51" not in macros

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -151,3 +151,32 @@ def test_non_samd_build_is_not_detected_as_samd() -> None:
     assert "FL_IS_SAMD" not in macros
     assert "FL_IS_SAMD21" not in macros
     assert "FL_IS_SAMD51" not in macros
+
+
+def test_samd_ldf_hint_declares_spi() -> None:
+    """The SAMD SPI backend needs <SPI.h>, so the LDF hint must declare it.
+
+    This guards the trap that caused #4011 to take two rounds to fix. Both
+    ``platforms/arm/samd/ldf_headers.h`` and the FL_IS_SAMD gate in
+    ``platforms/ldf_headers.h`` that reaches it were unreachable while
+    detection was broken, so the file's "no additional LDF hints needed
+    currently" comment looked true and was not. Fixing detection made the
+    SPI include live and the build failed on a missing SPI.h.
+
+    Tracked for a proper fix in #4016 -- until then the dependency is real and
+    must stay declared.
+    """
+    backend = (SRC / "platforms" / "arm" / "sam" / "fastspi_arm_sam.h").read_text(
+        encoding="utf-8"
+    )
+    if "#include <SPI.h>" not in backend:
+        pytest.skip("SAMD SPI backend no longer includes <SPI.h>; see #4016")
+
+    hint = (SRC / "platforms" / "arm" / "samd" / "ldf_headers.h").read_text(
+        encoding="utf-8"
+    )
+    assert "#include <SPI.h>" in hint, (
+        "platforms/arm/sam/fastspi_arm_sam.h includes <SPI.h> for SAMD, so "
+        "platforms/arm/samd/ldf_headers.h must hint it or SAMD builds fail "
+        "with 'SPI.h: No such file or directory'. See #4011 and #4016."
+    )

--- a/examples/Apa102/Apa102.ino
+++ b/examples/Apa102/Apa102.ino
@@ -6,8 +6,16 @@
 
 #define NUM_LEDS  20
 
+// Guarded so a board whose variant lacks these pins can override them from
+// build flags, the same way Blink guards PIN_DATA. Adafruit Feather M4, for
+// one, has no pin 2 (see platforms/arm/d51/fastpin_arm_d51.h).
+#ifndef STRIP_DATA_PIN
 #define STRIP_DATA_PIN 1
+#endif
+
+#ifndef STRIP_CLOCK_PIN
 #define STRIP_CLOCK_PIN 2
+#endif
 
 CRGB leds[NUM_LEDS] = {0};     // Software gamma mode.
 

--- a/examples/Apa102/Apa102.ino
+++ b/examples/Apa102/Apa102.ino
@@ -6,15 +6,16 @@
 
 #define NUM_LEDS  20
 
-// Guarded so a board whose variant lacks these pins can override them from
-// build flags, the same way Blink guards PIN_DATA. Adafruit Feather M4, for
-// one, has no pin 2 (see platforms/arm/d51/fastpin_arm_d51.h).
+// Defaults come from the board (platforms/default_pins.h) rather than a
+// literal, because a literal is a guess about hardware this sketch cannot
+// see -- Adafruit Feather M4 has no pin 2 at all. A sketch or build flag
+// defining these first still wins.
 #ifndef STRIP_DATA_PIN
-#define STRIP_DATA_PIN 1
+#define STRIP_DATA_PIN SPI_PIN_DATA_1
 #endif
 
 #ifndef STRIP_CLOCK_PIN
-#define STRIP_CLOCK_PIN 2
+#define STRIP_CLOCK_PIN SPI_PIN_CLOCK_1
 #endif
 
 CRGB leds[NUM_LEDS] = {0};     // Software gamma mode.

--- a/examples/Apa102/Apa102.ino
+++ b/examples/Apa102/Apa102.ino
@@ -11,11 +11,11 @@
 // see -- Adafruit Feather M4 has no pin 2 at all. A sketch or build flag
 // defining these first still wins.
 #ifndef STRIP_DATA_PIN
-#define STRIP_DATA_PIN SPI_PIN_DATA_1
+#define STRIP_DATA_PIN FL_PIN_SPI_DATA_1
 #endif
 
 #ifndef STRIP_CLOCK_PIN
-#define STRIP_CLOCK_PIN SPI_PIN_CLOCK_1
+#define STRIP_CLOCK_PIN FL_PIN_SPI_CLOCK_1
 #endif
 
 CRGB leds[NUM_LEDS] = {0};     // Software gamma mode.

--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -13,7 +13,7 @@
 // ground, and power), like the LPD8806 define both PIN_DATA and CLOCK_PIN
 // Clock pin only needed for SPI based chipsets when not using hardware SPI
 #ifndef PIN_DATA
-#define PIN_DATA CLOCKLESS_PIN_1
+#define PIN_DATA FL_PIN_CLOCKLESS_1
 #endif  // PIN_DATA
 
 #define CLOCK_PIN 13

--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -13,7 +13,7 @@
 // ground, and power), like the LPD8806 define both PIN_DATA and CLOCK_PIN
 // Clock pin only needed for SPI based chipsets when not using hardware SPI
 #ifndef PIN_DATA
-#define PIN_DATA 3
+#define PIN_DATA CLOCKLESS_PIN_1
 #endif  // PIN_DATA
 
 #define CLOCK_PIN 13

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -232,6 +232,9 @@
 
 #include "platforms.h"
 
+// Default example pins; must follow platforms.h so board pin tables win.
+#include "platforms/default_pins.h"
+
 // PlatformIO Library Dependency Finder (LDF) hint headers
 // These headers use #if 0 blocks to hint library dependencies to PlatformIO's LDF scanner
 // without actually compiling the code. This works around LDF's limitation of scanning

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -237,6 +237,13 @@ _FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0);
 #elif defined(ADAFRUIT_ITSYBITSY_M0)
 
 #define MAX_PIN 16
+
+// Default example pins: this board's table starts at pin 2, so the
+// SPI_PIN_DATA_1 fallback of 1 would fail FastPin<>::validpin().
+// CLOCKLESS_PIN_1 (3) is present and needs no override.
+// See platforms/default_pins.h.
+#define SPI_PIN_DATA_1 2
+#define SPI_PIN_CLOCK_1 4
 _FL_DEFPIN( 2, 14, 0); _FL_DEFPIN( 3, 9, 0); _FL_DEFPIN( 4, 8, 0);
 _FL_DEFPIN( 5, 15, 0); _FL_DEFPIN( 6, 20, 0); _FL_DEFPIN( 7, 21, 0);
 _FL_DEFPIN( 8, 6, 0); _FL_DEFPIN( 9, 7, 0); _FL_DEFPIN( 10, 18, 0);

--- a/src/platforms/arm/d21/fastpin_arm_d21.h
+++ b/src/platforms/arm/d21/fastpin_arm_d21.h
@@ -239,11 +239,11 @@ _FL_DEFPIN( 8, 11, 0); _FL_DEFPIN( 9, 9, 0); _FL_DEFPIN( 10, 10, 0);
 #define MAX_PIN 16
 
 // Default example pins: this board's table starts at pin 2, so the
-// SPI_PIN_DATA_1 fallback of 1 would fail FastPin<>::validpin().
-// CLOCKLESS_PIN_1 (3) is present and needs no override.
+// FL_PIN_SPI_DATA_1 fallback of 1 would fail FastPin<>::validpin().
+// FL_PIN_CLOCKLESS_1 (3) is present and needs no override.
 // See platforms/default_pins.h.
-#define SPI_PIN_DATA_1 2
-#define SPI_PIN_CLOCK_1 4
+#define FL_PIN_SPI_DATA_1 2
+#define FL_PIN_SPI_CLOCK_1 4
 _FL_DEFPIN( 2, 14, 0); _FL_DEFPIN( 3, 9, 0); _FL_DEFPIN( 4, 8, 0);
 _FL_DEFPIN( 5, 15, 0); _FL_DEFPIN( 6, 20, 0); _FL_DEFPIN( 7, 21, 0);
 _FL_DEFPIN( 8, 6, 0); _FL_DEFPIN( 9, 7, 0); _FL_DEFPIN( 10, 18, 0);

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -126,6 +126,13 @@ _FL_DEFPIN(24, 14, 0); _FL_DEFPIN(25,  13, 0); _FL_DEFPIN(26,  12, 0);
 #elif defined(ADAFRUIT_FEATHER_M4_CAN)
 
 #define MAX_PIN 19
+
+// Default example pins: this board has no pin 2 or 3 (see the pin table
+// below), so the CLOCKLESS_PIN_1 / SPI_PIN_CLOCK_1 fallbacks of 3 and 2
+// would fail FastPin<>::validpin(). Pin 1 is present, so only the clock
+// needs moving. See platforms/default_pins.h.
+#define CLOCKLESS_PIN_1 5
+#define SPI_PIN_CLOCK_1 4
 // D0-D13, including D8 (neopixel)  no pins 2 3
 _FL_DEFPIN( 0, 17, 1); _FL_DEFPIN( 1, 16, 1);
 _FL_DEFPIN( 4, 14, 0); _FL_DEFPIN( 5, 16, 0); _FL_DEFPIN( 6,  18, 0);
@@ -147,6 +154,13 @@ _FL_DEFPIN(23, 22, 1); _FL_DEFPIN(24,  23, 1); _FL_DEFPIN(25,  17, 0);
 #elif defined(ADAFRUIT_FEATHER_M4_EXPRESS)
 
 #define MAX_PIN 19
+
+// Default example pins: this board has no pin 2 or 3 (see the pin table
+// below), so the CLOCKLESS_PIN_1 / SPI_PIN_CLOCK_1 fallbacks of 3 and 2
+// would fail FastPin<>::validpin(). Pin 1 is present, so only the clock
+// needs moving. See platforms/default_pins.h.
+#define CLOCKLESS_PIN_1 5
+#define SPI_PIN_CLOCK_1 4
 // D0-D13, including D8 (neopixel)  no pins 2 3
 _FL_DEFPIN( 0, 17, 1); _FL_DEFPIN( 1, 16, 1);
 _FL_DEFPIN( 4, 14, 0); _FL_DEFPIN( 5, 16, 0); _FL_DEFPIN( 6,  18, 0);

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -128,11 +128,11 @@ _FL_DEFPIN(24, 14, 0); _FL_DEFPIN(25,  13, 0); _FL_DEFPIN(26,  12, 0);
 #define MAX_PIN 19
 
 // Default example pins: this board has no pin 2 or 3 (see the pin table
-// below), so the CLOCKLESS_PIN_1 / SPI_PIN_CLOCK_1 fallbacks of 3 and 2
+// below), so the FL_PIN_CLOCKLESS_1 / FL_PIN_SPI_CLOCK_1 fallbacks of 3 and 2
 // would fail FastPin<>::validpin(). Pin 1 is present, so only the clock
 // needs moving. See platforms/default_pins.h.
-#define CLOCKLESS_PIN_1 5
-#define SPI_PIN_CLOCK_1 4
+#define FL_PIN_CLOCKLESS_1 5
+#define FL_PIN_SPI_CLOCK_1 4
 // D0-D13, including D8 (neopixel)  no pins 2 3
 _FL_DEFPIN( 0, 17, 1); _FL_DEFPIN( 1, 16, 1);
 _FL_DEFPIN( 4, 14, 0); _FL_DEFPIN( 5, 16, 0); _FL_DEFPIN( 6,  18, 0);
@@ -156,11 +156,11 @@ _FL_DEFPIN(23, 22, 1); _FL_DEFPIN(24,  23, 1); _FL_DEFPIN(25,  17, 0);
 #define MAX_PIN 19
 
 // Default example pins: this board has no pin 2 or 3 (see the pin table
-// below), so the CLOCKLESS_PIN_1 / SPI_PIN_CLOCK_1 fallbacks of 3 and 2
+// below), so the FL_PIN_CLOCKLESS_1 / FL_PIN_SPI_CLOCK_1 fallbacks of 3 and 2
 // would fail FastPin<>::validpin(). Pin 1 is present, so only the clock
 // needs moving. See platforms/default_pins.h.
-#define CLOCKLESS_PIN_1 5
-#define SPI_PIN_CLOCK_1 4
+#define FL_PIN_CLOCKLESS_1 5
+#define FL_PIN_SPI_CLOCK_1 4
 // D0-D13, including D8 (neopixel)  no pins 2 3
 _FL_DEFPIN( 0, 17, 1); _FL_DEFPIN( 1, 16, 1);
 _FL_DEFPIN( 4, 14, 0); _FL_DEFPIN( 5, 16, 0); _FL_DEFPIN( 6,  18, 0);

--- a/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
@@ -39,7 +39,13 @@
 
 #include "platforms/arm/samd/is_samd.h"
 
-#if defined(FL_IS_SAMD51)
+// Opt-in: this driver has never compiled. FL_IS_SAMD51 never evaluated true
+// until FastLED#4011 fixed SAMD detection, and in the meantime it drifted out
+// of sync with fl::DMABuffer, which now owns its memory and offers no
+// non-owning construction path -- so acquireDMABuffer() cannot return a view
+// over a caller-managed span. Reconciling that is a design change on a driver
+// that has also never run on hardware. FastLED#4017 tracks bring-up.
+#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_2.h"
 #include "fl/log/log.h"
@@ -559,4 +565,4 @@ void SPIDualSAMD51::cleanup() {
 
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51
+#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI

--- a/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
@@ -32,7 +32,13 @@
 
 #include "platforms/arm/samd/is_samd.h"
 
-#if defined(FL_IS_SAMD51)
+// Opt-in: this driver has never compiled. FL_IS_SAMD51 never evaluated true
+// until FastLED#4011 fixed SAMD detection, and in the meantime it drifted out
+// of sync with fl::DMABuffer, which now owns its memory and offers no
+// non-owning construction path -- so acquireDMABuffer() cannot return a view
+// over a caller-managed span. Reconciling that is a design change on a driver
+// that has also never run on hardware. FastLED#4017 tracks bring-up.
+#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_4.h"
 #include "fl/log/log.h"
@@ -588,4 +594,4 @@ void initSpiHw4Instances() {
 
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51
+#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI

--- a/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
@@ -18,7 +18,13 @@
 
 #include "platforms/arm/samd/is_samd.h"
 
-#if defined(FL_IS_SAMD51)
+// Opt-in: this driver has never compiled. FL_IS_SAMD51 never evaluated true
+// until FastLED#4011 fixed SAMD detection, and in the meantime it drifted out
+// of sync with fl::DMABuffer, which now owns its memory and offers no
+// non-owning construction path -- so acquireDMABuffer() cannot return a view
+// over a caller-managed span. Reconciling that is a design change on a driver
+// that has also never run on hardware. FastLED#4017 tracks bring-up.
+#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_2.h"
 #include "platforms/shared/spi_hw_4.h"
@@ -91,4 +97,4 @@ void initSpiHardware() {
 }  // namespace platforms
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51
+#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI

--- a/src/platforms/arm/samd/is_samd.h
+++ b/src/platforms/arm/samd/is_samd.h
@@ -8,20 +8,30 @@
 /// @brief SAMD/SAME platform detection macros for FastLED
 ///
 /// This header provides detection for Microchip SAMD (ARM Cortex-M0+/M4) platforms.
-/// Detection uses both Arduino board-specific macros (e.g., ARDUINO_ARCH_SAMD) and 
-/// CPU-specific macros (e.g., __SAMD21G18A__).
+/// Detection keys off CPU-specific macros (e.g. `__SAMD21G18A__`), which name an
+/// exact part and are supplied by the board manifest itself.
+///
+/// `ARDUINO_ARCH_SAMD` is accepted as an *additional* way to recognize a SAMD
+/// board, never as a requirement. It is injected by PlatformIO's Arduino builder
+/// script rather than by the board manifest, so build systems that consume the
+/// manifest directly (fbuild) never define it. Requiring it here meant an
+/// unmistakable `-D__SAMD21G18A__` was ignored and the build fell through to the
+/// `#error` in `platforms/pin.h`. This matches the sibling detection headers:
+/// `is_nrf52.h` and `is_apollo3.h` likewise treat `ARDUINO_ARCH_*` as one
+/// alternative among several, and `is_teensy.h`/`is_rp.h`/`is_sam.h` do not
+/// consult it at all.
 
 // SAMD21 (ARM Cortex-M0+, 48 MHz)
-#if defined(ARDUINO_ARCH_SAMD) && (defined(__SAMD21__) || \
-    defined(__SAMD21G18A__) || defined(__SAMD21J18A__) || \
-    defined(__SAMD21E17A__) || defined(__SAMD21E18A__))
+#if defined(__SAMD21__) || defined(__SAMD21G18A__) || \
+    defined(__SAMD21J18A__) || defined(__SAMD21E17A__) || \
+    defined(__SAMD21E18A__)
 #define FL_IS_SAMD21
 #endif
 
 // SAMD51/SAME51 (ARM Cortex-M4F, 120 MHz)
-#if defined(ARDUINO_ARCH_SAMD) && (defined(__SAMD51__) || \
-    defined(__SAMD51G19A__) || defined(__SAMD51J19A__) || \
-    defined(__SAME51J19A__) || defined(__SAMD51P19A__) || defined(__SAMD51P20A__))
+#if defined(__SAMD51__) || defined(__SAMD51G19A__) || \
+    defined(__SAMD51J19A__) || defined(__SAME51J19A__) || \
+    defined(__SAMD51P19A__) || defined(__SAMD51P20A__)
 #define FL_IS_SAMD51
 #endif
 

--- a/src/platforms/arm/samd/ldf_headers.h
+++ b/src/platforms/arm/samd/ldf_headers.h
@@ -10,30 +10,11 @@
 /// This file contains #if 0 blocks with library includes to hint dependencies
 /// to PlatformIO's LDF scanner without actually compiling the code.
 
-// SPI: required, and required unconditionally.
+// No hints needed: SAMD uses bit-bang SPI and pulls in no Arduino library.
 //
-// platforms/spi_device_proxy.h routes SAMD into
-// platforms/arm/sam/spi_device_proxy.h -> fastspi_arm_sam.h, which does
-// `#include <SPI.h>` under `#if defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)`.
-// The hint goes here rather than in a board's lib_deps so that any consumer of
-// the library gets a working SAMD build, not just this repo's CI matrix.
-//
-// This was invisible until FastLED#4011: FL_IS_SAMD21/FL_IS_SAMD51 never
-// evaluated true, so the whole SAMD SPI stack -- and the FL_IS_SAMD gate in
-// platforms/ldf_headers.h that reaches this file -- was unreachable. Fixing
-// detection made both live, and the build failed with
-// `fastspi_arm_sam.h:17:10: fatal error: SPI.h: No such file or directory`.
-//
-// Unconditional on purpose. The include in fastspi_arm_sam.h is conditional,
-// but the LDF scanner does not evaluate conditionals, so narrowing the hint
-// would buy nothing and risk it being skipped. Cost is bounded: SPI is a small
-// core library. Contrast the ESP32 hints, which deliberately refuse WiFi.h and
-// friends because their global constructors become GC roots and defeat
-// --gc-sections. SPI's SPIClass instance is the same class of cost, which is
-// why FastLED#4016 tracks routing SAMD to a backend that does not need the
-// Arduino library at all.
-#if 0
-// IWYU pragma: begin_keep
-#include <SPI.h>
-// IWYU pragma: end_keep
-#endif
+// Do not restore a <SPI.h> hint here without reading FastLED#4011. The SAMD
+// hardware SPI backend does need it, but the hint alone cannot supply it:
+// fbuild does not implement lib_ldf_mode, its scan reaches neither an #if 0
+// hint nor a conditional include, and `lib_deps = SPI` fails as
+// "library 'SPI' not found in registry" because framework-bundled libraries
+// are not registry packages. See FastLED/fbuild#1371 and FastLED#4016.

--- a/src/platforms/arm/samd/ldf_headers.h
+++ b/src/platforms/arm/samd/ldf_headers.h
@@ -10,5 +10,30 @@
 /// This file contains #if 0 blocks with library includes to hint dependencies
 /// to PlatformIO's LDF scanner without actually compiling the code.
 
-// SAMD platform - no additional LDF hints needed currently
-// Add library includes here if LDF issues are discovered
+// SPI: required, and required unconditionally.
+//
+// platforms/spi_device_proxy.h routes SAMD into
+// platforms/arm/sam/spi_device_proxy.h -> fastspi_arm_sam.h, which does
+// `#include <SPI.h>` under `#if defined(FL_IS_SAMD21) || defined(FL_IS_SAMD51)`.
+// The hint goes here rather than in a board's lib_deps so that any consumer of
+// the library gets a working SAMD build, not just this repo's CI matrix.
+//
+// This was invisible until FastLED#4011: FL_IS_SAMD21/FL_IS_SAMD51 never
+// evaluated true, so the whole SAMD SPI stack -- and the FL_IS_SAMD gate in
+// platforms/ldf_headers.h that reaches this file -- was unreachable. Fixing
+// detection made both live, and the build failed with
+// `fastspi_arm_sam.h:17:10: fatal error: SPI.h: No such file or directory`.
+//
+// Unconditional on purpose. The include in fastspi_arm_sam.h is conditional,
+// but the LDF scanner does not evaluate conditionals, so narrowing the hint
+// would buy nothing and risk it being skipped. Cost is bounded: SPI is a small
+// core library. Contrast the ESP32 hints, which deliberately refuse WiFi.h and
+// friends because their global constructors become GC roots and defeat
+// --gc-sections. SPI's SPIClass instance is the same class of cost, which is
+// why FastLED#4016 tracks routing SAMD to a backend that does not need the
+// Arduino library at all.
+#if 0
+// IWYU pragma: begin_keep
+#include <SPI.h>
+// IWYU pragma: end_keep
+#endif

--- a/src/platforms/default_pins.h
+++ b/src/platforms/default_pins.h
@@ -5,11 +5,22 @@
 /// @file platforms/default_pins.h
 /// @brief Default LED pins for examples and quick-start sketches.
 ///
-/// Examples have to name *some* pin, and a literal in a sketch is a guess about
-/// hardware the sketch cannot see. These macros let a board state the answer
-/// instead. A board defines them next to its `_FL_DEFPIN` table -- the one place
-/// that actually knows which pins exist -- and the fallbacks below apply
-/// everywhere else, so no existing platform changes behaviour.
+/// The intent is a one-pin setup that works on every platform FastLED
+/// supports: an example says `FL_PIN_CLOCKLESS_1` and gets a pin that is
+/// actually usable for a single-wire strip on the board being built for, with
+/// no edit to the sketch.
+///
+/// A board declares its value beside its `_FL_DEFPIN` table -- the one place
+/// that knows which pins exist. Examples have to name *some* pin, and a literal
+/// in a sketch is a guess about hardware the sketch cannot see.
+///
+/// Status: only the SAMD boards that needed one declare a value so far. The
+/// fallbacks below are the literals `Blink` and `Apa102` already hardcoded, so
+/// adding this indirection changed no platform's behaviour -- but equal to the
+/// old literal is not the same as correct. FastLED#4018 tracks auditing and
+/// declaring a real value per platform, including the part `validpin()` cannot
+/// check: a pin can exist and still be a bad default if it is a strapping pin,
+/// the UART, or already committed on common dev boards.
 ///
 /// Why this exists: `Blink` hardcoded pin 3 and `Apa102` hardcoded pins 1 and 2.
 /// Adafruit Feather M4 has neither pin 2 nor pin 3 (`fastpin_arm_d51.h` says so
@@ -27,16 +38,16 @@
 /// already had their say.
 
 /// @brief Default data pin for single-wire (clockless) chipsets: WS2812, etc.
-#ifndef CLOCKLESS_PIN_1
-#define CLOCKLESS_PIN_1 3
+#ifndef FL_PIN_CLOCKLESS_1
+#define FL_PIN_CLOCKLESS_1 3
 #endif
 
 /// @brief Default data pin for clocked/SPI chipsets: APA102, LPD8806, etc.
-#ifndef SPI_PIN_DATA_1
-#define SPI_PIN_DATA_1 1
+#ifndef FL_PIN_SPI_DATA_1
+#define FL_PIN_SPI_DATA_1 1
 #endif
 
 /// @brief Default clock pin for clocked/SPI chipsets.
-#ifndef SPI_PIN_CLOCK_1
-#define SPI_PIN_CLOCK_1 2
+#ifndef FL_PIN_SPI_CLOCK_1
+#define FL_PIN_SPI_CLOCK_1 2
 #endif

--- a/src/platforms/default_pins.h
+++ b/src/platforms/default_pins.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// ok no namespace fl
+
+/// @file platforms/default_pins.h
+/// @brief Default LED pins for examples and quick-start sketches.
+///
+/// Examples have to name *some* pin, and a literal in a sketch is a guess about
+/// hardware the sketch cannot see. These macros let a board state the answer
+/// instead. A board defines them next to its `_FL_DEFPIN` table -- the one place
+/// that actually knows which pins exist -- and the fallbacks below apply
+/// everywhere else, so no existing platform changes behaviour.
+///
+/// Why this exists: `Blink` hardcoded pin 3 and `Apa102` hardcoded pins 1 and 2.
+/// Adafruit Feather M4 has neither pin 2 nor pin 3 (`fastpin_arm_d51.h` says so
+/// outright: "no pins 2 3"), so both examples failed to compile for it with
+/// `FastPin<3>::validpin()` / `FastPin<2>::validpin()` static assertions -- the
+/// error text is about noisy or read-only pins, which sends you looking in
+/// entirely the wrong place. Nobody noticed because SAMD had never built at all
+/// until FastLED#4011.
+///
+/// These are compile-time defaults, not a claim about wiring. A sketch that
+/// defines `PIN_DATA` (or the SPI pins) before including FastLED still wins,
+/// and a board build flag still overrides both.
+///
+/// Included from `FastLED.h` after `platforms.h`, so board pin tables have
+/// already had their say.
+
+/// @brief Default data pin for single-wire (clockless) chipsets: WS2812, etc.
+#ifndef CLOCKLESS_PIN_1
+#define CLOCKLESS_PIN_1 3
+#endif
+
+/// @brief Default data pin for clocked/SPI chipsets: APA102, LPD8806, etc.
+#ifndef SPI_PIN_DATA_1
+#define SPI_PIN_DATA_1 1
+#endif
+
+/// @brief Default clock pin for clocked/SPI chipsets.
+#ifndef SPI_PIN_CLOCK_1
+#define SPI_PIN_CLOCK_1 2
+#endif

--- a/src/platforms/spi_device_proxy.h
+++ b/src/platforms/spi_device_proxy.h
@@ -27,7 +27,12 @@
 #elif defined(FL_IS_NRF52)
 #include "platforms/arm/nrf52/spi_device_proxy.h"
 
-#elif defined(FL_IS_SAM) || defined(FL_IS_SAMD)
+// SAMD is deliberately absent: platforms/arm/sam/ hardware SPI needs the
+// Arduino <SPI.h> library, and had never compiled on any board until
+// FastLED#4011 fixed SAMD detection. SAMD falls through to bit-bang SPI
+// below, which is the behaviour every SAMD build has actually had.
+// FastLED#4016 tracks bringing up a real SAMD SERCOM backend.
+#elif defined(FL_IS_SAM)
 #include "platforms/arm/sam/spi_device_proxy.h"
 
 #elif defined(FL_IS_STM32)

--- a/src/platforms/spi_output_template.h
+++ b/src/platforms/spi_output_template.h
@@ -47,7 +47,12 @@
 #elif defined(FL_IS_TEENSY_LC)
 #include "platforms/arm/teensy/teensy_lc/spi_output_template.h"
 
-#elif defined(FL_IS_SAM) || defined(FL_IS_SAMD)
+// SAMD is deliberately absent: platforms/arm/sam/ hardware SPI needs the
+// Arduino <SPI.h> library, and had never compiled on any board until
+// FastLED#4011 fixed SAMD detection. SAMD falls through to bit-bang SPI
+// below, which is the behaviour every SAMD build has actually had.
+// FastLED#4016 tracks bringing up a real SAMD SERCOM backend.
+#elif defined(FL_IS_SAM)
 #include "platforms/arm/sam/spi_output_template.h"
 
 #elif defined(FL_IS_STM32)


### PR DESCRIPTION
Closes #4011. Takes all four SAMD badges from red to green.

## The reported bug

Every SAMD workflow failed on every `src/**` PR:

```
platforms/pin.h:56:6: error: "Platform-specific pin implementation not
  defined for this Arduino variant."
```

`pin.h` **has** an `#elif defined(FL_IS_SAMD)` branch and `pin_samd.hpp` exists — dispatch simply never selected it. `is_samd.h` required `ARDUINO_ARCH_SAMD` **and** a CPU macro:

```c
#if defined(ARDUINO_ARCH_SAMD) && (defined(__SAMD21__) || defined(__SAMD21G18A__) || ...)
```

`ARDUINO_ARCH_<ARCH>` is injected by PlatformIO's Arduino *builder script*, not by the board manifest. `bash compile samd21` now drives **fbuild**, which reads the manifest directly and so never defines it — while the manifest does supply an unambiguous part macro that detection then discarded:

| board | `build.extra_flags` | `ARDUINO_ARCH_SAMD`? |
|---|---|---|
| samd21 → adafruit_feather_m0 | `-D__SAMD21G18A__` | no |
| samd21_zero → zeroUSB | `-D__SAMD21G18A__` | no |
| samd51j → adafruit_feather_m4 | `-D__SAMD51J19A__ -D__SAMD51__` | no |
| metro_m4 → adafruit_metro_m4 | `-D__SAMD51J19A__ -D__SAMD51__` | no |

The fix keys off part macros and keeps `ARDUINO_ARCH_SAMD` as an *additional* alternative, so PlatformIO-driven builds are unaffected. This restores consistency rather than inventing a convention: `is_nrf52.h` and `is_apollo3.h` already treat `ARDUINO_ARCH_*` as one alternative among several; `is_teensy.h`, `is_rp.h` and `is_sam.h` never consult it. **SAMD was the only platform making it mandatory — and the only one failing.**

Also four boards affected, not the two the issue listed.

## What was underneath

Fixing detection made `FL_IS_SAMD21` / `FL_IS_SAMD51` true **for the first time ever**, which switched on a stack of code that had never compiled. Each layer only became visible once the one above it was cleared:

**1. Arduino `<SPI.h>` could not be supplied.** SAMD routed into `platforms/arm/sam/` hardware SPI, which includes `<SPI.h>`. Under fbuild nothing can provide it: `lib_ldf_mode` is unimplemented, the framework-library scan reaches neither an `#if 0` LDF hint nor the active conditional include, and `lib_deps = SPI` fails with *"library 'SPI' not found in registry"* because framework-bundled libraries are not registry packages. Filed **FastLED/fbuild#1371**.

I tried the LDF hint and `lib_deps` in turn before asking the better question: that backend had never compiled and never run, so switching it on was a *side effect* of fixing detection, not a goal. SAMD now falls through to `platforms/shared/spi_bitbang/` — what every SAMD build has actually been doing. The device proxy is documented as optional per platform. **#4016** tracks a real SERCOM backend.

**2. The SAMD51 SPI drivers had bit-rotted.** `spi_hw_4_samd51.cpp.hpp` returns `SPIError` where `DMABuffer` is expected. Four errors are mechanical — `DMABuffer(SPIError)` is `explicit` — but `acquireDMABuffer()` also returns a view over a `malloc`'d span it caches, and `DMABuffer` now *owns* its memory with no non-owning construction path. That is an API decision affecting every SPI platform, on a driver that has never run on hardware, so it is gated behind `FASTLED_SAMD51_HW_SPI` (off) and tracked in **#4017**. Safe to defer: `init_channel_driver_samd51` reaches these through the shared `SpiHw4::getAll()` registries, so gating them leaves the registries empty.

**3. Two examples named pins that do not exist.** `Blink` hardcoded pin 3, `Apa102` pins 1 and 2. Adafruit Feather M4 has **no pin 2 and no pin 3** — `fastpin_arm_d51.h` says so outright, *"no pins 2 3"* — so both failed with `FastPin<N>::validpin()` assertions whose message talks about ground and read-only and noisy pins, sending you to look at wiring rather than at a pin table.

## Default pins, properly

The first fix was `-DPIN_DATA=6` in `ci/boards.py`. That is the same mistake as `lib_deps`: it turns this repo's matrix green and leaves **every downstream Feather M4 user unable to compile Blink**.

`platforms/default_pins.h` adds `FL_PIN_CLOCKLESS_1`, `FL_PIN_SPI_DATA_1`, `FL_PIN_SPI_CLOCK_1`. A board declares its value beside its `_FL_DEFPIN` table — the one place that knows which pins exist. Fallbacks are `3`, `1`, `2`: exactly the literals the examples already used, so **no existing platform changes behaviour**.

```
Feather M4 Express / CAN   FL_PIN_CLOCKLESS_1 5, FL_PIN_SPI_CLOCK_1 4   (no pin 2 or 3)
ItsyBitsy M0               FL_PIN_SPI_DATA_1 2,  FL_PIN_SPI_CLOCK_1 4   (table starts at 2)
```

`ci/boards.py` carries no pin flags. **#4018** tracks declaring real values for every platform — the fallbacks being equal to the old literals is not the same as their being correct, and `validpin()` cannot catch a pin that exists but is a strapping pin or the UART.

## Tests

Both are preprocessor/parser level, so they need no SAMD toolchain.

- `test_samd_platform_detection.py` — resolves detection with the exact flags each board manifest provides. **4 of 7 fail against the old header**; the controls pass both ways, confirming `ARDUINO_ARCH_SAMD` alone still works and non-SAMD stays undetected.
- `test_samd_default_pins.py` — resolves all three pin macros for **all 21 SAMD board branches** and checks each lands in that board's pin table, covering boards with no badge (e.g. Grand Central M4). Verified to fail, naming board and macro, when the Feather M4 overrides are removed. It self-checks the parser, because a silently-broken parser passes everything.

A C++ unit test cannot cover the detection case, and it is worth recording why: `tests/test_pch.h` force-includes `FastLED.h`, so `is_samd.h` — `#pragma once` — is *always* already included before any test TU can set up its macros. I wrote that test first; it reported failure identically with and against the fix, which is a false positive, not a result.

## Verification

- All four SAMD workflows green (`samd21`, `samd21_zero`, `samd51j`, `metro_m4`), red on master before this.
- Full matrix green — this touches `FastLED.h` and two shared examples, so the non-SAMD boards are the real regression check.
- `bash lint` clean, `bash test --cpp` green.
- Macro resolution confirmed with the host preprocessor over the real headers for Feather M4 Express/CAN, Metro M4, Arduino Zero and ItsyBitsy M0.

Local `bash compile samd51j` could not be completed: fbuild's toolchain download restarts from zero at ~90–116 MB and never finishes (**FastLED/fbuild#1370**, 8 resets in one run), and the daemon dropped at 25 minutes on an earlier attempt (**fbuild#1360**). CI is the verification here.

## Filed

| Issue | Subject |
|---|---|
| #4016 | SAMD pulls in Arduino SPI unconditionally; that stack has never compiled |
| #4017 | SAMD51 hardware SPI drivers do not compile; gated pending bring-up |
| #4018 | Set `FL_PIN_CLOCKLESS_1` correctly for every platform |
| FastLED/fbuild#1370 | Toolchain download restarts from zero, never completes |
| FastLED/fbuild#1371 | Framework-library scan misses `<SPI.h>` for SAMD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
