### PR TITLE
feat(pins): declare ESP32's clockless default; document the FL_PIN_ contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 | Looking up MCU datasheets / user manuals | Prefer https://github.com/FastLED/datasheets when available, then vendor primary documentation |
 | Creating an API wrapper type | `agents/docs/cpp-standards.md` → "API Object Pattern" |
 | Adding a global setting / configuration knob | `agents/docs/cpp-standards.md` → "Public Settings Pattern" (new setters go on `CFastLED`, not as bare `fl::set_*` free functions) |
+| Choosing a default pin for an example, or porting an example off a hardcoded pin | `agents/docs/cpp-standards.md` -> "Default Example Pins" (platform declares `FL_PIN_CLOCKLESS_1`; undeclared falls back to 3) |
 | Writing/editing Python code | `agents/docs/python-standards.md` |
 | Editing meson.build files | `agents/docs/build-system.md` |
 | Running tests, Docker, WASM, QEMU | `agents/docs/testing-commands.md` |

--- a/agents/docs/cpp-standards.md
+++ b/agents/docs/cpp-standards.md
@@ -220,6 +220,63 @@ For a subsystem (e.g., `Watchdog`, `Audio`, `Codec`) that has multi-tier platfor
 
 **Distinction from Type 1 (`FL_IS_*`):** Type 1 says "I am running on platform X." Type 3 says "this component has feature Y on this platform." A single platform may carry many Type 3 flags from independent components.
 
+## Default Example Pins (`FL_PIN_*`) — Platform Declares, Header Falls Back
+
+Examples must not hardcode pin numbers. A literal in a sketch is a guess about hardware the sketch cannot see; the platform is the only layer that knows which pins exist.
+
+| Macro | Fallback | Use |
+|---|---|---|
+| `FL_PIN_CLOCKLESS_1` | `3` | data pin, single-wire chipsets (WS2812 etc.) |
+| `FL_PIN_SPI_DATA_1` | `1` | data pin, clocked chipsets (APA102 etc.) |
+| `FL_PIN_SPI_CLOCK_1` | `2` | clock pin, clocked chipsets |
+
+**The contract, both halves:**
+
+1. **A platform SHOULD declare its own value** beside its `_FL_DEFPIN` table (or its pin-mask block), guarded with `#ifndef` so a sketch or build flag still wins.
+2. **A platform that declares nothing gets the fallback**, defined in `src/platforms/default_pins.h`. That is a supported outcome, not an omission to be linted — most platforms are fine on pin 3.
+
+```cpp
+// in the platform's fastpin_*.h, next to the pin table that justifies it
+#ifndef FL_PIN_CLOCKLESS_1
+#define FL_PIN_CLOCKLESS_1 4
+#endif
+```
+
+`platforms/default_pins.h` is included from `FastLED.h` *after* `platforms.h`, so platform declarations always win. Declaring in a `.cpp.hpp` is wrong — examples need the value at preprocess time.
+
+**Examples consume the macro, never a literal:**
+
+```cpp
+#ifndef PIN_DATA
+#define PIN_DATA FL_PIN_CLOCKLESS_1   // sketch/build flag still overrides
+#endif
+```
+
+### Choosing a value
+
+Compiling is the floor, not the bar. `FastPin<N>::validpin()` catches only pins the platform declares invalid; it cannot catch a pin that exists and is still a bad default. A good value is:
+
+- **present in that board's `_FL_DEFPIN` table** — the compile-time failure, and the cheapest to check
+- **not the UART the examples print on** — most examples call `Serial.begin()`, so a default that lands on `RX`/`TX` has the sketch fighting its own console
+- **not a boot-strapping pin** — sampled at reset; an attached strip can hold it and stop the board booting
+- **not reserved for flash, PSRAM, or USB/JTAG**
+- **actually broken out** on the reference board for that platform
+
+Platform headers usually already record this. `fastpin_esp32.h` documents its UART and flash pins per variant in the `FASTLED_UNUSABLE_PIN_MASK` comments — read those before picking, rather than inferring from a datasheet.
+
+### Enforcement
+
+`ci/tests/test_samd_default_pins.py` parses each board branch's pin table, resolves all three macros (declared value, else fallback), and asserts the result is in that table. It is preprocessor/parser level, so it needs no cross-toolchain. Extend it as platforms declare values — the shape generalises beyond SAMD.
+
+### Why this exists
+
+Two failures, both invisible for a long time:
+
+- **Adafruit Feather M4 has no pin 2 and no pin 3** (`fastpin_arm_d51.h` says so outright: "no pins 2 3"). `Blink` hardcoded 3 and `Apa102` hardcoded 1/2, so neither compiled for that board — with a `validpin()` assertion whose message talks about ground and read-only and noisy pins, sending you to look at wiring rather than at a pin table. Nobody noticed because SAMD had never built at all (#4011).
+- **On ESP32 classic, GPIO 3 is `U0RXD`** — the pin `Serial` receives on. That compiles cleanly and is wrong on hardware, which is the worse failure: the example silently does nothing and there is nothing to search for.
+
+Tracking issue for the per-platform audit: **#4018**.
+
 ## Warning and Debug Output
 - **Use proper warning macros** from `fl/stl/compiler_control.h`
 - **Use `FL_DBG("message" << var)`** for debug prints (easily stripped in release builds)

--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -543,14 +543,18 @@ def announce_storage_requirements(scan: AssetScanResult) -> None:
     """Report what the sketch's assets need from the build.
 
     An asset that declares ``storage=littlefs`` (or ``spiffs``) is stating a
-    build requirement: the firmware has to be able to read on-chip flash. The
-    build satisfies that itself rather than making the user also remember a
-    flag -- so this prints, in green, that the filesystem was added and which
-    assets asked for it.
+    build requirement: the firmware has to be able to read on-chip flash. This
+    prints, in green, which assets asked for it and where that requirement is
+    already met.
 
-    Green because it is neither a warning nor an error. Nothing is wrong; the
-    build is telling the user it did something on their behalf, and naming the
-    assets so the reason is visible rather than magic. An unrecognised target
+    It does not claim the build enabled anything. ESP32 genuinely is automatic
+    -- `platforms/embedded_fs.h` selects LittleFS with no flag -- but ESP8266
+    still needs `FL_ESP8266_EMBEDDED_FS`, and `embedded_fs_defines` is not yet
+    consumed by any build layer (FastLED#4020). Saying "enabled automatically"
+    on ESP8266 would report work that did not happen, which is worse than
+    saying nothing: the user would stop looking.
+
+    Green because it is neither a warning nor an error. An unrecognised target
     is the yellow case -- a typo like `littleFS` would otherwise behave exactly
     like "undeclared", which looks identical to working.
 
@@ -578,6 +582,10 @@ def announce_storage_requirements(scan: AssetScanResult) -> None:
     if len(needs_fs) > 4:
         shown += f", +{len(needs_fs) - 4} more"
     print_green(
-        f"assets: embedded filesystem ({'/'.join(targets)}) enabled "
-        f"automatically -- {len(needs_fs)} asset(s) declare it: {shown}"
+        f"assets: {len(needs_fs)} asset(s) declare on-chip storage "
+        f"({'/'.join(targets)}): {shown}"
+    )
+    print_green(
+        "  ESP32 selects its embedded filesystem automatically. ESP8266 needs "
+        "-DFL_ESP8266_EMBEDDED_FS, which no build applies yet (FastLED#4020)."
     )

--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -54,6 +54,14 @@ from typing import Any, cast
 #: Optional multi-asset manifest living beside the ``.lnk`` sidecars.
 ASSETS_JSON = "assets.json"
 
+#: Storage targets an asset may declare, from FastLED/fbuild#1356. A target
+#: says where the bytes should END UP; the url says where they come from.
+STORAGE_TARGETS = frozenset({"littlefs", "spiffs", "sdcard", "firmware", "vfs", "none"})
+
+#: Targets backed by on-chip flash, i.e. the ones `fl::getEmbeddedFs()` serves.
+#: Declaring one of these is what pulls the embedded filesystem into a build.
+EMBEDDED_FS_TARGETS = frozenset({"littlefs", "spiffs"})
+
 #: One serialized manifest entry. This is a JSON wire shape, not a domain
 #: type — it is handed straight to ``json.dump`` — so it stays a plain dict
 #: rather than a dataclass.
@@ -79,6 +87,12 @@ class AssetEntry:
             used for a cheap mismatch check before hashing.
         extract: Optional archive handling (``"file"``/``"zip"``/``"tar.gz"``).
             Only the JSON form carries this; captured for forward-compat.
+        storage: Optional storage target — where the bytes should end up on the
+            device (``littlefs``, ``spiffs``, ``sdcard``, ``firmware``, ``vfs``,
+            ``none``). Absent means undeclared, which is not an error: a sketch
+            that never says where an asset goes still gets a manifest. Declaring
+            an on-chip target is what enables the embedded filesystem for the
+            build — see ``AssetScanResult.embedded_fs_assets``.
     """
 
     url: str
@@ -86,6 +100,7 @@ class AssetEntry:
     fallback: str | None = None
     size: int | None = None
     extract: str | None = None
+    storage: str | None = None
 
 
 @dataclass
@@ -103,6 +118,32 @@ class AssetScanResult:
 
     manifest: dict[str, AssetEntry] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
+
+    @property
+    def storage_targets(self) -> set[str]:
+        """Every distinct storage target declared by any asset."""
+        return {e.storage for e in self.manifest.values() if e.storage}
+
+    def embedded_fs_assets(self) -> list[str]:
+        """Asset paths that ask to live on on-chip flash, sorted.
+
+        A non-empty result is what pulls the embedded filesystem into a build:
+        the assets have declared they need it, so nothing else should have to.
+        """
+        return sorted(
+            path
+            for path, entry in self.manifest.items()
+            if entry.storage in EMBEDDED_FS_TARGETS
+        )
+
+    def unknown_storage_targets(self) -> set[str]:
+        """Declared targets outside the known vocabulary.
+
+        Not an error -- a newer tool may write a target this scanner predates.
+        Reported so a typo (``littleFS``, ``lfs``) does not silently behave as
+        "undeclared", which would look identical to working.
+        """
+        return {t for t in self.storage_targets if t not in STORAGE_TARGETS}
 
     def to_json_dict(self) -> dict[str, ManifestRecord]:
         """Return manifest as a plain nested dict for JSON serialization.
@@ -123,6 +164,8 @@ class AssetScanResult:
                 record["size"] = entry.size
             if entry.extract is not None:
                 record["extract"] = entry.extract
+            if entry.storage is not None:
+                record["storage"] = entry.storage
             out[key] = record
         return out
 
@@ -130,6 +173,25 @@ class AssetScanResult:
 # -----------------------------------------------------------------------------
 # Internals
 # -----------------------------------------------------------------------------
+
+
+def _storage_of(spec: dict[str, Any], default: str | None = None) -> str | None:
+    """Read a storage target from a JSON spec.
+
+    Accepts both shapes in circulation: a flat ``"storage": "littlefs"`` and
+    fbuild's proposed ``"dest": {"target": "littlefs"}`` (FastLED/fbuild#1356).
+    An unrecognised target is passed through rather than dropped -- the scanner
+    reports it and lets the build decide, so a newer descriptor written by a
+    newer tool is not silently discarded by an older scanner.
+    """
+    raw: Any = spec.get("storage")
+    if raw is None:
+        dest: Any = spec.get("dest")
+        if isinstance(dest, dict):
+            raw = cast("dict[str, Any]", dest).get("target")
+    if raw is None:
+        return default
+    return str(raw).strip().lower()
 
 
 def _parse_assets_json(content: str) -> tuple[dict[str, AssetEntry], list[str]]:
@@ -148,9 +210,19 @@ def _parse_assets_json(content: str) -> tuple[dict[str, AssetEntry], list[str]]:
     if not isinstance(parsed, dict):
         return {}, ["top level must be an object"]
 
-    raw_entries: Any = cast("dict[str, Any]", parsed).get("assets")
+    top: dict[str, Any] = cast("dict[str, Any]", parsed)
+    raw_entries: Any = top.get("assets")
     if not isinstance(raw_entries, dict):
         return {}, ["missing 'assets' object"]
+
+    # A file-level default so many assets can share one target without
+    # repeating it (FastLED/fbuild#1356). Per-entry always wins.
+    raw_defaults: Any = top.get("defaults")
+    default_storage = (
+        _storage_of(cast("dict[str, Any]", raw_defaults))
+        if isinstance(raw_defaults, dict)
+        else None
+    )
 
     out: dict[str, AssetEntry] = {}
     for name, raw_spec in cast("dict[str, Any]", raw_entries).items():
@@ -177,6 +249,7 @@ def _parse_assets_json(content: str) -> tuple[dict[str, AssetEntry], list[str]]:
             sha256=str(sha) if sha is not None else None,
             fallback=urls[1] if len(urls) > 1 else None,
             size=int(size) if size is not None else None,
+            storage=_storage_of(spec, default_storage),
         )
     return out, problems
 
@@ -223,6 +296,7 @@ def _parse_lnk_json(content: str) -> AssetEntry | None:
         ),
         size=int(size) if size is not None else None,
         extract=str(extract) if extract is not None else None,
+        storage=_storage_of(doc_typed),
     )
 
 
@@ -238,7 +312,8 @@ def _parse_lnk_content(content: str) -> AssetEntry | None:
     - Comment lines (``#...``) and blank lines are skipped.
     - First non-comment line is the primary URL.
     - Subsequent ``key=value`` lines are recorded as metadata. Recognized
-      keys: ``sha256``, ``fallback``. Unknown keys are silently ignored.
+      keys: ``sha256``, ``fallback``, ``storage``. Unknown keys are silently
+      ignored.
 
     **JSON** — the format ``fbuild lnk add`` writes
     (``{"v": 1, "url": ..., "sha256": ..., "size": ...}``).
@@ -257,6 +332,7 @@ def _parse_lnk_content(content: str) -> AssetEntry | None:
     primary_url: str | None = None
     sha256: str | None = None
     fallback: str | None = None
+    storage: str | None = None
 
     for raw_line in content.splitlines():
         line = raw_line.strip()
@@ -278,12 +354,16 @@ def _parse_lnk_content(content: str) -> AssetEntry | None:
             sha256 = value
         elif key == "fallback":
             fallback = value
+        elif key == "storage":
+            storage = value.lower()
         # else: unknown metadata key, ignore.
 
     if primary_url is None:
         return None
 
-    return AssetEntry(url=primary_url, sha256=sha256, fallback=fallback)
+    return AssetEntry(
+        url=primary_url, sha256=sha256, fallback=fallback, storage=storage
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -437,3 +517,47 @@ def _cpp_string_literal(s: str) -> str:
         .replace("\t", "\\t")
     )
     return f'"{escaped}"'
+
+
+def announce_storage_requirements(scan: AssetScanResult) -> list[str]:
+    """Report what the sketch's assets need from the build, and return defines.
+
+    An asset that declares ``storage=littlefs`` (or ``spiffs``) is stating a
+    build requirement: the firmware has to be able to read on-chip flash. The
+    build satisfies that itself rather than making the user also remember a
+    flag -- so this prints, in green, that the filesystem was added and which
+    assets asked for it.
+
+    Green because it is neither a warning nor an error. Nothing is wrong; the
+    build is telling the user it did something on their behalf, and naming the
+    assets so the reason is visible rather than magic. A missing or wrong
+    target is the yellow case (see ``unknown_storage_targets``) and is reported
+    by the caller.
+
+    Returns the preprocessor defines the build should add, so the decision and
+    the message come from the same place and cannot drift apart.
+    """
+    from ci.util.color_output import print_green, print_yellow
+
+    unknown = scan.unknown_storage_targets()
+    if unknown:
+        print_yellow(
+            "assets: unrecognized storage target(s): "
+            + ", ".join(sorted(unknown))
+            + f". Known: {', '.join(sorted(STORAGE_TARGETS))}. "
+            "Treated as undeclared -- the asset will not pull in a filesystem."
+        )
+
+    needs_fs = scan.embedded_fs_assets()
+    if not needs_fs:
+        return []
+
+    targets = sorted(scan.storage_targets & EMBEDDED_FS_TARGETS)
+    shown = ", ".join(needs_fs[:4])
+    if len(needs_fs) > 4:
+        shown += f", +{len(needs_fs) - 4} more"
+    print_green(
+        f"assets: embedded filesystem ({'/'.join(targets)}) enabled "
+        f"automatically -- {len(needs_fs)} asset(s) declare it: {shown}"
+    )
+    return ["FASTLED_ESP8266_EMBEDDED_FS"]

--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -519,8 +519,28 @@ def _cpp_string_literal(s: str) -> str:
     return f'"{escaped}"'
 
 
-def announce_storage_requirements(scan: AssetScanResult) -> list[str]:
-    """Report what the sketch's assets need from the build, and return defines.
+def embedded_fs_defines(scan: AssetScanResult) -> list[str]:
+    """Preprocessor defines a build needs to satisfy the sketch's assets.
+
+    Separate from the reporting below so the decision is testable on its own
+    and has exactly one home. Empty unless some asset declares on-chip storage.
+
+    Today this is only non-empty for ESP8266. ESP32 needs no flag -- its
+    embedded filesystem is already selected automatically by
+    `platforms/embedded_fs.h` -- so on the platform people actually use for
+    LittleFS, an asset declaring `storage=littlefs` already works.
+
+    Nothing applies these yet: build defines are assembled per-board in
+    `ci/boards.py`, and this is per-sketch. Applying them would also currently
+    break the ESP8266 builds it targets, because that backend cannot compile
+    until FastLED/fbuild#1380 ships the core's littlefs submodule. Tracked in
+    FastLED#4020.
+    """
+    return ["FL_ESP8266_EMBEDDED_FS"] if scan.embedded_fs_assets() else []
+
+
+def announce_storage_requirements(scan: AssetScanResult) -> None:
+    """Report what the sketch's assets need from the build.
 
     An asset that declares ``storage=littlefs`` (or ``spiffs``) is stating a
     build requirement: the firmware has to be able to read on-chip flash. The
@@ -530,12 +550,13 @@ def announce_storage_requirements(scan: AssetScanResult) -> list[str]:
 
     Green because it is neither a warning nor an error. Nothing is wrong; the
     build is telling the user it did something on their behalf, and naming the
-    assets so the reason is visible rather than magic. A missing or wrong
-    target is the yellow case (see ``unknown_storage_targets``) and is reported
-    by the caller.
+    assets so the reason is visible rather than magic. An unrecognised target
+    is the yellow case -- a typo like `littleFS` would otherwise behave exactly
+    like "undeclared", which looks identical to working.
 
-    Returns the preprocessor defines the build should add, so the decision and
-    the message come from the same place and cannot drift apart.
+    Returns nothing on purpose. An earlier version returned the defines from
+    here and the caller dropped them, which read as if the build were applying
+    something it was not. `embedded_fs_defines` owns that decision.
     """
     from ci.util.color_output import print_green, print_yellow
 
@@ -550,7 +571,7 @@ def announce_storage_requirements(scan: AssetScanResult) -> list[str]:
 
     needs_fs = scan.embedded_fs_assets()
     if not needs_fs:
-        return []
+        return
 
     targets = sorted(scan.storage_targets & EMBEDDED_FS_TARGETS)
     shown = ", ".join(needs_fs[:4])
@@ -560,4 +581,3 @@ def announce_storage_requirements(scan: AssetScanResult) -> list[str]:
         f"assets: embedded filesystem ({'/'.join(targets)}) enabled "
         f"automatically -- {len(needs_fs)} asset(s) declare it: {shown}"
     )
-    return ["FASTLED_ESP8266_EMBEDDED_FS"]

--- a/ci/compiler/source_manager.py
+++ b/ci/compiler/source_manager.py
@@ -279,6 +279,24 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
             except ValueError:
                 print(f"Synced directory {file_path} to {dest_subdir}")
 
+    # Assets may declare where they belong on the device. An asset asking for
+    # on-chip flash is stating a build requirement, so say so rather than
+    # leaving the user to discover it -- see announce_storage_requirements.
+    # The example directory is scanned, not the copy: identical content, and it
+    # is the path the user recognises if something is misdeclared.
+    try:
+        from ci.compiler.asset_scanner import (
+            announce_storage_requirements,
+            scan_sketch_assets,
+        )
+
+        announce_storage_requirements(scan_sketch_assets(example_path))
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except Exception as exc:  # pragma: no cover - reporting must never break a build
+        print(f"asset scan skipped: {exc}")
+
     # Create or update stub main.cpp that includes the .ino files
     main_cpp_content = generate_main_cpp(ino_files)
     main_cpp_path = src_dir / "main.cpp"

--- a/ci/compiler/source_manager.py
+++ b/ci/compiler/source_manager.py
@@ -284,18 +284,17 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     # leaving the user to discover it -- see announce_storage_requirements.
     # The example directory is scanned, not the copy: identical content, and it
     # is the path the user recognises if something is misdeclared.
-    try:
-        from ci.compiler.asset_scanner import (
-            announce_storage_requirements,
-            scan_sketch_assets,
-        )
+    from ci.compiler.asset_scanner import (
+        announce_storage_requirements,
+        scan_sketch_assets,
+    )
 
-        announce_storage_requirements(scan_sketch_assets(example_path))
-    except KeyboardInterrupt as ki:
-        handle_keyboard_interrupt(ki)
-        raise
-    except Exception as exc:  # pragma: no cover - reporting must never break a build
-        print(f"asset scan skipped: {exc}")
+    # Not wrapped in a broad except: a storage declaration is build
+    # configuration, and a build that cannot read it should say so rather than
+    # continue as if the sketch had declared nothing. Malformed individual
+    # `.lnk` files are already non-fatal -- scan_sketch_assets collects those as
+    # warnings -- so reaching an exception here means something genuinely wrong.
+    announce_storage_requirements(scan_sketch_assets(example_path))
 
     # Create or update stub main.cpp that includes the .ino files
     main_cpp_content = generate_main_cpp(ino_files)

--- a/ci/tests/test_asset_scanner.py
+++ b/ci/tests/test_asset_scanner.py
@@ -5,6 +5,8 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest  # noqa: F401  # used in a type annotation only
+
 from ci.compiler.asset_scanner import (
     ASSETS_JSON,
     AssetEntry,
@@ -405,6 +407,26 @@ def test_on_chip_target_enables_the_filesystem() -> None:
     )
     assert scan.embedded_fs_assets() == ["data/v.rgb"]
     assert embedded_fs_defines(scan) == ["FL_ESP8266_EMBEDDED_FS"]
+
+
+def test_announcement_does_not_claim_work_it_did_not_do(
+    capsys: "pytest.CaptureFixture[str]",
+) -> None:
+    """No build consumes embedded_fs_defines yet (FastLED#4020).
+
+    So the report must name the requirement, not claim it was satisfied --
+    "enabled automatically" would send an ESP8266 user off looking elsewhere
+    for a failure whose cause is the missing define.
+    """
+    scan = AssetScanResult(
+        manifest={"data/v.rgb": AssetEntry(url="u", storage="littlefs")}
+    )
+    announce_storage_requirements(scan)
+
+    out = capsys.readouterr().out
+    assert "data/v.rgb" in out
+    assert "enabled automatically" not in out
+    assert "FL_ESP8266_EMBEDDED_FS" in out
 
 
 def test_sdcard_alone_does_not_enable_the_filesystem() -> None:

--- a/ci/tests/test_asset_scanner.py
+++ b/ci/tests/test_asset_scanner.py
@@ -11,6 +11,7 @@ from ci.compiler.asset_scanner import (
     AssetScanResult,
     _parse_lnk_content,
     announce_storage_requirements,
+    embedded_fs_defines,
     manifest_to_cpp_header,
     manifest_to_js_bootstrap,
     scan_sketch_assets,
@@ -392,7 +393,7 @@ def test_undeclared_storage_is_not_an_error() -> None:
 
     scan = AssetScanResult(manifest={"data/v.rgb": entry})
     assert scan.embedded_fs_assets() == []
-    assert announce_storage_requirements(scan) == []
+    assert embedded_fs_defines(scan) == []
 
 
 def test_on_chip_target_enables_the_filesystem() -> None:
@@ -403,7 +404,7 @@ def test_on_chip_target_enables_the_filesystem() -> None:
         }
     )
     assert scan.embedded_fs_assets() == ["data/v.rgb"]
-    assert announce_storage_requirements(scan) == ["FASTLED_ESP8266_EMBEDDED_FS"]
+    assert embedded_fs_defines(scan) == ["FL_ESP8266_EMBEDDED_FS"]
 
 
 def test_sdcard_alone_does_not_enable_the_filesystem() -> None:
@@ -412,7 +413,7 @@ def test_sdcard_alone_does_not_enable_the_filesystem() -> None:
         manifest={"data/v.rgb": AssetEntry(url="u", storage="sdcard")}
     )
     assert scan.embedded_fs_assets() == []
-    assert announce_storage_requirements(scan) == []
+    assert embedded_fs_defines(scan) == []
 
 
 def test_typo_target_is_reported_not_silently_ignored() -> None:
@@ -421,7 +422,7 @@ def test_typo_target_is_reported_not_silently_ignored() -> None:
         manifest={"data/v.rgb": AssetEntry(url="u", storage="littlefs2")}
     )
     assert scan.unknown_storage_targets() == {"littlefs2"}
-    assert announce_storage_requirements(scan) == []
+    assert embedded_fs_defines(scan) == []
 
 
 def test_storage_round_trips_through_the_manifest() -> None:

--- a/ci/tests/test_asset_scanner.py
+++ b/ci/tests/test_asset_scanner.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from ci.compiler.asset_scanner import (
+    ASSETS_JSON,
     AssetEntry,
     AssetScanResult,
     _parse_lnk_content,
+    announce_storage_requirements,
     manifest_to_cpp_header,
     manifest_to_js_bootstrap,
     scan_sketch_assets,
@@ -332,3 +334,101 @@ class TestRealCommittedLnkFiles(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Storage targets: an asset declaring on-chip storage enables the filesystem
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> Path:
+    p = tmp_path / "sketch" / "data" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return tmp_path / "sketch"
+
+
+def test_text_lnk_declares_storage() -> None:
+    entry = _parse_lnk_content("https://example.com/v.rgb\nstorage=littlefs\n")
+    assert entry is not None
+    assert entry.storage == "littlefs"
+
+
+def test_json_lnk_declares_storage_flat_and_nested() -> None:
+    """Both shapes in circulation parse: flat, and fbuild#1356's dest.target."""
+    flat = _parse_lnk_content('{"v":1,"url":"https://e/v.rgb","storage":"littlefs"}')
+    assert flat is not None and flat.storage == "littlefs"
+
+    nested = _parse_lnk_content(
+        '{"v":2,"url":"https://e/v.rgb","dest":{"target":"spiffs","path":"/v"}}'
+    )
+    assert nested is not None and nested.storage == "spiffs"
+
+
+def test_assets_json_file_level_default_applies_and_entry_wins(tmp_path: Path) -> None:
+    sketch = _write(
+        tmp_path,
+        ASSETS_JSON,
+        json.dumps(
+            {
+                "defaults": {"storage": "littlefs"},
+                "assets": {
+                    "a.rgb": {"url": "https://e/a"},
+                    "b.rgb": {"url": "https://e/b", "storage": "sdcard"},
+                },
+            }
+        ),
+    )
+    scan = scan_sketch_assets(sketch)
+    assert scan.manifest["data/a.rgb"].storage == "littlefs"
+    assert scan.manifest["data/b.rgb"].storage == "sdcard"
+
+
+def test_undeclared_storage_is_not_an_error() -> None:
+    """Most sketches never say. That must stay silent and pull in nothing."""
+    entry = _parse_lnk_content("https://example.com/v.rgb\n")
+    assert entry is not None
+    assert entry.storage is None
+
+    scan = AssetScanResult(manifest={"data/v.rgb": entry})
+    assert scan.embedded_fs_assets() == []
+    assert announce_storage_requirements(scan) == []
+
+
+def test_on_chip_target_enables_the_filesystem() -> None:
+    scan = AssetScanResult(
+        manifest={
+            "data/v.rgb": AssetEntry(url="u", storage="littlefs"),
+            "data/m.json": AssetEntry(url="u", storage="sdcard"),
+        }
+    )
+    assert scan.embedded_fs_assets() == ["data/v.rgb"]
+    assert announce_storage_requirements(scan) == ["FASTLED_ESP8266_EMBEDDED_FS"]
+
+
+def test_sdcard_alone_does_not_enable_the_filesystem() -> None:
+    """An SD card is not on-chip flash; it must not drag LittleFS in."""
+    scan = AssetScanResult(
+        manifest={"data/v.rgb": AssetEntry(url="u", storage="sdcard")}
+    )
+    assert scan.embedded_fs_assets() == []
+    assert announce_storage_requirements(scan) == []
+
+
+def test_typo_target_is_reported_not_silently_ignored() -> None:
+    """A typo must not look identical to 'undeclared', which looks like working."""
+    scan = AssetScanResult(
+        manifest={"data/v.rgb": AssetEntry(url="u", storage="littlefs2")}
+    )
+    assert scan.unknown_storage_targets() == {"littlefs2"}
+    assert announce_storage_requirements(scan) == []
+
+
+def test_storage_round_trips_through_the_manifest() -> None:
+    scan = AssetScanResult(
+        manifest={"data/v.rgb": AssetEntry(url="u", storage="littlefs")}
+    )
+    assert scan.to_json_dict()["data/v.rgb"]["storage"] == "littlefs"
+
+    plain = AssetScanResult(manifest={"data/v.rgb": AssetEntry(url="u")})
+    assert "storage" not in plain.to_json_dict()["data/v.rgb"]

--- a/src/platforms/embedded_fs.h
+++ b/src/platforms/embedded_fs.h
@@ -22,10 +22,10 @@
 // without it -- the directory is created empty, so <LittleFS.h> is present and
 // resolves, then fails on its own `#include "../lib/littlefs/lfs.h"`. A
 // FL_HAS_INCLUDE guard cannot see that: the header exists, its contents do not.
-// Tracked as FastLED/fbuild#1380. Define FASTLED_ESP8266_EMBEDDED_FS to opt in
+// Tracked as FastLED/fbuild#1380. Define FL_ESP8266_EMBEDDED_FS to opt in
 // on a toolchain whose core is complete; this can go back to automatic once
 // fbuild packages the submodule.
-#if defined(FL_IS_ESP32) || (defined(FL_IS_ESP8266) && defined(FASTLED_ESP8266_EMBEDDED_FS))
+#if defined(FL_IS_ESP32) || (defined(FL_IS_ESP8266) && defined(FL_ESP8266_EMBEDDED_FS))
 // ESP cores back on-chip flash with LittleFS.
 #include "platforms/esp/fs/embedded_fs_esp.hpp"
 #else

--- a/src/platforms/embedded_fs.h
+++ b/src/platforms/embedded_fs.h
@@ -17,7 +17,15 @@
 
 #include "platforms/is_platform.h"
 
-#if defined(FL_IS_ESP32) || defined(FL_IS_ESP8266)
+// ESP8266 is opt-in, not automatic. Its Arduino core carries littlefs as a git
+// submodule at libraries/LittleFS/lib/littlefs, and fbuild caches the core
+// without it -- the directory is created empty, so <LittleFS.h> is present and
+// resolves, then fails on its own `#include "../lib/littlefs/lfs.h"`. A
+// FL_HAS_INCLUDE guard cannot see that: the header exists, its contents do not.
+// Tracked as FastLED/fbuild#1380. Define FASTLED_ESP8266_EMBEDDED_FS to opt in
+// on a toolchain whose core is complete; this can go back to automatic once
+// fbuild packages the submodule.
+#if defined(FL_IS_ESP32) || (defined(FL_IS_ESP8266) && defined(FASTLED_ESP8266_EMBEDDED_FS))
 // ESP cores back on-chip flash with LittleFS.
 #include "platforms/esp/fs/embedded_fs_esp.hpp"
 #else

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -161,6 +161,14 @@ public:
 #define FASTLED_UNUSABLE_PIN_MASK (0ULL)
 #endif
 
+
+
+#endif
+
+// NOTE: outside the FASTLED_UNUSABLE_PIN_MASK guard on purpose. A build that
+// defines its own mask would otherwise skip this default and fall back to pin
+// 3 -- reintroducing exactly the UART collision described below, but only for
+// builds that customize the mask, which is the worst place for it to hide.
 // Default data pin for examples -- see platforms/default_pins.h.
 //
 // Deliberately not 3. On ESP32 classic GPIO 3 is U0RXD, the pin Serial
@@ -178,9 +186,6 @@ public:
 // particular board's wiring. FastLED#4018 tracks the wider per-platform audit.
 #ifndef FL_PIN_CLOCKLESS_1
 #define FL_PIN_CLOCKLESS_1 4
-#endif
-
-
 #endif
 
 

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -161,6 +161,25 @@ public:
 #define FASTLED_UNUSABLE_PIN_MASK (0ULL)
 #endif
 
+// Default data pin for examples -- see platforms/default_pins.h.
+//
+// Deliberately not 3. On ESP32 classic GPIO 3 is U0RXD, the pin Serial
+// receives on; the mask comments above already flag "GPIO 1 & 3 commonly used
+// for UART". Blink calls Serial.begin(), so the generic fallback of 3 would
+// have an example drive an output onto its own console RX line. GPIO 3 is also
+// a strapping pin on S3 (JTAG source select) and on H2.
+//
+// GPIO 4 is outside FASTLED_UNUSABLE_PIN_MASK for every variant above, is not
+// a UART pin on any of them, and is not reserved for flash or USB-JTAG. It is
+// a boot-strap pin on C6, which is harmless here: strapping pins are sampled
+// at reset and are ordinary outputs afterwards.
+//
+// This is a compile-time default for examples, not a claim about any
+// particular board's wiring. FastLED#4018 tracks the wider per-platform audit.
+#ifndef FL_PIN_CLOCKLESS_1
+#define FL_PIN_CLOCKLESS_1 4
+#endif
+
 
 #endif
 


### PR DESCRIPTION
Blink now resolves its data pin through `FL_PIN_CLOCKLESS_1` on every platform, and the contract behind that macro is written down.

## The contract

Two halves, both deliberate:

1. **A platform declares its value** beside the `_FL_DEFPIN` table that justifies it, `#ifndef`-guarded so a sketch or build flag still wins.
2. **A platform that declares nothing falls back to 3** (`platforms/default_pins.h`). That is a supported outcome, not an omission to be linted — most platforms are fine on pin 3. A declaration should mean *"3 is wrong here"* and carry a comment saying why.

Documented in `agents/docs/cpp-standards.md` -> "Default Example Pins", with a `CLAUDE.md` row so it is findable without already knowing it exists.

## ESP32 declares 4

The fallback of 3 compiles on ESP32 and is wrong on hardware: **GPIO 3 is `U0RXD`**, and `Blink` calls `Serial.begin()` — so the example drove an output onto its own console RX line. It would have looked like a dead strip with nothing to search for.

This is not inference. `fastpin_esp32.h` already said so in its own mask comments:

> `NOTE: GPIO 1 & 3 commonly used for UART and may cause flashes when uploading.`

GPIO 3 is also a strapping pin on S3 (JTAG source select) and on H2. GPIO 4 is outside `FASTLED_UNUSABLE_PIN_MASK` for every variant in that file, is UART on none of them, and is reserved for neither flash nor USB/JTAG.

This is exactly the failure class #4018 exists for, and the reason "it compiles" is not the bar.

## Verification: 12 boards, 12 families

`bash compile <board> --examples Blink`, all passing:

| family | board | | family | board |
|---|---|---|---|---|
| AVR | `uno` | | Teensy 4 | `teensy41` |
| AVR tiny | `attiny85` | | Teensy LC | `teensylc` |
| megaAVR | `nano_every` | | RP2040 | `rpipico` |
| ESP32 Xtensa | `esp32dev` | | nRF52 | `nrf52840_dk` |
| ESP32 RISC-V | `esp32c3` | | STM32 | `bluepill_f103c8` |
| ESP8266 | `esp8266` | | SAM3X | `due` |

Plus the four SAMD boards already verified in #4015. `bash lint` clean, `bash test --cpp` green.

Three of those boards failed their first run to fbuild daemon deaths (`lost connection to daemon mid-build`) and passed on retry — 3 of 12, a worse local hit-rate than FastLED/fbuild#1360 currently records. Noted there.

## Also fixes esp8266, which was red on master

Not a pin problem. fbuild caches the ESP8266 Arduino core **without its `littlefs` git submodule**, so `libraries/LittleFS/lib/littlefs/` is an empty directory:

```
libraries/LittleFS/src/LittleFS.h:38:10: fatal error: ../lib/littlefs/lfs.h: No such file or directory
```

The awkward part is that **no preprocessor guard can catch this** — `<LittleFS.h>` is present, so `FL_HAS_INCLUDE` correctly passes, and the thing it needs is missing. Filed as FastLED/fbuild#1380.

Embedded FS on ESP8266 is now opt-in behind `FASTLED_ESP8266_EMBEDDED_FS`, so the capability is preserved on a toolchain whose core is complete while the default build stops hitting it. This can go back to automatic once fbuild packages the submodule.

## Not in scope

ESP8266's own `FL_PIN_CLOCKLESS_1` is deliberately left at the fallback. Its pin numbering is board-dependent — `_FL_DEFPIN(3,5)` maps FastLED pin 3 to GPIO 5 on some variants and to GPIO 3 (`RXD0`) on others — so it needs per-variant evidence rather than a blanket value. Recorded in #4018 along with the C6/H2 strapping question.

Refs #4018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ESP32 examples now use GPIO 4 as the default clockless LED data pin when no pin is specified.
  - ESP8266 projects can explicitly enable the embedded LittleFS filesystem backend; ESP32 behavior remains unchanged.
  - Asset metadata supports storage destinations, including embedded filesystems, with build-time reporting and validation.

- **Bug Fixes**
  - Build asset-scanning errors are now surfaced instead of silently skipped.

- **Documentation**
  - Added guidance for selecting platform default pins and adapting examples with hardcoded pin assignments.
  - Documented pin selection criteria and validation expectations for supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->