### PR TITLE
fix: six defects from an adversarial pass over this session's work (#4027)

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -106,6 +106,23 @@ jobs:
           fi
           echo "All required files are present."
 
+      # The asset pipeline is only provable by running the page: a build proves
+      # the loader code exists, not that bytes reach the filesystem. AudioUrl is
+      # the case that matters because its only asset is a remote `.lnk`, so its
+      # files.json is literally `[]` -- if the asset appears at all, it came
+      # through the manifest path. See FastLED#4026.
+      - name: Build AudioUrl for the asset-pipeline check
+        run: uv run ci/ci-compile.py wasm --examples AudioUrl
+        shell: bash
+
+      - name: Install Chromium for Playwright
+        run: uv run python -m playwright install --with-deps chromium
+        shell: bash
+
+      - name: Verify .lnk assets reach the WASM filesystem
+        run: uv run python ci/tests/verify_wasm_assets.py --timeout 45
+        shell: bash
+
       - name: Generate timestamp and random hex
         id: generate_id
         run: |

--- a/ci/tests/verify_wasm_assets.py
+++ b/ci/tests/verify_wasm_assets.py
@@ -122,6 +122,9 @@ async def _run(example: str, headless: bool, timeout_s: int) -> int:
         "loaded completely before setup()": "embedded asset(s) loaded completely before setup()"
         in joined,
         "no incomplete asset reported": "is incomplete: wrote" not in joined,
+        # The manifest declares a digest; trusting it unverified was #4025.
+        "sha256 verified": f"Asset '{ASSET_PATH}' sha256 verified" in joined,
+        "no integrity failure": "failed integrity check" not in joined,
     }
 
     # Ordering is the whole point, so assert it rather than trusting the text.

--- a/ci/tests/verify_wasm_assets.py
+++ b/ci/tests/verify_wasm_assets.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""End-to-end check that a `.lnk` asset reaches the WASM filesystem.
+
+Builds nothing -- run `bash compile wasm --examples AudioUrl` first. This
+serves `examples/AudioUrl/fastled_js/`, loads it in headless Chromium, and
+watches the console for the asset actually being fetched and injected.
+
+Why a browser: the whole feature is "the bytes end up in the filesystem", and
+nothing short of running the page proves that. A green compile proves only that
+the loader code exists. `examples/AudioUrl` is the acceptance case because its
+only asset is a remote `.lnk` -- `files.json` for it is literally `[]`, so if
+the asset appears at all, it came through the manifest path.
+
+Usage:
+    uv run ci/tests/verify_wasm_assets.py [--example AudioUrl] [--headed]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import functools
+import http.server
+import socketserver
+import sys
+import threading
+from pathlib import Path
+
+from ci.util.global_interrupt_handler import handle_keyboard_interrupt
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+#: The asset AudioUrl declares, and the size we expect to see streamed. Both
+#: come from examples/AudioUrl/data/track.mp3.lnk resolving to FastLED/assets.
+ASSET_PATH = "data/track.mp3"
+
+
+def _serve(directory: Path) -> tuple[socketserver.TCPServer, int]:
+    """Start a background HTTP server on a free port, returning (server, port).
+
+    COOP/COEP headers are required: the FastLED WASM build uses threads, so the
+    page needs cross-origin isolation or the module refuses to instantiate.
+    """
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        # Windows resolves .js from the registry, which frequently yields
+        # text/plain -- and a module script served as text/plain is rejected
+        # outright by strict MIME checking, so nothing loads. Pin the types
+        # that matter rather than depending on the host's file associations.
+        extensions_map = {
+            **http.server.SimpleHTTPRequestHandler.extensions_map,
+            ".js": "text/javascript",
+            ".mjs": "text/javascript",
+            ".wasm": "application/wasm",
+            ".json": "application/json",
+            ".css": "text/css",
+            ".map": "application/json",
+        }
+
+        def end_headers(self) -> None:
+            self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+            self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+            self.send_header("Cache-Control", "no-store")
+            super().end_headers()
+
+        def log_message(self, fmt: str, *args: object) -> None:
+            pass  # keep the harness output readable
+
+    handler = functools.partial(Handler, directory=str(directory))
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, port
+
+
+async def _run(example: str, headless: bool, timeout_s: int) -> int:
+    from playwright.async_api import async_playwright
+
+    served = PROJECT_ROOT / "examples" / example / "fastled_js"
+    if not (served / "index.html").exists():
+        print(
+            f"FAIL: {served}/index.html missing -- run: bash compile wasm --examples {example}"
+        )
+        return 1
+
+    httpd, port = _serve(served)
+    url = f"http://127.0.0.1:{port}/index.html"
+    print(f"serving {served} at {url}")
+
+    logs: list[str] = []
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=headless)
+            page = await browser.new_page()
+            page.on("console", lambda m: logs.append(f"{m.type}: {m.text}"))
+            page.on("pageerror", lambda e: logs.append(f"pageerror: {e}"))
+
+            await page.goto(url, timeout=timeout_s * 1000)
+            # The asset is fetched during load; give the module time to boot,
+            # stream it, and run a few frames.
+            await page.wait_for_timeout(timeout_s * 1000)
+            await browser.close()
+    finally:
+        httpd.shutdown()
+
+    joined = "\n".join(logs)
+    print("\n--- browser console ---")
+    for line in logs:
+        print(f"  {line}")
+    print("--- end console ---\n")
+
+    checks = {
+        "manifest loaded": "fastledAssetManifest" in joined,
+        "asset resolved to its url": f"Asset '{ASSET_PATH}'" in joined,
+        "asset injected into the filesystem": "manifest asset(s) into the filesystem"
+        in joined,
+        "bytes streamed": f"File fetched: {ASSET_PATH}" in joined,
+        # Parity with a device: on ESP the file is simply present when setup()
+        # runs. "Arrives eventually" means the preview is lying to the sketch,
+        # so completeness *before* setup is the property under test.
+        "loaded completely before setup()": "embedded asset(s) loaded completely before setup()"
+        in joined,
+        "no incomplete asset reported": "is incomplete: wrote" not in joined,
+    }
+
+    # Ordering is the whole point, so assert it rather than trusting the text.
+    complete_at = next(
+        (i for i, ln in enumerate(logs) if "loaded completely before setup()" in ln),
+        None,
+    )
+    setup_at = next((i for i, ln in enumerate(logs) if "Starting fastled" in ln), None)
+    checks["completion preceded setup() starting"] = (
+        complete_at is not None and setup_at is not None and complete_at < setup_at
+    )
+    failures = [name for name, ok in checks.items() if not ok]
+    for name, ok in checks.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} check(s) failed: {', '.join(failures)}")
+        return 1
+    print("\nPASS: the .lnk asset reached the WASM filesystem")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--example", default="AudioUrl")
+    ap.add_argument("--headed", action="store_true", help="show the browser")
+    ap.add_argument("--timeout", type=int, default=15)
+    args = ap.parse_args()
+    try:
+        return asyncio.run(_run(args.example, not args.headed, args.timeout))
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -1626,39 +1626,6 @@ def _run_npx(args: list[str], cwd: Path) -> int:
     return npx_func(args, cwd=str(cwd))
 
 
-def _get_vite_source_mtime(template_dir: Path) -> float:
-    """Get the most recent mtime of any Vite frontend source file.
-
-    Uses os.scandir with directory-level pruning instead of rglob to avoid
-    walking node_modules (2626 files, 420ms → 4ms). On Windows, DirEntry.stat()
-    reuses FindFirstFile data (no extra syscall per file).
-    """
-    max_mtime = 0.0
-    _EXTS = frozenset((".ts", ".js", ".html", ".css", ".json"))
-    _SKIP = frozenset(("node_modules", "dist"))
-    stack = [str(template_dir)]
-    while stack:
-        current = stack.pop()
-        try:
-            with os.scandir(current) as it:
-                for entry in it:
-                    try:
-                        if entry.is_dir(follow_symlinks=False):
-                            if entry.name not in _SKIP:
-                                stack.append(entry.path)
-                        elif entry.is_file(follow_symlinks=False):
-                            _, ext = os.path.splitext(entry.name)
-                            if ext in _EXTS:
-                                mtime = entry.stat(follow_symlinks=False).st_mtime
-                                if mtime > max_mtime:
-                                    max_mtime = mtime
-                    except OSError:
-                        pass
-        except OSError:
-            pass
-    return max_mtime
-
-
 def copy_templates(output_dir: Path) -> None:
     """Copy template files using the bundled esbuild frontend pipeline."""
     from ci.esbuild_frontend import copy_dist_to_output

--- a/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_2_samd51.cpp.hpp
@@ -45,7 +45,7 @@
 // non-owning construction path -- so acquireDMABuffer() cannot return a view
 // over a caller-managed span. Reconciling that is a design change on a driver
 // that has also never run on hardware. FastLED#4017 tracks bring-up.
-#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
+#if defined(FL_IS_SAMD51) && defined(FL_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_2.h"
 #include "fl/log/log.h"
@@ -565,4 +565,4 @@ void SPIDualSAMD51::cleanup() {
 
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI
+#endif  // FL_IS_SAMD51 && FL_SAMD51_HW_SPI

--- a/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_4_samd51.cpp.hpp
@@ -38,7 +38,7 @@
 // non-owning construction path -- so acquireDMABuffer() cannot return a view
 // over a caller-managed span. Reconciling that is a design change on a driver
 // that has also never run on hardware. FastLED#4017 tracks bring-up.
-#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
+#if defined(FL_IS_SAMD51) && defined(FL_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_4.h"
 #include "fl/log/log.h"
@@ -594,4 +594,4 @@ void initSpiHw4Instances() {
 
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI
+#endif  // FL_IS_SAMD51 && FL_SAMD51_HW_SPI

--- a/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
+++ b/src/platforms/arm/d51/spi_hw_manager_samd51.cpp.hpp
@@ -24,7 +24,7 @@
 // non-owning construction path -- so acquireDMABuffer() cannot return a view
 // over a caller-managed span. Reconciling that is a design change on a driver
 // that has also never run on hardware. FastLED#4017 tracks bring-up.
-#if defined(FL_IS_SAMD51) && defined(FASTLED_SAMD51_HW_SPI)
+#if defined(FL_IS_SAMD51) && defined(FL_SAMD51_HW_SPI)
 
 #include "platforms/shared/spi_hw_2.h"
 #include "platforms/shared/spi_hw_4.h"
@@ -97,4 +97,4 @@ void initSpiHardware() {
 }  // namespace platforms
 }  // namespace fl
 
-#endif  // FL_IS_SAMD51 && FASTLED_SAMD51_HW_SPI
+#endif  // FL_IS_SAMD51 && FL_SAMD51_HW_SPI

--- a/src/platforms/embedded_fs.h
+++ b/src/platforms/embedded_fs.h
@@ -28,9 +28,13 @@
 #if defined(FL_IS_ESP32) || (defined(FL_IS_ESP8266) && defined(FL_ESP8266_EMBEDDED_FS))
 // ESP cores back on-chip flash with LittleFS.
 #include "platforms/esp/fs/embedded_fs_esp.hpp"
+#elif defined(FL_IS_WASM)
+// The browser VFS stands in for on-chip flash so a LittleFS sketch runs
+// unmodified in the web preview.
+#include "platforms/wasm/fs/embedded_fs_wasm.hpp"
 #else
-// No embedded storage on this platform (host/stub, WASM, AVR, Teensy,
-// ARM). RP2040 also ships LittleFS and should gain a fragment here.
+// No embedded storage on this platform (host/stub, AVR, Teensy, ARM).
+// RP2040 also ships LittleFS and should gain a fragment here.
 #include "platforms/shared/embedded_fs_noop.hpp"
 #endif
 

--- a/src/platforms/esp/32/core/fastpin_esp32.h
+++ b/src/platforms/esp/32/core/fastpin_esp32.h
@@ -188,6 +188,58 @@ public:
 #define FL_PIN_CLOCKLESS_1 4
 #endif
 
+// Default SPI pins for examples -- see platforms/default_pins.h.
+//
+// Deliberately not the generic 1/2 fallback: GPIO 1 is U0TXD on ESP32 classic,
+// the pin Serial transmits on, and the mask comments above flag "GPIO 1 & 3
+// commonly used for UART". A clocked chipset defaulting there drives its data
+// line onto the console. GPIO 2 is a strapping pin on classic, C3 and H2.
+//
+// Per-variant, because no single pair is safe across the family: below GPIO 6
+// everything is UART or strapping, 6-17 is flash on one variant or another,
+// and above 17 exceeds the pin count on C2/C3. Each pair below is outside that
+// variant's FASTLED_UNUSABLE_PIN_MASK, is not its UART, and is not a strapping
+// pin for it.
+//
+// Not taken from the Arduino core's MOSI/SCK, though that was the first
+// instinct: those are `static const uint8_t`, not macros, so `#if defined(MOSI)`
+// is always false and the guard silently selects the fallback instead. Seven
+// variants also set `MOSI = -1`, which would fail FastPin<>::validpin().
+//
+// Compile-time defaults for examples, not a claim about any board's wiring.
+// FastLED#4022 tracks confirming these on hardware.
+#if defined(FL_IS_ESP_32S2)
+#define FL_PIN_SPI_DATA_1_DEFAULT 35
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 36
+#elif defined(FL_IS_ESP_32S3)
+#define FL_PIN_SPI_DATA_1_DEFAULT 11
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 12
+#elif defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32C2) || defined(FL_IS_ESP_32C5)
+#define FL_PIN_SPI_DATA_1_DEFAULT 7
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 6
+#elif defined(FL_IS_ESP_32C6)
+#define FL_PIN_SPI_DATA_1_DEFAULT 19
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 18
+#elif defined(FL_IS_ESP_32H2)
+#define FL_PIN_SPI_DATA_1_DEFAULT 11
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 10
+#elif defined(FL_IS_ESP_32P4)
+#define FL_PIN_SPI_DATA_1_DEFAULT 23
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 22
+#else
+// ESP32 classic, and any variant this file does not recognise. 23/18 are the
+// conventional VSPI MOSI/SCK and are free of flash, UART and strapping duty.
+#define FL_PIN_SPI_DATA_1_DEFAULT 23
+#define FL_PIN_SPI_CLOCK_1_DEFAULT 18
+#endif
+
+#ifndef FL_PIN_SPI_DATA_1
+#define FL_PIN_SPI_DATA_1 FL_PIN_SPI_DATA_1_DEFAULT
+#endif
+#ifndef FL_PIN_SPI_CLOCK_1
+#define FL_PIN_SPI_CLOCK_1 FL_PIN_SPI_CLOCK_1_DEFAULT
+#endif
+
 
 
 // SOC GPIO mask was not added until version IDF version 4.3.  Prior to this only ESP32 chip was supported, so only

--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -730,59 +730,113 @@ async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
  * @param {Object} moduleInstance - The loaded WASM module instance
  * @param {Array<Object>} filesJson - Array of files to load into the virtual filesystem
  */
+/** How long a single embedded asset may take to fetch before the build gives up. */
+const EMBEDDED_ASSET_TIMEOUT_MS = 30000;
+
+/**
+ * Hex-encodes a SHA-256 digest of the given bytes.
+ * @param {Uint8Array} bytes
+ * @returns {Promise<string>} lowercase hex, or '' if the platform has no SubtleCrypto
+ */
+async function sha256Hex(bytes) {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) return '';
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Fetches one asset, following its declared `fallback` if the primary fails.
+ * @returns {Promise<Uint8Array|null>}
+ */
+async function fetchAssetBytes(path, spec) {
+  const urls = [spec.url, spec.fallback].filter(Boolean);
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(EMBEDDED_ASSET_TIMEOUT_MS) });
+      if (!response.ok) {
+        console.warn(`Asset '${path}': ${response.status} from ${url}`);
+        continue;
+      }
+      // Buffered rather than streamed on purpose. These assets must be whole
+      // before setup() anyway, and holding the bytes gives an exact length
+      // without depending on Content-Length -- which many hosts omit, exactly
+      // where a truncated download is most likely -- and allows the declared
+      // digest to be checked before anything reaches the sketch.
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (url !== spec.url) {
+        console.log(`Asset '${path}': primary failed, served from fallback ${url}`);
+      }
+      return bytes;
+    } catch (err) {
+      const why = (err && err.name === 'TimeoutError')
+        ? `timed out after ${EMBEDDED_ASSET_TIMEOUT_MS}ms`
+        : String(err);
+      console.warn(`Asset '${path}' from ${url}: ${why}`);
+    }
+  }
+  return null;
+}
+
 /**
  * Resolves `window.fastledAssetManifest` entries into virtual-filesystem
  * entries (FastLED issue #2284).
  *
  * A `.lnk` / `assets.json` asset lives at a remote URL and has no local file,
  * so `files.json` cannot list it -- for a sketch whose only asset is a `.lnk`,
- * `files.json` is literally `[]`. Until now the manifest was used only to hand
- * C++ a URL to stream; nothing put the bytes into the filesystem. That left
- * `fl::getEmbeddedFs()` with nothing to read, so a sketch written against ESP
- * LittleFS could not be previewed in the browser -- the one platform whose job
- * is to imitate the device was the one that could not.
+ * `files.json` is literally `[]`. Without this the manifest only ever handed
+ * C++ a URL to stream, so `fl::getEmbeddedFs()` had nothing to read and a
+ * sketch written against ESP LittleFS could not be previewed.
  *
- * The fetch happens here rather than in `processFile` because
- * `fastled_declare_files` needs a size before any streaming starts, and a
- * remote asset's size is only known from its response. Issuing the request and
- * reading `Content-Length` off the headers costs no extra round trip: the body
- * is handed back and streamed by the normal path.
- *
- * A failed asset is skipped with a warning rather than aborting the load. One
- * unreachable URL should not stop a sketch whose other assets are fine.
+ * Each asset is fetched whole, verified against its declared `sha256`, and
+ * only then handed on. A failure here is reported and the asset dropped: the
+ * sketch still starts, because a preview that never runs tells the user less
+ * than one that runs with a missing file and says so.
  *
  * @param {Object} manifest - path -> {url, sha256, fallback, size?}
  * @returns {Promise<Array<Object>>} records shaped like `files.json` entries,
- *   each carrying its already-open `response` for streaming.
+ *   each carrying the verified `bytes`.
  */
 async function resolveManifestAssets(manifest) {
   const entries = Object.entries(manifest || {});
   if (entries.length === 0) return [];
 
   const resolved = await Promise.all(entries.map(async ([path, spec]) => {
-    const url = spec && spec.url;
-    if (!url) {
+    if (!spec || !spec.url) {
       console.warn(`Asset '${path}' has no url; skipping`);
       return null;
     }
-    try {
-      const response = await fetch(url);
-      if (!response.ok) {
-        console.warn(`Asset '${path}' fetch failed (${response.status}) from ${url}`);
-        return null;
-      }
-      // Prefer a size the declaration stated; fall back to the response.
-      const declared = Number(spec.size)
-        || Number(response.headers.get('content-length'))
-        || 0;
-      console.log(`Asset '${path}' -> ${url} (${declared} bytes)`);
-      // `embedded` marks this as backing fl::getEmbeddedFs(), which forces
-      // full load before setup() -- see the ordering below.
-      return { path, size: declared, response, embedded: true };
-    } catch (err) {
-      console.warn(`Asset '${path}' fetch threw:`, err);
+    const bytes = await fetchAssetBytes(path, spec);
+    if (!bytes) {
+      console.error(`Asset '${path}' could not be fetched; the sketch will see no such file`);
       return null;
     }
+
+    if (spec.sha256) {
+      const actual = await sha256Hex(bytes);
+      if (actual && actual !== String(spec.sha256).toLowerCase()) {
+        console.error(
+          `Asset '${path}' failed integrity check: declared ${spec.sha256}, got ${actual}. Dropping it.`,
+        );
+        return null;
+      }
+      if (actual) console.log(`Asset '${path}' sha256 verified`);
+      else console.warn(`Asset '${path}': no SubtleCrypto, sha256 not verified`);
+    } else {
+      console.warn(`Asset '${path}' declares no sha256; contents are unverified`);
+    }
+
+    if (spec.size && Number(spec.size) !== bytes.length) {
+      console.warn(
+        `Asset '${path}': declared size ${spec.size} but received ${bytes.length} bytes`,
+      );
+    }
+    console.log(`Asset '${path}' -> ${spec.url} (${bytes.length} bytes)`);
+    // `embedded` marks this as backing fl::getEmbeddedFs(), which forces full
+    // load before setup() -- see the ordering below. The size is the real byte
+    // count, so the completeness check downstream can never be skipped.
+    return { path, size: bytes.length, bytes, embedded: true };
   }));
   return resolved.filter(Boolean);
 }
@@ -822,9 +876,14 @@ async function fastledLoadSetupLoop(
   const processFile = async (file) => {
     let written = 0;
     try {
-      // Manifest assets arrive with their response already open (the size had
-      // to be read from its headers); local files are fetched by path.
-      const response = file.response || await fetch(file.path);
+      // Manifest assets arrive already fetched and verified, so they are
+      // injected in one shot; local files are still streamed by path.
+      if (file.bytes) {
+        jsAppendFileUint8(moduleInstance, file.path, file.bytes);
+        console.log(`File fetched: ${file.path}, size: ${file.bytes.length}`);
+        return file.bytes.length;
+      }
+      const response = await fetch(file.path);
       const reader = response.body.getReader();
 
       console.log(`File fetched: ${file.path}, size: ${file.size}`);
@@ -910,7 +969,10 @@ async function fastledLoadSetupLoop(
   // bytes that are never coming, with nothing in the log to explain it.
   const embeddedResults = await Promise.all(embeddedFiles.map(async (file) => {
     const written = await processFile(file);
-    const complete = file.size === 0 || written === file.size;
+    // No `size === 0` escape hatch: an embedded asset's size is the real byte
+    // count from its buffer, so the check cannot silently disable itself the
+    // way it did when the size came from a possibly-absent Content-Length.
+    const complete = written === file.size;
     if (!complete) {
       console.error(
         `Embedded asset '${file.path}' is incomplete: wrote ${written} of ${file.size} bytes. `

--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -730,6 +730,63 @@ async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
  * @param {Object} moduleInstance - The loaded WASM module instance
  * @param {Array<Object>} filesJson - Array of files to load into the virtual filesystem
  */
+/**
+ * Resolves `window.fastledAssetManifest` entries into virtual-filesystem
+ * entries (FastLED issue #2284).
+ *
+ * A `.lnk` / `assets.json` asset lives at a remote URL and has no local file,
+ * so `files.json` cannot list it -- for a sketch whose only asset is a `.lnk`,
+ * `files.json` is literally `[]`. Until now the manifest was used only to hand
+ * C++ a URL to stream; nothing put the bytes into the filesystem. That left
+ * `fl::getEmbeddedFs()` with nothing to read, so a sketch written against ESP
+ * LittleFS could not be previewed in the browser -- the one platform whose job
+ * is to imitate the device was the one that could not.
+ *
+ * The fetch happens here rather than in `processFile` because
+ * `fastled_declare_files` needs a size before any streaming starts, and a
+ * remote asset's size is only known from its response. Issuing the request and
+ * reading `Content-Length` off the headers costs no extra round trip: the body
+ * is handed back and streamed by the normal path.
+ *
+ * A failed asset is skipped with a warning rather than aborting the load. One
+ * unreachable URL should not stop a sketch whose other assets are fine.
+ *
+ * @param {Object} manifest - path -> {url, sha256, fallback, size?}
+ * @returns {Promise<Array<Object>>} records shaped like `files.json` entries,
+ *   each carrying its already-open `response` for streaming.
+ */
+async function resolveManifestAssets(manifest) {
+  const entries = Object.entries(manifest || {});
+  if (entries.length === 0) return [];
+
+  const resolved = await Promise.all(entries.map(async ([path, spec]) => {
+    const url = spec && spec.url;
+    if (!url) {
+      console.warn(`Asset '${path}' has no url; skipping`);
+      return null;
+    }
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        console.warn(`Asset '${path}' fetch failed (${response.status}) from ${url}`);
+        return null;
+      }
+      // Prefer a size the declaration stated; fall back to the response.
+      const declared = Number(spec.size)
+        || Number(response.headers.get('content-length'))
+        || 0;
+      console.log(`Asset '${path}' -> ${url} (${declared} bytes)`);
+      // `embedded` marks this as backing fl::getEmbeddedFs(), which forces
+      // full load before setup() -- see the ordering below.
+      return { path, size: declared, response, embedded: true };
+    } catch (err) {
+      console.warn(`Asset '${path}' fetch threw:`, err);
+      return null;
+    }
+  }));
+  return resolved.filter(Boolean);
+}
+
 async function fastledLoadSetupLoop(
   frame_rate,
   moduleInstance,
@@ -737,20 +794,37 @@ async function fastledLoadSetupLoop(
 ) {
   console.log('Calling setup function...');
 
+  // Remote assets become filesystem entries alongside the local ones, so
+  // everything downstream -- declaration, streaming, fl::FileSystem -- treats
+  // them identically and neither C++ nor the loader needs to know the
+  // difference.
+  const manifestFiles = await resolveManifestAssets((window as any).fastledAssetManifest);
+  if (manifestFiles.length > 0) {
+    console.log(`Injecting ${manifestFiles.length} manifest asset(s) into the filesystem`);
+    filesJson = (filesJson || []).concat(manifestFiles);
+  }
+
   const fileManifest = getFileManifestJson(filesJson, frame_rate);
   moduleInstance.cwrap('fastled_declare_files', null, ['string'])(JSON.stringify(fileManifest));
   console.log('Files JSON:', filesJson);
 
   /**
-   * Processes a single file by streaming it to the WASM module
-   * @async
-   * @param {Object} file - File object with path and data
-   * @param {string} file.path - File path in the virtual filesystem
-   * @param {number} file.size - File size in bytes
+   * Streams one file into the WASM filesystem.
+   *
+   * Returns the number of bytes actually written so the caller can verify a
+   * file arrived whole. A short read is otherwise invisible: `FileData` keeps
+   * the declared capacity, so `is_eof()` stays false while `read()` returns 0,
+   * and a sketch waits forever on bytes that are never coming.
+   *
+   * @param {Object} file - {path, size, response?}
+   * @returns {Promise<number>} bytes written
    */
   const processFile = async (file) => {
+    let written = 0;
     try {
-      const response = await fetch(file.path);
+      // Manifest assets arrive with their response already open (the size had
+      // to be read from its headers); local files are fetched by path.
+      const response = file.response || await fetch(file.path);
       const reader = response.body.getReader();
 
       console.log(`File fetched: ${file.path}, size: ${file.size}`);
@@ -761,10 +835,12 @@ async function fastledLoadSetupLoop(
         if (done) break;
         // Allocate and copy chunk data
         jsAppendFileUint8(moduleInstance, file.path, value);
+        written += value.length;
       }
     } catch (error) {
       console.error(`Error processing file ${file.path}:`, error);
     }
+    return written;
   };
 
   /**
@@ -801,14 +877,51 @@ async function fastledLoadSetupLoop(
     console.log('FastLED Event System ready with stats:', fastLEDEvents.getEventStats());
   }
 
-  // Come back to this later - we want to partition the files into immediate and streaming files
-  // so that large projects don't try to download ALL the large files BEFORE setup/loop is called.
-  const [immediateFiles, streamingFiles] = partition(filesJson, ['.json', '.csv', '.txt', '.cfg']);
+  // Assets declared through the manifest back `fl::getEmbeddedFs()`, which on
+  // a device is LittleFS -- and on a device those files are simply *there*
+  // when setup() runs. Streaming them during loop() would make the browser
+  // diverge from the hardware in the way that matters most: a sketch reading
+  // an asset in setup() would see an empty file in the preview and a complete
+  // one on an ESP32, and the preview would be quietly lying.
+  //
+  // So embedded assets are always immediate and always awaited to completion,
+  // regardless of extension or size. The extension-based partition below still
+  // governs ordinary `files.json` entries, where streaming is a deliberate
+  // trade for startup latency on large sketch data.
+  const embeddedFiles = filesJson.filter((f) => f.embedded);
+  const localFiles = filesJson.filter((f) => !f.embedded);
+
+  const [immediateFiles, streamingFiles] = partition(localFiles, ['.json', '.csv', '.txt', '.cfg']);
+  if (embeddedFiles.length > 0) {
+    console.log(
+      'Embedded filesystem assets loaded fully before setup() (LittleFS parity):',
+      embeddedFiles.map((f) => f.path),
+    );
+  }
   console.log(
     'The following files will be immediatly available and can be read during setup():',
     immediateFiles,
   );
   console.log('The following files will be streamed in during loop():', streamingFiles);
+
+  // Embedded assets must be whole before setup(), and verified whole: a
+  // truncated download leaves FileData with its declared capacity intact, so
+  // is_eof() stays false while read() returns 0 -- a sketch would block on
+  // bytes that are never coming, with nothing in the log to explain it.
+  const embeddedResults = await Promise.all(embeddedFiles.map(async (file) => {
+    const written = await processFile(file);
+    const complete = file.size === 0 || written === file.size;
+    if (!complete) {
+      console.error(
+        `Embedded asset '${file.path}' is incomplete: wrote ${written} of ${file.size} bytes. `
+        + 'The filesystem will report the declared size while reads return nothing.',
+      );
+    }
+    return complete;
+  }));
+  if (embeddedFiles.length > 0 && embeddedResults.every(Boolean)) {
+    console.log(`All ${embeddedFiles.length} embedded asset(s) loaded completely before setup().`);
+  }
 
   const promiseImmediateFiles = fetchAllFiles(immediateFiles, () => {
     if (immediateFiles.length !== 0) {

--- a/src/platforms/wasm/fs/embedded_fs_wasm.hpp
+++ b/src/platforms/wasm/fs/embedded_fs_wasm.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file platforms/wasm/fs/embedded_fs_wasm.hpp
+/// @brief Browser-VFS fragment backing `fl::getEmbeddedFs()` on WASM.
+///
+/// The point is simulation. A sketch written against ESP on-chip flash --
+/// `fs.begin(fl::getEmbeddedFs())` -- should run unmodified in the web
+/// preview, so the browser stands in for LittleFS. Without this the WASM
+/// build fell through to the no-op fragment and `getEmbeddedFs()` returned
+/// null, which is backwards for a simulator: the platform whose whole job is
+/// to imitate the device was the one platform that could not.
+///
+/// It returns the same `FsImplWasm` that `make_sdcard_filesystem()` returns,
+/// deliberately. There is exactly one filesystem in the browser -- files
+/// injected from JS into a shared `FileRegistry` -- so "embedded flash" and
+/// "SD card" are two names for it here. Handing back the same backend means a
+/// sketch that opens an asset through either API sees the same bytes, which is
+/// what makes swapping the storage target a build-time decision rather than a
+/// code change.
+///
+/// A plain header, not a `.cpp.hpp`: it composes into whichever translation
+/// unit includes it, keeping the backend inside `fl.fs.embedded+.cpp.o` so it
+/// still drops out when a sketch never asks for embedded storage. Same shape
+/// as the ESP fragment beside it.
+
+#include "fl/stl/compiler_control.h"
+#include "fl/fs/fs.h"
+#include "platforms/wasm/fs_wasm.h"
+
+namespace fl {
+namespace platforms {
+
+inline FsImplPtr makeEmbeddedFs(bool format_on_fail) FL_NO_EXCEPT {
+    // Nothing to format: the browser VFS is populated by the loader before
+    // the sketch runs, and a failed mount is not a state it can reach.
+    FASTLED_UNUSED(format_on_fail);
+    // cs_pin is meaningless here -- FsImplWasm ignores it. Passing 0 rather
+    // than inventing a second factory keeps one backend and one registry.
+    return fl::make_sdcard_filesystem(0);
+}
+
+} // namespace platforms
+} // namespace fl


### PR DESCRIPTION
Fixes every sub-issue of #4027 — an adversarial pass over work landed earlier in the same session. Every defect here is one I introduced or left behind.

## The pattern

**Four of six were half-finished fixes**: the first half implemented, tested and reported done, while the symmetric second half was never checked — because the test that would have shown it was the one I had just written to pass.

## Fixed

| # | Defect |
|---|---|
| #4021 | `FASTLED_SAMD51_HW_SPI` violated the `FL_` macro standard and was already on master |
| #4022 | ESP32 SPI defaults still landed on GPIO 1 (`U0TXD`) — only the clockless half was fixed |
| #4023 | Embedded asset fetch had no timeout, so a stalled URL hung `setup()` forever |
| #4024 | Completeness check disabled itself when size was unknown |
| #4025 | Declared `sha256`/`fallback` were parsed and ignored — assets trusted unverified |
| #4026 | `verify_wasm_assets.py` was not wired into CI |

## #4022 went wrong twice, and the second way is worth reading

The first fix took the board's own `MOSI`/`SCK` behind `#if defined(MOSI)`. Sound reasoning, dead implementation: across the ESP32 core's **398 variants**, `MOSI` is declared `static const uint8_t` and **never** as a macro. The guard is always false, so it silently selected a `4/4` fallback — data and clock on the same pin.

It compiled. `esp32dev` and `samd51j` both passed against it. That is exactly why "it builds" was never sufficient evidence here.

Checking the variant headers also turned up **7 variants setting `MOSI = -1`** (→ 255), which would have failed `validpin()` outright.

Replaced with explicit per-variant pins, each pair outside that variant's `FASTLED_UNUSABLE_PIN_MASK`, not its UART, not a strapping pin:

| variant | data | clock |
|---|---|---|
| classic / unrecognised | 23 | 18 |
| S2 | 35 | 36 |
| S3 | 11 | 12 |
| C3 / C2 / C5 | 7 | 6 |
| C6 | 19 | 18 |
| H2 | 11 | 10 |
| P4 | 23 | 22 |

Verified by macro **expansion**, not `-dM` — which prints definitions, not values, and my first check was reading the wrong output.

## One change fixed three WASM defects

Buffering embedded assets rather than streaming them was the right primitive. They must be whole before `setup()` regardless, so holding the bytes yields an **exact length** without depending on `Content-Length` (#4024) and lets the digest be checked before injection (#4025), while `AbortSignal.timeout` plus `fallback` bounds the wait (#4023). A failed asset is dropped with an error so the sketch still starts — a preview that never runs tells the user less than one that runs with a missing file and says so.

## Verification

- `Blink` **and** `Apa102` compile for `esp32dev`, `esp32c3`, `samd51j` — the two-example sweep whose absence let #4022 through.
- `verify_wasm_assets.py`: **9/9** against a live headless page, including `sha256 verified` and positional proof that completion precedes `setup()`.
- `bash lint` clean.

`esp32s3` could not be built locally: fbuild's daemon failed to start across repeated attempts (`daemon did not become healthy after 3 spawn attempts`), unrelated to this change. Its pins are covered by expansion but not by a compile — stating that rather than implying full coverage.

Closes #4021, #4022, #4023, #4024, #4025, #4026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable WASM asset loading with fallback handling, SHA-256 verification, size checks, and complete loading before application startup.
  * Added embedded filesystem support for WASM, allowing browser-based applications to access packaged storage.
  * Added automatic default SPI pin settings across supported ESP32 variants while preserving custom configurations.

* **Bug Fixes**
  * Improved platform configuration consistency for SAMD51 SPI hardware support.

* **Tests**
  * Added end-to-end browser validation for WASM asset delivery and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->