### PR TITLE
test(lint): keep history audits out of CI

### DIFF
--- a/ci/lint_cpp_rs/deep_history_audit.sh
+++ b/ci/lint_cpp_rs/deep_history_audit.sh
@@ -6,5 +6,5 @@ cd "$project_root"
 
 uv run soldr --no-cache cargo test \
   --manifest-path ci/lint_cpp_rs/Cargo.toml \
-  deep_live_history_matches_per_file_git_for_mark_and_sam \
+  live_history \
   -- --ignored --nocapture

--- a/ci/lint_cpp_rs/src/checkers/file_legal.rs
+++ b/ci/lint_cpp_rs/src/checkers/file_legal.rs
@@ -599,21 +599,12 @@ mod history_tests {
     }
 
     #[test]
+    #[ignore = "one-off audit: requires the repository's complete Git history"]
     fn live_fastled_history_contains_known_pre_and_post_move_authors() {
         let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .and_then(Path::parent)
             .unwrap();
-        let shallow = Command::new("git")
-            .current_dir(project_root)
-            .args(["rev-parse", "--is-shallow-repository"])
-            .output()
-            .unwrap();
-        assert!(shallow.status.success());
-        if String::from_utf8_lossy(&shallow.stdout).trim() == "true" {
-            eprintln!("skipping live history assertions in a shallow Git checkout");
-            return;
-        }
         let known_paths = [
             "src/FastLED.h",
             "src/chipsets.h",


### PR DESCRIPTION
Marks the two repository-history audits ignored by default because they require full Git history and are one-off validation, not CI gates. The audit script explicitly runs both ignored tests. No src changes.\n\nValidation: Rust suite 105 passed, 2 ignored; shell syntax passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the history audit to use the live Git-history test.
  * The live history test now runs only when explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->