### PR TITLE
fix(autoresearch): use fbuild artifact API

### DIFF
--- a/ci/autoresearch/build_driver.py
+++ b/ci/autoresearch/build_driver.py
@@ -46,7 +46,7 @@ class BuildDriver(Protocol):
         log_file: IO[str] | None = None,
     ) -> bool | DeployResult: ...
 
-    def firmware_path(self, build_dir: Path, environment: str) -> Path: ...
+    def firmware_path(self, build_dir: Path, environment: str) -> Path | None: ...
 
 
 class FbuildDriver:
@@ -94,17 +94,11 @@ class FbuildDriver:
             message=result.output,
         )
 
-    def firmware_path(self, build_dir: Path, environment: str) -> Path:
-        fbuild_root = build_dir / ".fbuild" / "build"
-        release_firmware = fbuild_root / "release" / "firmware.bin"
-        if release_firmware.is_file():
-            return release_firmware
+    def firmware_path(self, build_dir: Path, environment: str) -> Path | None:
+        from fbuild import find_firmware
 
-        environment_firmware = fbuild_root / environment / "release" / "firmware.bin"
-        if environment_firmware.is_file():
-            return environment_firmware
-
-        return release_firmware
+        resolved = find_firmware(str(build_dir), environment, "firmware.bin")
+        return Path(resolved) if resolved is not None else None
 
 
 class PlatformIODriver:

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -50,7 +50,7 @@ async def run_ota_peer_autoresearch(
     upload_port: str,
     peer_upload_port: str,
     serial_iface: "SerialInterface | None",
-    firmware_path: Path,
+    firmware_path: Path | None,
     timeout: float = 360.0,
 ) -> int:
     """Update RP2350W from an ESP32-C6 fixture without host WiFi access.
@@ -63,7 +63,7 @@ async def run_ota_peer_autoresearch(
 
     print("\nOTA PEER AUTORESEARCH: RP2350W <- ESP32-C6")
     print("  Host WiFi is not used or changed by this mode.")
-    if not firmware_path.is_file():
+    if firmware_path is None or not firmware_path.is_file():
         print(
             f"  {Fore.RED}RP2350W firmware is missing: {firmware_path}{Style.RESET_ALL}"
         )

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -6,6 +6,8 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from ci.autoresearch.net import run_net_peer_autoresearch
 from ci.autoresearch.ota import run_ota_peer_autoresearch
 
@@ -14,6 +16,23 @@ def _response(data: dict[str, Any]) -> MagicMock:
     response = MagicMock()
     response.data = data
     return response
+
+
+def test_ota_peer_reports_missing_firmware(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A missing fbuild artifact fails cleanly before opening either board."""
+    result = asyncio.run(
+        run_ota_peer_autoresearch(
+            upload_port="COM18",
+            peer_upload_port="COM9",
+            serial_iface=None,
+            firmware_path=None,
+        )
+    )
+
+    assert result == 1
+    assert "RP2350W firmware is missing: None" in capsys.readouterr().out
 
 
 def test_net_peer_runs_ten_device_only_reconnect_cycles() -> None:

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -85,23 +85,33 @@ def test_autoresearch_fbuild_install_packages_does_not_call_platformio(
 
 
 def test_autoresearch_fbuild_firmware_path_uses_release_artifact(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    firmware = tmp_path / ".fbuild" / "build" / "release" / "firmware.bin"
-    firmware.parent.mkdir(parents=True)
-    firmware.touch()
+    firmware = tmp_path / "resolved" / "firmware.bin"
+    captured: list[tuple[str, str, str | None]] = []
+
+    def fake_find_firmware(
+        project_dir: str,
+        environment: str,
+        firmware_name: str | None = None,
+    ) -> str:
+        captured.append((project_dir, environment, firmware_name))
+        return str(firmware)
+
+    monkeypatch.setattr("fbuild.find_firmware", fake_find_firmware)
 
     assert FbuildDriver().firmware_path(tmp_path, "rp2350w") == firmware
+    assert captured == [(str(tmp_path), "rp2350w", "firmware.bin")]
 
 
-def test_autoresearch_fbuild_firmware_path_supports_environment_release(
+def test_autoresearch_fbuild_firmware_path_returns_none_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    firmware = tmp_path / ".fbuild" / "build" / "rp2350w" / "release" / "firmware.bin"
-    firmware.parent.mkdir(parents=True)
-    firmware.touch()
+    monkeypatch.setattr("fbuild.find_firmware", lambda *_args: None)
 
-    assert FbuildDriver().firmware_path(tmp_path, "rp2350w") == firmware
+    assert FbuildDriver().firmware_path(tmp_path, "rp2350w") is None
 
 
 def test_autoresearch_parse_args_warns_for_deprecated_fbuild_flags(

--- a/ci/tests/test_fbuild_default_selection.py
+++ b/ci/tests/test_fbuild_default_selection.py
@@ -109,7 +109,14 @@ def test_autoresearch_fbuild_firmware_path_returns_none_when_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr("fbuild.find_firmware", lambda *_args: None)
+    def fake_find_firmware(
+        project_dir: str,
+        environment: str,
+        firmware_name: str | None = None,
+    ) -> None:
+        return None
+
+    monkeypatch.setattr("fbuild.find_firmware", fake_find_firmware)
 
     assert FbuildDriver().firmware_path(tmp_path, "rp2350w") is None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.20",
+    "fbuild==2.5.21",
     # Decodes the FastLED/boards `usb-vids.proto.zstd` registry artifact in
     # ci/util/audit_usb_registry.py. Declared explicitly rather than relied on
     # transitively (clang-tool-chain-bins pulls it in today) so the documented


### PR DESCRIPTION
## Summary

Replace AutoResearch's private `.fbuild/build/...` path probing with the public `fbuild.find_firmware()` artifact API released in fbuild 2.5.21.

- pin FastLED to `fbuild==2.5.21`;
- delegate FbuildDriver firmware discovery to `find_firmware(project_dir, environment, "firmware.bin")`;
- propagate a missing artifact as `None` and preserve the peer-OTA harness's clean failure;
- test the public API boundary instead of duplicating fbuild's directory layout.

## Dependency chain

- Structured API: https://github.com/FastLED/fbuild/pull/1402
- Release repair: https://github.com/FastLED/fbuild/pull/1403
- Published release: https://github.com/FastLED/fbuild/releases/tag/v2.5.21
- Replaces temporary path stopgap: #4029

## Validation

- `uv run python -c "import fbuild; print(fbuild.__version__); print(hasattr(fbuild, 'find_firmware'))"` -> `2.5.21`, `True`
- `uv run pytest ci/tests/test_fbuild_default_selection.py ci/tests/test_autoresearch_net.py ci/tests/test_autoresearch_phases.py -q` -> 192 passed
- Ruff check passed for all changed Python files
- Ruff format check passed for all changed Python files
- `git diff --check`
- clud-review: clean

## Hardware gate

Attached boards were freshly discovered as healthy:

- RP2350W: COM18, `2E8A:F00F`, serial `2DCB876B587EA334`
- ESP32-C6 peer: COM9, `303A:1001`, serial `8C:BF:EA:CF:87:B4`

Canonical run:

`bash autoresearch rp2350w --net-peer --ota --upload-port COM18 --peer-environment esp32c6 --peer-upload-port COM9 --timeout 120s --skip-lint`

Results:

- RP2350W built and flashed successfully with fbuild 2.5.21.
- ESP32-C6 peer built and flashed successfully with fbuild 2.5.21.
- The API resolved `C:\Users\niteris\dev\fastled10\.build\pio\rp2350w\.fbuild\build\release\firmware.bin` (`exists=True`, 977124 bytes).
- Peer schema validation succeeded (70 methods), and the run entered OTA peer mode. This proves the former hard-coded `.fbuild/build/rp2350w/firmware.bin` failure is fixed.
- The run then hit the pre-existing, separate OTA transport failure: `No response with ID 3 within 20.0s` during artifact transfer.
- One cold-cache attempt also reproduced FastLED/fbuild#1360 (unresponsive daemon after the RP2350W build); `fbuild daemon stop` recovered it and the warm-cache rerun reached OTA as described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware detection and selection for OTA peer testing.
  * OTA operations now report a clear missing-firmware error instead of failing unexpectedly.

* **Tests**
  * Added regression coverage for missing firmware scenarios and firmware selection.

* **Chores**
  * Updated the build tooling dependency to version 2.5.21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->