### PR TITLE
fix(autoresearch): resolve fbuild release firmware

### DIFF
--- a/ci/autoresearch/build_driver.py
+++ b/ci/autoresearch/build_driver.py
@@ -95,7 +95,16 @@ class FbuildDriver:
         )
 
     def firmware_path(self, build_dir: Path, environment: str) -> Path:
-        return build_dir / ".fbuild" / "build" / environment / "firmware.bin"
+        fbuild_root = build_dir / ".fbuild" / "build"
+        release_firmware = fbuild_root / "release" / "firmware.bin"
+        if release_firmware.is_file():
+            return release_firmware
+
+        environment_firmware = fbuild_root / environment / "release" / "firmware.bin"
+        if environment_firmware.is_file():
+            return environment_firmware
+
+        return release_firmware
 
 
 class PlatformIODriver:

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -84,6 +84,26 @@ def test_autoresearch_fbuild_install_packages_does_not_call_platformio(
     assert FbuildDriver().install_packages(Path("."), "esp32s3") is True
 
 
+def test_autoresearch_fbuild_firmware_path_uses_release_artifact(
+    tmp_path: Path,
+) -> None:
+    firmware = tmp_path / ".fbuild" / "build" / "release" / "firmware.bin"
+    firmware.parent.mkdir(parents=True)
+    firmware.touch()
+
+    assert FbuildDriver().firmware_path(tmp_path, "rp2350w") == firmware
+
+
+def test_autoresearch_fbuild_firmware_path_supports_environment_release(
+    tmp_path: Path,
+) -> None:
+    firmware = tmp_path / ".fbuild" / "build" / "rp2350w" / "release" / "firmware.bin"
+    firmware.parent.mkdir(parents=True)
+    firmware.touch()
+
+    assert FbuildDriver().firmware_path(tmp_path, "rp2350w") == firmware
+
+
 def test_autoresearch_parse_args_warns_for_deprecated_fbuild_flags(
     capsys: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
## Summary

- resolve AutoResearch firmware from fbuild's current `.fbuild/build/release/firmware.bin` layout
- retain support for the environment-scoped `.fbuild/build/<env>/release/firmware.bin` layout
- add regression coverage for both artifact layouts

## Validation

- `uv run pytest ci/tests/test_fbuild_default_selection.py ci/tests/test_ota_peer_hardening.py ci/tests/test_autoresearch_phases.py -q` — 205 passed
- `bash lint ci/autoresearch/build_driver.py ci/tests/test_fbuild_default_selection.py` — passed
- `/clud-review` — clean
- `fbuild port scan` — RP2350W COM18 and ESP32-C6 COM9 healthy
- `bash autoresearch rp2350w --net-peer --ota --upload-port COM18 --peer-environment esp32c6 --peer-upload-port COM9 --timeout 120s --skip-lint` — cleared the previous missing-firmware failure, accepted the artifact, and reached OTA RPC execution

## Remaining HIL result

The peer run now proceeds through `beginOtaArtifact`, then the ESP32-C6 times out on response ID 3 at the first `writeOtaArtifact` chunk. That later transport/storage failure is separate from this path-resolution fix.

Relates #3956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware artifact discovery to support both standard release and environment-specific release layouts.
  * Added fallback handling when the preferred firmware location is unavailable.

* **Tests**
  * Added coverage for default and environment-specific firmware release paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->