### PR TITLE
fix(autoresearch): stabilize RP peer networking and OTA

### DIFF
--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -82,7 +82,9 @@ async def run_ota_peer_autoresearch(
         return min(20.0, remaining)
 
     async def rpc_data(
-        client: RpcClient, method: str, params: list[Any] | dict[str, Any] | None = None
+        client: RpcClient,
+        method: str,
+        params: list[Any] | dict[str, Any] | str | None = None,
     ) -> dict[str, Any]:
         response = await client.send(method, params or {}, timeout=rpc_timeout())
         if not isinstance(response.data, dict):
@@ -115,7 +117,7 @@ async def run_ota_peer_autoresearch(
             raise RuntimeError(f"C6 refused OTA artifact: {begin}")
         for offset in range(0, len(artifact), 512):
             encoded = base64.b64encode(artifact[offset : offset + 512]).decode("ascii")
-            written = await rpc_data(peer, "writeOtaArtifact", [encoded])
+            written = await rpc_data(peer, "writeOtaArtifact", encoded)
             if not written.get("success"):
                 raise RuntimeError(
                     f"C6 artifact write failed at byte {offset}: {written}"

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1597,13 +1597,22 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
     build_driver = ctx.build_driver
     assert build_driver is not None
 
-    # Preflight: an explicitly-named port that is not attached can only fail,
-    # and it fails at deploy — after ~7 minutes of install, lint and build.
-    # Checked before Phase 0 so the operator gets the real reason in seconds.
-    # Only an explicit --upload-port is gated: without one, fbuild can still
-    # reach an RP-series board through the BOOTSEL volume with no CDC record.
+    # Preflight: an explicitly named absent non-RP port can only fail after a
+    # long build. RP deployment is different: fbuild owns the recovery ladder
+    # and can use an unambiguous BOOTSEL volume when the CDC name is stale.
     if args.upload_port:
         absent = absent_port_error(args.upload_port)
+        if (
+            absent
+            and build_driver.name == "fbuild"
+            and bool(_active_rp2xxx_environment(final_environment_norm))
+        ):
+            print(
+                f"\n{Fore.YELLOW}RP runtime port is absent; delegating "
+                f"{args.upload_port} to fbuild's CDC/BOOTSEL recovery ladder."
+                f"{Style.RESET_ALL}"
+            )
+            absent = None
         if absent:
             print(f"\n❌ {absent}")
             return 1

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -371,7 +371,7 @@ class RpcClient:
     async def send(
         self,
         function: str,
-        args: list[Any] | dict[str, Any] | None = None,
+        args: list[Any] | dict[str, Any] | str | None = None,
         timeout: float | None = None,
         retries: int = 1,
         return_on_ack: bool = False,
@@ -381,9 +381,9 @@ class RpcClient:
         Args:
             function: RPC function name
             args: Function arguments passed as the single `fl::json` RPC
-                parameter — a list for positional handlers, or a dict for
-                object-param handlers (default: {}). Wrapped verbatim into
-                `params` as `[args]`.
+                parameter - a list for positional handlers, a dict for
+                object-param handlers, or a string for scalar handlers
+                (default: {}). Wrapped verbatim into `params` as `[args]`.
             timeout: Override default timeout for this call
             retries: Number of retry attempts (default: 1 = no retries)
 

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -182,4 +183,10 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
 
     assert result == 0
     assert peer.send.await_args_list[1].args[0] == "beginOtaArtifact"
-    assert any(call.args[0] == "writeOtaArtifact" for call in peer.send.await_args_list)
+    write_calls = [
+        call for call in peer.send.await_args_list if call.args[0] == "writeOtaArtifact"
+    ]
+    assert len(write_calls) == 1
+    encoded = write_calls[0].args[1]
+    assert isinstance(encoded, str), "RpcClient performs the one-parameter wrapping"
+    assert base64.b64decode(encoded) == b"firmware"

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -2180,6 +2180,47 @@ class TestRunBuildDeploy:
         assert rc is None
         assert mock_driver.deploy.call_args.kwargs["environment"] == "rp2350w"
 
+    def test_absent_rp_port_is_delegated_to_fbuild_recovery(self) -> None:
+        mock_driver = _make_mock_driver()
+        ctx = _make_ctx(
+            args=_make_args(skip_lint=True, upload_port="COM18"),
+            build_driver=mock_driver,
+            final_environment="rp2350w",
+            upload_port="COM18",
+        )
+        qctx = QuietContext(quiet=False)
+
+        with patch(
+            f"{_PATCH_MOD}.absent_port_error",
+            return_value="COM18 is not attached",
+        ):
+            rc = asyncio.run(_run_build_deploy(ctx, qctx))
+
+        assert rc is None
+        mock_driver.install_packages.assert_called_once()
+        mock_driver.deploy.assert_called_once()
+        assert mock_driver.deploy.call_args.kwargs["upload_port"] == "COM18"
+
+    def test_absent_non_rp_port_still_fails_before_build(self) -> None:
+        mock_driver = _make_mock_driver()
+        ctx = _make_ctx(
+            args=_make_args(skip_lint=True, upload_port="COM9"),
+            build_driver=mock_driver,
+            final_environment="esp32c6",
+            upload_port="COM9",
+        )
+        qctx = QuietContext(quiet=False)
+
+        with patch(
+            f"{_PATCH_MOD}.absent_port_error",
+            return_value="COM9 is not attached",
+        ):
+            rc = asyncio.run(_run_build_deploy(ctx, qctx))
+
+        assert rc == 1
+        mock_driver.install_packages.assert_not_called()
+        mock_driver.deploy.assert_not_called()
+
     def test_net_peer_deploys_c6_through_fbuild_on_explicit_port(self) -> None:
         mock_driver = _make_mock_driver()
         ctx = _make_ctx(

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -256,3 +256,49 @@ def test_rp2350w_autoresearch_exposes_the_cyw43_http_peer_surface() -> None:
     assert "delay(10);" in net_source
     assert "} while (static_cast<int32_t>(millis() - deadline_ms) < 0);" in net_source
     assert 'response.set("error", "TCP server failed to listen")' in net_source
+
+
+def test_esp32_autoresearch_serial_rx_queue_fits_ota_rpc_frames() -> None:
+    """A 512-byte OTA chunk expands beyond HWCDC's 256-byte default queue."""
+    source = AUTORESEARCH_SKETCH.read_text(encoding="utf-8")
+    init_buffers = source[
+        source.index("void init_serial_buffers()") : source.index(
+            "// Global State", source.index("void init_serial_buffers()")
+        )
+    ]
+    setup = source[source.index("void setup()") :]
+
+    assert "Serial.setRxBufferSize(4096);" in init_buffers
+    assert setup.index("init_serial_buffers();") < setup.index(
+        "fl::serial_begin(115200);"
+    )
+
+
+def test_rp_http_peer_passively_closes_completed_responses() -> None:
+    """The C6 must own TIME_WAIT so repeat cycles do not exhaust RP TCP PCBs."""
+    source = AUTORESEARCH_NET.read_text(encoding="utf-8")
+    state = source[source.index("struct RpPeerState") : source.index("RpPeerState&")]
+    reset = source[
+        source.index("void resetRpPeerRequest") : source.index("void writeHttpResponse")
+    ]
+    response = source[
+        source.index("void writeHttpResponse") : source.index(
+            "fl::json runRpHttpRequestTest"
+        )
+    ]
+    poll = source[source.index("void pollNetServer()") : source.index("#else  //")]
+
+    assert "bool mResponseSent = false;" in state
+    assert "state.mResponseSent = false;" in reset
+    assert "state.mResponseSent = true;" in response
+    assert "state.request_started_ms = millis();" in response
+    assert ".stop()" not in response
+    assert "if (state.mResponseSent)" in poll
+    passive_close = poll[
+        poll.index("if (state.mResponseSent)") : poll.index(
+            "while (state.client->available()"
+        )
+    ]
+    assert "!state.client->connected()" in passive_close
+    assert "state.client.reset();" in passive_close
+    assert "state.client->stop();" in passive_close, "retain a bounded timeout fallback"

--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -345,6 +345,11 @@ fl::shared_ptr<AutoResearchState> g_autoresearch_state;  // Shared state pointer
 // Initialize serial buffers with platform-specific configuration
 // Note: Some boards (ESP32S2) don't support setTxBufferSize() on USBCDC interface
 void init_serial_buffers() {
+#if defined(FL_IS_ESP32)
+    // A 512-byte OTA chunk expands past the ESP HWCDC 256-byte RX default
+    // after base64 and JSON-RPC framing (FastLED#4059).
+    Serial.setRxBufferSize(4096);  // ok serial - platform-specific RX buffer sizing, no fl:: equivalent
+#endif
 #if defined(FL_IS_ESP32) && !defined(FL_IS_ESP_32S2)
     Serial.setTxBufferSize(4096);  // 4KB buffer (default is 256 bytes)  // ok serial - platform-specific TX buffer sizing, no fl:: equivalent
 #endif

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -774,6 +774,7 @@ struct RpPeerState {
     size_t body_length = 0;
     size_t expected_body_length = 0;
     bool headers_complete = false;
+    bool mResponseSent = false;
     uint32_t request_started_ms = 0;
 };
 
@@ -786,28 +787,31 @@ void resetRpPeerRequest(RpPeerState& state) {
     state.body_length = 0;
     state.expected_body_length = 0;
     state.headers_complete = false;
+    state.mResponseSent = false;
     state.request_started_ms = 0;
     state.request[0] = '\0';
     state.body[0] = '\0';
 }
 
-void writeHttpResponse(WiFiClient& client, const char* body,
-                       const char* content_type) {
-    client.print("HTTP/1.1 200 OK\r\nContent-Type: ");
+void writeHttpResponse(RpPeerState& state, const char* body,
+                       const char* content_type, const char* status = "200 OK") {
+    WiFiClient& client = *state.client;
+    client.print("HTTP/1.1 ");
+    client.print(status);
+    client.print("\r\nContent-Type: ");
     client.print(content_type);
     client.print("\r\nContent-Length: ");
     client.print(fl::strlen(body));
     client.print("\r\nConnection: close\r\n\r\n");
     client.print(body);
-    client.stop();
+    // The declared body length lets the C6 finish and close first. Keeping the
+    // RP as the passive closer avoids accumulating lwIP closing-state PCBs.
+    state.mResponseSent = true;
+    state.request_started_ms = millis();
 }
 
-void writeHttpNotFoundResponse(WiFiClient& client, const char* body) {
-    client.print("HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: ");
-    client.print(fl::strlen(body));
-    client.print("\r\nConnection: close\r\n\r\n");
-    client.print(body);
-    client.stop();
+void writeHttpNotFoundResponse(RpPeerState& state, const char* body) {
+    writeHttpResponse(state, body, "application/json", "404 Not Found");
 }
 
 fl::json runRpHttpRequestTest(const char* host_ip, uint16_t port,
@@ -1131,6 +1135,21 @@ void pollNetServer() {
     if (!state.client) {
         return;
     }
+    if (state.mResponseSent) {
+        const bool peer_closed = !state.client->connected();
+        const bool deadline_expired =
+            static_cast<int32_t>(millis() - state.request_started_ms) >= 2000;
+        if (peer_closed || deadline_expired) {
+            if (!peer_closed) {
+                // A peer that ignores Connection: close still gets a bounded
+                // fallback so one client cannot hold the server forever.
+                state.client->stop();
+            }
+            state.client.reset();
+            resetRpPeerRequest(state);
+        }
+        return;
+    }
     if (static_cast<int32_t>(millis() - state.request_started_ms) >= 2000) {
         state.client->stop();
         state.client.reset();
@@ -1153,11 +1172,9 @@ void pollNetServer() {
     }
     if (!state.headers_complete) {
         if (state.request_length + 1 == sizeof(state.request)) {
-            state.client->print(
-                "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n");
-            state.client->stop();
-            state.client.reset();
-            resetRpPeerRequest(state);
+            writeHttpResponse(state, "{\"error\":\"request headers too large\"}",
+                              "application/json",
+                              "431 Request Header Fields Too Large");
         }
         return;
     }
@@ -1168,10 +1185,8 @@ void pollNetServer() {
     if (is_post && state.expected_body_length == 0) {
         const char* content_length = fl::strstr(state.request, "\r\nContent-Length:");
         if (content_length == nullptr) {
-            state.client->print("HTTP/1.1 411 Length Required\r\nConnection: close\r\n\r\n");
-            state.client->stop();
-            state.client.reset();
-            resetRpPeerRequest(state);
+            writeHttpResponse(state, "{\"error\":\"content length required\"}",
+                              "application/json", "411 Length Required");
             return;
         }
         content_length = fl::strstr(content_length, ":");
@@ -1181,28 +1196,22 @@ void pollNetServer() {
         }
         while (*content_length >= '0' && *content_length <= '9') {
             if (state.expected_body_length > (sizeof(state.body) - 1) / 10) {
-                state.client->print("HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n");
-                state.client->stop();
-                state.client.reset();
-                resetRpPeerRequest(state);
+                writeHttpResponse(state, "{\"error\":\"payload too large\"}",
+                                  "application/json", "413 Payload Too Large");
                 return;
             }
             state.expected_body_length = state.expected_body_length * 10 +
                                          static_cast<size_t>(*content_length - '0');
             if (state.expected_body_length >= sizeof(state.body)) {
-                state.client->print("HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n");
-                state.client->stop();
-                state.client.reset();
-                resetRpPeerRequest(state);
+                writeHttpResponse(state, "{\"error\":\"payload too large\"}",
+                                  "application/json", "413 Payload Too Large");
                 return;
             }
             ++content_length;
         }
         if (state.expected_body_length == 0) {
-            state.client->print("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
-            state.client->stop();
-            state.client.reset();
-            resetRpPeerRequest(state);
+            writeHttpResponse(state, "{\"error\":\"empty request body\"}",
+                              "application/json", "400 Bad Request");
             return;
         }
     }
@@ -1220,60 +1229,57 @@ void pollNetServer() {
     state.body[state.body_length] = '\0';
 
     if (fl::strncmp(state.request, "GET /ping ", 10) == 0) {
-        writeHttpResponse(*state.client, "pong", "text/plain");
+        writeHttpResponse(state, "pong", "text/plain");
     } else if (fl::strncmp(state.request, "GET /status ", 12) == 0) {
-        writeHttpResponse(*state.client,
+        writeHttpResponse(state,
                           "{\"chip\":\"rp2350w\",\"network\":\"cyw43\"}",
                           "application/json");
     } else if (fl::strncmp(state.request, "GET /leds ", 10) == 0) {
-        writeHttpResponse(*state.client, "{\"num_leds\":10,\"brightness\":64}",
+        writeHttpResponse(state, "{\"num_leds\":10,\"brightness\":64}",
                           "application/json");
     } else if (fl::strncmp(state.request, "GET /rpc/discover ", 18) == 0) {
-        writeHttpResponse(*state.client,
+        writeHttpResponse(state,
                           "{\"jsonrpc\":\"2.0\",\"result\":{\"methods\":[\"rpc.discover\",\"ping\",\"debugTest\",\"status\"]},\"id\":1}",
                           "application/json");
     } else if (fl::strncmp(state.request, "GET /rpc/ping ", 14) == 0) {
-        writeHttpResponse(*state.client,
+        writeHttpResponse(state,
                           "{\"jsonrpc\":\"2.0\",\"result\":{\"pong\":true},\"id\":1}",
                           "application/json");
     } else if (fl::strncmp(state.request, "GET /rpc/status ", 16) == 0) {
-        writeHttpResponse(*state.client,
+        writeHttpResponse(state,
                           "{\"jsonrpc\":\"2.0\",\"result\":{\"ready\":true},\"id\":1}",
                           "application/json");
     } else if (fl::strncmp(state.request, "GET /rpc/unknown ", 17) == 0) {
-        writeHttpNotFoundResponse(*state.client,
+        writeHttpNotFoundResponse(state,
                                   "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"},\"id\":1}");
     } else if (is_post_echo) {
-        writeHttpResponse(*state.client, state.body, "application/octet-stream");
+        writeHttpResponse(state, state.body, "application/octet-stream");
     } else if (is_post_rpc) {
         if (!fl::strstr(state.body, "\"jsonrpc\":\"2.0\"") ||
             !fl::strstr(state.body, "\"method\"")) {
-            state.client->print("HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n");
-            state.client->print("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"},\"id\":1}");
-            state.client->stop();
+            writeHttpResponse(state,
+                              "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"},\"id\":1}",
+                              "application/json", "400 Bad Request");
         } else if (fl::strstr(state.body, "\"method\":\"rpc.discover\"")) {
-            writeHttpResponse(*state.client,
+            writeHttpResponse(state,
                               "{\"jsonrpc\":\"2.0\",\"result\":{\"methods\":[\"rpc.discover\",\"ping\",\"debugTest\",\"status\"]},\"id\":1}",
                               "application/json");
         } else if (fl::strstr(state.body, "\"method\":\"ping\"")) {
-            writeHttpResponse(*state.client,
+            writeHttpResponse(state,
                               "{\"jsonrpc\":\"2.0\",\"result\":{\"pong\":true},\"id\":1}",
                               "application/json");
         } else if (fl::strstr(state.body, "\"method\":\"status\"")) {
-            writeHttpResponse(*state.client,
+            writeHttpResponse(state,
                               "{\"jsonrpc\":\"2.0\",\"result\":{\"ready\":true},\"id\":1}",
                               "application/json");
         } else {
-            writeHttpResponse(*state.client,
+            writeHttpResponse(state,
                               "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"},\"id\":1}",
                               "application/json");
         }
     } else {
-        state.client->print("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
-        state.client->stop();
+        writeHttpNotFoundResponse(state, "{\"error\":\"not found\"}");
     }
-    state.client.reset();
-    resetRpPeerRequest(state);
 }
 
 #else  // !FL_IS_ESP32 && !FL_IS_RP2350


### PR DESCRIPTION
## Summary

- pass OTA chunks to `RpcClient.send` as scalar strings so its single-parameter wrapper emits the firmware payload shape expected by the ESP32-C6 fixture
- enlarge the ESP32 AutoResearch serial RX queue before `Serial.begin()` so base64 JSON-RPC OTA frames fit
- keep RP2350W HTTP responses length-delimited and let the peer close first, with a bounded fallback, so repeated peer cycles do not exhaust lwIP TCP PCBs
- delegate explicitly named absent RP2040/RP2350 runtime ports to fbuild's CDC/BOOTSEL recovery ladder while retaining the early failure for non-RP ports
- add focused regression contracts for OTA argument shape, serial buffering, passive-close behavior, and the RP/non-RP port-preflight boundary

## Validation

- `uv run --no-sync ty check ci/autoresearch/ota.py ci/rpc_client.py`
- focused AutoResearch Python regressions (RED before implementation, GREEN after)
- `uv run --no-sync pytest -q ci/tests/test_autoresearch_phases.py ci/tests/test_usb_power.py` — 204 passed
- `uv run --no-sync ruff check ci/autoresearch/phases.py ci/tests/test_autoresearch_phases.py`
- broader selected AutoResearch Python regression set
- `bash test --cpp` — 284 unit tests and 84 host examples passed
- `bash lint --cpp`
- `bash compile rp2350w --examples AutoResearch`
- `bash compile esp32c6 --examples AutoResearch`
- pre-push review clean

## Dependency and merge order

Depends on FastLED/fbuild#1405.

1. Merge FastLED/fbuild#1405.
2. Release the first fbuild version newer than 2.5.21 containing that fix.
3. Update this branch's exact fbuild pin and `uv.lock` to that release.
4. Complete the attached RP2350W + ESP32-C6 network and OTA HIL runs, then merge this PR.

Released fbuild 2.5.21 can copy an RP2350 UF2 image but may omit `FBUILD_DEPLOY_PORT` when Windows changes a stale `COM18` devnode back to healthy under the same name. #1405 makes the pre-flash snapshot health-aware so both explicit `UF2=<volume>` and stale direct-COM selectors converge on the recovered healthy CDC endpoint.

## Hardware gate still pending

The exact RP2350W is serial `2DCB876B587EA334` (runtime COM18 / BOOTSEL `H:`); the ESP32-C6 is serial `8C:BF:EA:CF:87:B4` on COM9. The released-fbuild run reproduced the same-name CDC handoff failure after a successful UF2 copy. Final canonical network and OTA assertions will be recorded here after the dependent release is pinned.

Closes #4059
Refs #3956
Refs #3832