### PR TITLE
feat(fled): specify and validate the video.color source-color contract

### DIFF
--- a/agents/docs/fled-format.md
+++ b/agents/docs/fled-format.md
@@ -16,3 +16,13 @@
 - `pixel_format` `0x05` is `rgb16_linear` (6 B/LED) and requires `transfer: "linear"`. Reserved values now start at `0x06`.
 - FastLED **carries and validates** this declaration; it does not yet transform pixels by it. Read side: `fl::fled::resolveVideoColor()` / `Fled::videoColor()` in `src/fl/fled/color.h`, tests in `tests/fl/fled/fled_color.cpp`.
 - The producer-side enforcement lives in ledmapper (`packages/gfx/src/render/fled-color.ts` + `tests/unit/fled-color.test.ts`). The two suites are halves of one cross-repo contract: change a rule in one and the other must move in the same change.
+
+### Adding a pixel format is a three-hop cascade
+
+FastLED has **two** `.fled` readers, and adding an enum value to one leaves the other behind:
+
+1. `src/fl/fled/detail/pixel_format.h` — the on-device C++ reader.
+2. `src/platforms/wasm/compiler/package.json` pins `@fastled/gfx` to a **released tarball** (currently `gfx-v0.1.1`), whose bundled reader carries its own bytes-per-LED table. Until that pin moves, the WASM preview rejects any format the release predates.
+3. The canonical ledmapper spec + producer.
+
+`rgb16_linear` (`0x05`) is in this state today: it resolves on device but `gfx-v0.1.1` returns `unknown-format` for it in the browser preview. That fails loudly rather than misparsing, which is why it was allowed to land — but the pin must move once ledmapper cuts a release containing the format, and the ordering is fixed: **ledmapper merge → gfx release → bump the pin here**.

--- a/agents/docs/fled-format.md
+++ b/agents/docs/fled-format.md
@@ -7,3 +7,12 @@
 - Legacy `fl::Video` remains relevant for `.rgb` and for consuming the video section inside `.fled`.
 - The container is designed to grow beyond video.
 - Roadmap sections include channels config plus MicroPython and WASM scripts so one `.fled` can carry video, screenmap, channels, and behavior.
+
+## Source color metadata (`video.color`)
+
+- `video.color` declares what the payload's numbers mean: `{primaries, transfer, matrix, range}`, four independent fields that must never be collapsed into one "BT.709" label.
+- Absent metadata resolves to the default tuple `{bt709, srgb, rgb, full}` for formats that define one; that is the historical interpretation and must keep working. Only a declaration that is *present and invalid* is rejected.
+- Key inheritance is scoped to formats with a default tuple (the display-encoded RGB family plus `rgb16_linear`). `gray8`/`rgbw8` are all-or-nothing — this is what stops a future YCbCr format from silently inheriting `matrix: "rgb"`.
+- `pixel_format` `0x05` is `rgb16_linear` (6 B/LED) and requires `transfer: "linear"`. Reserved values now start at `0x06`.
+- FastLED **carries and validates** this declaration; it does not yet transform pixels by it. Read side: `fl::fled::resolveVideoColor()` / `Fled::videoColor()` in `src/fl/fled/color.h`, tests in `tests/fl/fled/fled_color.cpp`.
+- The producer-side enforcement lives in ledmapper (`packages/gfx/src/render/fled-color.ts` + `tests/unit/fled-color.test.ts`). The two suites are halves of one cross-repo contract: change a rule in one and the other must move in the same change.

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -158,11 +158,29 @@ function unresolved.
 | --- | --- | --- | --- |
 | `rgb8`, `rgba8`, `rgb565le` | display-encoded RGB | `{bt709, srgb, rgb, full}` | `transfer` must be `srgb` or `bt709` |
 | `rgb16_linear` | linear-light RGB | `{bt709, linear, rgb, full}` | `transfer` must be `linear` |
-| `gray8`, `rgbw8` | no defined tuple | none | if `video.color` is present it must declare all four keys explicitly |
+| `gray8`, `rgbw8` | no defined tuple | none | `video.color` must declare all four keys; absent or partial is unresolvable |
 
 `gray8` carries no chromaticity and `rgbw8`'s white channel is a device
 primary that RGB primaries cannot describe, so neither format inherits a
-default tuple. Their color metadata is all-or-nothing.
+default tuple. Their color metadata is all-or-nothing: absent or partial
+resolves to `NoDefaultTuple`, which is *unresolvable*, not *malformed* — the
+caller decides whether it cares, rather than treating the file as corrupt.
+
+### Declaration verdicts vs. consumer policy
+
+Rejecting a *declaration* is not the same as refusing a *file*:
+
+- On the display-encoded RGB formats the declaration is **advisory**. A consumer
+  that cannot resolve it — an unrecognized name from a future minor, say — may
+  fall back to the default tuple and surface a diagnostic, so a newer reader is
+  never strictly worse than an older one on the same file.
+- On a format whose color semantics are **mandatory** (`rgb16_linear`), an
+  unresolvable declaration means the payload cannot be interpreted, and the
+  consumer must refuse rather than guess.
+
+Producers and validation tooling always take the strict reading. `resolveVideoColor()`
+reports every violation; the latitude above is a playback-consumer policy, and
+FastLED does not exercise it yet because nothing here renders from the profile.
 
 ### Validation rules
 
@@ -182,6 +200,10 @@ A conforming producer must not write, and a conforming validator must reject:
    (`gray8`, `rgbw8`) — those must be complete or absent;
 7. `video.color` present but not a JSON object, or a custom `primaries` object
    missing any of `red`/`green`/`blue`/`white` or with a malformed xy pair.
+
+An explicit JSON `null` for `video.color` is treated as **absent**, not as a
+malformed object: many serializers emit `null` for an unset optional, and
+omitting the key must not have a different outcome from nulling it.
 
 `pq` and `hlg` are reserved transfer names. They are rejected in v1: a 16-bit
 linear integer payload cannot faithfully carry PQ-decoded content, so HDR

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -47,7 +47,7 @@ truncated input.
 
 ## Pixel Format Enum
 
-Values `0x00` through `0x04` are defined for FLED v1. Values `0x05` through
+Values `0x00` through `0x05` are defined for FLED v1. Values `0x06` through
 `0xff` are reserved for future formats.
 
 | Value | Name | Bytes per LED | Payload byte order | Notes |
@@ -57,7 +57,8 @@ Values `0x00` through `0x04` are defined for FLED v1. Values `0x05` through
 | `0x02` | `rgba8` | 4 | `R, G, B, A` | 8-bit RGB plus alpha. Alpha handling is consumer-defined. |
 | `0x03` | `rgbw8` | 4 | `R, G, B, W` | 8-bit RGB plus white channel. |
 | `0x04` | `rgb565le` | 2 | little-endian RGB565 | 5 bits red, 6 bits green, 5 bits blue. |
-| `0x05`-`0xff` | reserved | variable | TBD | Reserved by ledmapper for future pixel encodings. |
+| `0x05` | `rgb16_linear` | 6 | `R, G, B` (`u16le` each) | Linear-light 16-bit RGB. Requires `transfer: "linear"`. |
+| `0x06`-`0xff` | reserved | variable | TBD | Reserved by ledmapper for future pixel encodings. |
 
 ## JSON Envelope
 
@@ -77,6 +78,8 @@ Video metadata:
 - `video.fps` may be present to declare the playback frame rate.
 - If `video.fps` is absent, consumers may use an application default, sketch
   parameter, or external playback setting.
+- `video.color` may be present to declare the source color encoding of the
+  payload. See "Source color metadata" below.
 - The raw frame payload immediately follows the JSON envelope; it is not base64
   or otherwise embedded in JSON.
 
@@ -92,10 +95,109 @@ Example envelope shape:
     }
   },
   "video": {
-    "fps": 30
+    "fps": 30,
+    "color": {
+      "primaries": "bt709",
+      "transfer": "srgb",
+      "matrix": "rgb",
+      "range": "full"
+    }
   }
 }
 ```
+
+## Source Color Metadata
+
+`video.color` describes how the payload's numbers encode color. It describes
+the **encoded payload only** — independently of LED layout, output chipset, and
+the physical emitter profile of the strip that will display it.
+
+The four fields are independent and must never be collapsed into a single
+ambiguous label such as "BT.709":
+
+| field | v1 values | meaning |
+| --- | --- | --- |
+| `primaries` | `bt709`, `display-p3`, `bt2020`, or a custom object | Chromaticities + white point. `bt709` means the BT.709/sRGB primaries with D65 white. |
+| `transfer` | `srgb`, `bt709`, `linear` | The transfer function. `srgb` is the piecewise sRGB function — it is **not** the BT.709 camera OETF and must not be approximated by an unnamed power law. |
+| `matrix` | `rgb` | Payload carries direct RGB components; the identity/no-matrix case. YCbCr coefficient values are reserved. |
+| `range` | `full` | All codes are image values: for 8-bit, `0` is black and `255` is full channel. `limited` is reserved. |
+
+A custom `primaries` object carries CIE xy pairs:
+
+```json
+"primaries": {
+  "red":   [0.640, 0.330],
+  "green": [0.300, 0.600],
+  "blue":  [0.150, 0.060],
+  "white": [0.3127, 0.3290]
+}
+```
+
+`"none"` is not a valid `transfer` value — it is ambiguous. Producers with
+genuinely linear-light samples declare `transfer: "linear"` and use a pixel
+format whose semantics permit linear data (`rgb16_linear`).
+
+### Default tuple
+
+The canonical default tuple is:
+
+```json
+{ "primaries": "bt709", "transfer": "srgb", "matrix": "rgb", "range": "full" }
+```
+
+When `video.color` is **absent**, a payload whose pixel format defines a default
+tuple is interpreted as that tuple. For the display-encoded RGB formats this
+preserves the historical interpretation of `.fled` RGB8 data. Individual missing
+keys inherit from the same tuple — but **only** for pixel formats that define
+one. Do not describe this default as merely "BT.709"; that leaves the transfer
+function unresolved.
+
+### Color classes by pixel format
+
+| pixel_format | color class | default tuple | constraints |
+| --- | --- | --- | --- |
+| `rgb8`, `rgba8`, `rgb565le` | display-encoded RGB | `{bt709, srgb, rgb, full}` | `transfer` must be `srgb` or `bt709` |
+| `rgb16_linear` | linear-light RGB | `{bt709, linear, rgb, full}` | `transfer` must be `linear` |
+| `gray8`, `rgbw8` | no defined tuple | none | if `video.color` is present it must declare all four keys explicitly |
+
+`gray8` carries no chromaticity and `rgbw8`'s white channel is a device
+primary that RGB primaries cannot describe, so neither format inherits a
+default tuple. Their color metadata is all-or-nothing.
+
+### Validation rules
+
+A conforming producer must not write, and a conforming validator must reject:
+
+1. any unrecognized value in any of the four fields — reject with a clear
+   diagnostic naming the field and value; never silently fall back;
+2. `transfer` of `linear`, `pq`, or `hlg` on a display-encoded RGB format —
+   `rgb8` is display-encoded data and must never carry linear-light samples;
+3. `rgb16_linear` with any `transfer` other than `linear`;
+4. `range: "limited"` on any v1 format — reserved for explicitly labeled
+   future/imported payloads;
+5. any `matrix` other than `rgb` in v1 — YCbCr payloads need a pixel format
+   that does not exist yet, and must then declare their coefficients
+   explicitly;
+6. a partial `video.color` on a pixel format with no default tuple
+   (`gray8`, `rgbw8`) — those must be complete or absent;
+7. `video.color` present but not a JSON object, or a custom `primaries` object
+   missing any of `red`/`green`/`blue`/`white` or with a malformed xy pair.
+
+`pq` and `hlg` are reserved transfer names. They are rejected in v1: a 16-bit
+linear integer payload cannot faithfully carry PQ-decoded content, so HDR
+transfers wait for a payload format and working domain that can.
+
+### Forward compatibility
+
+`video.color` is **advisory** for the display-encoded RGB formats. A reader
+that predates this section ignores the key and lands on exactly the default
+tuple, so old readers degrade to reduced fidelity, never to wrong data. That is
+why adding `video.color` is not a version bump.
+
+Payloads whose color semantics are **mandatory** rather than advisory gate on a
+new `pixel_format` value instead: `rgb16_linear` is meaningless without its
+declaration, and readers that predate it already reject unknown pixel formats.
+Mandatory-ness is a property of the payload format, not a version flag.
 
 ## Frame Payload
 

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -162,9 +162,10 @@ function unresolved.
 
 `gray8` carries no chromaticity and `rgbw8`'s white channel is a device
 primary that RGB primaries cannot describe, so neither format inherits a
-default tuple. Their color metadata is all-or-nothing: absent or partial
-resolves to `NoDefaultTuple`, which is *unresolvable*, not *malformed* — the
-caller decides whether it cares, rather than treating the file as corrupt.
+default tuple. Their color metadata is all-or-nothing, and the two failures are
+reported distinctly: an **absent** declaration resolves to `NoDefaultTuple`,
+a **partial** one to `IncompleteForFormat`. Neither is *malformed* — the caller
+decides whether it cares, rather than treating the file as corrupt.
 
 ### Declaration verdicts vs. consumer policy
 

--- a/src/fl/fled/_build.cpp.hpp
+++ b/src/fl/fled/_build.cpp.hpp
@@ -3,6 +3,7 @@
 
 // begin current directory includes
 #include "fl/fled/builder.cpp.hpp"
+#include "fl/fled/color.cpp.hpp"
 #include "fl/fled/fled.cpp.hpp"
 
 // begin sub directory includes

--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -1,0 +1,265 @@
+// ok no header - implementation for fl/fled/color.h.
+
+#include "fl/fled/color.h"
+
+#include "fl/fled/detail/pixel_format.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/json.h"
+#include "fl/stl/string.h"
+
+namespace fl {
+namespace fled {
+
+namespace {
+
+// Recognized transfer names. Pq/Hlg are spec-reserved: named so the
+// diagnostic can say "reserved" instead of "unrecognized", but rejected by
+// every v1 pixel format.
+enum class TransferName : fl::u8 { Srgb, Bt709, Linear, Pq, Hlg, Unrecognized };
+
+bool nameIs(const fl::string& s, const char* lit) FL_NO_EXCEPT {
+    return fl::strcmp(s.c_str(), lit) == 0;
+}
+
+TransferName parseTransferName(const fl::string& s) FL_NO_EXCEPT {
+    if (nameIs(s, "srgb"))   return TransferName::Srgb;
+    if (nameIs(s, "bt709"))  return TransferName::Bt709;
+    if (nameIs(s, "linear")) return TransferName::Linear;
+    if (nameIs(s, "pq"))     return TransferName::Pq;
+    if (nameIs(s, "hlg"))    return TransferName::Hlg;
+    return TransferName::Unrecognized;
+}
+
+// Display-encoded RGB family: rgb8, rgba8, rgb565le.
+bool isDisplayEncodedRgb(fl::u8 pf) FL_NO_EXCEPT {
+    return pf == static_cast<fl::u8>(PixelFormat::Rgb8) ||
+           pf == static_cast<fl::u8>(PixelFormat::Rgba8) ||
+           pf == static_cast<fl::u8>(PixelFormat::Rgb565Le);
+}
+
+bool isLinearRgb(fl::u8 pf) FL_NO_EXCEPT {
+    return pf == static_cast<fl::u8>(PixelFormat::Rgb16Linear);
+}
+
+// Reads one CIE xy pair: a 2-element array of numbers.
+bool readXy(const fl::json& node, float* outX, float* outY) FL_NO_EXCEPT {
+    if (!node.is_array()) return false;
+    if (!node.contains(static_cast<fl::size>(0)) ||
+        !node.contains(static_cast<fl::size>(1))) {
+        return false;
+    }
+    auto x = node[static_cast<fl::size>(0)].as_float();
+    auto y = node[static_cast<fl::size>(1)].as_float();
+    if (!x || !y) return false;
+    *outX = static_cast<float>(*x);
+    *outY = static_cast<float>(*y);
+    return true;
+}
+
+// Custom primaries object: red/green/blue/white, each a CIE xy pair.
+bool readCustomPrimaries(const fl::json& node, float* out8) FL_NO_EXCEPT {
+    static const char* const kKeys[4] = {"red", "green", "blue", "white"};
+    for (fl::size i = 0; i < 4; ++i) {
+        const fl::string key(kKeys[i]);
+        if (!node.contains(key)) return false;
+        if (!readXy(node[key], &out8[i * 2], &out8[i * 2 + 1])) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool pixelFormatHasDefaultTuple(fl::u8 pixelFormat) FL_NO_EXCEPT {
+    return isDisplayEncodedRgb(pixelFormat) || isLinearRgb(pixelFormat);
+}
+
+bool defaultVideoColor(fl::u8 pixelFormat, VideoColor* out) FL_NO_EXCEPT {
+    if (!out) return false;
+    if (!pixelFormatHasDefaultTuple(pixelFormat)) return false;
+    out->primaries = ColorPrimaries::Bt709;
+    out->transfer  = isLinearRgb(pixelFormat) ? ColorTransfer::Linear
+                                              : ColorTransfer::Srgb;
+    out->matrix    = ColorMatrix::Rgb;
+    out->range     = ColorRange::Full;
+    out->declared  = false;
+    for (fl::size i = 0; i < 8; ++i) {
+        out->customPrimaries[i] = 0.0f;
+    }
+    return true;
+}
+
+ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
+                              VideoColor* out) FL_NO_EXCEPT {
+    if (!out) return ColorStatus::NotAnObject;
+
+    const bool hasTuple = pixelFormatHasDefaultTuple(pixelFormat);
+
+    // Locate video.color without requiring either level to exist.
+    const fl::string kVideo("video");
+    const fl::string kColor("color");
+    bool present = false;
+    fl::json colorNode;
+    if (envelope.is_object() && envelope.contains(kVideo)) {
+        const fl::json videoNode = envelope[kVideo];
+        if (videoNode.is_object() && videoNode.contains(kColor)) {
+            colorNode = videoNode[kColor];
+            present = true;
+        }
+    }
+
+    if (!present) {
+        // Absent metadata: the format's default tuple is the historical
+        // interpretation. Formats without one are simply unresolvable.
+        VideoColor resolved;
+        if (!defaultVideoColor(pixelFormat, &resolved)) {
+            return ColorStatus::NoDefaultTuple;
+        }
+        *out = resolved;
+        return ColorStatus::Ok;
+    }
+
+    if (!colorNode.is_object()) {
+        return ColorStatus::NotAnObject;
+    }
+
+    const fl::string kPrimaries("primaries");
+    const fl::string kTransfer("transfer");
+    const fl::string kMatrix("matrix");
+    const fl::string kRange("range");
+
+    const bool hasP = colorNode.contains(kPrimaries);
+    const bool hasT = colorNode.contains(kTransfer);
+    const bool hasM = colorNode.contains(kMatrix);
+    const bool hasR = colorNode.contains(kRange);
+
+    // Key inheritance is scoped to formats that define a default tuple.
+    // Everything else is all-or-nothing, so a future YCbCr format can never
+    // silently inherit `matrix: rgb`.
+    if (!hasTuple && !(hasP && hasT && hasM && hasR)) {
+        return ColorStatus::IncompleteForFormat;
+    }
+
+    VideoColor resolved;
+    if (!defaultVideoColor(pixelFormat, &resolved)) {
+        // No tuple to seed from; every field is explicit here (checked above).
+        resolved.primaries = ColorPrimaries::Bt709;
+        resolved.transfer  = ColorTransfer::Srgb;
+        resolved.matrix    = ColorMatrix::Rgb;
+        resolved.range     = ColorRange::Full;
+        for (fl::size i = 0; i < 8; ++i) resolved.customPrimaries[i] = 0.0f;
+    }
+    resolved.declared = true;
+
+    // ---- primaries ----
+    if (hasP) {
+        const fl::json node = colorNode[kPrimaries];
+        if (node.is_object()) {
+            if (!readCustomPrimaries(node, resolved.customPrimaries)) {
+                return ColorStatus::MalformedCustomPrimaries;
+            }
+            resolved.primaries = ColorPrimaries::Custom;
+        } else if (node.is_string()) {
+            auto s = node.as_string();
+            if (!s) return ColorStatus::UnknownPrimaries;
+            if (nameIs(*s, "bt709"))            resolved.primaries = ColorPrimaries::Bt709;
+            else if (nameIs(*s, "display-p3"))  resolved.primaries = ColorPrimaries::DisplayP3;
+            else if (nameIs(*s, "bt2020"))      resolved.primaries = ColorPrimaries::Bt2020;
+            else return ColorStatus::UnknownPrimaries;
+        } else {
+            return ColorStatus::UnknownPrimaries;
+        }
+    }
+
+    // ---- transfer ----
+    if (hasT) {
+        const fl::json node = colorNode[kTransfer];
+        if (!node.is_string()) return ColorStatus::UnknownTransfer;
+        auto s = node.as_string();
+        if (!s) return ColorStatus::UnknownTransfer;
+        switch (parseTransferName(*s)) {
+        case TransferName::Srgb:   resolved.transfer = ColorTransfer::Srgb;   break;
+        case TransferName::Bt709:  resolved.transfer = ColorTransfer::Bt709;  break;
+        case TransferName::Linear: resolved.transfer = ColorTransfer::Linear; break;
+        case TransferName::Pq:
+        case TransferName::Hlg:
+            // Reserved names: no v1 payload format can carry them.
+            return ColorStatus::TransferConflictsWithFormat;
+        case TransferName::Unrecognized:
+            return ColorStatus::UnknownTransfer;
+        }
+    }
+
+    // Transfer must agree with what the pixel format's bytes actually hold.
+    if (isDisplayEncodedRgb(pixelFormat) &&
+        resolved.transfer == ColorTransfer::Linear) {
+        return ColorStatus::TransferConflictsWithFormat;
+    }
+    if (isLinearRgb(pixelFormat) && resolved.transfer != ColorTransfer::Linear) {
+        return ColorStatus::TransferConflictsWithFormat;
+    }
+
+    // ---- matrix ----
+    if (hasM) {
+        const fl::json node = colorNode[kMatrix];
+        if (!node.is_string()) return ColorStatus::UnknownMatrix;
+        auto s = node.as_string();
+        if (!s) return ColorStatus::UnknownMatrix;
+        if (!nameIs(*s, "rgb")) {
+            // Recognized-but-reserved (ycbcr coefficient sets) and outright
+            // unknown both land here: v1 defines only the identity case.
+            return ColorStatus::MatrixUnsupported;
+        }
+        resolved.matrix = ColorMatrix::Rgb;
+    }
+
+    // ---- range ----
+    if (hasR) {
+        const fl::json node = colorNode[kRange];
+        if (!node.is_string()) return ColorStatus::UnknownRange;
+        auto s = node.as_string();
+        if (!s) return ColorStatus::UnknownRange;
+        if (nameIs(*s, "full")) {
+            resolved.range = ColorRange::Full;
+        } else if (nameIs(*s, "limited")) {
+            return ColorStatus::LimitedRangeUnsupported;
+        } else {
+            return ColorStatus::UnknownRange;
+        }
+    }
+
+    *out = resolved;
+    return ColorStatus::Ok;
+}
+
+const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT {
+    switch (status) {
+    case ColorStatus::Ok:
+        return "ok";
+    case ColorStatus::NoDefaultTuple:
+        return "video.color is absent and this pixel_format defines no default color tuple";
+    case ColorStatus::NotAnObject:
+        return "video.color must be a JSON object";
+    case ColorStatus::UnknownPrimaries:
+        return "video.color.primaries is not a recognized name or custom xy object";
+    case ColorStatus::UnknownTransfer:
+        return "video.color.transfer is not a recognized transfer function";
+    case ColorStatus::UnknownMatrix:
+        return "video.color.matrix is not a recognized value";
+    case ColorStatus::UnknownRange:
+        return "video.color.range is not a recognized value";
+    case ColorStatus::TransferConflictsWithFormat:
+        return "video.color.transfer conflicts with the header pixel_format";
+    case ColorStatus::LimitedRangeUnsupported:
+        return "video.color.range \"limited\" is reserved and unsupported in v1";
+    case ColorStatus::MatrixUnsupported:
+        return "video.color.matrix values other than \"rgb\" are reserved in v1";
+    case ColorStatus::IncompleteForFormat:
+        return "this pixel_format defines no default tuple: video.color must declare all four keys or be absent";
+    case ColorStatus::MalformedCustomPrimaries:
+        return "video.color.primaries object needs red/green/blue/white CIE xy pairs";
+    }
+    return "unknown color status";
+}
+
+}  // namespace fled
+}  // namespace fl

--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -59,10 +59,10 @@ bool isLinearRgb(fl::u8 pf) FL_NO_EXCEPT {
 // Reads one CIE xy pair: a 2-element array of numbers.
 bool readXy(const fl::json& node, float* outX, float* outY) FL_NO_EXCEPT {
     if (!node.is_array()) return false;
-    if (!node.contains(static_cast<fl::size>(0)) ||
-        !node.contains(static_cast<fl::size>(1))) {
-        return false;
-    }
+    // Exactly two, not at least two: [0.64, 0.33, 1] would otherwise resolve
+    // while silently dropping the third item. ledmapper's validator already
+    // requires exactly two, and the two must agree.
+    if (node.size() != 2) return false;
     auto x = node[static_cast<fl::size>(0)].as_float();
     auto y = node[static_cast<fl::size>(1)].as_float();
     if (!x || !y) return false;

--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -30,6 +30,21 @@ TransferName parseTransferName(const fl::string& s) FL_NO_EXCEPT {
     return TransferName::Unrecognized;
 }
 
+// Matrix names that standard video metadata defines but that v1 reserves:
+// they describe YCbCr coefficient sets, and no v1 pixel format carries YCbCr.
+// Distinguished from outright-unknown values so the diagnostic can say
+// "reserved" (look it up in the spec) rather than "unrecognized" (you typoed).
+bool isReservedMatrixName(const fl::string& s) FL_NO_EXCEPT {
+    static const char* const kReserved[] = {
+        "bt709", "bt601", "bt470bg", "smpte170m", "bt2020ncl", "bt2020cl",
+        "ycbcr", "ycgco", "fcc",
+    };
+    for (fl::size i = 0; i < sizeof(kReserved) / sizeof(kReserved[0]); ++i) {
+        if (nameIs(s, kReserved[i])) return true;
+    }
+    return false;
+}
+
 // Display-encoded RGB family: rgb8, rgba8, rgb565le.
 bool isDisplayEncodedRgb(fl::u8 pf) FL_NO_EXCEPT {
     return pf == static_cast<fl::u8>(PixelFormat::Rgb8) ||
@@ -90,7 +105,7 @@ bool defaultVideoColor(fl::u8 pixelFormat, VideoColor* out) FL_NO_EXCEPT {
 
 ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
                               VideoColor* out) FL_NO_EXCEPT {
-    if (!out) return ColorStatus::NotAnObject;
+    if (!out) return ColorStatus::NullOutput;
 
     const bool hasTuple = pixelFormatHasDefaultTuple(pixelFormat);
 
@@ -103,7 +118,10 @@ ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
         const fl::json videoNode = envelope[kVideo];
         if (videoNode.is_object() && videoNode.contains(kColor)) {
             colorNode = videoNode[kColor];
-            present = true;
+            // An explicit JSON null means "not set" for most serializers.
+            // Treat it as absent rather than rejecting the file - omitting
+            // the key and nulling it should not have opposite outcomes.
+            present = !colorNode.is_null();
         }
     }
 
@@ -205,9 +223,10 @@ ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
         auto s = node.as_string();
         if (!s) return ColorStatus::UnknownMatrix;
         if (!nameIs(*s, "rgb")) {
-            // Recognized-but-reserved (ycbcr coefficient sets) and outright
-            // unknown both land here: v1 defines only the identity case.
-            return ColorStatus::MatrixUnsupported;
+            // "reserved" sends the author to the spec; "unrecognized" tells
+            // them they typoed. Conflating the two wastes their time.
+            return isReservedMatrixName(*s) ? ColorStatus::MatrixUnsupported
+                                            : ColorStatus::UnknownMatrix;
         }
         resolved.matrix = ColorMatrix::Rgb;
     }
@@ -235,6 +254,8 @@ const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT {
     switch (status) {
     case ColorStatus::Ok:
         return "ok";
+    case ColorStatus::NullOutput:
+        return "resolveVideoColor called with a null out-pointer";
     case ColorStatus::NoDefaultTuple:
         return "video.color is absent and this pixel_format defines no default color tuple";
     case ColorStatus::NotAnObject:

--- a/src/fl/fled/color.h
+++ b/src/fl/fled/color.h
@@ -51,6 +51,9 @@ enum class ColorRange : fl::u8 {
 // diagnostic rather than a silent fallback.
 enum class ColorStatus : fl::u8 {
     Ok = 0,
+    // Caller passed a null out-pointer. API misuse, not a bad file - kept
+    // distinct so a diagnostic never sends someone hunting a valid envelope.
+    NullOutput,
     // `video.color` absent on a pixel format that defines no default tuple
     // (gray8, rgbw8). Not malformed - just undeclared, and unresolvable.
     NoDefaultTuple,

--- a/src/fl/fled/color.h
+++ b/src/fl/fled/color.h
@@ -1,0 +1,112 @@
+#pragma once
+
+// Source color metadata for the .fled v1 container - the `video.color`
+// envelope block. See FLED_FORMAT.md "Source Color Metadata" for the
+// canonical contract (the authority is the ledmapper spec that file mirrors).
+//
+// This layer only CARRIES and VALIDATES the declaration. Nothing here feeds
+// the render path: FastLED does not yet transform pixels according to the
+// declared source profile. Reading a .fled tells you what its numbers mean;
+// acting on that is the color-pipeline work tracked separately.
+
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+class json;
+
+namespace fled {
+
+// Chromaticities + white point of the source. Custom carries explicit CIE xy
+// pairs in VideoColor::customPrimaries.
+enum class ColorPrimaries : fl::u8 {
+    Bt709 = 0,   // BT.709 / sRGB primaries, D65 white
+    DisplayP3,
+    Bt2020,
+    Custom,
+};
+
+// Transfer function. `Srgb` is the piecewise sRGB function, NOT the BT.709
+// camera OETF - the spec keeps them distinct on purpose.
+enum class ColorTransfer : fl::u8 {
+    Srgb = 0,
+    Bt709,
+    Linear,
+};
+
+// Component encoding. v1 defines only the identity (direct RGB) case;
+// YCbCr coefficient sets are reserved for a pixel format that can carry them.
+enum class ColorMatrix : fl::u8 {
+    Rgb = 0,
+};
+
+// Code range. v1 defines only full range; `limited` is reserved.
+enum class ColorRange : fl::u8 {
+    Full = 0,
+};
+
+// Outcome of resolving `video.color` against the header's pixel_format.
+// Every non-Ok value is a rejection: FLED_FORMAT.md requires a clear
+// diagnostic rather than a silent fallback.
+enum class ColorStatus : fl::u8 {
+    Ok = 0,
+    // `video.color` absent on a pixel format that defines no default tuple
+    // (gray8, rgbw8). Not malformed - just undeclared, and unresolvable.
+    NoDefaultTuple,
+    // `video.color` present but not a JSON object.
+    NotAnObject,
+    UnknownPrimaries,
+    UnknownTransfer,
+    UnknownMatrix,
+    UnknownRange,
+    // Rules 2/3: display-encoded formats reject linear/pq/hlg;
+    // rgb16_linear rejects anything but linear.
+    TransferConflictsWithFormat,
+    // Rule 4: `range: "limited"` is reserved in v1.
+    LimitedRangeUnsupported,
+    // Rule 5: any matrix other than `rgb` is reserved in v1.
+    MatrixUnsupported,
+    // Rule 6: gray8/rgbw8 must declare all four keys or none.
+    IncompleteForFormat,
+    // Rule 7: custom primaries object missing a key or with a malformed pair.
+    MalformedCustomPrimaries,
+};
+
+// A resolved source-color declaration. `declared` distinguishes "the file
+// said so" from "the default tuple was applied", which matters because the
+// default is a compatibility interpretation, not an author's statement.
+struct VideoColor {
+    ColorPrimaries primaries;
+    ColorTransfer  transfer;
+    ColorMatrix    matrix;
+    ColorRange     range;
+    bool           declared;
+    // Valid only when primaries == Custom. Layout:
+    // {red.x, red.y, green.x, green.y, blue.x, blue.y, white.x, white.y}
+    float          customPrimaries[8];
+};
+
+// True if `pixelFormat` defines a default color tuple (the display-encoded
+// RGB family and rgb16_linear). gray8 and rgbw8 do not: gray8 carries no
+// chromaticity and rgbw8's white is a device primary RGB cannot describe.
+bool pixelFormatHasDefaultTuple(fl::u8 pixelFormat) FL_NO_EXCEPT;
+
+// The default tuple for a pixel format, per FLED_FORMAT.md. Returns false
+// (leaving *out untouched) for formats that define none.
+bool defaultVideoColor(fl::u8 pixelFormat, VideoColor* out) FL_NO_EXCEPT;
+
+// Resolve `envelope["video"]["color"]` against the header's pixel_format,
+// applying the default tuple for absent keys where the format defines one
+// and enforcing every validation rule in FLED_FORMAT.md.
+//
+// On ColorStatus::Ok, *out holds the resolved tuple. On any other status
+// *out is left untouched and the status names the rejection reason.
+ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
+                              VideoColor* out) FL_NO_EXCEPT;
+
+// Stable human-readable text for a status, for diagnostics. Never null.
+const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT;
+
+}  // namespace fled
+}  // namespace fl

--- a/src/fl/fled/detail/pixel_format.cpp.hpp
+++ b/src/fl/fled/detail/pixel_format.cpp.hpp
@@ -12,6 +12,7 @@ fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT {
     case static_cast<fl::u8>(PixelFormat::Rgba8):    return 4;
     case static_cast<fl::u8>(PixelFormat::Rgbw8):    return 4;
     case static_cast<fl::u8>(PixelFormat::Rgb565Le): return 2;
+    case static_cast<fl::u8>(PixelFormat::Rgb16Linear): return 6;
     default:                                         return 0;
     }
 }

--- a/src/fl/fled/detail/pixel_format.h
+++ b/src/fl/fled/detail/pixel_format.h
@@ -11,15 +11,16 @@ namespace fl {
 namespace fled {
 
 enum class PixelFormat : fl::u8 {
-    Rgb8     = 0x00,  // 3 bpp - R, G, B
-    Gray8    = 0x01,  // 1 bpp - Y
-    Rgba8    = 0x02,  // 4 bpp - R, G, B, A
-    Rgbw8    = 0x03,  // 4 bpp - R, G, B, W
-    Rgb565Le = 0x04,  // 2 bpp - little-endian RGB565
+    Rgb8        = 0x00,  // 3 bpp - R, G, B
+    Gray8       = 0x01,  // 1 bpp - Y
+    Rgba8       = 0x02,  // 4 bpp - R, G, B, A
+    Rgbw8       = 0x03,  // 4 bpp - R, G, B, W
+    Rgb565Le    = 0x04,  // 2 bpp - little-endian RGB565
+    Rgb16Linear = 0x05,  // 6 bpp - R, G, B as u16le, linear light
 };
 
 // Returns the bytes-per-LED for a v1 pixel-format byte.
-// Returns 0 for unknown / reserved formats (0x05 - 0xff) - callers should
+// Returns 0 for unknown / reserved formats (0x06 - 0xff) - callers should
 // treat 0 as "consumer does not support this pixel_format" and reject
 // before reading frame bytes per FLED_FORMAT.md.
 fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT;

--- a/src/fl/fled/fled.cpp.hpp
+++ b/src/fl/fled/fled.cpp.hpp
@@ -133,7 +133,7 @@ float Fled::videoFps(float defaultFps) const FL_NO_EXCEPT {
 }
 
 fled::ColorStatus Fled::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
-    if (!out) return fled::ColorStatus::NotAnObject;
+    if (!out) return fled::ColorStatus::NullOutput;
     if (!mImpl) {
         // Null bundle: no envelope, no header. Resolve as an undeclared
         // rgb8 payload so callers get the historical default tuple.

--- a/src/fl/fled/fled.cpp.hpp
+++ b/src/fl/fled/fled.cpp.hpp
@@ -132,6 +132,18 @@ float Fled::videoFps(float defaultFps) const FL_NO_EXCEPT {
     return static_cast<float>(*fpsOpt);
 }
 
+fled::ColorStatus Fled::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
+    if (!out) return fled::ColorStatus::NotAnObject;
+    if (!mImpl) {
+        // Null bundle: no envelope, no header. Resolve as an undeclared
+        // rgb8 payload so callers get the historical default tuple.
+        return fled::resolveVideoColor(nullJson(),
+                                       static_cast<fl::u8>(fled::PixelFormat::Rgb8),
+                                       out);
+    }
+    return fled::resolveVideoColor(mImpl->envelope(), pixelFormat(), out);
+}
+
 // ---- blobs ----
 
 fl::shared_ptr<const fl::u8> Fled::blob(const char *sectionName,

--- a/src/fl/fled/fled.h
+++ b/src/fl/fled/fled.h
@@ -15,6 +15,7 @@
 //     json()["video"] for metadata. No Video object is reconstructed here.
 //   - No script() accessor. Scripting is a future-v2 surface (docs only).
 
+#include "fl/fled/color.h"
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/shared_ptr.h"
@@ -59,7 +60,7 @@ class Fled {
     fl::u8 pixelFormat() const FL_NO_EXCEPT;
 
     // Bytes-per-LED for the configured pixel_format, per FLED_FORMAT.md.
-    // Returns 0 for unknown / reserved pixel formats (0x05 - 0xff) - the
+    // Returns 0 for unknown / reserved pixel formats (0x06 - 0xff) - the
     // FLED_FORMAT.md spec says consumers should reject before reading
     // frame bytes in that case.
     fl::u8 bytesPerLed() const FL_NO_EXCEPT;
@@ -79,6 +80,17 @@ class Fled {
     // "If video.fps is absent, consumers may use an application default,
     // sketch parameter, or external playback setting."
     float videoFps(float defaultFps = 30.0f) const FL_NO_EXCEPT;
+
+    // Resolves video.color against the header's pixel_format per
+    // FLED_FORMAT.md "Source Color Metadata": applies the format's default
+    // tuple for absent keys and enforces every validation rule.
+    //
+    // Returns ColorStatus::Ok with *out populated, or a status naming the
+    // rejection. A null Fled resolves as if the envelope were empty.
+    //
+    // This only reports what the file declares its numbers to mean. FastLED
+    // does not yet transform pixels according to that declaration.
+    fled::ColorStatus videoColor(fled::VideoColor *out) const FL_NO_EXCEPT;
 
     // Parsed JSON envelope. For null Fled, returns a reference to a static
     // empty json (safe to chain into).

--- a/src/platforms/wasm/fs_wasm.cpp.hpp
+++ b/src/platforms/wasm/fs_wasm.cpp.hpp
@@ -49,6 +49,7 @@
 // IWYU pragma: end_keep
 
 #include "fl/log/log.h"
+#include "fl/fled/detail/parser.h"
 #include "fl/fs/fs.h"
 #include "fl/stl/json.h"
 #include "fl/math/math.h"
@@ -279,6 +280,87 @@ FileDataPtr _createIfNotExists(const fl::string &path, size_t len) {
     return entry;
 }
 
+// Dump a .fled file's JSON metadata envelope to the browser console.
+//
+// Files arrive here either whole (jsInjectFile) or in chunks (jsDeclareFile +
+// jsAppendFile), so this runs after every append and reports as soon as the
+// header plus the declared json_length have landed - not when the whole
+// payload has, which for a video is orders of magnitude later.
+//
+// printf is routed to console.log on this platform (see platforms/wasm/readme),
+// so println() is the console. Anything that is not a .fled stays silent: this
+// is a diagnostic for FLED bundles, not a log line for every asset.
+void _logFledEnvelopeOnce(const fl::string &path, const FileDataPtr &entry) {
+    if (!entry) {
+        return;
+    }
+
+    static fl::vector<fl::string> sReported;
+    static fl::mutex sReportedMutex;
+
+    const size_t have = entry->bytesRead();
+    if (have < 12) {
+        return;  // header not complete yet
+    }
+
+    // json_length lives at offset 8 as u32 little-endian.
+    fl::u8 header[12] = {0};
+    if (entry->read(0, header, 12) != 12) {
+        return;
+    }
+    if (header[0] != 'F' || header[1] != 'L' || header[2] != 'E' ||
+        header[3] != 'D') {
+        return;  // not a FLED container
+    }
+    const fl::u32 jsonLen =
+        static_cast<fl::u32>(header[8]) |
+        (static_cast<fl::u32>(header[9]) << 8) |
+        (static_cast<fl::u32>(header[10]) << 16) |
+        (static_cast<fl::u32>(header[11]) << 24);
+
+    const size_t envelopeEnd = 12u + static_cast<size_t>(jsonLen);
+    if (have < envelopeEnd) {
+        return;  // envelope still streaming
+    }
+
+    {
+        fl::unique_lock<fl::mutex> lock(sReportedMutex);
+        for (size_t i = 0; i < sReported.size(); ++i) {
+            if (sReported[i] == path) {
+                return;  // already reported this file
+            }
+        }
+        sReported.push_back(path);
+    }
+
+    fl::vector<fl::u8> buf;
+    buf.resize(envelopeEnd);
+    if (entry->read(0, buf.data(), envelopeEnd) != envelopeEnd) {
+        return;
+    }
+
+    fl::fled::ParsedHeader hdr{};
+    fl::json envelope;
+    if (!fl::fled::parseHeaderAndEnvelope(buf.data(), buf.size(), &hdr,
+                                          &envelope)) {
+        fl::println("[FLED] malformed container, cannot read metadata");
+        return;
+    }
+
+    fl::string out = "[FLED] ";
+    out += path;
+    out += " (v";
+    out += fl::to_string(static_cast<int>(hdr.version));
+    out += ", pixel_format 0x";
+    const char kHex[] = "0123456789abcdef";
+    char pf[3] = {kHex[(hdr.pixelFormat >> 4) & 0x0f],
+                  kHex[hdr.pixelFormat & 0x0f], '\0'};
+    out += pf;
+    out += ") metadata: ";
+    out += envelope.to_string();
+    fl::println(out.c_str());
+}
+
 } // namespace fl
 
 extern "C" {
@@ -292,6 +374,7 @@ EMSCRIPTEN_KEEPALIVE bool jsInjectFile(const char *path, const fl::u8 *data,
         return false;
     }
     inserted->append(data, len);
+    fl::_logFledEnvelopeOnce(fl::string(path), inserted);
     return true;
 }
 
@@ -303,6 +386,7 @@ EMSCRIPTEN_KEEPALIVE bool jsAppendFile(const char *path, const fl::u8 *data,
         return false;
     }
     entry->append(data, len);
+    fl::_logFledEnvelopeOnce(fl::string(path), entry);
     return true;
 }
 

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -330,6 +330,12 @@ FL_TEST_CASE("FLED_COLOR - malformed custom primaries are rejected") {
                      "\"red\":\"0.64,0.33\",\"green\":[0.3,0.6],"
                      "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
                      kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+    // Three components is not an xy pair - accepting it would silently drop
+    // the extra value rather than telling the producer it wrote nonsense.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[0.64,0.33,1.0],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
 }
 
 // ============================================================================
@@ -484,16 +490,43 @@ FL_TEST_CASE("FLED_COLOR - the serialized envelope carries the whole metadata") 
     FL_CHECK(static_cast<bool>(f));
 
     const fl::string dumped = f.json().to_string();
-    // Geometry, playback rate, and the full color tuple all survive.
-    FL_CHECK(dumped.find("map") != fl::string::npos);
-    FL_CHECK(dumped.find("fps") != fl::string::npos);
-    FL_CHECK(dumped.find("primaries") != fl::string::npos);
-    FL_CHECK(dumped.find("bt709") != fl::string::npos);
-    FL_CHECK(dumped.find("transfer") != fl::string::npos);
-    FL_CHECK(dumped.find("srgb") != fl::string::npos);
-    FL_CHECK(dumped.find("matrix") != fl::string::npos);
-    FL_CHECK(dumped.find("range") != fl::string::npos);
-    FL_CHECK(dumped.find("full") != fl::string::npos);
+
+    // Re-parse rather than substring-match: a token appearing *somewhere* in
+    // the string would not prove it survived in the right place, which is the
+    // only thing that makes the dump worth printing.
+    fl::json round = fl::json::parse(dumped);
+    FL_CHECK(round.is_object());
+
+    // Geometry survives, nested.
+    FL_CHECK(round.contains(fl::string("map")));
+    FL_CHECK(round["map"].is_object());
+    FL_CHECK(round["map"].contains(fl::string("a")));
+    FL_CHECK(round["map"]["a"]["x"].is_array());
+    FL_CHECK(round["map"]["a"]["y"].is_array());
+
+    // Playback rate survives with its value.
+    FL_CHECK(round["video"].is_object());
+    auto fps = round["video"]["fps"].as_float();
+    FL_CHECK(static_cast<bool>(fps));
+    FL_CHECK(*fps == 60.0f);
+
+    // The color tuple survives under video.color, key by key.
+    const fl::json color = round["video"]["color"];
+    FL_CHECK(color.is_object());
+    struct { const char* key; const char* value; } expected[4] = {
+        {"primaries", "bt709"}, {"transfer", "srgb"},
+        {"matrix", "rgb"},      {"range", "full"},
+    };
+    for (fl::size i = 0; i < 4; ++i) {
+        auto got = color[fl::string(expected[i].key)].as_string();
+        FL_CHECK(static_cast<bool>(got));
+        FL_CHECK(fl::strcmp(got->c_str(), expected[i].value) == 0);
+    }
+
+    // And the round-tripped envelope still resolves to the same declaration.
+    VideoColor c;
+    FL_CHECK(fl::fled::resolveVideoColor(round, kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == true);
 }
 
 FL_TEST_CASE("FLED_COLOR - videoColor on a null Fled yields the default tuple") {

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -205,6 +205,25 @@ FL_TEST_CASE("FLED_COLOR - non-rgb matrix values are reserved and rejected") {
 // Rule 1: unrecognized values are rejected, never silently defaulted
 // ============================================================================
 
+FL_TEST_CASE("FLED_COLOR - an explicit null color is treated as absent") {
+    // Omitting the key and setting it to null must not have opposite
+    // outcomes; many serializers emit null for an unset optional.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":null}}", kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == false);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+}
+
+FL_TEST_CASE("FLED_COLOR - a typo'd matrix reads as unknown, not reserved") {
+    VideoColor c;
+    // Reserved YCbCr coefficient names stay "reserved"...
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"matrix\":\"ycbcr\"}}}",
+                     kRgb8, &c) == ColorStatus::MatrixUnsupported);
+    // ...but a typo is unrecognized, so the author is not sent to the spec.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"matrix\":\"rbg\"}}}",
+                     kRgb8, &c) == ColorStatus::UnknownMatrix);
+}
+
 FL_TEST_CASE("FLED_COLOR - unknown values are rejected per field") {
     VideoColor c;
     FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"rec2100\"}}}",
@@ -320,6 +339,7 @@ FL_TEST_CASE("FLED_COLOR - malformed custom primaries are rejected") {
 FL_TEST_CASE("FLED_COLOR - every status has a non-empty message") {
     const ColorStatus all[] = {
         ColorStatus::Ok,
+        ColorStatus::NullOutput,
         ColorStatus::NoDefaultTuple,
         ColorStatus::NotAnObject,
         ColorStatus::UnknownPrimaries,
@@ -455,7 +475,7 @@ FL_TEST_CASE("FLED_COLOR - videoColor on a null Fled yields the default tuple") 
     FL_CHECK(null.videoColor(&c) == ColorStatus::Ok);
     FL_CHECK(c.declared == false);
     FL_CHECK(c.transfer == ColorTransfer::Srgb);
-    FL_CHECK(null.videoColor(nullptr) == ColorStatus::NotAnObject);
+    FL_CHECK(null.videoColor(nullptr) == ColorStatus::NullOutput);
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -469,6 +469,33 @@ FL_TEST_CASE("FLED_COLOR - accepts ledmapper's emitted rgb16_linear envelope") {
     FL_CHECK(c.transfer == ColorTransfer::Linear);
 }
 
+FL_TEST_CASE("FLED_COLOR - the serialized envelope carries the whole metadata") {
+    // The WASM platform dumps json().to_string() to console.log when a .fled
+    // is injected (platforms/wasm/fs_wasm.cpp.hpp). That diagnostic is only
+    // useful if serializing round-trips every section, not just the one the
+    // reader happens to understand - so pin it here, on the host, where it
+    // can actually be asserted.
+    const char* env =
+        "{\"map\":{\"a\":{\"x\":[0],\"y\":[0]}},\"video\":{\"fps\":60,\"color\":"
+        "{\"primaries\":\"bt709\",\"transfer\":\"srgb\",\"matrix\":\"rgb\","
+        "\"range\":\"full\"}}}";
+    fl::vector<fl::u8> buf = buildBundle(0x00, env, fl::strlen(env));
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+
+    const fl::string dumped = f.json().to_string();
+    // Geometry, playback rate, and the full color tuple all survive.
+    FL_CHECK(dumped.find("map") != fl::string::npos);
+    FL_CHECK(dumped.find("fps") != fl::string::npos);
+    FL_CHECK(dumped.find("primaries") != fl::string::npos);
+    FL_CHECK(dumped.find("bt709") != fl::string::npos);
+    FL_CHECK(dumped.find("transfer") != fl::string::npos);
+    FL_CHECK(dumped.find("srgb") != fl::string::npos);
+    FL_CHECK(dumped.find("matrix") != fl::string::npos);
+    FL_CHECK(dumped.find("range") != fl::string::npos);
+    FL_CHECK(dumped.find("full") != fl::string::npos);
+}
+
 FL_TEST_CASE("FLED_COLOR - videoColor on a null Fled yields the default tuple") {
     Fled null;
     VideoColor c;

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -403,6 +403,52 @@ FL_TEST_CASE("FLED_COLOR - a legacy bundle with no color still resolves") {
     FL_CHECK(c.transfer == ColorTransfer::Srgb);
 }
 
+// ============================================================================
+// Cross-repo conformance vectors
+//
+// These two envelopes are the VERBATIM output of ledmapper's producer
+// (src/moviemaker/recording.ts embedFps() -> buildVideoColor(format)), captured
+// from a real run. FastLED is the consumer half of this contract, so what the
+// producer actually emits must resolve here without complaint. If a future
+// ledmapper change alters the emitted shape, this is the test that notices.
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - accepts ledmapper's emitted rgb8 envelope verbatim") {
+    const char* env =
+        "{\"map\":{\"a\":{\"x\":[0],\"y\":[0]}},\"video\":{\"fps\":60,\"color\":"
+        "{\"primaries\":\"bt709\",\"transfer\":\"srgb\",\"matrix\":\"rgb\","
+        "\"range\":\"full\"}}}";
+    fl::vector<fl::u8> buf = buildBundle(0x00, env, fl::strlen(env));
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+
+    VideoColor c;
+    FL_CHECK(f.videoColor(&c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == true);
+    FL_CHECK(c.primaries == ColorPrimaries::Bt709);
+    FL_CHECK(c.transfer  == ColorTransfer::Srgb);
+    FL_CHECK(c.matrix    == ColorMatrix::Rgb);
+    FL_CHECK(c.range     == ColorRange::Full);
+    // The rest of the envelope still parses normally alongside it.
+    FL_CHECK(f.videoFps() == 60.0f);
+}
+
+FL_TEST_CASE("FLED_COLOR - accepts ledmapper's emitted rgb16_linear envelope") {
+    const char* env =
+        "{\"map\":{\"a\":{\"x\":[0],\"y\":[0]}},\"video\":{\"fps\":60,\"color\":"
+        "{\"primaries\":\"bt709\",\"transfer\":\"linear\",\"matrix\":\"rgb\","
+        "\"range\":\"full\"}}}";
+    fl::vector<fl::u8> buf = buildBundle(0x05, env, fl::strlen(env));
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    FL_CHECK_EQ(f.bytesPerLed(), 6);
+
+    VideoColor c;
+    FL_CHECK(f.videoColor(&c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == true);
+    FL_CHECK(c.transfer == ColorTransfer::Linear);
+}
+
 FL_TEST_CASE("FLED_COLOR - videoColor on a null Fled yields the default tuple") {
     Fled null;
     VideoColor c;

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -1,0 +1,415 @@
+// Tests for the .fled v1 `video.color` source-color contract.
+//
+// The normative rules live in src/fl/fled/FLED_FORMAT.md ("Source Color
+// Metadata"), which mirrors the canonical ledmapper spec. This file walks
+// every rule that document states:
+//
+//   - the default tuple {bt709, srgb, rgb, full} on absent metadata;
+//   - key inheritance, scoped to formats that define a default tuple;
+//   - rejection of linear/pq/hlg transfers on display-encoded formats;
+//   - rgb16_linear requiring transfer: linear;
+//   - reserved `limited` range and non-`rgb` matrix values;
+//   - all-or-nothing declarations for gray8/rgbw8;
+//   - custom primaries as CIE xy pairs.
+//
+// FastLED only CARRIES this declaration today - nothing here asserts that
+// pixels are transformed by it.
+
+#include "fl/fled/color.h"
+#include "fl/fled/detail/pixel_format.h"
+#include "fl/fled/fled.h"
+#include "fl/stl/cstring.h"
+#include "fl/stl/int.h"
+#include "fl/stl/json.h"
+#include "fl/stl/move.h"
+#include "fl/stl/string.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+using fl::fled::ColorMatrix;
+using fl::fled::ColorPrimaries;
+using fl::fled::ColorRange;
+using fl::fled::ColorStatus;
+using fl::fled::ColorTransfer;
+using fl::fled::PixelFormat;
+using fl::fled::VideoColor;
+
+namespace {
+
+// Resolve a JSON envelope literal against a pixel format.
+ColorStatus resolve(const char* envelopeText, fl::u8 pixelFormat,
+                    VideoColor* out) {
+    fl::json env = fl::json::parse(fl::string(envelopeText));
+    return fl::fled::resolveVideoColor(env, pixelFormat, out);
+}
+
+constexpr fl::u8 kRgb8     = static_cast<fl::u8>(PixelFormat::Rgb8);
+constexpr fl::u8 kRgba8    = static_cast<fl::u8>(PixelFormat::Rgba8);
+constexpr fl::u8 kRgb565Le = static_cast<fl::u8>(PixelFormat::Rgb565Le);
+constexpr fl::u8 kGray8    = static_cast<fl::u8>(PixelFormat::Gray8);
+constexpr fl::u8 kRgbw8    = static_cast<fl::u8>(PixelFormat::Rgbw8);
+constexpr fl::u8 kRgb16Lin = static_cast<fl::u8>(PixelFormat::Rgb16Linear);
+
+// The canonical declaration a conforming rgb8 producer writes.
+const char* const kCanonical =
+    "{\"video\":{\"color\":{\"primaries\":\"bt709\",\"transfer\":\"srgb\","
+    "\"matrix\":\"rgb\",\"range\":\"full\"}}}";
+
+}  // namespace
+
+// ============================================================================
+// Pixel format: rgb16_linear joins the v1 enum
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - rgb16_linear is 6 bytes per LED") {
+    FL_CHECK_EQ(fl::fled::bytesPerLed(kRgb16Lin), 6);
+    // 0x06 and up remain reserved / rejected.
+    FL_CHECK_EQ(fl::fled::bytesPerLed(static_cast<fl::u8>(0x06)), 0);
+    FL_CHECK_EQ(fl::fled::bytesPerLed(static_cast<fl::u8>(0xff)), 0);
+}
+
+// ============================================================================
+// Default tuple + absent metadata
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - absent video.color resolves to the default tuple") {
+    VideoColor c;
+    FL_CHECK(resolve("{}", kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::Bt709);
+    FL_CHECK(c.transfer  == ColorTransfer::Srgb);
+    FL_CHECK(c.matrix    == ColorMatrix::Rgb);
+    FL_CHECK(c.range     == ColorRange::Full);
+    // The default is a compatibility interpretation, not an author's claim.
+    FL_CHECK(c.declared == false);
+}
+
+FL_TEST_CASE("FLED_COLOR - a video block without color still defaults") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"fps\":30}}", kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+    FL_CHECK(c.declared == false);
+}
+
+FL_TEST_CASE("FLED_COLOR - the whole display-encoded family shares the tuple") {
+    const fl::u8 formats[3] = {kRgb8, kRgba8, kRgb565Le};
+    for (fl::size i = 0; i < 3; ++i) {
+        VideoColor c;
+        FL_CHECK(resolve("{}", formats[i], &c) == ColorStatus::Ok);
+        FL_CHECK(c.transfer == ColorTransfer::Srgb);
+        FL_CHECK(c.primaries == ColorPrimaries::Bt709);
+    }
+}
+
+FL_TEST_CASE("FLED_COLOR - canonical declaration round-trips as declared") {
+    VideoColor c;
+    FL_CHECK(resolve(kCanonical, kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::Bt709);
+    FL_CHECK(c.transfer  == ColorTransfer::Srgb);
+    FL_CHECK(c.matrix    == ColorMatrix::Rgb);
+    FL_CHECK(c.range     == ColorRange::Full);
+    FL_CHECK(c.declared == true);
+}
+
+// ============================================================================
+// Key inheritance (scoped to formats with a default tuple)
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - missing keys inherit from the default tuple") {
+    VideoColor c;
+    const char* env =
+        "{\"video\":{\"color\":{\"primaries\":\"display-p3\"}}}";
+    FL_CHECK(resolve(env, kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::DisplayP3);  // explicit
+    FL_CHECK(c.transfer  == ColorTransfer::Srgb);        // inherited
+    FL_CHECK(c.matrix    == ColorMatrix::Rgb);           // inherited
+    FL_CHECK(c.range     == ColorRange::Full);           // inherited
+    FL_CHECK(c.declared == true);
+}
+
+FL_TEST_CASE("FLED_COLOR - bt2020 primaries are recognized") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"bt2020\"}}}",
+                     kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::Bt2020);
+}
+
+FL_TEST_CASE("FLED_COLOR - bt709 transfer is distinct from srgb") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"bt709\"}}}",
+                     kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.transfer == ColorTransfer::Bt709);
+}
+
+// ============================================================================
+// Rule 2/3: transfer must agree with what the payload bytes hold
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - rgb8 rejects a linear transfer") {
+    // "A producer must not put linear-light samples in rgb8."
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"linear\"}}}",
+                     kRgb8, &c) == ColorStatus::TransferConflictsWithFormat);
+}
+
+FL_TEST_CASE("FLED_COLOR - reserved HDR transfers are rejected in v1") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"pq\"}}}",
+                     kRgb8, &c) == ColorStatus::TransferConflictsWithFormat);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"hlg\"}}}",
+                     kRgb8, &c) == ColorStatus::TransferConflictsWithFormat);
+    // ... on the linear format too - no v1 payload can carry them.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"pq\"}}}",
+                     kRgb16Lin, &c) == ColorStatus::TransferConflictsWithFormat);
+}
+
+FL_TEST_CASE("FLED_COLOR - rgb16_linear defaults to a linear transfer") {
+    VideoColor c;
+    FL_CHECK(resolve("{}", kRgb16Lin, &c) == ColorStatus::Ok);
+    FL_CHECK(c.transfer  == ColorTransfer::Linear);
+    FL_CHECK(c.primaries == ColorPrimaries::Bt709);
+    FL_CHECK(c.range     == ColorRange::Full);
+}
+
+FL_TEST_CASE("FLED_COLOR - rgb16_linear accepts only a linear transfer") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"linear\"}}}",
+                     kRgb16Lin, &c) == ColorStatus::Ok);
+    FL_CHECK(c.transfer == ColorTransfer::Linear);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"srgb\"}}}",
+                     kRgb16Lin, &c) == ColorStatus::TransferConflictsWithFormat);
+}
+
+// ============================================================================
+// Rules 4/5: reserved range and matrix values
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - limited range is reserved and rejected") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"range\":\"limited\"}}}",
+                     kRgb8, &c) == ColorStatus::LimitedRangeUnsupported);
+}
+
+FL_TEST_CASE("FLED_COLOR - non-rgb matrix values are reserved and rejected") {
+    VideoColor c;
+    // A YCbCr payload needs a pixel format that does not exist yet.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"matrix\":\"bt709\"}}}",
+                     kRgb8, &c) == ColorStatus::MatrixUnsupported);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"matrix\":\"bt2020ncl\"}}}",
+                     kRgb8, &c) == ColorStatus::MatrixUnsupported);
+}
+
+// ============================================================================
+// Rule 1: unrecognized values are rejected, never silently defaulted
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - unknown values are rejected per field") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"rec2100\"}}}",
+                     kRgb8, &c) == ColorStatus::UnknownPrimaries);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"gamma22\"}}}",
+                     kRgb8, &c) == ColorStatus::UnknownTransfer);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"range\":\"studio\"}}}",
+                     kRgb8, &c) == ColorStatus::UnknownRange);
+}
+
+FL_TEST_CASE("FLED_COLOR - transfer \"none\" is not a valid value") {
+    // The spec forbids "none" explicitly: it is ambiguous. Linear-light
+    // producers must say "linear" and use a format that permits it.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":\"none\"}}}",
+                     kRgb8, &c) == ColorStatus::UnknownTransfer);
+}
+
+FL_TEST_CASE("FLED_COLOR - non-string scalars are rejected, not coerced") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"transfer\":42}}}",
+                     kRgb8, &c) == ColorStatus::UnknownTransfer);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"matrix\":true}}}",
+                     kRgb8, &c) == ColorStatus::UnknownMatrix);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"range\":null}}}",
+                     kRgb8, &c) == ColorStatus::UnknownRange);
+}
+
+FL_TEST_CASE("FLED_COLOR - video.color must be an object") {
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":\"bt709\"}}", kRgb8, &c) ==
+             ColorStatus::NotAnObject);
+    FL_CHECK(resolve("{\"video\":{\"color\":[1,2]}}", kRgb8, &c) ==
+             ColorStatus::NotAnObject);
+}
+
+// ============================================================================
+// Rule 6: gray8 / rgbw8 have no default tuple - all or nothing
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - gray8 and rgbw8 define no default tuple") {
+    FL_CHECK(fl::fled::pixelFormatHasDefaultTuple(kRgb8));
+    FL_CHECK(fl::fled::pixelFormatHasDefaultTuple(kRgb16Lin));
+    FL_CHECK(!fl::fled::pixelFormatHasDefaultTuple(kGray8));
+    FL_CHECK(!fl::fled::pixelFormatHasDefaultTuple(kRgbw8));
+
+    VideoColor c;
+    FL_CHECK(resolve("{}", kGray8, &c) == ColorStatus::NoDefaultTuple);
+    FL_CHECK(resolve("{}", kRgbw8, &c) == ColorStatus::NoDefaultTuple);
+}
+
+FL_TEST_CASE("FLED_COLOR - a partial declaration cannot inherit without a tuple") {
+    // This is the guard that keeps a future YCbCr format from silently
+    // inheriting matrix: rgb.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"bt709\"}}}",
+                     kRgbw8, &c) == ColorStatus::IncompleteForFormat);
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"bt709\","
+                     "\"transfer\":\"srgb\",\"matrix\":\"rgb\"}}}",
+                     kGray8, &c) == ColorStatus::IncompleteForFormat);
+}
+
+FL_TEST_CASE("FLED_COLOR - a complete declaration is accepted without a tuple") {
+    VideoColor c;
+    FL_CHECK(resolve(kCanonical, kRgbw8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+    FL_CHECK(c.declared == true);
+}
+
+// ============================================================================
+// Rule 7: custom primaries
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - custom primaries carry CIE xy pairs") {
+    VideoColor c;
+    const char* env =
+        "{\"video\":{\"color\":{\"primaries\":{"
+        "\"red\":[0.640,0.330],\"green\":[0.300,0.600],"
+        "\"blue\":[0.150,0.060],\"white\":[0.3127,0.3290]}}}}";
+    FL_CHECK(resolve(env, kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::Custom);
+    FL_CHECK(c.customPrimaries[0] > 0.63f);
+    FL_CHECK(c.customPrimaries[0] < 0.65f);
+    FL_CHECK(c.customPrimaries[7] > 0.32f);
+    FL_CHECK(c.customPrimaries[7] < 0.34f);
+    // Unstated keys still inherit.
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+}
+
+FL_TEST_CASE("FLED_COLOR - malformed custom primaries are rejected") {
+    VideoColor c;
+    // Missing white.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[0.64,0.33],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+    // A one-element pair is not an xy.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[0.64],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+    // A string where a pair belongs.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":\"0.64,0.33\",\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+}
+
+// ============================================================================
+// Diagnostics
+// ============================================================================
+
+FL_TEST_CASE("FLED_COLOR - every status has a non-empty message") {
+    const ColorStatus all[] = {
+        ColorStatus::Ok,
+        ColorStatus::NoDefaultTuple,
+        ColorStatus::NotAnObject,
+        ColorStatus::UnknownPrimaries,
+        ColorStatus::UnknownTransfer,
+        ColorStatus::UnknownMatrix,
+        ColorStatus::UnknownRange,
+        ColorStatus::TransferConflictsWithFormat,
+        ColorStatus::LimitedRangeUnsupported,
+        ColorStatus::MatrixUnsupported,
+        ColorStatus::IncompleteForFormat,
+        ColorStatus::MalformedCustomPrimaries,
+    };
+    for (fl::size i = 0; i < sizeof(all) / sizeof(all[0]); ++i) {
+        const char* msg = fl::fled::colorStatusMessage(all[i]);
+        FL_CHECK(msg != nullptr);
+        FL_CHECK(msg[0] != '\0');
+    }
+}
+
+// ============================================================================
+// Fled::videoColor() - the accessor over a real bundle
+// ============================================================================
+
+namespace {
+
+// Hand-assemble a v1 .fled bundle (see FLED_FORMAT.md layout table).
+fl::vector<fl::u8> buildBundle(fl::u8 pixelFormat, const char* envelope,
+                               fl::size envelopeLen) {
+    const fl::u32 jsonLen = static_cast<fl::u32>(envelopeLen);
+    fl::vector<fl::u8> out;
+    out.resize(12 + envelopeLen);
+    out[0] = 'F'; out[1] = 'L'; out[2] = 'E'; out[3] = 'D';
+    out[4] = 1;
+    out[5] = pixelFormat;
+    out[6] = 0; out[7] = 0;
+    out[8]  = static_cast<fl::u8>(jsonLen & 0xff);
+    out[9]  = static_cast<fl::u8>((jsonLen >> 8) & 0xff);
+    out[10] = static_cast<fl::u8>((jsonLen >> 16) & 0xff);
+    out[11] = static_cast<fl::u8>((jsonLen >> 24) & 0xff);
+    for (fl::size i = 0; i < envelopeLen; ++i) {
+        out[12 + i] = static_cast<fl::u8>(envelope[i]);
+    }
+    return out;
+}
+
+}  // namespace
+
+FL_TEST_CASE("FLED_COLOR - videoColor reads a declared tuple off a bundle") {
+    fl::vector<fl::u8> buf = buildBundle(0x00, kCanonical,
+                                          fl::strlen(kCanonical));
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+
+    VideoColor c;
+    FL_CHECK(f.videoColor(&c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == true);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+}
+
+FL_TEST_CASE("FLED_COLOR - videoColor honors the header's pixel_format") {
+    // Same envelope, different header byte: rgb16_linear rejects srgb.
+    fl::vector<fl::u8> buf = buildBundle(0x05, kCanonical,
+                                          fl::strlen(kCanonical));
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+    FL_CHECK_EQ(f.pixelFormat(), 0x05);
+
+    VideoColor c;
+    FL_CHECK(f.videoColor(&c) == ColorStatus::TransferConflictsWithFormat);
+}
+
+FL_TEST_CASE("FLED_COLOR - a legacy bundle with no color still resolves") {
+    const char env[] = "{\"map\":{\"a\":{\"x\":[0],\"y\":[0]}}}";
+    fl::vector<fl::u8> buf = buildBundle(0x00, env, sizeof(env) - 1);
+    Fled f = Fled::loadFromVector(fl::move(buf));
+    FL_CHECK(static_cast<bool>(f));
+
+    VideoColor c;
+    FL_CHECK(f.videoColor(&c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == false);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+}
+
+FL_TEST_CASE("FLED_COLOR - videoColor on a null Fled yields the default tuple") {
+    Fled null;
+    VideoColor c;
+    FL_CHECK(null.videoColor(&c) == ColorStatus::Ok);
+    FL_CHECK(c.declared == false);
+    FL_CHECK(c.transfer == ColorTransfer::Srgb);
+    FL_CHECK(null.videoColor(nullptr) == ColorStatus::NotAnObject);
+}
+
+}  // FL_TEST_FILE

--- a/tests/fl/fled/fled_format.cpp
+++ b/tests/fl/fled/fled_format.cpp
@@ -76,18 +76,20 @@ FL_TEST_CASE("FLED_FORMAT - bytesPerLed for all defined v1 pixel formats") {
     //   0x02 rgba8    -> 4 bpp
     //   0x03 rgbw8    -> 4 bpp
     //   0x04 rgb565le -> 2 bpp
+    //   0x05 rgb16_linear -> 6 bpp
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x00)), fl::u8(3));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x01)), fl::u8(1));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x02)), fl::u8(4));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x03)), fl::u8(4));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x04)), fl::u8(2));
+    FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x05)), fl::u8(6));
 }
 
 FL_TEST_CASE("FLED_FORMAT - bytesPerLed for reserved values returns 0") {
-    // Per spec: 0x05..0xff are reserved for future formats. Returning 0
+    // Per spec: 0x06..0xff are reserved for future formats. Returning 0
     // signals "consumer does not support" so callers reject before
     // reading frame bytes.
-    FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x05)), fl::u8(0));
+    FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x06)), fl::u8(0));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0x10)), fl::u8(0));
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0xff)), fl::u8(0));
 }

--- a/tests/test_fled_format_docs.py
+++ b/tests/test_fled_format_docs.py
@@ -13,14 +13,60 @@ def test_fled_format_mirror_documents_v1_layout_and_authority() -> None:
 
     assert "Authority:" in text
     assert "https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md" in text
-    assert "https://github.com/zackees/ledmapper/blob/main/scripts/inspect-fled.mjs" in text
+    assert (
+        "https://github.com/zackees/ledmapper/blob/main/scripts/inspect-fled.mjs"
+        in text
+    )
     assert "| 0 | 4 | `magic`" in text
     assert "| 8 | 4 | `json_length`" in text
     assert "| `0x00` | `rgb8` | 3 |" in text
     assert "| `0x04` | `rgb565le` | 2 |" in text
+    assert "| `0x05` | `rgb16_linear` | 6 |" in text
     assert "channels" in text
     assert "script.micropython" in text
     assert "script.wasm" in text
+
+
+def test_fled_format_mirror_specifies_the_source_color_contract() -> None:
+    """The `.fled` mirror must carry the full `video.color` contract.
+
+    FastLED does not yet transform pixels by the declared source profile, but
+    a file that fails to *specify* its color encoding is unrecoverable later:
+    the numbers stop meaning anything definite. So the carry contract - the
+    four independent fields, the default tuple, and the rejection rules - is
+    spec'd and tested before any engine support exists.
+    """
+    text = _read("src/fl/fled/FLED_FORMAT.md")
+
+    assert "## Source Color Metadata" in text
+
+    # The four fields stay independent - never collapsed into one "BT.709".
+    for field in ("`primaries`", "`transfer`", "`matrix`", "`range`"):
+        assert field in text
+
+    # The default tuple, stated exactly.
+    assert '"primaries": "bt709"' in text
+    assert '"transfer": "srgb"' in text
+    assert '"matrix": "rgb"' in text
+    assert '"range": "full"' in text
+
+    # sRGB transfer is not the BT.709 OETF, and "none" is not a value.
+    assert "not** the BT.709 camera OETF" in text
+    assert '`"none"` is not a valid `transfer` value' in text
+
+    # Per-format color classes, including the formats with no default tuple.
+    assert "### Color classes by pixel format" in text
+    assert "no defined tuple" in text
+
+    # The rejection rules a validator must enforce.
+    assert "### Validation rules" in text
+    assert "never silently fall back" in text
+    assert "reserved" in text
+
+    # Forward compatibility: advisory for rgb8, mandatory via pixel_format.
+    assert "### Forward compatibility" in text
+    assert "advisory" in text
+    assert "not a version bump" in text
 
 
 def test_fled_readme_opens_with_format_spec_link() -> None:


### PR DESCRIPTION
## What

Implements the `.fled` **source-color specification** on the FastLED side: the container now carries and validates `video.color`, the block that declares what a payload's numbers actually mean.

FastLED does **not** yet transform pixels according to the declared source profile — that's the color-pipeline work tracked in #4034 / #4038. This is deliberately the carry-and-validate layer only, because the metadata has to exist and be trustworthy *before* an engine can act on it. A file recorded today without a color declaration is unrecoverable later; there's no way to reconstruct what its numbers meant.

## Changes

- **`FLED_FORMAT.md`** — full "Source Color Metadata" section mirroring the canonical ledmapper spec: the four independent fields (`primaries`, `transfer`, `matrix`, `range`), the `{bt709, srgb, rgb, full}` default tuple, per-format color classes, seven validation rules, and the forward-compatibility rule.
- **New `pixel_format` `0x05` `rgb16_linear`** (6 bytes/LED), which requires `transfer: "linear"`. Reserved values now start at `0x06`. Adding an enum value is not a version bump — unknown values already have defined rejection behavior.
- **`fl::fled::resolveVideoColor()`** (`src/fl/fled/color.h`) — applies the default tuple, scopes key inheritance to formats that define one, and rejects `linear`/`pq`/`hlg` on display-encoded formats, `limited` range, non-`rgb` matrices, partial declarations on `gray8`/`rgbw8`, and malformed custom primaries. Returns a `ColorStatus` with a diagnostic message rather than silently falling back.
- **`Fled::videoColor()`** accessor, mirroring the existing `videoFps()`.
- **25 C++ tests** over every rule, plus doc-conformance tests asserting the mirror actually specifies the contract.
- **`agents/docs/fled-format.md`** updated, per the rule that a format/public-API change updates its routing doc in the same PR.

## Two design points worth review

**Absent metadata is never an error.** Every `.fled` predating this field must keep loading, so a format with a default tuple resolves to it and reports `declared == false`. Only a declaration that is present and invalid is rejected. `declared` exists precisely so callers can tell "the file said so" from "the compatibility default was applied" — those must not be conflated once the pipeline starts acting on them.

**Key inheritance is scoped to formats that define a default tuple.** `gray8` carries no chromaticity and `rgbw8`'s white is a device primary that RGB primaries cannot describe, so both are all-or-nothing. This is what stops a future YCbCr format from silently inheriting `matrix: "rgb"` — an invalid, silently wrong interpretation of chroma-subsampled data.

## Validation

- `bash test fled_color` — 25/25 pass
- `bash test --cpp` — full suite green (exit 0)
- `uv run pytest tests/test_fled_format_docs.py` — 4/4 pass
- `bash lint` — clean

One pre-existing test needed updating: `bytesPerLed for reserved values` asserted `0x05` was reserved, which this change makes false by definition.

## Cross-repo

The canonical spec and the producer-side enforcement live in ledmapper — companion PR: zackees/ledmapper#508. The two test suites (`tests/fl/fled/fled_color.cpp` here, `tests/unit/fled-color.test.ts` there) are halves of one contract: change a rule in one and the other must move in the same change.

Refs #4038 (P4 of the color-pipeline plan, scoped here to the carry/validate layer).

## One boundary worth a reviewer's eye

The transfer constraint applies to the display-encoded RGB family, not to `gray8`/`rgbw8`, so `{pixel_format: rgbw8, transfer: "linear"}` resolves `Ok`. Deliberate: the rule's rationale is precision (8 bits of linear light crushes the dark end), which argues for tightening — but `gray8` is a brightness/effect mask, where a linear declaration is legitimate. Formats with no default tuple must already declare all four keys explicitly, and nothing interprets their color today. One-line change to `isDisplayEncodedRgb()` if a reviewer disagrees.

## Review round (post-review commits)

An independent review of the first commits found four issues, all fixed here:

- **Spec/code contradiction (HIGH)** — the color-classes table said `gray8`/`rgbw8` could declare all four keys "or be absent", while the resolver rejects an absent declaration there. The strict reading is right; the doc was wrong. It now also states `NoDefaultTuple` is *unresolvable*, not *malformed*.
- **"Advisory" vs hard rejection (MEDIUM)** — the spec called `video.color` advisory while rule 1 made an unknown value a hard rejection, so a reader on today's rules would refuse a file a pre-color reader plays fine. The spec now separates a *declaration verdict* from a *consumer's file policy*.
- **Diagnostic honesty (LOW×2)** — a typo'd matrix reported as "reserved" (sending the author to a spec section that will never mention it); a null out-pointer reported as `NotAnObject` (sending callers hunting through a valid envelope). Both now have accurate statuses, and an explicit JSON null is treated as absent.

The review also flagged that `src/platforms/wasm/compiler/package.json` pins `@fastled/gfx` to `gfx-v0.1.1`, whose bundled reader predates `rgb16_linear` — so the format resolves on device but is rejected in the WASM preview. It fails loudly rather than misparsing, and the fix is ordered (ledmapper merge → gfx release → bump the pin). The cascade is now documented in `agents/docs/fled-format.md` rather than left as tribal knowledge.

## Scope note

The validator is deliberately **not** wired into any decode path yet — `videoColor()` is an opt-in accessor and nothing renders from the profile. That's the requested scope ("even if the FastLED engine can't understand it yet"): the metadata has to exist and be trustworthy before an engine can act on it.

## WASM console diagnostic

The container's metadata was invisible in the browser — nothing on the WASM side reported what a loaded `.fled` declares, so diagnosing "these colors look wrong" meant guessing at the file instead of reading it. `platforms/wasm/fs_wasm.cpp.hpp` now dumps the **entire** JSON envelope (screenmap, `video.fps`, and the `video.color` tuple) to `console.log` on load:

```
[FLED] /data/clip.fled (v1, pixel_format 0x00) metadata: {"map":{...},"video":{"fps":60,"color":{"primaries":"bt709","transfer":"srgb","matrix":"rgb","range":"full"}}}
```

`printf` is routed to `console.log` on this platform (per `platforms/wasm/readme`), so `println()` is the console — no `EM_ASM` needed.

Two details worth noting: files arrive either whole (`jsInjectFile`) or in chunks (`jsDeclareFile` + `jsAppendFile`), so the dump runs after every append and fires as soon as the header plus the declared `json_length` have landed — not when the whole payload has, which for a video is orders of magnitude later. And non-FLED files stay silent; this is a diagnostic for bundles, not a log line for every asset.

Verified with `bash compile wasm --examples Blink`. The WASM path can't be asserted in the unit suite, so a host test pins the part that matters — that serializing round-trips every section, which is what makes the dump worth printing at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the FLED v1 `rgb16_linear` pixel format for 16-bit linear-light RGB data.
  * Added source video color metadata for primaries, transfer characteristics, matrices, and range.
  * Added automatic defaults, validation, compatibility checks, and status diagnostics.
  * Added a public accessor for resolving video color information.
  * Added browser-side logging of `.fled` metadata envelopes for troubleshooting.

* **Documentation**
  * Expanded the FLED specification with color metadata rules, compatibility guidance, and preview limitations.

* **Tests**
  * Added coverage for pixel formats, color metadata resolution, validation, inheritance, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->