### PR TITLE
fix(samd51): avoid incompatible Arduino I2S

### DIFF
--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -65,3 +65,27 @@
 - [x] Compile the WASM example and launch its local preview.
 - [x] Review and push the FastLED PR.
 - [x] Gate HydroPack launches on calibrated SPL and stable musical tempo.
+
+## SAMD51 unused Arduino I2S compile regression (#4030)
+
+- [x] Capture an unmasked SAMD51 RED build from current master.
+- [x] Add focused source-selection regression coverage.
+- [x] Exclude incompatible generic Arduino I2S on SAMD51 in source.
+- [x] Remove SAMD51-only CI `I2S` masks.
+- [x] Run focused tests, lint, the C++ suite, and all three SAMD51 board builds.
+- [x] Run the pre-push review gate.
+- [ ] Push a PR, drive checks/reviews green, merge, and verify master/issue state.
+
+### Review
+
+- RED: unmasked Metro M4 Blink/Apa102 both failed while preprocessing
+  `fl.audio+.cpp`, with SAMD51's `I2S` register macro expanded as a header name.
+- GREEN: the poisoned-header guard test passes; Metro M4, Feather M4, and
+  Grand Central M4 compile Blink/Apa102 without masks; SAMD21, Uno, and ESP32
+  Blink compile; full lint passes; all 284 native unit tests and 84 host
+  examples pass.
+- The full Python suite improved from 1037 to 1038 passes after the source fix;
+  its two remaining failures are unchanged WASM-path and QEMU-fixture failures
+  unrelated to this diff. The focused I2S guard selection passes independently.
+- The one-agent pre-push review is clean after improving failed-preprocessor
+  diagnostics with platform and exit-code context.

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1540,10 +1540,6 @@ SAMD51J19A_FEATHER_M4 = Board(
     real_board_name="adafruit_feather_m4",
     platform="atmelsam",
     framework="arduino",
-    lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
-    defines=[
-        "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
-    ],
 )
 
 SAMD51P20A_GRANDCENTRAL = Board(
@@ -1551,10 +1547,6 @@ SAMD51P20A_GRANDCENTRAL = Board(
     real_board_name="adafruit_grand_central_m4",
     platform="atmelsam",
     framework="arduino",
-    lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
-    defines=[
-        "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
-    ],
 )
 
 # Builds with ADAFRUIT_METRO_M4_EXPRESS defined, which is the only SAMD51 board
@@ -1564,10 +1556,6 @@ SAMD51J19A_METRO_M4 = Board(
     real_board_name="adafruit_metro_m4",
     platform="atmelsam",
     framework="arduino",
-    lib_ignore=["I2S"],  # I2S library has SAMD51 compatibility issues
-    defines=[
-        "FASTLED_USES_ARDUINO_AUDIO_INPUT=0",  # Disable Arduino audio (I2S not available)
-    ],
 )
 
 # Teknic ClearCore (Microchip SAME53N19A, Cortex-M4F @ 120 MHz).

--- a/ci/tests/test_renesas_i2s_include_guard.py
+++ b/ci/tests/test_renesas_i2s_include_guard.py
@@ -1,18 +1,20 @@
-"""Regression test for Renesas boards with an unusable Arduino I2S header."""
+"""Regression tests for boards with an unusable Arduino I2S header."""
 
 from __future__ import annotations
 
 import shutil
-import subprocess
 from pathlib import Path
 
 import pytest
+from running_process import RunningProcess
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_renesas_guard_skips_poisonous_i2s_header(tmp_path: Path) -> None:
+def _assert_guard_skips_poisonous_i2s_header(
+    tmp_path: Path, platform: str, define: str
+) -> None:
     compiler = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
     if compiler is None:
         pytest.skip("No C++ preprocessor is available")
@@ -21,33 +23,50 @@ def test_renesas_guard_skips_poisonous_i2s_header(tmp_path: Path) -> None:
     include_dir.mkdir()
     (include_dir / "Arduino.h").write_text("#pragma once\n", encoding="utf-8")
     (include_dir / "I2S.h").write_text(
-        '#error "Renesas I2S.h must not be included"\n',
+        f'#error "{platform} I2S.h must not be included"\n',
         encoding="utf-8",
     )
 
-    source = tmp_path / "renesas_i2s_guard.cpp"
+    source = tmp_path / f"{platform.lower()}_i2s_guard.cpp"
     source.write_text(
-        """
+        f"""
 #include "platforms/arduino/audio_input.hpp"
 
 #if ARDUINO_I2S_FULLY_SUPPORTED
-#error "Renesas I2S support must remain disabled"
+#error "{platform} generic Arduino I2S support must remain disabled"
 #endif
 """,
         encoding="utf-8",
     )
 
-    subprocess.run(
+    proc = RunningProcess.run(
         [
             compiler,
             "-E",
             "-x",
             "c++",
-            "-DARDUINO_ARCH_RENESAS",
+            f"-D{define}",
             f"-I{include_dir}",
             f"-I{PROJECT_ROOT / 'src'}",
             str(source),
         ],
-        check=True,
-        stdout=subprocess.DEVNULL,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
+    assert proc.returncode == 0, (
+        f"{platform} preprocessing failed with exit code {proc.returncode}:\n"
+        f"{proc.stdout}"
+    )
+
+
+def test_renesas_guard_skips_poisonous_i2s_header(tmp_path: Path) -> None:
+    _assert_guard_skips_poisonous_i2s_header(
+        tmp_path, "Renesas", "ARDUINO_ARCH_RENESAS"
+    )
+
+
+def test_samd51_guard_skips_poisonous_i2s_header(tmp_path: Path) -> None:
+    """#4030: SAMD51 must not include Adafruit's incompatible I2S library."""
+    _assert_guard_skips_poisonous_i2s_header(tmp_path, "SAMD51", "__SAMD51J19A__")

--- a/src/platforms/arduino/audio_input.hpp
+++ b/src/platforms/arduino/audio_input.hpp
@@ -31,6 +31,9 @@
 #elif defined(FL_IS_SAMD21)
 #define ARDUINO_I2S_FULLY_SUPPORTED 0
 #define ARDUINO_I2S_BROKEN_REASON "I2S not supported on SAMD21"
+#elif defined(FL_IS_SAMD51)
+#define ARDUINO_I2S_FULLY_SUPPORTED 0
+#define ARDUINO_I2S_BROKEN_REASON "Arduino I2S library is incompatible with SAMD51"
 #elif FL_HAS_INCLUDE(<I2S.h>)
 // IWYU pragma: begin_keep
 #include <I2S.h>


### PR DESCRIPTION
## Summary

- stop SAMD51 from probing Adafruit's incompatible generic Arduino `I2S.h`
- remove the `I2S` exclusion and `FASTLED_USES_ARDUINO_AUDIO_INPUT=0` masks from all SAMD51 CI boards
- extend the poisoned-header preprocessor regression test to cover SAMD51 while migrating it to `RunningProcess`

Fixes #4030.

## RED -> GREEN evidence

RED on current master after removing only the board masks:

```text
bash compile metro_m4 --examples Blink,Apa102
cc1plus.exe: fatal error: .../variants/metro_m4/((I2s *)0x43002800UL).h: Invalid argument
FAILED: Blink
FAILED: Apa102
```

The SAMD51 CMSIS `I2S` register macro was expanded inside the `<I2S.h>` feature probe in `fl.audio+.cpp`.

GREEN after the source guard:

- focused `i2s_include_guard` tests pass
- `bash compile metro_m4 --examples Blink,Apa102`
- `bash compile samd51j --examples Blink,Apa102`
- `bash compile samd51p --examples Blink,Apa102`
- `bash compile samd21 --examples Blink`
- `bash compile uno --examples Blink`
- `bash compile esp32dev --examples Blink`
- `bash lint`
- `bash test --cpp`: 284/284 unit tests and 84/84 host examples

The full Python suite moved from 1037 to 1038 passes when the new regression turned green. Its two remaining failures are unchanged workspace failures in the WASM-path expectation and QEMU smoke fixture, unrelated to this diff.

## Review

The required one-agent pre-push review is clean after improving failed-preprocessor diagnostic context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio input compilation issues on SAMD51 boards.
  * SAMD51 boards now safely fall back to the null audio input when Arduino I2S is incompatible.
  * Improved coverage for I2S compatibility across supported boards.
* **Tests**
  * Added regression checks for SAMD51 and Renesas board builds to prevent future I2S include failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->