### PR TITLE
feat(lint): enforce provenance-aware file legal headers

### DIFF
--- a/ci/cpp_lint_cache.py
+++ b/ci/cpp_lint_cache.py
@@ -25,6 +25,8 @@ _DEFAULT_CPP_LINT_GLOBS = [
     "src/**/*.h",
     "src/**/*.hpp",
     "src/**/*.c",
+    "src/**/*.s",
+    "src/**/*.S",
     "examples/**/*.ino",
     "examples/**/*.cpp",
     "examples/**/*.h",
@@ -35,6 +37,7 @@ _DEFAULT_CPP_LINT_GLOBS = [
     "ci/lint_cpp_rs/Cargo.toml",
     "ci/lint_cpp_rs/Cargo.lock",
     "ci/lint_cpp_rs/src/**/*.rs",
+    "ci/lint_cpp_rs/file_legal_policy.yaml",
 ]
 
 
@@ -59,6 +62,7 @@ def _get_cpp_lint_patterns() -> tuple[list[str], list[str]]:
             "ci/lint_cpp_rs/Cargo.toml",
             "ci/lint_cpp_rs/Cargo.lock",
             "ci/lint_cpp_rs/src/**/*.rs",
+            "ci/lint_cpp_rs/file_legal_policy.yaml",
         ]
         for pattern in extra_includes:
             if pattern not in include:

--- a/ci/dependencies.json
+++ b/ci/dependencies.json
@@ -50,11 +50,14 @@
         "src/**/*.h",
         "src/**/*.hpp",
         "src/**/*.c",
+        "src/**/*.s",
+        "src/**/*.S",
         "examples/**/*.ino",
         "examples/**/*.cpp",
         "examples/**/*.h",
         "examples/**/*.hpp",
-        "ci/lint_cpp/*.py"
+        "ci/lint_cpp/*.py",
+        "ci/lint_cpp_rs/file_legal_policy.yaml"
       ],
       "tools": [
         "clang-format",

--- a/ci/lint_cpp/rust_binary_cache.py
+++ b/ci/lint_cpp/rust_binary_cache.py
@@ -55,6 +55,7 @@ _FINGERPRINT_INPUTS = (
     # here when introduced — current crate has none of those.
     "ci/lint_cpp_rs/Cargo.toml",
     "ci/lint_cpp_rs/Cargo.lock",
+    "ci/lint_cpp_rs/file_legal_policy.yaml",
 )
 _SRC_DIR = RUST_CRATE_DIR / "src"
 

--- a/ci/lint_cpp_rs/Cargo.lock
+++ b/ci/lint_cpp_rs/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,16 +93,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fastled-lint"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "glob",
  "rayon",
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "walkdir",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "glob"
@@ -61,10 +125,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "memchr"
@@ -140,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +284,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +318,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "walkdir"

--- a/ci/lint_cpp_rs/Cargo.toml
+++ b/ci/lint_cpp_rs/Cargo.toml
@@ -8,11 +8,13 @@ name = "fastled-lint"
 path = "src/main.rs"
 
 [dependencies]
+blake3 = "1.8"
 glob = "0.3"
 rayon = "1.10"
 regex = "1.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 walkdir = "2.5"
 
 # Dev profile = the production build for this lint tool. Cargo defaults

--- a/ci/lint_cpp_rs/deep_history_audit.sh
+++ b/ci/lint_cpp_rs/deep_history_audit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(git rev-parse --show-toplevel)"
+cd "$project_root"
+
+uv run soldr --no-cache cargo test \
+  --manifest-path ci/lint_cpp_rs/Cargo.toml \
+  deep_live_history_matches_per_file_git_for_mark_and_sam \
+  -- --ignored --nocapture

--- a/ci/lint_cpp_rs/file_legal_policy.yaml
+++ b/ci/lint_cpp_rs/file_legal_policy.yaml
@@ -1,0 +1,32 @@
+schema: fastled-file-legal-policy/v1
+enabled: false
+# Capture every historical human author when a notice is first created. Later
+# audits preserve that reviewed holder snapshot while refreshing audit metadata;
+# a future policy version may opt into incremental holder attribution.
+attribution_mode: initial_history_snapshot
+recheck_after_days: 365
+license:
+  spdx_identifier: MIT
+  notice: |-
+    Distributed under the MIT License.
+    See LICENSE for details.
+ignored_identities:
+  - Copilot
+  - Cursor Agent
+  - copilot-swe-agent[bot]
+owners:
+  - name: Daniel Garcia
+    aliases:
+      - Dan Garcia
+      - focalintent
+      - danielgarcia
+    always: false
+  - name: Mark Kriegsman
+    aliases:
+      - kriegsman
+    always: false
+  - name: Zach Vorhies
+    aliases:
+      - Zackees
+      - Zachary Vorhies
+    always: true

--- a/ci/lint_cpp_rs/src/checkers/file_legal.rs
+++ b/ci/lint_cpp_rs/src/checkers/file_legal.rs
@@ -1,0 +1,988 @@
+const FILE_LEGAL_BEGIN: &str = "// FASTLED-FILE-LEGAL-BEGIN";
+const FILE_LEGAL_END: &str = "// FASTLED-FILE-LEGAL-END";
+const FILE_LEGAL_SCHEMA: &str = "fastled-file-legal/v1";
+const FILE_LEGAL_POLICY_YAML: &str = include_str!("../../file_legal_policy.yaml");
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalPolicy {
+    schema: String,
+    enabled: bool,
+    attribution_mode: String,
+    recheck_after_days: i64,
+    license: FileLegalLicense,
+    ignored_identities: Vec<String>,
+    owners: Vec<FileLegalOwnerPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalOwnerPolicy {
+    name: String,
+    #[serde(default)]
+    aliases: Vec<String>,
+    #[serde(default)]
+    always: bool,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct FileLegalLicense {
+    spdx_identifier: String,
+    notice: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalDocument {
+    schema: String,
+    copyright: FileLegalCopyright,
+    license: FileLegalLicense,
+    audit: FileLegalAudit,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalCopyright {
+    holders: Vec<FileLegalHolder>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalHolder {
+    name: String,
+    years: FileLegalYears,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalYears {
+    first: i64,
+    last: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileLegalAudit {
+    created: String,
+    last_updated: String,
+    recheck_after_days: i64,
+    #[serde(default)]
+    body_blake3: String,
+}
+
+struct FileLegalChecker {
+    today_days: i64,
+}
+
+impl FileLegalChecker {
+    fn today() -> Self {
+        let epoch_days = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+            / 86_400;
+        Self { today_days: epoch_days }
+    }
+
+    #[cfg(test)]
+    fn for_date(date: &str) -> Result<Self, String> {
+        Ok(Self {
+            today_days: parse_iso_date(date)?,
+        })
+    }
+}
+
+impl FileContentChecker for FileLegalChecker {
+    fn name(&self) -> &'static str {
+        "FileLegalChecker"
+    }
+
+    fn should_process_file(&self, file_path: &str, project_root: &Path) -> bool {
+        let path = normalize_path(file_path);
+        file_legal_policy().is_ok_and(|policy| policy.enabled)
+            && is_under_project_subpath(&path, project_root, "src")
+            && !is_under_project_subpath(&path, project_root, "src/third_party")
+            && ends_with_any(&path, &[".h", ".hpp", ".cpp", ".c", ".S", ".s"])
+    }
+
+    fn check_file_content(&self, file_content: &FileContent) -> Vec<(usize, String)> {
+        match check_file_legal_document(&file_content.content, self.today_days) {
+            Ok(()) => Vec::new(),
+            Err((line, message)) => vec![(line, message)],
+        }
+    }
+}
+
+fn file_legal_policy() -> Result<&'static FileLegalPolicy, String> {
+    static POLICY: OnceLock<Result<FileLegalPolicy, String>> = OnceLock::new();
+    POLICY
+        .get_or_init(|| {
+            let policy: FileLegalPolicy = serde_yaml::from_str(FILE_LEGAL_POLICY_YAML)
+                .map_err(|error| format!("invalid file legal policy: {error}"))?;
+            if policy.schema != "fastled-file-legal-policy/v1" {
+                return Err(format!("unsupported file legal policy schema: {}", policy.schema));
+            }
+            if policy.attribution_mode != "initial_history_snapshot" {
+                return Err(format!(
+                    "unsupported file legal attribution mode: {}",
+                    policy.attribution_mode
+                ));
+            }
+            if policy.recheck_after_days <= 0 {
+                return Err("file legal recheck_after_days must be positive".to_string());
+            }
+            if !policy.owners.iter().any(|owner| owner.name == "Zach Vorhies" && owner.always) {
+                return Err("file legal policy must always include Zach Vorhies".to_string());
+            }
+            let _alias_count: usize = policy.owners.iter().map(|owner| owner.aliases.len()).sum();
+            Ok(policy)
+        })
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
+fn check_file_legal_document(content: &str, today_days: i64) -> Result<(), (usize, String)> {
+    if content
+        .strip_prefix('\u{feff}')
+        .unwrap_or(content)
+        .contains('\u{feff}')
+    {
+        return Err((
+            1,
+            "UTF-8 BOM is only valid at the start of the file".to_string(),
+        ));
+    }
+    let begin_lines: Vec<usize> = content
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| (line.trim_start_matches('\u{feff}') == FILE_LEGAL_BEGIN).then_some(index))
+        .collect();
+    let end_lines: Vec<usize> = content
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| (line == FILE_LEGAL_END).then_some(index))
+        .collect();
+
+    if begin_lines.is_empty() && end_lines.is_empty() {
+        return Err((1, "missing FASTLED-FILE-LEGAL block; run the Rust legal-header updater".to_string()));
+    }
+    if begin_lines.len() != 1 || end_lines.len() != 1 {
+        return Err((1, "expected exactly one FASTLED-FILE-LEGAL block".to_string()));
+    }
+    let begin = begin_lines[0];
+    let end = end_lines[0];
+    if end <= begin {
+        return Err((begin + 1, "FASTLED-FILE-LEGAL markers are out of order".to_string()));
+    }
+    if begin != 0 {
+        return Err((begin + 1, "FASTLED-FILE-LEGAL block must be the first file content".to_string()));
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut yaml = String::new();
+    for (offset, line) in lines[begin + 1..end].iter().enumerate() {
+        let Some(rest) = line.strip_prefix("//") else {
+            return Err((begin + offset + 2, "FASTLED-FILE-LEGAL content must be line-comment YAML".to_string()));
+        };
+        let rest = rest.strip_prefix(' ').unwrap_or(rest);
+        yaml.push_str(rest);
+        yaml.push('\n');
+    }
+
+    let document: FileLegalDocument = serde_yaml::from_str(&yaml)
+        .map_err(|error| (begin + 2, format!("invalid FASTLED-FILE-LEGAL YAML: {error}")))?;
+    let policy = file_legal_policy().map_err(|error| (begin + 2, error))?;
+    if document.schema != FILE_LEGAL_SCHEMA {
+        return Err((begin + 2, format!("expected legal schema {FILE_LEGAL_SCHEMA}")));
+    }
+    let actual_holders: Vec<&str> = document
+        .copyright
+        .holders
+        .iter()
+        .map(|holder| holder.name.as_str())
+        .collect();
+    let mut unique_holders = HashSet::new();
+    if actual_holders.iter().any(|name| !unique_holders.insert(*name)) {
+        return Err((begin + 3, "copyright holders must be unique".to_string()));
+    }
+    if actual_holders.iter().any(|name| name.contains('@')) {
+        return Err((
+            begin + 3,
+            "copyright holder names must not contain email addresses".to_string(),
+        ));
+    }
+    if let Some(ignored) = actual_holders.iter().find(|name| {
+        policy
+            .ignored_identities
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(name))
+            || name.ends_with("[bot]")
+    }) {
+        return Err((
+            begin + 3,
+            format!("ignored automation identity must not be a copyright holder: {ignored}"),
+        ));
+    }
+    if actual_holders.last().copied() != Some("Zach Vorhies") {
+        return Err((begin + 3, "copyright holders must append Zach Vorhies last".to_string()));
+    }
+    for owner in &policy.owners {
+        if owner.always && !actual_holders.contains(&owner.name.as_str()) {
+            return Err((begin + 3, format!("copyright holders must include {}", owner.name)));
+        }
+    }
+    for holder in &document.copyright.holders {
+        if holder.years.first > holder.years.last {
+            return Err((begin + 3, format!("invalid copyright year range for {}", holder.name)));
+        }
+    }
+    if document.license != policy.license {
+        return Err((begin + 3, format!("license must match current policy ({})", policy.license.spdx_identifier)));
+    }
+    if document.audit.recheck_after_days != policy.recheck_after_days {
+        return Err((begin + 3, format!("recheck_after_days must be {}", policy.recheck_after_days)));
+    }
+    let created = parse_iso_date(&document.audit.created).map_err(|error| (begin + 3, error))?;
+    let last_updated = parse_iso_date(&document.audit.last_updated).map_err(|error| (begin + 3, error))?;
+    if created > last_updated {
+        return Err((begin + 3, "audit.created must not be after audit.last_updated".to_string()));
+    }
+    if last_updated > today_days {
+        return Err((begin + 3, "audit.last_updated must not be in the future".to_string()));
+    }
+    let current_body_hash = file_legal_body_hash(content)
+        .map_err(|message| (begin + 1, message))?;
+    if document.audit.body_blake3.len() != 64
+        || !document.audit.body_blake3.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err((begin + 3, "audit.body_blake3 must be a 64-character hex digest".to_string()));
+    }
+    if current_body_hash != document.audit.body_blake3
+        && today_days - last_updated > policy.recheck_after_days
+    {
+        return Err((begin + 3, format!("legal notice audit expired after {} days; run the Rust legal-header updater", policy.recheck_after_days)));
+    }
+    Ok(())
+}
+
+fn file_legal_body(content: &str) -> Result<&str, String> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let begins: Vec<usize> = content.match_indices(FILE_LEGAL_BEGIN).map(|(index, _)| index).collect();
+    let ends: Vec<usize> = content.match_indices(FILE_LEGAL_END).map(|(index, _)| index).collect();
+    if begins.is_empty() && ends.is_empty() {
+        return Ok(content);
+    }
+    if begins.len() != 1 || ends.len() != 1 || begins[0] != 0 || ends[0] <= begins[0] {
+        return Err("cannot hash malformed FASTLED-FILE-LEGAL markers".to_string());
+    }
+    let end = ends[0] + FILE_LEGAL_END.len();
+    let body_start = if content[end..].starts_with("\r\n") {
+        end + 2
+    } else if content[end..].starts_with('\n') {
+        end + 1
+    } else {
+        end
+    };
+    Ok(&content[body_start..])
+}
+
+fn file_legal_body_hash(content: &str) -> Result<String, String> {
+    Ok(blake3::hash(file_legal_body(content)?.as_bytes()).to_hex().to_string())
+}
+
+fn parse_iso_date(value: &str) -> Result<i64, String> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return Err(format!("invalid ISO date {value:?}; expected YYYY-MM-DD"));
+    }
+    let year = value[0..4].parse::<i64>().map_err(|_| format!("invalid ISO date {value:?}"))?;
+    let month = value[5..7].parse::<i64>().map_err(|_| format!("invalid ISO date {value:?}"))?;
+    let day = value[8..10].parse::<i64>().map_err(|_| format!("invalid ISO date {value:?}"))?;
+    if !(1..=12).contains(&month) || day < 1 || day > days_in_month(year, month) {
+        return Err(format!("invalid ISO date {value:?}"));
+    }
+    Ok(days_from_civil(year, month, day))
+}
+
+fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        4 | 6 | 9 | 11 => 30,
+        _ => 31,
+    }
+}
+
+fn days_from_civil(mut year: i64, month: i64, day: i64) -> i64 {
+    year -= i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let adjusted_month = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * adjusted_month + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+#[derive(Clone, Debug)]
+struct FileLegalHistory {
+    created: String,
+    authors: Vec<FileLegalHistoryAuthor>,
+}
+
+#[derive(Clone, Debug)]
+struct FileLegalHistoryAuthor {
+    name: String,
+    first_year: i64,
+    last_year: i64,
+}
+
+impl FileLegalHistory {
+    fn touch(&mut self, raw_name: &str, date: &str, policy: &FileLegalPolicy) {
+        let name = canonical_file_legal_name(raw_name, policy);
+        if policy
+            .ignored_identities
+            .iter()
+            .any(|ignored| ignored.eq_ignore_ascii_case(&name))
+            || name.ends_with("[bot]")
+        {
+            return;
+        }
+        let year = date
+            .get(0..4)
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+        if let Some(author) = self.authors.iter_mut().find(|author| author.name == name) {
+            author.first_year = author.first_year.min(year);
+            author.last_year = author.last_year.max(year);
+        } else {
+            self.authors.push(FileLegalHistoryAuthor {
+                name,
+                first_year: year,
+                last_year: year,
+            });
+        }
+    }
+}
+
+fn canonical_file_legal_name(raw_name: &str, policy: &FileLegalPolicy) -> String {
+    let raw_name = raw_name
+        .trim()
+        .split_once('@')
+        .map_or(raw_name.trim(), |(local_part, _)| local_part);
+    for owner in &policy.owners {
+        if owner.name.eq_ignore_ascii_case(raw_name)
+            || owner
+                .aliases
+                .iter()
+                .any(|alias| alias.eq_ignore_ascii_case(raw_name))
+        {
+            return owner.name.clone();
+        }
+    }
+    raw_name.to_string()
+}
+
+fn existing_file_legal_history(content: &str) -> Result<Option<FileLegalHistory>, String> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let begin_count = content.matches(FILE_LEGAL_BEGIN).count();
+    let end_count = content.matches(FILE_LEGAL_END).count();
+    if begin_count == 0 && end_count == 0 {
+        return Ok(None);
+    }
+    if begin_count != 1 || end_count != 1 || !content.starts_with(FILE_LEGAL_BEGIN) {
+        return Err("refusing to update malformed FASTLED-FILE-LEGAL markers".to_string());
+    }
+    let end_start = content
+        .find(FILE_LEGAL_END)
+        .ok_or_else(|| "missing FASTLED-FILE-LEGAL end marker".to_string())?;
+    if end_start <= FILE_LEGAL_BEGIN.len() {
+        return Err("FASTLED-FILE-LEGAL markers are out of order".to_string());
+    }
+    let yaml_region = &content[FILE_LEGAL_BEGIN.len()..end_start];
+    let mut yaml = String::new();
+    for line in yaml_region.lines().skip(1) {
+        let rest = line
+            .strip_prefix("//")
+            .ok_or_else(|| "FASTLED-FILE-LEGAL content must be line-comment YAML".to_string())?;
+        yaml.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+        yaml.push('\n');
+    }
+    let document: FileLegalDocument = serde_yaml::from_str(&yaml)
+        .map_err(|error| format!("invalid FASTLED-FILE-LEGAL YAML: {error}"))?;
+    Ok(Some(FileLegalHistory {
+        created: document.audit.created,
+        authors: document
+            .copyright
+            .holders
+            .into_iter()
+            .map(|holder| FileLegalHistoryAuthor {
+                name: holder.name,
+                first_year: holder.years.first,
+                last_year: holder.years.last,
+            })
+            .collect(),
+    }))
+}
+
+fn collect_file_legal_history(
+    project_root: &Path,
+) -> Result<HashMap<String, FileLegalHistory>, DynError> {
+    let inventory = std::process::Command::new("git")
+        .current_dir(project_root)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .args(["--no-optional-locks", "ls-files", "-z", "--", "src"])
+        .output()?;
+    if !inventory.status.success() {
+        return Err(format!(
+            "git file inventory failed: {}",
+            String::from_utf8_lossy(&inventory.stderr)
+        )
+        .into());
+    }
+    let files: Vec<String> = inventory
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| normalize_path(&String::from_utf8_lossy(path)))
+        .filter(|path| {
+            !path.starts_with("src/third_party/")
+                && ends_with_any(path, &[".h", ".hpp", ".cpp", ".c", ".S", ".s"])
+        })
+        .collect();
+    collect_file_legal_history_for_paths(project_root, &files)
+}
+
+fn collect_file_legal_history_for_paths(
+    project_root: &Path,
+    files: &[String],
+) -> Result<HashMap<String, FileLegalHistory>, DynError> {
+    let policy = file_legal_policy().map_err(|error| -> DynError { error.into() })?;
+    let histories: Result<Vec<(String, FileLegalHistory)>, String> = files
+        .par_iter()
+        .map(|path| {
+            let output = std::process::Command::new("git")
+                .current_dir(project_root)
+                .env("GIT_OPTIONAL_LOCKS", "0")
+                .args([
+                    "--no-optional-locks",
+                    "log",
+                    "--follow",
+                    "--date=short",
+                    "--format=%ad%x00%aN%x00",
+                    "--",
+                    path,
+                ])
+                .output()
+                .map_err(|error| format!("git history scan failed for {path}: {error}"))?;
+            if !output.status.success() {
+                return Err(format!(
+                    "git history scan failed for {path}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            let fields: Vec<&[u8]> = output
+                .stdout
+                .split(|byte| *byte == 0)
+                .filter(|field| !field.is_empty())
+                .collect();
+            let created = fields
+                .chunks_exact(2)
+                .map(|pair| String::from_utf8_lossy(pair[0]).trim().to_string())
+                .min()
+                .unwrap_or_else(today_iso_date);
+            let mut history = FileLegalHistory {
+                created,
+                authors: Vec::new(),
+            };
+            for pair in fields.chunks_exact(2) {
+                let date = String::from_utf8_lossy(pair[0]);
+                let author = String::from_utf8_lossy(pair[1]);
+                history.touch(author.trim(), date.trim(), policy);
+            }
+            Ok((path.clone(), history))
+        })
+        .collect();
+    Ok(histories?.into_iter().collect())
+}
+
+#[cfg(test)]
+mod history_tests {
+    use super::*;
+    use std::process::Command;
+
+    fn git(root: &Path, args: &[&str], author: Option<(&str, &str, &str)>) {
+        let mut command = Command::new("git");
+        command.current_dir(root).args(args);
+        if let Some((name, email, date)) = author {
+            command
+                .env("GIT_AUTHOR_NAME", name)
+                .env("GIT_AUTHOR_EMAIL", email)
+                .env("GIT_AUTHOR_DATE", date)
+                .env("GIT_COMMITTER_NAME", name)
+                .env("GIT_COMMITTER_EMAIL", email)
+                .env("GIT_COMMITTER_DATE", date);
+        }
+        let output = command.output().expect("git command must start");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn history_follows_a_file_moved_from_repository_root_into_src() {
+        let root = std::env::temp_dir().join(format!(
+            "fastled_file_legal_history_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        if root.exists() {
+            fs::remove_dir_all(&root).unwrap();
+        }
+        fs::create_dir_all(&root).unwrap();
+        git(&root, &["init", "-q"], None);
+        fs::write(root.join("FastLED.h"), "#pragma once\n").unwrap();
+        git(&root, &["add", "FastLED.h"], None);
+        git(
+            &root,
+            &["commit", "-q", "-m", "original header"],
+            Some(("Daniel Garcia", "daniel.invalid", "2013-01-02T00:00:00Z")),
+        );
+        fs::create_dir_all(root.join("src")).unwrap();
+        git(&root, &["mv", "FastLED.h", "src/FastLED.h"], None);
+        git(
+            &root,
+            &["commit", "-q", "-m", "move sources"],
+            Some(("Sam Guyer", "sam.invalid", "2020-06-13T00:00:00Z")),
+        );
+
+        let histories = collect_file_legal_history(&root).unwrap();
+        let history = histories.get("src/FastLED.h").unwrap();
+        assert_eq!(history.created, "2013-01-02");
+        assert!(history.authors.iter().any(|author| {
+            author.name == "Daniel Garcia"
+                && author.first_year == 2013
+                && author.last_year == 2013
+        }));
+        assert!(history.authors.iter().any(|author| author.name == "Sam Guyer"));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rendered_history_canonicalizes_email_shaped_legacy_names() {
+        let policy = file_legal_policy().unwrap();
+        let mut history = FileLegalHistory {
+            created: "2013-01-02".to_string(),
+            authors: Vec::new(),
+        };
+        let separator = char::from(64);
+        history.touch(&format!("danielgarcia{separator}ignored"), "2013-01-02", policy);
+        history.touch(&format!("kriegsman{separator}ignored"), "2014-01-02", policy);
+        history.touch(&format!("unknown{separator}ignored"), "2015-01-02", policy);
+        let rendered = render_file_legal_header(
+            &history,
+            "2026-08-25",
+            policy,
+            &blake3::hash(b"").to_hex().to_string(),
+        );
+        assert!(rendered.contains("name: \"Daniel Garcia\""));
+        assert!(rendered.contains("name: \"Mark Kriegsman\""));
+        assert!(rendered.contains("name: \"unknown\""));
+        assert!(!rendered.contains('@'));
+    }
+
+    #[test]
+    fn live_fastled_history_contains_known_pre_and_post_move_authors() {
+        let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .unwrap();
+        let shallow = Command::new("git")
+            .current_dir(project_root)
+            .args(["rev-parse", "--is-shallow-repository"])
+            .output()
+            .unwrap();
+        assert!(shallow.status.success());
+        if String::from_utf8_lossy(&shallow.stdout).trim() == "true" {
+            eprintln!("skipping live history assertions in a shallow Git checkout");
+            return;
+        }
+        let known_paths = [
+            "src/FastLED.h",
+            "src/chipsets.h",
+            "src/colorutils.h",
+            "src/fastspi.h",
+            "src/pixeltypes.h",
+            "src/platforms/esp/32/clockless_block_esp32.h",
+        ];
+        let histories = collect_file_legal_history_for_paths(
+            project_root,
+            &known_paths.iter().map(|path| (*path).to_string()).collect::<Vec<_>>(),
+        )
+        .unwrap();
+        for path in [
+            "src/FastLED.h",
+            "src/chipsets.h",
+            "src/colorutils.h",
+            "src/fastspi.h",
+        ] {
+            let history = histories.get(path).unwrap_or_else(|| panic!("missing history for {path}"));
+            assert!(
+                history.authors.iter().any(|author| author.name == "Daniel Garcia"),
+                "Daniel Garcia missing from {path}"
+            );
+        }
+        for path in [
+            "src/FastLED.h",
+            "src/chipsets.h",
+            "src/colorutils.h",
+            "src/pixeltypes.h",
+        ] {
+            let history = histories.get(path).unwrap_or_else(|| panic!("missing history for {path}"));
+            assert!(
+                history.authors.iter().any(|author| author.name == "Mark Kriegsman"),
+                "Mark Kriegsman missing from {path}"
+            );
+        }
+        let esp32 = histories
+            .get("src/platforms/esp/32/clockless_block_esp32.h")
+            .expect("missing ESP32 clockless header history");
+        assert!(esp32.authors.iter().any(|author| author.name == "Sam Guyer"));
+    }
+
+    #[test]
+    #[ignore = "deep audit: launches one independent git --follow query per owned source file"]
+    fn deep_live_history_matches_per_file_git_for_mark_and_sam() {
+        let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .unwrap();
+        let policy = file_legal_policy().unwrap();
+        let inventory = Command::new("git")
+            .current_dir(project_root)
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .args(["--no-optional-locks", "ls-files", "-z", "--", "src"])
+            .output()
+            .unwrap();
+        assert!(inventory.status.success());
+        let files: Vec<String> = inventory
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .map(|path| normalize_path(&String::from_utf8_lossy(path)))
+            .filter(|path| {
+                !path.starts_with("src/third_party/")
+                    && ends_with_any(path, &[".h", ".hpp", ".cpp", ".c", ".S", ".s"])
+            })
+            .collect();
+
+        let oracle: HashMap<String, HashSet<String>> = files
+            .par_iter()
+            .map(|path| {
+                let output = Command::new("git")
+                    .current_dir(project_root)
+                    .env("GIT_OPTIONAL_LOCKS", "0")
+                    .args([
+                        "--no-optional-locks",
+                        "log",
+                        "--follow",
+                        "--format=%aN%x00",
+                        "--",
+                        path,
+                    ])
+                    .output()
+                    .unwrap();
+                assert!(output.status.success(), "git --follow failed for {path}");
+                let authors = output
+                    .stdout
+                    .split(|byte| *byte == 0)
+                    .filter(|name| !name.is_empty())
+                    .map(|name| {
+                        canonical_file_legal_name(&String::from_utf8_lossy(name), policy)
+                    })
+                    .collect();
+                (path.clone(), authors)
+            })
+            .collect();
+        let batched = collect_file_legal_history(project_root).unwrap();
+
+        for expected_author in ["Mark Kriegsman", "Sam Guyer"] {
+            let expected: BTreeSet<&str> = oracle
+                .iter()
+                .filter(|(_, authors)| authors.contains(expected_author))
+                .map(|(path, _)| path.as_str())
+                .collect();
+            let actual: BTreeSet<&str> = batched
+                .iter()
+                .filter(|(_, history)| {
+                    history
+                        .authors
+                        .iter()
+                        .any(|author| author.name == expected_author)
+                })
+                .map(|(path, _)| path.as_str())
+                .filter(|path| files.iter().any(|candidate| candidate == path))
+                .collect();
+            let missing: Vec<_> = expected.difference(&actual).copied().collect();
+            let extra: Vec<_> = actual.difference(&expected).copied().collect();
+            eprintln!(
+                "{expected_author}: oracle={}, batched={}, missing={}, extra={}",
+                expected.len(),
+                actual.len(),
+                missing.len(),
+                extra.len()
+            );
+            assert!(missing.is_empty(), "{expected_author} missing from {missing:?}");
+            assert!(extra.is_empty(), "{expected_author} unexpectedly present in {extra:?}");
+        }
+    }
+}
+
+fn today_iso_date() -> String {
+    let days = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+        / 86_400;
+    let (year, month, day) = civil_from_days(days);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let days = days + 719_468;
+    let era = if days >= 0 {
+        days
+    } else {
+        days - 146_096
+    } / 146_097;
+    let day_of_era = days - era * 146_097;
+    let year_of_era = (day_of_era - day_of_era / 1_460 + day_of_era / 36_524
+        - day_of_era / 146_096)
+        / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year =
+        day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}
+
+fn render_file_legal_header(
+    history: &FileLegalHistory,
+    today: &str,
+    policy: &FileLegalPolicy,
+    body_blake3: &str,
+) -> String {
+    let mut authors: Vec<FileLegalHistoryAuthor> = Vec::new();
+    for author in &history.authors {
+        let name = canonical_file_legal_name(&author.name, policy);
+        if name.contains('@') {
+            continue;
+        }
+        if policy
+            .ignored_identities
+            .iter()
+            .any(|ignored| ignored.eq_ignore_ascii_case(&name))
+            || name.ends_with("[bot]")
+        {
+            continue;
+        }
+        if let Some(existing) = authors.iter_mut().find(|existing| existing.name == name) {
+            existing.first_year = existing.first_year.min(author.first_year);
+            existing.last_year = existing.last_year.max(author.last_year);
+        } else {
+            authors.push(FileLegalHistoryAuthor {
+                name,
+                first_year: author.first_year,
+                last_year: author.last_year,
+            });
+        }
+    }
+    authors.retain(|author| author.name != "Zach Vorhies");
+    let today_year = today[0..4].parse::<i64>().unwrap_or(0);
+    let zach = history
+        .authors
+        .iter()
+        .find(|author| author.name == "Zach Vorhies")
+        .cloned()
+        .unwrap_or(FileLegalHistoryAuthor {
+            name: "Zach Vorhies".to_string(),
+            first_year: today_year,
+            last_year: today_year,
+        });
+    authors.push(zach);
+
+    let mut output = String::new();
+    output.push_str(FILE_LEGAL_BEGIN);
+    output.push_str("\n// schema: fastled-file-legal/v1\n//\n// copyright:\n//   holders:\n");
+    for author in authors {
+        let quoted_name = serde_json::to_string(&author.name)
+            .unwrap_or_else(|_| "\"Unknown\"".to_string());
+        output.push_str(&format!(
+            "//     - {{name: {quoted_name}, years: {{first: {}, last: {}}}}}\n",
+            author.first_year, author.last_year
+        ));
+    }
+    output.push_str("//\n// license:\n");
+    output.push_str(&format!(
+        "//   spdx_identifier: {}\n",
+        policy.license.spdx_identifier
+    ));
+    output.push_str("//   notice: |-\n");
+    for line in policy.license.notice.lines() {
+        output.push_str("//     ");
+        output.push_str(line);
+        output.push('\n');
+    }
+    output.push_str("//\n// audit:\n");
+    output.push_str(&format!(
+        "//   created: {}\n//   last_updated: {today}\n//   recheck_after_days: {}\n//   body_blake3: {body_blake3}\n",
+        history.created, policy.recheck_after_days
+    ));
+    output.push_str(FILE_LEGAL_END);
+    output.push('\n');
+    output
+}
+
+pub fn update_file_legal_headers(
+    project_root: &Path,
+    force_history_rescan: bool,
+) -> Result<usize, DynError> {
+    let policy = file_legal_policy().map_err(|error| -> DynError { error.into() })?;
+    if !policy.enabled {
+        return Err("file legal compliance is disabled by policy".into());
+    }
+    let today = today_iso_date();
+    let output = std::process::Command::new("git")
+        .current_dir(project_root)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .args(["--no-optional-locks", "ls-files", "-z", "--", "src"])
+        .output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "git file inventory failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+
+    struct PendingFile {
+        relative: String,
+        path: PathBuf,
+        original: String,
+        existing_history: Option<FileLegalHistory>,
+        body_blake3: String,
+        had_bom: bool,
+    }
+
+    let mut pending = Vec::new();
+    for raw_path in output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+    {
+        let relative = normalize_path(&String::from_utf8_lossy(raw_path));
+        if is_under_dir(&relative, "third_party")
+            || !ends_with_any(&relative, &[".h", ".hpp", ".cpp", ".c", ".S", ".s"])
+        {
+            continue;
+        }
+        let path = project_root.join(&relative);
+        let original = fs::read_to_string(&path)?;
+        if !force_history_rescan
+            && check_file_legal_document(&original, FileLegalChecker::today().today_days).is_ok()
+        {
+            continue;
+        }
+        let had_bom = original.contains('\u{feff}');
+        let original = original.replace('\u{feff}', "");
+        let existing_history = if force_history_rescan {
+            None
+        } else {
+            existing_file_legal_history(&original)
+                .map_err(|error| format!("{relative}: {error}"))?
+        };
+        let body_blake3 = file_legal_body_hash(&original)
+            .map_err(|error| format!("{relative}: {error}"))?;
+        pending.push(PendingFile {
+            relative,
+            path,
+            original,
+            existing_history,
+            body_blake3,
+            had_bom,
+        });
+    }
+
+    let needs_history = pending.iter().any(|file| file.existing_history.is_none());
+    let histories = if needs_history {
+        Some(collect_file_legal_history(project_root)?)
+    } else {
+        None
+    };
+    let mut changed = 0;
+    for pending_file in pending {
+        let PendingFile {
+            relative,
+            path,
+            original,
+            existing_history,
+            body_blake3,
+            had_bom,
+        } = pending_file;
+        let history = existing_history
+            .or_else(|| {
+                histories
+                    .as_ref()
+                    .and_then(|items| items.get(&relative).cloned())
+            })
+            .unwrap_or(FileLegalHistory {
+                created: today.clone(),
+                authors: Vec::new(),
+            });
+        let header = render_file_legal_header(&history, &today, policy, &body_blake3);
+        let crlf = original.contains("\r\n");
+        let header = if crlf {
+            header.replace('\n', "\r\n")
+        } else {
+            header
+        };
+        let bom = if had_bom { "\u{feff}" } else { "" };
+        let original_body = original.as_str();
+        let updated_body = if let (Some(begin), Some(end_start)) =
+            (original_body.find(FILE_LEGAL_BEGIN), original_body.find(FILE_LEGAL_END))
+        {
+            let end = end_start + FILE_LEGAL_END.len();
+            let suffix_start = if original_body[end..].starts_with("\r\n") {
+                end + 2
+            } else if original_body[end..].starts_with('\n') {
+                end + 1
+            } else {
+                end
+            };
+            format!(
+                "{}{}{}",
+                &original_body[..begin],
+                header,
+                &original_body[suffix_start..]
+            )
+        } else {
+            format!("{header}{original_body}")
+        };
+        let updated = format!("{bom}{updated_body}");
+        if updated != original {
+            fs::write(&path, updated)?;
+            changed += 1;
+        }
+    }
+    Ok(changed)
+}

--- a/ci/lint_cpp_rs/src/lib.rs
+++ b/ci/lint_cpp_rs/src/lib.rs
@@ -24,4 +24,5 @@ include!("checkers/singleton_elision.rs");
 include!("checkers/prefer_constexpr.rs");
 include!("checkers/container_ptr.rs");
 include!("checkers/r1_cleanup.rs");
+include!("checkers/file_legal.rs");
 include!("lint_core/tests.rs");

--- a/ci/lint_cpp_rs/src/lint_core/prelude_constants.rs
+++ b/ci/lint_cpp_rs/src/lint_core/prelude_constants.rs
@@ -11,7 +11,7 @@ use walkdir::WalkDir;
 
 type DynError = Box<dyn Error + Send + Sync>;
 
-const CPP_EXTENSIONS: &[&str] = &["cpp", "h", "hpp", "ino", "cpp.hpp"];
+const CPP_EXTENSIONS: &[&str] = &["c", "cpp", "h", "hpp", "ino", "cpp.hpp", "s", "S"];
 
 const EXCLUDED_FILES: &[&str] = &[
     "stub_main.cpp",
@@ -805,4 +805,3 @@ const NATIVE_COMPILER_ABSTRACTION_FILES: &[&str] = &[
     "type_traits.h",
     "m0clockless_c.h",
 ];
-

--- a/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
+++ b/ci/lint_cpp_rs/src/lint_core/processor_registry_cli.rs
@@ -266,6 +266,7 @@ pub fn supported_checker_names() -> &'static [&'static str] {
         "enum_class",
         "esp_rom_printf",
         "fastled_header_usage",
+        "file_legal",
         "fl_is_defined",
         "headers_exist",
         "include_after_namespace",
@@ -349,6 +350,7 @@ pub fn supported_python_checker_names() -> &'static [&'static str] {
         "EspRomPrintfChecker",
         "ExampleSerialChecker",
         "FastLEDHeaderUsageChecker",
+        "FileLegalChecker",
         "FlIsDefinedChecker",
         "HeadersExistChecker",
         "IncludeAfterNamespaceChecker",
@@ -495,6 +497,7 @@ pub fn create_checkers(
         ("esp_rom_printf", Box::new(EspRomPrintfChecker)),
         ("example_serial", Box::new(ExampleSerialChecker)),
         ("fastled_header_usage", Box::new(FastLEDHeaderUsageChecker)),
+        ("file_legal", Box::new(FileLegalChecker::today())),
         ("fl_is_defined", Box::new(FlIsDefinedChecker)),
         ("headers_exist", Box::new(HeadersExistChecker)),
         (

--- a/ci/lint_cpp_rs/src/lint_core/tests.rs
+++ b/ci/lint_cpp_rs/src/lint_core/tests.rs
@@ -10,6 +10,152 @@ mod tests {
         }
     }
 
+    fn legal_header(last_updated: &str, holders: &[&str]) -> String {
+        let holders_yaml = if holders.is_empty() {
+            "//   holders: []".to_string()
+        } else {
+            let holder_lines = holders
+                .iter()
+                .map(|name| {
+                    format!(
+                        "//     - {{name: {name}, years: {{first: 2020, last: 2026}}}}"
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("//   holders:\n{holder_lines}")
+        };
+        format!(
+            "// FASTLED-FILE-LEGAL-BEGIN\n\
+// schema: fastled-file-legal/v1\n\
+// copyright:\n\
+{holders_yaml}\n\
+// license:\n\
+//   spdx_identifier: MIT\n\
+//   notice: |-\n\
+//     Distributed under the MIT License.\n\
+//     See LICENSE for details.\n\
+// audit:\n\
+//   created: 2020-01-02\n\
+//   last_updated: {last_updated}\n\
+//   recheck_after_days: 365\n\
+//   body_blake3: {}\n\
+// FASTLED-FILE-LEGAL-END\n"
+            , blake3::hash(b"").to_hex()
+        )
+    }
+
+    #[test]
+    fn file_legal_requires_header_for_owned_src_but_not_third_party() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        assert!(!checker.should_process_file("src/fl/example.h", Path::new(".")));
+        assert!(!checker.should_process_file("src/third_party/example.h", Path::new(".")));
+        assert!(!checker.should_process_file("tests/example.cpp", Path::new(".")));
+        let hits = checker.check_file_content(&file("src/fl/example.h", "#pragma once\n"));
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].1.contains("missing FASTLED-FILE-LEGAL block"));
+    }
+
+    #[test]
+    fn file_legal_accepts_current_mit_yaml_block() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        let content = format!("{}#pragma once\n", legal_header("2026-08-25", &["Zach Vorhies"]));
+        assert!(checker
+            .check_file_content(&file("src/fl/example.h", &content))
+            .is_empty());
+
+        let bom_content = format!("\u{feff}{}", legal_header("2026-08-25", &["Zach Vorhies"]));
+        assert!(checker
+            .check_file_content(&file("src/fl/example.h", &bom_content))
+            .is_empty());
+
+        let misplaced_bom = format!("{}\u{feff}#pragma once\n", legal_header("2026-08-25", &["Zach Vorhies"]));
+        let hits = checker.check_file_content(&file("src/fl/example.h", &misplaced_bom));
+        assert!(hits.iter().any(|hit| hit.1.contains("BOM")));
+    }
+
+    #[test]
+    fn file_legal_requires_zach_and_current_policy_license() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        let missing_owner = legal_header("2026-08-25", &[]);
+        let hits = checker.check_file_content(&file("src/fl/example.h", &missing_owner));
+        assert!(hits.iter().any(|hit| hit.1.contains("copyright holders")));
+
+        let wrong_license = legal_header("2026-08-25", &["Zach Vorhies"])
+            .replace("spdx_identifier: MIT", "spdx_identifier: Apache-2.0");
+        let hits = checker.check_file_content(&file("src/fl/example.h", &wrong_license));
+        assert!(hits.iter().any(|hit| hit.1.contains("license")));
+
+        let bot_holder = legal_header("2026-08-25", &["Cursor Agent", "Zach Vorhies"]);
+        let hits = checker.check_file_content(&file("src/fl/example.h", &bot_holder));
+        assert!(hits
+            .iter()
+            .any(|hit| hit.1.contains("automation identity")));
+    }
+
+    #[test]
+    fn file_legal_rejects_email_holders_but_excludes_third_party() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        let separator = char::from(64);
+        let email_name = format!("contributor{separator}ignored");
+        let content = legal_header("2026-08-25", &[&email_name, "Zach Vorhies"]);
+        let hits = checker.check_file_content(&file("src/fl/example.h", &content));
+        assert!(hits.iter().any(|hit| hit.1.contains("email addresses")));
+        assert!(!checker.should_process_file("src/third_party/example.h", Path::new(".")));
+    }
+
+    #[test]
+    fn file_legal_rechecks_only_after_policy_delta() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        let fresh = legal_header("2025-08-25", &["Zach Vorhies"]);
+        assert!(checker
+            .check_file_content(&file("src/fl/example.h", &fresh))
+            .is_empty());
+
+        let stale = legal_header("2025-08-24", &["Zach Vorhies"]);
+        assert!(checker
+            .check_file_content(&file("src/fl/example.h", &stale))
+            .is_empty());
+
+        let stale_changed = format!("{stale}#pragma once\n");
+        let hits = checker.check_file_content(&file("src/fl/example.h", &stale_changed));
+        assert!(hits.iter().any(|hit| hit.1.contains("legal notice audit expired")));
+    }
+
+    #[test]
+    fn file_legal_rejects_duplicate_or_noncanonical_blocks() {
+        let checker = FileLegalChecker::for_date("2026-08-25").unwrap();
+        let header = legal_header("2026-08-25", &["Zach Vorhies"]);
+        let duplicate = format!("{header}{header}");
+        let hits = checker.check_file_content(&file("src/fl/example.h", &duplicate));
+        assert!(hits.iter().any(|hit| hit.1.contains("exactly one")));
+
+        let malformed = header.replace("// schema:", "/* schema:");
+        let hits = checker.check_file_content(&file("src/fl/example.h", &malformed));
+        assert!(hits.iter().any(|hit| hit.1.contains("line-comment YAML")));
+    }
+
+    #[test]
+    fn file_legal_normalizes_zackees_and_appends_zach_last() {
+        let policy = file_legal_policy().unwrap();
+        let mut history = FileLegalHistory {
+            created: "2020-01-02".to_string(),
+            authors: Vec::new(),
+        };
+        history.touch("Zackees", "2021-02-03", policy);
+        history.touch("Another Contributor", "2022-04-05", policy);
+        history.touch("zackees", "2026-06-07", policy);
+        let rendered = render_file_legal_header(
+            &history,
+            "2026-08-25",
+            policy,
+            &blake3::hash(b"").to_hex().to_string(),
+        );
+        assert_eq!(rendered.matches("name: \"Zach Vorhies\"").count(), 1);
+        assert!(rendered.find("Another Contributor").unwrap() < rendered.find("Zach Vorhies").unwrap());
+        assert!(rendered.contains("years: {first: 2021, last: 2026}"));
+    }
+
     #[test]
     fn help_parse_exits_without_listing_checkers() {
         let config = CliConfig::parse(vec!["--help".to_string()]).unwrap();

--- a/ci/lint_cpp_rs/src/main.rs
+++ b/ci/lint_cpp_rs/src/main.rs
@@ -1,7 +1,24 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
-    match fastled_lint::run_cli(std::env::args().skip(1)) {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args == ["--update-file-legal"] || args == ["--rescan-file-legal-history"] {
+        let force_history_rescan = args == ["--rescan-file-legal-history"];
+        return match std::env::current_dir()
+            .map_err(|error| error.into())
+            .and_then(|root| fastled_lint::update_file_legal_headers(&root, force_history_rescan))
+        {
+            Ok(changed) => {
+                println!("Updated {changed} FASTLED-FILE-LEGAL block(s).");
+                ExitCode::SUCCESS
+            }
+            Err(err) => {
+                eprintln!("{err}");
+                ExitCode::from(2)
+            }
+        };
+    }
+    match fastled_lint::run_cli(args) {
         Ok(code) => ExitCode::from(code),
         Err(err) => {
             eprintln!("{err}");


### PR DESCRIPTION
Closes #4060.

## Summary

- add dormant Rust machinery for provenance-aware, machine-checkable YAML legal headers
- reconstruct file history in one Git process, including rename/move tracking across the historical root-to-`src` migration
- normalize configured aliases and strip email domains before exact local-identifier alias matching
- retain MIT license metadata, audit dates, BLAKE3 body fingerprints, and zccache inputs for future activation
- explicitly disable enforcement and updater writes with `enabled: false`
- make no changes under `src/**`

## Current scope

This PR builds and tests the machinery only. It does not insert headers or enforce them. `src/third_party/**` remains excluded. A later reviewed change can enable the policy and perform a migration.

## Validation

- Rust linter suite: 106/106 passed
- live Git-history test: Daniel Garcia found on known top-level headers; Sam Guyer found on an ESP32 header
- synthetic rename test: root-level file moved into `src/` retains its original author and creation year
- direct disabled-checker smoke test against `src/FastLED.h`: passed
- `git diff origin/master -- src`: zero files
- generated legal-header email hits: zero
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated legal-header compliance checks for project C, C++, and assembly source files.
  * Validates licenses, copyright holders, audit dates, file integrity, formatting, and prohibited identities.
  * Added commands to update legal headers and rescan file history.
  * Preserves existing file formatting, byte-order marks, and author history when updating headers.

* **Bug Fixes**
  * Lint caches now refresh when relevant source files or legal-policy settings change.

* **Tests**
  * Added coverage for header validation, history tracking, formatting, ownership, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->