### PR TITLE
test(mp3): add CPU profiling and codegen ledgers

### DIFF
--- a/.github/workflows/mp3_cpu_audit.yml
+++ b/.github/workflows/mp3_cpu_audit.yml
@@ -1,0 +1,90 @@
+name: MP3 CPU audit
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/fl/codec/mp3*'
+      - 'src/third_party/libhelix_mp3/**'
+      - 'src/third_party/minimp3/**'
+      - 'tests/data/codec/minimp3/**'
+      - 'ci/codec_cpu/**'
+      - 'ci/codec_memory/*_audit.cpp'
+      - 'codec_cpu_ledger.md'
+      - 'codec_cpu_trend.json'
+      - 'pyproject.toml'
+      - '.github/workflows/mp3_cpu_audit.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/fl/codec/mp3*'
+      - 'src/third_party/libhelix_mp3/**'
+      - 'src/third_party/minimp3/**'
+      - 'tests/data/codec/minimp3/**'
+      - 'ci/codec_cpu/**'
+      - 'ci/codec_memory/*_audit.cpp'
+      - 'codec_cpu_ledger.md'
+      - 'codec_cpu_trend.json'
+      - 'pyproject.toml'
+      - '.github/workflows/mp3_cpu_audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          version: '0.8.0'
+
+      - name: Install audit tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm valgrind
+          for governor in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+            if [ -e "$governor" ]; then
+              echo performance | sudo tee "$governor"
+            fi
+          done
+
+      - name: Install project and MCU toolchains
+        run: |
+          uv sync
+          uv run pio pkg install -g -t 'espressif/toolchain-xtensa-esp32@8.4.0+2021r2-patch3'
+          uv run pio pkg install -g -t 'espressif/toolchain-riscv32-esp@12.2.0+20230208'
+          uv run pio pkg install -g -t 'platformio/toolchain-gccarmnoneeabi@1.120301.0'
+
+      - name: Verify the focused CPU gate
+        env:
+          PYTEST_ADDOPTS: -k codec_cpu_audit
+        run: bash test --py --verbose
+
+      - name: Enforce operation, host, and target-codegen trends
+        run: >-
+          uv run python ci/codec_cpu/audit.py --check
+          --write codec_cpu_current.json
+
+      - name: Upload measured report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codec-cpu-current
+          path: codec_cpu_current.json
+          if-no-files-found: error

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -37,3 +37,28 @@
 - A WASM-only per-frame telemetry toggle can expose raw Beat and Tempo
   confidence alongside Vibe levels without adding a physical output pixel to
   the HydroPack fixture.
+
+- When consuming a tool's stderr through `RunningProcess.run`, request
+  `stderr=PIPE` explicitly and test the real output format. Default capture
+  combines streams and leaves `result.stderr` unset.
+
+- GitHub-hosted Azure Linux VMs can return `<not supported>` for every PMU
+  event even after relaxing `perf_event_paranoid`. For a reproducible hosted
+  gate, record pinned N=30 compiler cycle-counter medians and pair them with
+  explicitly labeled deterministic Callgrind instruction/branch simulation;
+  never relabel simulated data as hardware `perf` output.
+
+- LLVM operation ledgers must follow product values through O0 casts and spill
+  slots before classifying accumulations; direct SSA-use matching changes
+  across compiler versions even when the source operations are identical.
+
+- Target codegen audits must keep production optimization flags. If a static
+  kernel is fully inlined and its symbol disappears, retain it with a narrow
+  no-inline audit caller and measure the optimized kernel body, rather than
+  disabling inlining for the entire translation unit.
+- When a regression test mutates a primary metric in a schema with validated
+  derived metrics, recompute the derived fields first so the test reaches the
+  intended regression gate instead of failing schema validation.
+- GitHub-hosted runner labels can rotate among materially different CPU
+  models. Host performance gates need separate environment-keyed baselines;
+  a single baseline for an OS label either flakes or compares unlike machines.

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -44,7 +44,71 @@
 - [x] Measure and itemize codec static/flash symbols with `nm` and `size`.
 - [x] Add a machine-parsed `codec_memory_ledger.md` with a 2% regression gate.
 - [x] Run focused/broad validation and the pre-push code-review gate.
-- [ ] Push, merge the closing PR, and verify issue #4052/G1 state.
+- [x] Push, merge the closing PR, and verify issue #4052/G1 state.
+
+## MP3 Phase 2 CPU profiling audit (#4053)
+
+- [x] Capture the focused RED signal for missing CPU audit/trend/codegen ledgers.
+- [x] Instrument exact multiply/MAC counts per decoder stage for both backends.
+- [x] Add N=30 host counters, attribution, and per-stage median timing reports.
+- [x] Enforce `codec_cpu_trend.json` with a 5% regression gate.
+- [x] Record `-Os` inner-loop codegen for Xtensa, RISC-V, M0+, and M4.
+- [x] Run focused and broad validation plus the pre-push review gate.
+- [ ] Push, merge the closing PR, and verify issue #4053/G2 state.
+
+### Review
+
+- RED: the focused test failed at collection because `ci/codec_cpu/audit.py`
+  and `codec_cpu_trend.json` did not exist.
+- Tier 1 now instruments optimized decoder LLVM IR and records exact totals
+  plus mechanically derived per-frame multiply/MAC counts for all eight
+  stages across the same 892-frame, five-file corpus for both backends.
+- Tier 3 cross-compiles the complete codec build translation units at `-Os`
+  and records whole-kernel and real loop-body instruction counts
+  for Xtensa ESP32, RISC-V ESP32, Cortex-M0+, and Cortex-M4.
+- Stage coverage is fail-closed: every dedicated stage requires static
+  instrumentation and a positive timing, while the two codec-specific fused
+  stages are declared explicitly. Multiply/MAC accounting uses one MAC per
+  accumulation, including Helix sums of `MULSHIFT32` products.
+- Host trends are keyed by CPU model, compiler, and governor so measurements
+  from unlike hosted runners cannot be compared; Callgrind requires at least
+  eight attributed codec functions and enforces normalized function shares.
+- Focused validation passes 24 tests, operation and four-target codegen audits
+  pass locally, lint is clean, and the repeated pre-push review is clean after
+  resolving all five initial findings plus two follow-up accounting findings.
+- The first native runs exposed compiler-dependent direct-use MAC attribution
+  and unavailable PMU hardware counters. The audit follows multiply results
+  through LLVM casts and spill slots to their consuming accumulations; Clang
+  14 Linux and Clang 21 Windows produce identical operation sites and exact
+  ledgers across the full corpus.
+- CodeRabbit's first pass is addressed: Callgrind event/value cardinality is
+  strict, fixture allocation/read failures clean up, unattributed operations
+  abort, the audit-only macro follows the `FL_` rule, and target codegen now
+  uses production inlining/contraction flags. Narrow callers retain minimp3's
+  otherwise fully inlined kernels without changing optimization inside them.
+- The N=30 stage timer and Callgrind attribution tiers are locally green.
+  GitHub's hosted Azure VM reports all `perf stat` PMU events as unsupported,
+  so the fail-closed host ledger records N=30 pinned Clang cycle-counter
+  medians plus deterministic Callgrind instructions and simulated branch
+  misses over the same decode regions, with explicit provenance and IPC
+  derived from those two sources. Schema validation recomputes every identity.
+- Native Ubuntu run 32927438193 captured the authoritative AMD EPYC 9V74 /
+  Clang 18 baseline: Helix median 147,513,314 cycles, 461,845,281 Callgrind
+  instructions, and 453,948 simulated branch misses; minimp3-float median
+  54,515,955 cycles, 261,532,799 instructions, and 555,920 branch misses.
+- Follow-up run 32927721702 proved the same `ubuntu-24.04` label rotates among
+  CPU models and captured the AMD EPYC 7763 profile. The trend selects a
+  distinct checked-in host baseline by CPU/compiler/governor key.
+- Run 32928148824 captured the third observed pool profile, Intel Xeon Platinum
+  8573C with the `performance` governor exposed.
+- Run 32928388694 captured Intel Xeon 6973P-C, the fourth observed pool model.
+  GitHub documents only the standard runner's core count and architecture, not
+  its CPU model. Every environment remains fail-closed: matching profiles gate
+  all trends at 5%, while unknown models upload evidence and fail for explicit
+  baseline onboarding.
+- Broad Python validation passed 1,070 tests, skipped 35, and passed 40
+  subtests; its sole cold-build QEMU timeout passed on the required immediate
+  focused rerun in 12m56s.
 
 ### Review
 
@@ -79,6 +143,8 @@
   closed, persistent Helix state is tagged accurately, and memory-tag hooks
   are bounds-checked and balance every bucket. Focused Python/C++ tests, the
   release profile, lint, WASM, Uno, and the repeated pre-push review are green.
+- PR #4058 merged as `b0969cbec`; issue #4052 closed automatically and the
+  Phase 2 branch was rebased onto the verified merge.
 
 ## Frame-task lifecycle (#3896)
 

--- a/bosn.toml
+++ b/bosn.toml
@@ -1,0 +1,20 @@
+[stack.cpu]
+dockerfile = "ci/codec_cpu/Dockerfile"
+family = "python"
+default = true
+
+[stack.cpu.mounts]
+repo = { source = ".", destination = "/repo", readonly = true }
+
+[stack.cpu.volumes]
+build-nonroot = { scope = "stack", destination = "/build-volume" }
+venv-nonroot = { scope = "stack", destination = "/venv-volume" }
+uv-cache-nonroot = { scope = "machine", destination = "/home/audit/.cache/uv" }
+
+[task.linux-host]
+stack = "cpu"
+cmd = "UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/venv-volume/project CODEC_CPU_BUILD=/build-volume/audit uv sync --frozen && UV_PROJECT_ENVIRONMENT=/venv-volume/project CODEC_CPU_BUILD=/build-volume/audit uv run --no-sync python ci/codec_cpu/audit.py --linux-host"
+
+[task.linux-cycles]
+stack = "cpu"
+cmd = "UV_LINK_MODE=copy UV_PROJECT_ENVIRONMENT=/venv-volume/project CODEC_CPU_BUILD=/build-volume/audit uv sync --frozen && UV_PROJECT_ENVIRONMENT=/venv-volume/project CODEC_CPU_BUILD=/build-volume/audit uv run --no-sync python ci/codec_cpu/audit.py --cycles"

--- a/ci/codec_cpu/Dockerfile
+++ b/ci/codec_cpu/Dockerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/astral-sh/uv:0.8.0-python3.12-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang llvm valgrind \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 audit \
+    && mkdir -p /build-volume /venv-volume /home/audit/.cache/uv \
+    && chown -R audit:audit /build-volume /venv-volume /home/audit/.cache/uv
+
+ENV UV_CACHE_DIR=/home/audit/.cache/uv
+
+WORKDIR /repo
+
+USER audit

--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -1,0 +1,1358 @@
+#!/usr/bin/env python3
+"""Build and enforce the three-tier MP3 CPU audit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from running_process import RunningProcess
+from typeguard import typechecked
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TREND_PATH = ROOT / "codec_cpu_trend.json"
+BUILD = Path(os.environ.get("CODEC_CPU_BUILD", ROOT / ".build" / "codec-cpu-audit"))
+REGRESSION_TOLERANCE = 0.05
+PROFILE_RUNS = 30
+BACKENDS = ("helix", "minimp3-float")
+STAGES = (
+    "scalefactors",
+    "huffman",
+    "dequant",
+    "stereo",
+    "reorder",
+    "antialias",
+    "imdct",
+    "synthesis",
+)
+TARGETS = ("xtensa-esp32", "riscv32-esp", "cortex-m0plus", "cortex-m4")
+KERNELS = ("dct32", "polyphase")
+CORPUS = (
+    "tests/data/codec/minimp3/l3-hecommon.bit",
+    "tests/data/codec/minimp3/l3-compl-cut.mp3",
+    "tests/data/codec/minimp3/l3-he_free.bit",
+    "tests/data/codec/minimp3/l3-lame-vbrtag.bit",
+    "tests/data/codec/minimp3/M2L3_bitrate_16_all.bit",
+)
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class CallgrindData:
+    summary: dict[str, int]
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class TargetTools:
+    compiler: Path
+    objdump: Path
+    flags: list[str]
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class InstrumentationResult:
+    text: str
+    operation_sites: int
+    stage_sites: dict[str, int]
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class InstrumentedDriver:
+    binary: Path
+    stage_coverage: dict[str, dict[str, dict[str, Any]]]
+
+
+_STAGE_SYMBOLS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("scalefactors", ("UnpackScaleFactors", "L3_decode_scalefactors", "L12_apply_scf")),
+    ("huffman", ("DecodeHuffman", "L3_huffman")),
+    ("dequant", ("Dequantize", "L12_dequantize_granule")),
+    (
+        "stereo",
+        (
+            "MidSideProc",
+            "IntensityProcMPEG1",
+            "IntensityProcMPEG2",
+            "L3_intensity_stereo",
+            "L3_midside_stereo",
+        ),
+    ),
+    ("reorder", ("L3_reorder",)),
+    ("antialias", ("AntiAlias", "L3_antialias")),
+    ("imdct", ("IMDCT", "L3_imdct_gr")),
+    (
+        "synthesis",
+        ("Subband", "FDCT32", "Polyphase", "mp3d_synth_granule", "mp3d_DCT_II"),
+    ),
+)
+
+_FUSED_STAGES = {
+    "helix": {"reorder": "dequant"},
+    "minimp3-float": {"dequant": "huffman"},
+}
+
+_LLVM_DEFINE_RE = re.compile(r'^\s*define\b.*@(?:"([^"]+)"|([^\s(]+))\(')
+_LLVM_VALUE_RE = re.compile(r"^\s*(%[-\w.$]+)\s*=")
+_LLVM_VECTOR_RE = re.compile(r"<\s*(\d+)\s+x\s+(?:half|float|double)\s*>")
+
+
+def load_trend(path: Path = TREND_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def environment_key(environment: dict[str, Any]) -> str:
+    fields = ("cpu_model", "compiler", "governor")
+    if any(not isinstance(environment.get(field), str) for field in fields):
+        raise RuntimeError("host environment is incomplete")
+    return " | ".join(environment[field] for field in fields)
+
+
+def classify_stage(symbol: str) -> str | None:
+    for stage, needles in _STAGE_SYMBOLS:
+        if any(needle in symbol for needle in needles):
+            return stage
+    return None
+
+
+def cached_compiler_candidates(os_name: str) -> list[Path]:
+    if os_name != "nt":
+        return []
+    candidates = [ROOT / ".cached" / "clang-native" / "ctc-clang++.exe"]
+    if len(ROOT.parents) > 1:
+        candidates.append(
+            ROOT.parents[1] / ".cached" / "clang-native" / "ctc-clang++.exe"
+        )
+    return candidates
+
+
+def compiler_path() -> Path:
+    override = os.environ.get("CODEC_CPU_COMPILER")
+    if override:
+        compiler = Path(override)
+        if compiler.exists() or shutil.which(override):
+            return compiler
+        raise RuntimeError(f"CODEC_CPU_COMPILER does not exist: {override}")
+    candidates = cached_compiler_candidates(os.name)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    compiler = shutil.which("clang++")
+    if compiler:
+        return Path(compiler)
+    raise RuntimeError("clang++ is required for the codec CPU audit")
+
+
+def _llvm_functions(lines: list[str]) -> list[tuple[int, int, str]]:
+    functions: list[tuple[int, int, str]] = []
+    start: int | None = None
+    symbol = ""
+    for index, line in enumerate(lines):
+        if start is None:
+            match = _LLVM_DEFINE_RE.search(line)
+            if match:
+                start = index
+                symbol = match.group(1) or match.group(2)
+        elif line.strip() == "}":
+            functions.append((start, index, symbol))
+            start = None
+            symbol = ""
+    if start is not None:
+        raise RuntimeError(f"unterminated LLVM function: {symbol}")
+    return functions
+
+
+def _operation_stage(backend: str, symbol: str) -> str | None:
+    if backend == "minimp3-float" and ("L3_huffman" in symbol or "L3_pow_43" in symbol):
+        return "dequant"
+    return classify_stage(symbol)
+
+
+def _uses_llvm_value(line: str, value: str) -> bool:
+    return re.search(rf"{re.escape(value)}(?:\s|,|$)", line) is not None
+
+
+def _tainted_accumulate_lines(
+    body: list[str], seed_values: set[str], add_pattern: str
+) -> set[int]:
+    """Find arithmetic fed by products across LLVM SSA casts and O0 spills."""
+    tainted = set(seed_values)
+    tainted_slots: set[str] = set()
+    accumulates: set[int] = set()
+    for index, line in enumerate(body):
+        match = _LLVM_VALUE_RE.match(line)
+        result = match.group(1) if match else None
+        rhs = line.split("=", 1)[1] if match else line
+        uses_tainted = any(_uses_llvm_value(rhs, value) for value in tainted)
+        values = re.findall(r"%[-\w.$]+", rhs)
+        if re.search(r"\bstore\b", rhs) and values:
+            slot = values[-1]
+            if uses_tainted:
+                tainted_slots.add(slot)
+            else:
+                tainted_slots.discard(slot)
+        if (
+            result
+            and re.search(r"\bload\b", rhs)
+            and values
+            and values[-1] in tainted_slots
+        ):
+            tainted.add(result)
+            uses_tainted = True
+        if not result or not uses_tainted:
+            continue
+        if re.search(add_pattern, rhs):
+            accumulates.add(index)
+        elif re.search(
+            r"\b(?:sext|zext|trunc|bitcast|freeze|fpext|fptrunc|phi|select)\b",
+            rhs,
+        ):
+            tainted.add(result)
+    return accumulates
+
+
+def instrument_llvm_ir(
+    text: str, backend: str, *, operations: bool = True
+) -> InstrumentationResult:
+    """Inject dynamic stage timers and arithmetic counters into Clang IR."""
+    lines = text.splitlines()
+    functions = _llvm_functions(lines)
+    inserts: dict[int, list[str]] = {}
+    operation_sites = 0
+    stage_sites = {stage: 0 for stage in STAGES}
+    for start, end, symbol in functions:
+        stage = classify_stage(symbol)
+        stage_index = STAGES.index(stage) if stage else None
+        if stage is not None and stage_index is not None:
+            stage_sites[stage] += 1
+            entry_label = next(
+                (
+                    index
+                    for index in range(start + 1, end)
+                    if re.match(r"^[-\w.$]+:\s*(?:;.*)?$", lines[index])
+                ),
+                None,
+            )
+            if entry_label is None:
+                raise RuntimeError(f"basic-block entry missing for {symbol}")
+            inserts.setdefault(entry_label + 1, []).append(
+                f"  call void @fastled_mp3_cpu_stage_enter(i32 {stage_index})"
+            )
+            for index in range(start + 1, end):
+                if lines[index].lstrip().startswith("ret "):
+                    inserts.setdefault(index, []).append(
+                        f"  call void @fastled_mp3_cpu_stage_exit(i32 {stage_index})"
+                    )
+        body = lines[start + 1 : end]
+        operation_stage = _operation_stage(backend, symbol)
+        operation_stage_index = STAGES.index(operation_stage) if operation_stage else -1
+        fmul_values = {
+            match.group(1)
+            for line in body
+            if re.search(r"\bfmul\b", line)
+            if (match := _LLVM_VALUE_RE.match(line))
+        }
+        mulshift_values = {
+            match.group(1)
+            for line in body
+            if "MULSHIFT32" in line and re.search(r"\bcall\b", line)
+            if (match := _LLVM_VALUE_RE.match(line))
+        }
+        float_accumulates = _tainted_accumulate_lines(
+            body, fmul_values, r"\bf(?:add|sub)\b"
+        )
+        helix_accumulates = _tainted_accumulate_lines(
+            body,
+            mulshift_values,
+            r"\b(?:add|sub)(?:\s+nsw|\s+nuw)*\s+i(?:32|64)\b",
+        )
+        for relative, line in enumerate(body, start=start + 1):
+            if (
+                operations
+                and backend == "minimp3-float"
+                and re.search(r"\bfmul\b", line)
+            ):
+                vector = _LLVM_VECTOR_RE.search(line)
+                lanes = int(vector.group(1)) if vector else 1
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 {operation_stage_index}, i32 {lanes}, i32 0)"
+                )
+                operation_sites += 1
+            elif (
+                operations
+                and backend == "minimp3-float"
+                and relative - (start + 1) in float_accumulates
+            ):
+                vector = _LLVM_VECTOR_RE.search(line)
+                lanes = int(vector.group(1)) if vector else 1
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 {operation_stage_index}, i32 0, i32 {lanes})"
+                )
+                operation_sites += 1
+            elif (
+                operations
+                and backend == "helix"
+                and ("MULSHIFT32" in symbol or "MADD64" in symbol)
+                and re.search(r"\bmul(?:\s+nsw|\s+nuw)*\s+i64\b", line)
+            ):
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 -1, i32 1, i32 {1 if 'MADD64' in symbol else 0})"
+                )
+                operation_sites += 1
+            elif (
+                operations
+                and backend == "helix"
+                and relative - (start + 1) in helix_accumulates
+            ):
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 {operation_stage_index}, i32 0, i32 1)"
+                )
+                operation_sites += 1
+    if operations and operation_sites == 0:
+        raise RuntimeError(f"no arithmetic sites found in {backend} LLVM IR")
+    declarations = [
+        "declare void @fastled_mp3_cpu_stage_enter(i32)",
+        "declare void @fastled_mp3_cpu_stage_exit(i32)",
+        "declare void @fastled_mp3_cpu_operation(i32, i32, i32)",
+        "",
+    ]
+    first_define = min(start for start, _, _ in functions)
+    output: list[str] = []
+    for index, line in enumerate(lines):
+        if index == first_define:
+            output.extend(declarations)
+        output.extend(inserts.get(index, ()))
+        output.append(line)
+    return InstrumentationResult(
+        text="\n".join(output) + "\n",
+        operation_sites=operation_sites,
+        stage_sites=stage_sites,
+    )
+
+
+def _common_compile_flags(optimization: str = "-O0") -> list[str]:
+    return [
+        f"-I{ROOT / 'src'}",
+        f"-I{ROOT / 'src' / 'platforms' / 'stub'}",
+        "-std=gnu++11",
+        optimization,
+        "-fno-inline",
+        "-fno-exceptions",
+        "-fno-rtti",
+        "-fno-strict-aliasing",
+        "-ffp-contract=off",
+        "-fno-discard-value-names",
+        "-DFASTLED_USE_PROGMEM=0",
+        "-DSTUB_PLATFORM",
+        "-DARDUINO=10808",
+        "-DFASTLED_USE_STUB_ARDUINO",
+        "-DFASTLED_STUB_IMPL",
+        "-DFASTLED_TESTING",
+        "-DFASTLED_NO_AUTO_NAMESPACE",
+        "-DFASTLED_NO_PINMAP",
+        "-DMINIMP3_NO_SIMD",
+    ]
+
+
+def build_instrumented_driver(*, operations: bool = True) -> InstrumentedDriver:
+    BUILD.mkdir(parents=True, exist_ok=True)
+    compiler = compiler_path()
+    sources = {
+        "helix": ROOT / "ci" / "codec_memory" / "helix_audit.cpp",
+        "minimp3-float": ROOT / "ci" / "codec_memory" / "minimp3_audit.cpp",
+    }
+    objects: list[Path] = []
+    stage_coverage: dict[str, dict[str, dict[str, Any]]] = {}
+    for backend, source in sources.items():
+        stem = backend.replace("-float", "")
+        mode = "operations" if operations else "timing"
+        raw_ir = BUILD / f"{stem}.{mode}.ll"
+        instrumented_ir = BUILD / f"{stem}.{mode}.instrumented.ll"
+        obj = BUILD / f"{stem}.{mode}.instrumented.o"
+        RunningProcess.run(
+            [
+                str(compiler),
+                *_common_compile_flags("-O0" if operations else "-O1"),
+                "-S",
+                "-emit-llvm",
+                str(source),
+                "-o",
+                str(raw_ir),
+            ],
+            check=True,
+        )
+        instrumentation = instrument_llvm_ir(
+            raw_ir.read_text(encoding="utf-8"), backend, operations=operations
+        )
+        instrumented_ir.write_text(instrumentation.text, encoding="utf-8")
+        print(
+            f"LLVM_INSTRUMENT:{backend}:mode={mode}:"
+            f"sites={instrumentation.operation_sites}"
+        )
+        fused = _FUSED_STAGES[backend]
+        coverage: dict[str, dict[str, Any]] = {}
+        for stage in STAGES:
+            sites = instrumentation.stage_sites[stage]
+            if stage in fused:
+                coverage[stage] = {
+                    "mode": "fused",
+                    "fused_with": fused[stage],
+                    "instrumentation_sites": 0,
+                }
+            else:
+                if sites <= 0:
+                    raise RuntimeError(
+                        f"missing stage instrumentation for {backend}/{stage}"
+                    )
+                coverage[stage] = {
+                    "mode": "dedicated",
+                    "instrumentation_sites": sites,
+                }
+            print(
+                f"STAGE_COVERAGE:backend={backend}:stage={stage}:"
+                f"mode={coverage[stage]['mode']}:sites="
+                f"{coverage[stage]['instrumentation_sites']}"
+            )
+        stage_coverage[backend] = coverage
+        RunningProcess.run(
+            [str(compiler), "-c", str(instrumented_ir), "-o", str(obj)],
+            check=True,
+        )
+        objects.append(obj)
+    suffix = ".exe" if os.name == "nt" else ""
+    mode = "operations" if operations else "timing"
+    binary = BUILD / f"codec_cpu_driver_{mode}{suffix}"
+    RunningProcess.run(
+        [
+            str(compiler),
+            *_common_compile_flags("-O0" if operations else "-O1"),
+            str(Path(__file__).with_name("driver.cpp")),
+            *(str(obj) for obj in objects),
+            "-o",
+            str(binary),
+        ],
+        check=True,
+    )
+    return InstrumentedDriver(binary=binary, stage_coverage=stage_coverage)
+
+
+def build_plain_driver() -> Path:
+    BUILD.mkdir(parents=True, exist_ok=True)
+    compiler = compiler_path()
+    objects: list[Path] = []
+    for backend in ("helix", "minimp3"):
+        source = ROOT / "ci" / "codec_memory" / f"{backend}_audit.cpp"
+        obj = BUILD / f"{backend}.plain.o"
+        RunningProcess.run(
+            [
+                str(compiler),
+                *_common_compile_flags("-O1"),
+                "-g",
+                "-gdwarf-4",
+                "-c",
+                str(source),
+                "-o",
+                str(obj),
+            ],
+            check=True,
+        )
+        objects.append(obj)
+    suffix = ".exe" if os.name == "nt" else ""
+    binary = BUILD / f"codec_cpu_driver_plain{suffix}"
+    RunningProcess.run(
+        [
+            str(compiler),
+            *_common_compile_flags("-O1"),
+            "-g",
+            "-gdwarf-4",
+            str(Path(__file__).with_name("driver.cpp")),
+            *(str(obj) for obj in objects),
+            "-o",
+            str(binary),
+        ],
+        check=True,
+    )
+    return binary
+
+
+_OPS_RE = re.compile(r"OPS:backend=([^:]+):stage=([^:]+):multiplies=(\d+):macs=(\d+)")
+_TIMING_RE = re.compile(r"TIMING:backend=([^:]+):stage=([^:]+):nanoseconds=(\d+)")
+_RESULT_RE = re.compile(
+    r"CPU_AUDIT_RESULT:backend=([^:]+):frames=(\d+):checksum=(\d+):cycles=(\d+)"
+)
+
+
+def run_operation_audit(binary: Path) -> dict[str, dict[str, Any]]:
+    report: dict[str, dict[str, Any]] = {}
+    for backend in BACKENDS:
+        result = RunningProcess.run(
+            [str(binary.resolve()), backend],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        counts: dict[str, dict[str, int]] = {}
+        for match in _OPS_RE.finditer(result.stdout):
+            if match.group(1) == backend:
+                counts[match.group(2)] = {
+                    "multiplies": int(match.group(3)),
+                    "macs": int(match.group(4)),
+                }
+        validate_operation_counts(counts)
+        frame_match = _RESULT_RE.search(result.stdout)
+        if not frame_match or frame_match.group(1) != backend:
+            raise RuntimeError(f"operation profile result missing for {backend}")
+        frames = int(frame_match.group(2))
+        if frames <= 0:
+            raise RuntimeError(f"operation profile decoded no frames for {backend}")
+        stages: dict[str, dict[str, int | float]] = {}
+        for stage, metrics in counts.items():
+            stages[stage] = {
+                "total_multiplies": metrics["multiplies"],
+                "total_macs": metrics["macs"],
+                "multiplies_per_frame": round(metrics["multiplies"] / frames, 6),
+                "macs_per_frame": round(metrics["macs"] / frames, 6),
+            }
+        report[backend] = {"frames": frames, "stages": stages}
+        print(result.stdout, end="")
+    return report
+
+
+def run_host_stage_profile(binary: Path) -> dict[str, dict[str, float]]:
+    affinity = host_affinity_prefix()
+    samples: dict[str, dict[str, list[float]]] = {
+        backend: {stage: [] for stage in STAGES} for backend in BACKENDS
+    }
+    for backend in BACKENDS:
+        expected_frames: int | None = None
+        for _ in range(PROFILE_RUNS):
+            result = RunningProcess.run(
+                [*affinity, str(binary.resolve()), backend],
+                cwd=ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            frame_match = _RESULT_RE.search(result.stdout)
+            if not frame_match or frame_match.group(1) != backend:
+                raise RuntimeError(f"timing profile result missing for {backend}")
+            frames = int(frame_match.group(2))
+            if expected_frames is None:
+                expected_frames = frames
+            elif frames != expected_frames:
+                raise RuntimeError(f"non-deterministic frame count for {backend}")
+            emitted: set[str] = set()
+            for match in _TIMING_RE.finditer(result.stdout):
+                if match.group(1) != backend:
+                    continue
+                stage = match.group(2)
+                samples[backend][stage].append(int(match.group(3)) / frames)
+                emitted.add(stage)
+            if emitted != set(STAGES):
+                raise RuntimeError(f"timing stages missing for {backend}")
+    medians: dict[str, dict[str, float]] = {}
+    for backend in BACKENDS:
+        medians[backend] = {
+            stage: round(statistics.median(samples[backend][stage]), 3)
+            for stage in STAGES
+        }
+        for stage, value in medians[backend].items():
+            print(
+                f"HOST_STAGE:backend={backend}:stage={stage}:"
+                f"median_ns_per_frame={value}:runs={PROFILE_RUNS}"
+            )
+    return medians
+
+
+def run_cycle_profile(binary: Path) -> dict[str, float]:
+    affinity = host_affinity_prefix()
+    samples: dict[str, list[int]] = {backend: [] for backend in BACKENDS}
+    for backend in BACKENDS:
+        for _ in range(PROFILE_RUNS):
+            result = RunningProcess.run(
+                [
+                    *affinity,
+                    str(binary.resolve()),
+                    backend,
+                ],
+                cwd=ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            match = _RESULT_RE.search(result.stdout)
+            if not match or match.group(1) != backend:
+                raise RuntimeError(f"cycle profile result missing for {backend}")
+            samples[backend].append(int(match.group(4)))
+    report: dict[str, float] = {}
+    for backend in BACKENDS:
+        report[backend] = round(statistics.median(samples[backend]), 6)
+        print(
+            f"HOST_CYCLES:backend={backend}:runs={PROFILE_RUNS}:"
+            f"median={report[backend]}:source=clang-readcyclecounter"
+        )
+    return report
+
+
+def parse_callgrind(path: Path) -> CallgrindData:
+    events: list[str] = []
+    summary_values: list[int] = []
+    total_values: list[int] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("events:"):
+            events = line.split()[1:]
+        elif line.startswith("summary:") and events:
+            summary_values = [int(value) for value in line.split()[1:]]
+        elif line.startswith("totals:") and events:
+            total_values = [int(value) for value in line.split()[1:]]
+    values = total_values or summary_values
+    summary = dict(zip(events, values, strict=True))
+    if "Ir" not in summary:
+        raise RuntimeError("callgrind output is missing instruction summary")
+    return CallgrindData(summary=summary)
+
+
+def parse_callgrind_attribution(text: str) -> dict[str, int]:
+    functions: dict[str, int] = {}
+    row_re = re.compile(r"^\s*([\d,]+)\s+\([^)]*\)\s+(.+)$")
+    for line in text.splitlines():
+        match = row_re.match(line)
+        if not match:
+            continue
+        descriptor = match.group(2)
+        marker = "src/third_party/"
+        marker_index = descriptor.find(marker)
+        if marker_index < 0:
+            continue
+        descriptor = descriptor[marker_index:]
+        descriptor = re.sub(r"\s+\[[^]]+\]$", "", descriptor)
+        instructions = int(match.group(1).replace(",", ""))
+        functions[descriptor] = max(functions.get(descriptor, 0), instructions)
+    if not functions:
+        raise RuntimeError("callgrind output is missing codec function attribution")
+    return functions
+
+
+def run_callgrind_profile(binary: Path) -> dict[str, dict[str, Any]]:
+    valgrind = shutil.which("valgrind")
+    if not valgrind:
+        raise RuntimeError("valgrind is required for host function attribution")
+    annotate = shutil.which("callgrind_annotate")
+    if not annotate:
+        raise RuntimeError("callgrind_annotate is required for function attribution")
+    report: dict[str, dict[str, Any]] = {}
+    for backend in BACKENDS:
+        output = BUILD / f"callgrind.{backend}.out"
+        RunningProcess.run(
+            [
+                valgrind,
+                "--quiet",
+                "--tool=callgrind",
+                "--branch-sim=yes",
+                "--instr-atstart=no",
+                f"--callgrind-out-file={output}",
+                str(binary.resolve()),
+                backend,
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        )
+        data = parse_callgrind(output)
+        annotation = RunningProcess.run(
+            [
+                annotate,
+                "--inclusive=yes",
+                "--threshold=100",
+                "--auto=no",
+                "--show=Ir",
+                str(output),
+            ],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        functions = parse_callgrind_attribution(annotation.stdout)
+        top = sorted(functions.items(), key=lambda item: item[1], reverse=True)[:20]
+        branches = data.summary.get("Bc", 0) + data.summary.get("Bi", 0)
+        branch_misses = data.summary.get("Bcm", 0) + data.summary.get("Bim", 0)
+        report[backend] = {
+            "instructions": data.summary["Ir"],
+            "branches": branches,
+            "branch_misses": branch_misses,
+            "functions": dict(top),
+        }
+        print(
+            f"CALLGRIND:backend={backend}:instructions={data.summary['Ir']}:"
+            f"branches={branches}:branch_misses={branch_misses}:functions={len(top)}"
+        )
+        for symbol, instructions in top:
+            print(
+                f"CALLGRIND_FUNCTION:backend={backend}:"
+                f"instructions={instructions}:symbol={symbol}"
+            )
+    return report
+
+
+def compose_host_counters(
+    cycle_medians: dict[str, float], callgrind: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, int | float]]:
+    report: dict[str, dict[str, int | float]] = {}
+    for backend in BACKENDS:
+        cycles = cycle_medians[backend]
+        instructions = callgrind[backend]["instructions"]
+        branch_misses = callgrind[backend]["branch_misses"]
+        if cycles <= 0 or instructions <= 0 or branch_misses <= 0:
+            raise RuntimeError(f"invalid deterministic host counters for {backend}")
+        report[backend] = {
+            "cycles": cycles,
+            "instructions": instructions,
+            "ipc": round(instructions / cycles, 6),
+            "branch_misses": branch_misses,
+        }
+    return report
+
+
+def validate_operation_counts(counts: dict[str, dict[str, int]]) -> None:
+    for stage in STAGES:
+        if stage not in counts:
+            raise RuntimeError(f"missing operation stage: {stage}")
+        metrics = counts[stage]
+        for name in ("multiplies", "macs"):
+            value = metrics.get(name)
+            if not isinstance(value, int) or value < 0:
+                raise RuntimeError(f"invalid {stage} {name}: {value}")
+        if metrics["macs"] > metrics["multiplies"]:
+            raise RuntimeError(f"MAC count exceeds multiplies for {stage}")
+
+
+def check_regression(baseline: dict[str, int], current: dict[str, int]) -> None:
+    for backend in BACKENDS:
+        if backend not in baseline or backend not in current:
+            raise RuntimeError(f"missing regression metric for {backend}")
+        limit = baseline[backend] * (1.0 + REGRESSION_TOLERANCE)
+        if current[backend] > limit:
+            raise RuntimeError(f"{backend} regressed: {current[backend]} > {limit:.2f}")
+
+
+def validate_operations(backend: str, operations: dict[str, Any]) -> None:
+    frames = operations.get("frames")
+    if not isinstance(frames, int) or frames <= 0:
+        raise RuntimeError(f"invalid operation frame count for {backend}")
+    stages = operations.get("stages")
+    if not isinstance(stages, dict):
+        raise RuntimeError(f"missing operation stages for {backend}")
+    for stage in STAGES:
+        metrics = stages.get(stage)
+        if not isinstance(metrics, dict):
+            raise RuntimeError(f"missing operation stage: {backend}/{stage}")
+        multiplies = metrics.get("total_multiplies")
+        macs = metrics.get("total_macs")
+        if not isinstance(multiplies, int) or multiplies < 0:
+            raise RuntimeError(f"invalid total multiplies for {backend}/{stage}")
+        if not isinstance(macs, int) or macs < 0 or macs > multiplies:
+            raise RuntimeError(f"invalid total MACs for {backend}/{stage}")
+        expected = {
+            "multiplies_per_frame": round(multiplies / frames, 6),
+            "macs_per_frame": round(macs / frames, 6),
+        }
+        for name, value in expected.items():
+            if metrics.get(name) != value:
+                raise RuntimeError(
+                    f"inexact derived operation metric {backend}/{stage}/{name}"
+                )
+
+
+def validate_host(backend: str, host: dict[str, Any]) -> None:
+    counters = host.get("counter_median", {})
+    for metric in ("cycles", "instructions", "ipc", "branch_misses"):
+        if not isinstance(counters.get(metric), (int, float)) or counters[metric] <= 0:
+            raise RuntimeError(f"missing host counter {backend}/{metric}")
+    source = host.get("counter_source", {})
+    if set(source) != {"cycles", "instructions", "ipc", "branch_misses"}:
+        raise RuntimeError(f"missing host counter provenance for {backend}")
+    if any(not isinstance(value, str) or not value for value in source.values()):
+        raise RuntimeError(f"invalid host counter provenance for {backend}")
+    callgrind = host.get("callgrind", {})
+    for metric in ("instructions", "branches", "branch_misses"):
+        if not isinstance(callgrind.get(metric), int) or callgrind[metric] <= 0:
+            raise RuntimeError(f"missing callgrind {metric} for {backend}")
+    if counters["instructions"] != callgrind["instructions"]:
+        raise RuntimeError(f"host instruction sources disagree for {backend}")
+    if counters["branch_misses"] != callgrind["branch_misses"]:
+        raise RuntimeError(f"host branch-miss sources disagree for {backend}")
+    expected_ipc = round(counters["instructions"] / counters["cycles"], 6)
+    if counters["ipc"] != expected_ipc:
+        raise RuntimeError(f"inexact derived host IPC for {backend}")
+    functions = callgrind.get("functions")
+    if not isinstance(functions, dict) or len(functions) < 8:
+        raise RuntimeError(f"missing callgrind functions for {backend}")
+    if any(not isinstance(value, int) or value <= 0 for value in functions.values()):
+        raise RuntimeError(f"invalid callgrind function metric for {backend}")
+    stage_ns = host.get("stage_ns_median", {})
+    coverage = host.get("stage_coverage", {})
+    for stage in STAGES:
+        if not isinstance(stage_ns.get(stage), (int, float)) or stage_ns[stage] < 0:
+            raise RuntimeError(f"missing stage timing {backend}/{stage}")
+        stage_coverage = coverage.get(stage, {})
+        mode = stage_coverage.get("mode")
+        sites = stage_coverage.get("instrumentation_sites")
+        if mode == "dedicated":
+            if not isinstance(sites, int) or sites <= 0:
+                raise RuntimeError(
+                    f"missing dedicated stage coverage {backend}/{stage}"
+                )
+            if stage_ns[stage] <= 0:
+                raise RuntimeError(f"zero dedicated stage timing {backend}/{stage}")
+        elif mode == "fused":
+            if sites != 0 or stage_coverage.get("fused_with") not in STAGES:
+                raise RuntimeError(f"invalid fused stage coverage {backend}/{stage}")
+            if stage_ns[stage] != 0:
+                raise RuntimeError(
+                    f"fused stage must not claim dedicated timing {backend}/{stage}"
+                )
+        else:
+            raise RuntimeError(f"missing stage coverage {backend}/{stage}")
+
+
+def validate_trend(trend: dict[str, Any]) -> None:
+    if trend.get("schema_version") != 2:
+        raise RuntimeError("codec CPU trend schema_version must be 2")
+    if trend.get("profile_runs") != PROFILE_RUNS:
+        raise RuntimeError(f"host profile must use N={PROFILE_RUNS}")
+    if trend.get("regression_tolerance") != REGRESSION_TOLERANCE:
+        raise RuntimeError("codec CPU trend tolerance must be 5 percent")
+    environment = trend.get("environment")
+    if not isinstance(environment, dict):
+        raise RuntimeError("codec CPU trend is missing its host environment")
+    if trend.get("host_key") != environment_key(environment):
+        raise RuntimeError("codec CPU trend host_key does not match its environment")
+    backends = trend.get("backends")
+    if not isinstance(backends, dict):
+        raise RuntimeError("codec CPU trend is missing backends")
+    for backend in BACKENDS:
+        entry = backends.get(backend)
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"codec CPU trend is missing backend {backend}")
+        validate_operations(backend, entry.get("operations", {}))
+        validate_host(backend, entry.get("host", {}))
+        codegen = entry.get("codegen", {})
+        for target in TARGETS:
+            target_entry = codegen.get(target, {})
+            for kernel in KERNELS:
+                metrics = target_entry.get(kernel, {})
+                for name in ("instructions", "inner_loop_instructions"):
+                    if not isinstance(metrics.get(name), int) or metrics[name] < 0:
+                        raise RuntimeError(
+                            f"missing codegen metric {backend}/{target}/{kernel}/{name}"
+                        )
+    host_baselines = trend.get("host_baselines", {})
+    if not isinstance(host_baselines, dict):
+        raise RuntimeError("codec CPU trend host_baselines must be an object")
+    for key, profile in host_baselines.items():
+        if not isinstance(profile, dict):
+            raise RuntimeError(f"invalid host baseline {key}")
+        profile_environment = profile.get("environment")
+        if not isinstance(profile_environment, dict) or key != environment_key(
+            profile_environment
+        ):
+            raise RuntimeError(f"host baseline key does not match environment: {key}")
+        hosts = profile.get("hosts")
+        if not isinstance(hosts, dict) or set(hosts) != set(BACKENDS):
+            raise RuntimeError(f"host baseline is missing backends: {key}")
+        for backend in BACKENDS:
+            host = hosts[backend]
+            if not isinstance(host, dict):
+                raise RuntimeError(f"invalid host baseline {key}/{backend}")
+            validate_host(backend, host)
+
+
+def _check_upper_bound(path: str, baseline: float, current: float) -> None:
+    if baseline == 0:
+        if current != 0:
+            raise RuntimeError(f"{path} changed from zero to {current}")
+        return
+    limit = baseline * (1.0 + REGRESSION_TOLERANCE)
+    if current > limit:
+        raise RuntimeError(f"{path} regressed: {current} > {limit:.6f}")
+
+
+def _check_lower_bound(path: str, baseline: float, current: float) -> None:
+    limit = baseline * (1.0 - REGRESSION_TOLERANCE)
+    if current < limit:
+        raise RuntimeError(f"{path} regressed: {current} < {limit:.6f}")
+
+
+def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
+    """Enforce exact portable counts and a 5% CPU/codegen regression budget."""
+    validate_trend(baseline)
+    validate_trend(current)
+    current_host_key = current.get("host_key")
+    alternate_profile = None
+    if baseline.get("host_key") != current_host_key:
+        alternate_profile = baseline.get("host_baselines", {}).get(current_host_key)
+        if alternate_profile is None:
+            raise RuntimeError(f"host baseline is unknown: {current_host_key}")
+    for backend in BACKENDS:
+        baseline_entry = baseline["backends"][backend]
+        current_entry = current["backends"][backend]
+        baseline_operations = baseline_entry["operations"]
+        current_operations = current_entry["operations"]
+        if current_operations != baseline_operations:
+            raise RuntimeError(f"exact operation ledger changed for {backend}")
+
+        baseline_host = (
+            baseline_entry["host"]
+            if alternate_profile is None
+            else alternate_profile["hosts"][backend]
+        )
+        current_host = current_entry["host"]
+        for metric in ("cycles", "instructions", "branch_misses"):
+            _check_upper_bound(
+                f"{backend}/counter/{metric}",
+                baseline_host["counter_median"][metric],
+                current_host["counter_median"][metric],
+            )
+        _check_lower_bound(
+            f"{backend}/counter/ipc",
+            baseline_host["counter_median"]["ipc"],
+            current_host["counter_median"]["ipc"],
+        )
+        for stage in STAGES:
+            _check_upper_bound(
+                f"{backend}/stage/{stage}",
+                baseline_host["stage_ns_median"][stage],
+                current_host["stage_ns_median"][stage],
+            )
+        for metric in ("instructions", "branches", "branch_misses"):
+            _check_upper_bound(
+                f"{backend}/callgrind/{metric}",
+                baseline_host["callgrind"][metric],
+                current_host["callgrind"][metric],
+            )
+        baseline_functions = baseline_host["callgrind"]["functions"]
+        current_functions = current_host["callgrind"]["functions"]
+        for symbol, baseline_instructions in baseline_functions.items():
+            if symbol not in current_functions:
+                raise RuntimeError(
+                    f"callgrind attribution disappeared for {backend}/{symbol}"
+                )
+            baseline_share = (
+                baseline_instructions / baseline_host["callgrind"]["instructions"]
+            )
+            current_share = (
+                current_functions[symbol] / current_host["callgrind"]["instructions"]
+            )
+            _check_upper_bound(
+                f"{backend}/callgrind-function/{symbol}",
+                baseline_share,
+                current_share,
+            )
+
+        for target in TARGETS:
+            for kernel in KERNELS:
+                for metric in ("instructions", "inner_loop_instructions"):
+                    _check_upper_bound(
+                        f"{backend}/codegen/{target}/{kernel}/{metric}",
+                        baseline_entry["codegen"][target][kernel][metric],
+                        current_entry["codegen"][target][kernel][metric],
+                    )
+
+
+_FUNCTION_RE = re.compile(r"^\s*[0-9a-fA-F]+\s+<([^>]+)>:\s*$")
+_INSTRUCTION_RE = re.compile(
+    r"^\s*([0-9a-fA-F]+):\s+(?:[0-9a-fA-F]{2,8}\s+)+([A-Za-z.][\w.]*)\s*(.*)$"
+)
+_TARGET_RE = re.compile(r"(?:0x)?([0-9a-fA-F]+)\s*<[^>]+>")
+_CALL_MNEMONICS = {
+    "bl",
+    "blx",
+    "call",
+    "call0",
+    "call4",
+    "call8",
+    "call12",
+    "callx0",
+    "callx4",
+    "callx8",
+    "callx12",
+    "jal",
+    "jalr",
+}
+
+
+def parse_disassembly(text: str, symbol: str) -> dict[str, int]:
+    in_function = False
+    instructions: list[tuple[int, str, str]] = []
+    for line in text.splitlines():
+        function = _FUNCTION_RE.match(line)
+        if function:
+            if in_function:
+                break
+            in_function = function.group(1) == symbol
+            continue
+        if not in_function:
+            continue
+        match = _INSTRUCTION_RE.match(line)
+        if match:
+            instructions.append(
+                (int(match.group(1), 16), match.group(2), match.group(3))
+            )
+    if not instructions:
+        raise RuntimeError(f"symbol missing from disassembly: {symbol}")
+    loop_addresses: set[int] = set()
+    addresses = {address for address, _, _ in instructions}
+    for address, mnemonic, operands in instructions:
+        lowered = mnemonic.lower()
+        if lowered in _CALL_MNEMONICS:
+            continue
+        if not lowered.startswith(("b", "j", "loop")):
+            continue
+        targets = [int(value, 16) for value in _TARGET_RE.findall(operands)]
+        if lowered.startswith("loop"):
+            forwards = [target for target in targets if target > address]
+            if forwards:
+                end = min(forwards)
+                loop_addresses.update(
+                    item_address
+                    for item_address, _, _ in instructions
+                    if address < item_address < end
+                )
+            continue
+        backwards = [
+            target for target in targets if target < address and target in addresses
+        ]
+        if backwards:
+            target = max(backwards)
+            loop_addresses.update(
+                item_address
+                for item_address, _, _ in instructions
+                if target <= item_address <= address
+            )
+    return {
+        "instructions": len(instructions),
+        "inner_loop_instructions": len(loop_addresses),
+    }
+
+
+def matching_disassembly_symbols(text: str, needles: tuple[str, ...]) -> list[str]:
+    symbols: list[str] = []
+    for line in text.splitlines():
+        match = _FUNCTION_RE.match(line)
+        if match:
+            symbol = match.group(1)
+            if not symbol.startswith(".") and any(
+                needle in symbol for needle in needles
+            ):
+                symbols.append(symbol)
+    return symbols
+
+
+def aggregate_kernel_disassembly(text: str, needles: tuple[str, ...]) -> dict[str, int]:
+    symbols = matching_disassembly_symbols(text, needles)
+    if not symbols:
+        raise RuntimeError(f"codegen kernel missing: {','.join(needles)}")
+    totals = {"instructions": 0, "inner_loop_instructions": 0}
+    for symbol in symbols:
+        metrics = parse_disassembly(text, symbol)
+        for name in totals:
+            totals[name] += metrics[name]
+    return totals
+
+
+def _package_tool(package: str, executable: str) -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    names = (executable + suffix, executable)
+    for name in names:
+        located = shutil.which(name)
+        if located:
+            return Path(located)
+    package_roots = []
+    override = os.environ.get("PLATFORMIO_PACKAGES_DIR")
+    if override:
+        package_roots.append(Path(override))
+    package_roots.append(Path.home() / ".platformio" / "packages")
+    for root in package_roots:
+        for name in names:
+            candidate = root / package / "bin" / name
+            if candidate.exists():
+                return candidate
+    raise RuntimeError(f"missing tool {executable} from PlatformIO package {package}")
+
+
+def _target_tools(target: str) -> TargetTools:
+    if target == "xtensa-esp32":
+        prefix = "xtensa-esp32-elf"
+        package = "toolchain-xtensa-esp32"
+        flags: list[str] = [
+            "-DFL_CODEC_CPU_CODEGEN_ESP_TYPES",
+            "-D__thumb__",
+        ]
+    elif target == "riscv32-esp":
+        prefix = "riscv32-esp-elf"
+        package = "toolchain-riscv32-esp"
+        flags = [
+            "-march=rv32imc_zicsr",
+            "-mabi=ilp32",
+            "-DFL_CODEC_CPU_CODEGEN_ESP_TYPES",
+            "-D__thumb__",
+        ]
+    elif target in ("cortex-m0plus", "cortex-m4"):
+        prefix = "arm-none-eabi"
+        package = "toolchain-gccarmnoneeabi"
+        cpu = "cortex-m0plus" if target == "cortex-m0plus" else "cortex-m4"
+        flags = [f"-mcpu={cpu}", "-mthumb", "-DARDUINO_ARCH_NRF52"]
+    else:
+        raise RuntimeError(f"unknown CPU audit target: {target}")
+    return TargetTools(
+        compiler=_package_tool(package, f"{prefix}-g++"),
+        objdump=_package_tool(package, f"{prefix}-objdump"),
+        flags=flags,
+    )
+
+
+def run_codegen_audit() -> dict[str, dict[str, dict[str, dict[str, int]]]]:
+    BUILD.mkdir(parents=True, exist_ok=True)
+    sources = {
+        "helix": Path(__file__).with_name("helix_codegen.cpp"),
+        "minimp3-float": Path(__file__).with_name("minimp3_codegen.cpp"),
+    }
+    kernel_needles = {
+        "helix": {
+            "dct32": ("FDCT32",),
+            "polyphase": ("PolyphaseMono", "PolyphaseStereo"),
+        },
+        "minimp3-float": {
+            "dct32": ("mp3d_DCT_II",),
+            "polyphase": ("mp3d_synth_pair",),
+        },
+    }
+    report: dict[str, dict[str, dict[str, dict[str, int]]]] = {
+        backend: {} for backend in BACKENDS
+    }
+    for target in TARGETS:
+        tools = _target_tools(target)
+        for backend, source in sources.items():
+            stem = backend.replace("-float", "")
+            obj = BUILD / f"{stem}.{target}.o"
+            cross_flags = [
+                flag
+                for flag in _common_compile_flags("-Os")
+                if flag
+                not in (
+                    "-fno-discard-value-names",
+                    "-fno-inline",
+                    "-ffp-contract=off",
+                )
+            ]
+            RunningProcess.run(
+                [
+                    str(tools.compiler),
+                    *cross_flags,
+                    "-ffunction-sections",
+                    *tools.flags,
+                    "-c",
+                    str(source),
+                    "-o",
+                    str(obj),
+                ],
+                check=True,
+            )
+            result = RunningProcess.run(
+                [str(tools.objdump), "-d", "-C", str(obj)],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            report[backend][target] = {}
+            for kernel in KERNELS:
+                metrics = aggregate_kernel_disassembly(
+                    result.stdout, kernel_needles[backend][kernel]
+                )
+                report[backend][target][kernel] = metrics
+                print(
+                    f"CODEGEN:backend={backend}:target={target}:kernel={kernel}:"
+                    f"instructions={metrics['instructions']}:"
+                    "inner_loop_instructions="
+                    f"{metrics['inner_loop_instructions']}"
+                )
+    return report
+
+
+def _selected_affinity_cpu() -> int | None:
+    if hasattr(os, "sched_getaffinity"):
+        allowed = sorted(os.sched_getaffinity(0))
+        if allowed:
+            return allowed[0]
+    return None
+
+
+def make_affinity_prefix(taskset: str | None, cpu: int | None) -> list[str]:
+    if not taskset or cpu is None:
+        raise RuntimeError("host CPU audit requires taskset and a selectable CPU")
+    return [taskset, "-c", str(cpu)]
+
+
+def host_affinity_prefix() -> list[str]:
+    return make_affinity_prefix(shutil.which("taskset"), _selected_affinity_cpu())
+
+
+def host_environment() -> dict[str, Any]:
+    cpu_model = platform.processor()
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        match = re.search(
+            r"^(?:model name|Hardware)\s*:\s*(.+)$",
+            cpuinfo.read_text(encoding="utf-8", errors="replace"),
+            re.MULTILINE,
+        )
+        if match:
+            cpu_model = match.group(1).strip()
+    if not cpu_model:
+        raise RuntimeError("host CPU model is unavailable")
+    affinity_cpu = _selected_affinity_cpu()
+    governor = "not-exposed"
+    if affinity_cpu is not None:
+        governor_path = Path(
+            f"/sys/devices/system/cpu/cpu{affinity_cpu}/cpufreq/scaling_governor"
+        )
+        if governor_path.exists():
+            governor = governor_path.read_text(encoding="utf-8").strip()
+    compiler = compiler_path()
+    compiler_result = RunningProcess.run(
+        [str(compiler), "--version"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return {
+        "platform": platform.platform(),
+        "cpu_model": cpu_model,
+        "affinity_cpu": affinity_cpu,
+        "governor": governor,
+        "compiler": compiler_result.stdout.splitlines()[0],
+    }
+
+
+def corpus_provenance() -> list[dict[str, Any]]:
+    provenance: list[dict[str, Any]] = []
+    for relative in CORPUS:
+        path = ROOT / relative
+        data = path.read_bytes()
+        provenance.append(
+            {
+                "path": relative,
+                "bytes": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        )
+    return provenance
+
+
+def capture_audit() -> dict[str, Any]:
+    operation_driver = build_instrumented_driver()
+    operations = run_operation_audit(operation_driver.binary)
+    timing_driver = build_instrumented_driver(operations=False)
+    stage_timing = run_host_stage_profile(timing_driver.binary)
+    plain = build_plain_driver()
+    cycle_medians = run_cycle_profile(plain)
+    callgrind = run_callgrind_profile(plain)
+    counters = compose_host_counters(cycle_medians, callgrind)
+    codegen = run_codegen_audit()
+    environment = host_environment()
+    report: dict[str, Any] = {
+        "schema_version": 2,
+        "profile_runs": PROFILE_RUNS,
+        "regression_tolerance": REGRESSION_TOLERANCE,
+        "environment": environment,
+        "host_key": environment_key(environment),
+        "corpus": corpus_provenance(),
+        "backends": {},
+    }
+    for backend in BACKENDS:
+        report["backends"][backend] = {
+            "operations": operations[backend],
+            "host": {
+                "counter_median": counters[backend],
+                "counter_source": {
+                    "cycles": "Clang readcyclecounter median over 30 pinned runs",
+                    "instructions": "Valgrind Callgrind deterministic Ir",
+                    "ipc": "Callgrind Ir divided by median cycle counter",
+                    "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+                },
+                "stage_ns_median": stage_timing[backend],
+                "stage_coverage": timing_driver.stage_coverage[backend],
+                "callgrind": callgrind[backend],
+            },
+            "codegen": codegen[backend],
+        }
+    validate_trend(report)
+    return report
+
+
+def write_report(report: dict[str, Any], path: Path) -> None:
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote codec CPU audit report to {path}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--codegen", action="store_true")
+    parser.add_argument("--host", action="store_true")
+    parser.add_argument("--callgrind", action="store_true")
+    parser.add_argument("--linux-host", action="store_true")
+    parser.add_argument("--operations", action="store_true")
+    parser.add_argument("--cycles", action="store_true")
+    parser.add_argument("--write", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.all or args.check or args.write:
+        current = capture_audit()
+        if args.write:
+            write_report(current, args.write)
+        if args.check:
+            check_trend(load_trend(), current)
+            print("Codec CPU trend is complete and within the 5% budget")
+        return 0
+    if args.operations:
+        run_operation_audit(build_instrumented_driver().binary)
+    if args.host:
+        run_host_stage_profile(build_instrumented_driver(operations=False).binary)
+    if args.codegen:
+        run_codegen_audit()
+    if args.linux_host or args.cycles or args.callgrind:
+        plain = build_plain_driver()
+    if args.linux_host or args.cycles:
+        run_cycle_profile(plain)
+    if args.linux_host or args.callgrind:
+        run_callgrind_profile(plain)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/codec_cpu/driver.cpp
+++ b/ci/codec_cpu/driver.cpp
@@ -1,0 +1,322 @@
+#include <chrono>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fl/codec/mp3_memory.h"
+#include "third_party/libhelix_mp3/pub/mp3dec.h"
+#include "third_party/minimp3/minimp3.h"
+
+#if __has_include(<valgrind/callgrind.h>)
+#include <valgrind/callgrind.h>
+#define FL_CODEC_CPU_HAS_CALLGRIND
+#endif
+
+namespace {
+
+constexpr int STAGE_COUNT = 8;
+constexpr int STACK_DEPTH = 32;
+
+struct StageMetrics {
+    uint64_t multiplies;
+    uint64_t macs;
+    uint64_t nanoseconds;
+};
+
+StageMetrics gMetrics[STAGE_COUNT] = {};
+int gStageStack[STACK_DEPTH] = {};
+uint64_t gStartStack[STACK_DEPTH] = {};
+int gDepth = 0;
+
+uint64_t monotonicNanoseconds() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
+uint64_t cycleCounter() {
+#if defined(__clang__)
+    return __builtin_readcyclecounter();
+#else
+#error "The codec CPU audit requires Clang's cycle-counter builtin"
+#endif
+}
+
+void callgrindStart() {
+#if defined(FL_CODEC_CPU_HAS_CALLGRIND)
+    CALLGRIND_START_INSTRUMENTATION;
+#endif
+}
+
+void callgrindStop() {
+#if defined(FL_CODEC_CPU_HAS_CALLGRIND)
+    CALLGRIND_STOP_INSTRUMENTATION;
+#endif
+}
+
+void callgrindReset() {
+#if defined(FL_CODEC_CPU_HAS_CALLGRIND)
+    CALLGRIND_ZERO_STATS;
+#endif
+}
+
+const char* stageName(int stage) {
+    static const char* const names[STAGE_COUNT] = {
+        "scalefactors", "huffman", "dequant", "stereo", "reorder",
+        "antialias", "imdct", "synthesis",
+    };
+    return stage >= 0 && stage < STAGE_COUNT ? names[stage] : "invalid";
+}
+
+bool loadFixture(const char* path, unsigned char** data, size_t* size) {
+    FILE* file = ::fopen(path, "rb");
+    if (!file) {
+        return false;
+    }
+    ::fseek(file, 0, SEEK_END);
+    const long length = ::ftell(file);
+    ::rewind(file);
+    if (length <= 0) {
+        ::fclose(file);
+        return false;
+    }
+    *data = static_cast<unsigned char*>(::malloc(static_cast<size_t>(length)));
+    if (!*data) {
+        ::fclose(file);
+        return false;
+    }
+    *size = ::fread(*data, 1, static_cast<size_t>(length), file);
+    ::fclose(file);
+    if (*size != static_cast<size_t>(length)) {
+        ::free(*data);
+        *data = nullptr;
+        *size = 0;
+        return false;
+    }
+    return true;
+}
+
+uint64_t checksumPcm(const int16_t* pcm, int samples, int channels) {
+    uint64_t value = 1469598103934665603ULL;
+    for (int i = 0; i < samples * channels; ++i) {
+        value ^= static_cast<uint16_t>(pcm[i]);
+        value *= 1099511628211ULL;
+    }
+    return value;
+}
+
+bool decodeHelix(const unsigned char* data, size_t size, uint64_t* checksum,
+                 int* frames) {
+    const int frames_before = *frames;
+    HMP3Decoder decoder = fl::third_party::MP3InitDecoder();
+    if (!decoder) {
+        return false;
+    }
+    int16_t* pcm = static_cast<int16_t*>(::malloc(2304 * sizeof(int16_t)));
+    if (!pcm) {
+        fl::third_party::MP3FreeDecoder(decoder);
+        return false;
+    }
+    const unsigned char* input = data;
+    size_t remaining = size;
+    while (remaining > 4) {
+        const int offset = fl::third_party::MP3FindSyncWord(
+            input, static_cast<int>(remaining));
+        if (offset < 0) {
+            break;
+        }
+        input += offset;
+        remaining -= static_cast<size_t>(offset);
+        const size_t before = remaining;
+        const int result = fl::third_party::MP3Decode(
+            decoder, &input, &remaining, pcm, 0);
+        if (result == 0) {
+            MP3FrameInfo info = {};
+            fl::third_party::MP3GetLastFrameInfo(decoder, &info);
+            if (info.outputSamps > 0 && info.nChans > 0) {
+                *checksum ^= checksumPcm(
+                    pcm, info.outputSamps / info.nChans, info.nChans);
+                ++*frames;
+            }
+        }
+        if (remaining >= before) {
+            break;
+        }
+    }
+    ::free(pcm);
+    fl::third_party::MP3FreeDecoder(decoder);
+    return *frames > frames_before;
+}
+
+bool decodeMinimp3(const unsigned char* data, size_t size, uint64_t* checksum,
+                   int* frames) {
+    const int frames_before = *frames;
+    fl::third_party::mp3dec_t* decoder =
+        static_cast<fl::third_party::mp3dec_t*>(
+            ::malloc(sizeof(fl::third_party::mp3dec_t)));
+    fl::third_party::mp3dec_scratch_t* scratch =
+        static_cast<fl::third_party::mp3dec_scratch_t*>(
+            ::malloc(sizeof(fl::third_party::mp3dec_scratch_t)));
+    if (!decoder || !scratch) {
+        ::free(scratch);
+        ::free(decoder);
+        return false;
+    }
+    int16_t* pcm = static_cast<int16_t*>(::malloc(2304 * sizeof(int16_t)));
+    if (!pcm) {
+        ::free(scratch);
+        ::free(decoder);
+        return false;
+    }
+    fl::third_party::mp3dec_init(decoder);
+    size_t offset = 0;
+    while (offset + 4 < size) {
+        fl::third_party::mp3dec_frame_info_t info = {};
+        const int samples = fl::third_party::mp3dec_decode_frame_r(
+            decoder, scratch, data + offset, static_cast<int>(size - offset),
+            pcm, &info);
+        if (info.frame_bytes <= 0) {
+            break;
+        }
+        offset += static_cast<size_t>(info.frame_bytes);
+        if (samples > 0 && info.channels > 0) {
+            *checksum ^= checksumPcm(pcm, samples, info.channels);
+            ++*frames;
+        }
+    }
+    ::free(pcm);
+    ::free(scratch);
+    ::free(decoder);
+    return *frames > frames_before;
+}
+
+} // anonymous namespace
+
+extern "C" void fastled_mp3_cpu_stage_enter(int stage) {
+    if (stage < 0 || stage >= STAGE_COUNT || gDepth >= STACK_DEPTH) {
+        ::abort();
+    }
+    if (gDepth > 0) {
+        const uint64_t now = monotonicNanoseconds();
+        gMetrics[gStageStack[gDepth - 1]].nanoseconds +=
+            now - gStartStack[gDepth - 1];
+    }
+    gStageStack[gDepth] = stage;
+    gStartStack[gDepth] = monotonicNanoseconds();
+    ++gDepth;
+}
+
+extern "C" void fastled_mp3_cpu_stage_exit(int stage) {
+    if (gDepth <= 0 || gStageStack[gDepth - 1] != stage) {
+        ::abort();
+    }
+    const uint64_t now = monotonicNanoseconds();
+    --gDepth;
+    gMetrics[stage].nanoseconds += now - gStartStack[gDepth];
+    if (gDepth > 0) {
+        gStartStack[gDepth - 1] = monotonicNanoseconds();
+    }
+}
+
+extern "C" void fastled_mp3_cpu_operation(int stage, int multiplies,
+                                           int macs) {
+    if (multiplies < 0 || macs < 0) {
+        ::abort();
+    }
+    if (stage < 0 && gDepth > 0) {
+        stage = gStageStack[gDepth - 1];
+    }
+    if (stage < 0 || stage >= STAGE_COUNT) {
+        ::abort();
+    }
+    StageMetrics& metrics = gMetrics[stage];
+    metrics.multiplies += static_cast<uint64_t>(multiplies);
+    metrics.macs += static_cast<uint64_t>(macs);
+}
+
+namespace fl {
+
+void* memcpy(void* dst, const void* src, fl::size n) FL_NO_EXCEPT {
+    return ::memcpy(dst, src, n);
+}
+
+void* memmove(void* dst, const void* src, fl::size n) FL_NO_EXCEPT {
+    return ::memmove(dst, src, n);
+}
+
+void* memset(void* dst, int value, fl::size n) FL_NO_EXCEPT {
+    return ::memset(dst, value, n);
+}
+
+namespace third_party {
+
+FL_NO_INLINE void* Mp3MemoryAllocate(
+    fl::size bytes, Mp3MemoryTag tag) FL_NO_EXCEPT {
+    (void)tag;
+    return ::malloc(bytes);
+}
+
+void Mp3MemoryFree(void* ptr, fl::size bytes, Mp3MemoryTag tag) FL_NO_EXCEPT {
+    (void)bytes;
+    (void)tag;
+    ::free(ptr);
+}
+
+} // namespace third_party
+} // namespace fl
+
+int main(int argc, char** argv) {
+    if (argc != 2 ||
+        (::strcmp(argv[1], "helix") != 0 &&
+         ::strcmp(argv[1], "minimp3-float") != 0)) {
+        ::fprintf(stderr, "usage: codec_cpu_driver helix|minimp3-float\n");
+        return 2;
+    }
+    uint64_t checksum = 0;
+    uint64_t cycles = 0;
+    int frames = 0;
+    static const char* const corpus[] = {
+        "tests/data/codec/minimp3/l3-hecommon.bit",
+        "tests/data/codec/minimp3/l3-compl-cut.mp3",
+        "tests/data/codec/minimp3/l3-he_free.bit",
+        "tests/data/codec/minimp3/l3-lame-vbrtag.bit",
+        "tests/data/codec/minimp3/M2L3_bitrate_16_all.bit",
+    };
+    bool ok = true;
+    callgrindReset();
+    for (unsigned index = 0; index < sizeof(corpus) / sizeof(corpus[0]); ++index) {
+        unsigned char* data = nullptr;
+        size_t size = 0;
+        if (!loadFixture(corpus[index], &data, &size)) {
+            return 3;
+        }
+        callgrindStart();
+        const uint64_t cycle_start = cycleCounter();
+        const bool decoded = ::strcmp(argv[1], "helix") == 0
+                                 ? decodeHelix(data, size, &checksum, &frames)
+                                 : decodeMinimp3(data, size, &checksum, &frames);
+        cycles += cycleCounter() - cycle_start;
+        callgrindStop();
+        ::free(data);
+        ok = ok && decoded;
+    }
+    if (!ok || gDepth != 0 || frames <= 0) {
+        return 4;
+    }
+    for (int stage = 0; stage < STAGE_COUNT; ++stage) {
+        ::printf("OPS:backend=%s:stage=%s:multiplies=%llu:macs=%llu\n",
+                 argv[1], stageName(stage),
+                 static_cast<unsigned long long>(gMetrics[stage].multiplies),
+                 static_cast<unsigned long long>(gMetrics[stage].macs));
+        ::printf("TIMING:backend=%s:stage=%s:nanoseconds=%llu\n", argv[1],
+                 stageName(stage),
+                 static_cast<unsigned long long>(gMetrics[stage].nanoseconds));
+    }
+    ::printf(
+        "CPU_AUDIT_RESULT:backend=%s:frames=%d:checksum=%llu:cycles=%llu\n",
+        argv[1], frames, static_cast<unsigned long long>(checksum),
+        static_cast<unsigned long long>(cycles));
+    return 0;
+}

--- a/ci/codec_cpu/helix_codegen.cpp
+++ b/ci/codec_cpu/helix_codegen.cpp
@@ -1,0 +1,9 @@
+// Standalone Helix translation unit for target-ISA code generation auditing.
+
+#if defined(FL_CODEC_CPU_CODEGEN_ESP_TYPES)
+#define ESP32
+#include "fl/stl/stdint.h"
+#undef ESP32
+#endif
+
+#include "third_party/libhelix_mp3/_build.cpp.hpp"

--- a/ci/codec_cpu/minimp3_codegen.cpp
+++ b/ci/codec_cpu/minimp3_codegen.cpp
@@ -1,0 +1,26 @@
+// Standalone minimp3 translation unit for target-ISA code generation auditing.
+
+#include "fl/stl/compiler_control.h"
+
+#if defined(FL_CODEC_CPU_CODEGEN_ESP_TYPES)
+#define ESP32
+#include "fl/stl/stdint.h"
+#undef ESP32
+#else
+#include "fl/stl/stdint.h"
+#endif
+
+typedef fl::u64 uint64_t;
+
+#include "third_party/minimp3/_build.cpp.hpp"
+
+extern "C" FL_NO_INLINE void
+fl_codec_cpu_minimp3_dct32(float* grbuf, int bands) FL_NO_EXCEPT {
+    fl::third_party::mp3d_DCT_II(grbuf, bands);
+}
+
+extern "C" FL_NO_INLINE void fl_codec_cpu_minimp3_polyphase(
+    fl::third_party::mp3d_sample_t* pcm, int channels,
+    const float* coefficients) FL_NO_EXCEPT {
+    fl::third_party::mp3d_synth_pair(pcm, channels, coefficients);
+}

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "ci" / "codec_cpu" / "audit.py"
+SPEC = importlib.util.spec_from_file_location("codec_cpu_audit", MODULE_PATH)
+assert SPEC and SPEC.loader
+AUDIT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = AUDIT
+SPEC.loader.exec_module(AUDIT)
+
+
+def test_checked_in_cpu_trend_is_complete() -> None:
+    trend = AUDIT.load_trend()
+    AUDIT.validate_trend(trend)
+
+
+def test_five_percent_regression_gate() -> None:
+    baseline = {"helix": 1_000_000, "minimp3-float": 2_000_000}
+    AUDIT.check_regression(baseline, dict(baseline))
+    changed = dict(baseline)
+    changed["minimp3-float"] = 2_100_001
+    with pytest.raises(RuntimeError, match="regressed"):
+        AUDIT.check_regression(baseline, changed)
+
+
+def test_llvm_function_stage_classification() -> None:
+    assert AUDIT.classify_stage("_ZL10L3_huffman") == "huffman"
+    assert AUDIT.classify_stage("_Z7FDCT32Pii") == "synthesis"
+    assert AUDIT.classify_stage("_ZL11L3_imdct_gr") == "imdct"
+    assert AUDIT.classify_stage("unrelated") is None
+
+
+def test_float_mac_counts_one_accumulate_for_two_products() -> None:
+    llvm = """
+define void @L3_antialias() {
+entry:
+  %left = fmul float %a, %b
+  %right = fmul float %c, %d
+  %sum = fadd float %left, %right
+  ret void
+}
+"""
+    result = AUDIT.instrument_llvm_ir(llvm, "minimp3-float")
+    assert result.text.count("i32 5, i32 1, i32 0") == 2
+    assert result.text.count("i32 5, i32 0, i32 1") == 1
+
+
+def test_fused_minimp3_huffman_products_are_dequantized_operations() -> None:
+    llvm = """
+define void @L3_huffman() {
+entry:
+  %scaled = fmul float %sample, %scale
+  ret void
+}
+"""
+    result = AUDIT.instrument_llvm_ir(llvm, "minimp3-float")
+    assert "i32 2, i32 1, i32 0" in result.text
+    assert result.stage_sites["huffman"] == 1
+
+
+def test_helix_mulshift_accumulation_counts_one_mac() -> None:
+    llvm = """
+define i32 @MULSHIFT32(i32 %x, i32 %y) {
+entry:
+  %wide_x = sext i32 %x to i64
+  %wide_y = sext i32 %y to i64
+  %product = mul i64 %wide_x, %wide_y
+  %scaled = trunc i64 %product to i32
+  ret i32 %scaled
+}
+define i32 @AntiAlias(i32 %a, i32 %b, i32 %c) {
+entry:
+  %left = call i32 @MULSHIFT32(i32 %a, i32 %b)
+  %right = call i32 @MULSHIFT32(i32 %a, i32 %c)
+  %sum = add i32 %left, %right
+  ret i32 %sum
+}
+"""
+    result = AUDIT.instrument_llvm_ir(llvm, "helix")
+    assert result.text.count("i32 -1, i32 1, i32 0") == 1
+    assert result.text.count("i32 5, i32 0, i32 1") == 1
+
+
+def test_helix_mulshift_accumulation_survives_o0_spills_and_casts() -> None:
+    llvm = """
+define i64 @AntiAlias(i32 %a, i32 %b, ptr %slot) {
+entry:
+  %product = call i32 @MULSHIFT32(i32 %a, i32 %b)
+  store i32 %product, ptr %slot
+  %loaded = load i32, ptr %slot
+  %wide = sext i32 %loaded to i64
+  %first = add i64 %wide, 1
+  %second = sub i64 %first, 2
+  ret i64 %second
+}
+"""
+    result = AUDIT.instrument_llvm_ir(llvm, "helix")
+    assert result.text.count("i32 5, i32 0, i32 1") == 1
+
+
+def test_host_counters_combine_cycle_median_and_callgrind() -> None:
+    cycles = {"helix": 100.0, "minimp3-float": 200.0}
+    callgrind = {
+        backend: {"instructions": 250, "branch_misses": 4} for backend in AUDIT.BACKENDS
+    }
+    counters = AUDIT.compose_host_counters(cycles, callgrind)
+    assert counters["helix"] == {
+        "cycles": 100.0,
+        "instructions": 250,
+        "branch_misses": 4,
+        "ipc": 2.5,
+    }
+    assert counters["minimp3-float"]["ipc"] == 1.25
+
+
+def test_host_affinity_is_fail_closed() -> None:
+    assert AUDIT.make_affinity_prefix("/usr/bin/taskset", 3) == [
+        "/usr/bin/taskset",
+        "-c",
+        "3",
+    ]
+    with pytest.raises(RuntimeError, match="requires taskset"):
+        AUDIT.make_affinity_prefix(None, 3)
+
+
+def test_linux_compiler_discovery_rejects_windows_cache() -> None:
+    assert AUDIT.cached_compiler_candidates("posix") == []
+    assert all(
+        candidate.suffix == ".exe"
+        for candidate in AUDIT.cached_compiler_candidates("nt")
+    )
+
+
+def test_instruction_parser_counts_inner_backedge() -> None:
+    disassembly = """
+00000000 <kernel>:
+   0:  00 00       nop
+   2:  00 00       nop
+   4:  fc ff       bne 2 <kernel+0x2>
+   6:  00 00       ret
+"""
+    metrics = AUDIT.parse_disassembly(disassembly, "kernel")
+    assert metrics == {"instructions": 4, "inner_loop_instructions": 2}
+
+
+def test_instruction_parser_excludes_arm_calls() -> None:
+    disassembly = """
+00000000 <kernel>:
+   0:  b500       push {lr}
+   2:  f7ff fffe  bl 0 <callee>
+   6:  bd00       pop {pc}
+"""
+    metrics = AUDIT.parse_disassembly(disassembly, "kernel")
+    assert metrics == {"instructions": 3, "inner_loop_instructions": 0}
+
+
+def test_instruction_parser_counts_xtensa_zero_overhead_loop() -> None:
+    disassembly = """
+00000000 <kernel>:
+   0:  108276     loop a2, 9 <kernel+0x9>
+   3:  223a       add.n a2, a2, a3
+   5:  334a       add.n a3, a3, a4
+   7:  f01d       retw.n
+   9:  f01d       retw.n
+"""
+    metrics = AUDIT.parse_disassembly(disassembly, "kernel")
+    assert metrics == {"instructions": 5, "inner_loop_instructions": 3}
+
+
+def test_operation_report_requires_every_stage() -> None:
+    counts = {stage: {"multiplies": 1, "macs": 0} for stage in AUDIT.STAGES}
+    AUDIT.validate_operation_counts(counts)
+    del counts["synthesis"]
+    with pytest.raises(RuntimeError, match="missing operation stage"):
+        AUDIT.validate_operation_counts(counts)
+
+
+def test_operation_ledger_is_exact_per_frame() -> None:
+    operations = {
+        "frames": 4,
+        "stages": {
+            stage: {
+                "total_multiplies": 10,
+                "total_macs": 4,
+                "multiplies_per_frame": 2.5,
+                "macs_per_frame": 1.0,
+            }
+            for stage in AUDIT.STAGES
+        },
+    }
+    AUDIT.validate_operations("helix", operations)
+    operations["stages"]["imdct"]["multiplies_per_frame"] = 2.4
+    with pytest.raises(RuntimeError, match="inexact derived operation metric"):
+        AUDIT.validate_operations("helix", operations)
+
+
+def test_callgrind_attribution_keeps_codec_functions() -> None:
+    annotation = """
+100 (50.0%) /repo/src/third_party/minimp3/minimp3.h:mp3d_synth
+100 (50.0%) src/third_party/minimp3/minimp3.h:mp3d_synth [/tmp/a.out]
+80 (40.0%) /lib/libc.so:memcpy
+"""
+    assert AUDIT.parse_callgrind_attribution(annotation) == {
+        "src/third_party/minimp3/minimp3.h:mp3d_synth": 100
+    }
+
+
+def test_callgrind_parser_rejects_mismatched_event_values(tmp_path: Path) -> None:
+    output = tmp_path / "callgrind.out"
+    output.write_text("events: Ir Bc Bcm\nsummary: 100 20\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="shorter"):
+        AUDIT.parse_callgrind(output)
+
+
+def test_callgrind_parser_prefers_complete_totals(tmp_path: Path) -> None:
+    output = tmp_path / "callgrind.out"
+    output.write_text(
+        "events: Ir Bc Bcm\nsummary: 0 0 0\ntotals: 100 20 3\n",
+        encoding="utf-8",
+    )
+    assert AUDIT.parse_callgrind(output).summary == {"Ir": 100, "Bc": 20, "Bcm": 3}
+
+
+def test_trend_gate_rejects_more_than_five_percent() -> None:
+    baseline = AUDIT.load_trend()
+    current = json.loads(json.dumps(baseline))
+    counters = current["backends"]["helix"]["host"]["counter_median"]
+    counters["cycles"] *= 1.051
+    counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
+    with pytest.raises(RuntimeError, match="helix/counter/cycles regressed"):
+        AUDIT.check_trend(baseline, current)
+
+
+def test_trend_validation_rejects_inconsistent_derived_counters() -> None:
+    trend = AUDIT.load_trend()
+    trend["backends"]["helix"]["host"]["counter_median"]["ipc"] = 0.5
+    with pytest.raises(RuntimeError, match="inexact derived host IPC"):
+        AUDIT.validate_trend(trend)
+
+
+def test_trend_gate_fails_closed_on_unknown_host() -> None:
+    baseline = AUDIT.load_trend()
+    current = json.loads(json.dumps(baseline))
+    current["environment"]["cpu_model"] = "different hosted runner"
+    current["host_key"] = AUDIT.environment_key(current["environment"])
+    with pytest.raises(RuntimeError, match="host baseline is unknown"):
+        AUDIT.check_trend(baseline, current)
+
+
+def test_trend_gate_selects_known_host_baseline() -> None:
+    baseline = AUDIT.load_trend()
+    current = json.loads(json.dumps(baseline))
+    current["environment"]["cpu_model"] = "alternate hosted runner"
+    current["host_key"] = AUDIT.environment_key(current["environment"])
+    primary_counters = baseline["backends"]["helix"]["host"]["counter_median"]
+    primary_counters["cycles"] /= 2
+    primary_counters["ipc"] = round(
+        primary_counters["instructions"] / primary_counters["cycles"], 6
+    )
+    baseline["host_baselines"] = {
+        current["host_key"]: {
+            "environment": current["environment"],
+            "hosts": json.loads(
+                json.dumps(
+                    {
+                        backend: current["backends"][backend]["host"]
+                        for backend in AUDIT.BACKENDS
+                    }
+                )
+            ),
+        }
+    }
+    AUDIT.check_trend(baseline, current)
+    counters = current["backends"]["helix"]["host"]["counter_median"]
+    counters["cycles"] *= 1.051
+    counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
+    with pytest.raises(RuntimeError, match="helix/counter/cycles regressed"):
+        AUDIT.check_trend(baseline, current)
+
+
+def test_trend_gate_checks_callgrind_function_share() -> None:
+    baseline = AUDIT.load_trend()
+    current = json.loads(json.dumps(baseline))
+    functions = current["backends"]["helix"]["host"]["callgrind"]["functions"]
+    function = next(iter(functions))
+    functions[function] = functions[function] * 1051 // 1000
+    with pytest.raises(RuntimeError, match=r"callgrind-function/.+ regressed"):
+        AUDIT.check_trend(baseline, current)
+
+
+def test_parse_args_accepts_explicit_argv() -> None:
+    args = AUDIT.parse_args(["--operations"])
+    assert args.operations

--- a/codec_cpu_trend.json
+++ b/codec_cpu_trend.json
@@ -1,0 +1,959 @@
+{
+  "backends": {
+    "helix": {
+      "codegen": {
+        "cortex-m0plus": {
+          "dct32": {
+            "inner_loop_instructions": 498,
+            "instructions": 885
+          },
+          "polyphase": {
+            "inner_loop_instructions": 1179,
+            "instructions": 2015
+          }
+        },
+        "cortex-m4": {
+          "dct32": {
+            "inner_loop_instructions": 536,
+            "instructions": 547
+          },
+          "polyphase": {
+            "inner_loop_instructions": 372,
+            "instructions": 679
+          }
+        },
+        "riscv32-esp": {
+          "dct32": {
+            "inner_loop_instructions": 0,
+            "instructions": 15
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 776
+          }
+        },
+        "xtensa-esp32": {
+          "dct32": {
+            "inner_loop_instructions": 117,
+            "instructions": 551
+          },
+          "polyphase": {
+            "inner_loop_instructions": 1251,
+            "instructions": 2075
+          }
+        }
+      },
+      "host": {
+        "callgrind": {
+          "branch_misses": 453948,
+          "branches": 8294798,
+          "functions": {
+            "src/third_party/libhelix_mp3/mp3dec.hpp:fl::third_party::MP3Decode(void*, unsigned char const**, unsigned long*, short*, int)": 453016441,
+            "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MADD64(long long, int, int)": 96979680,
+            "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MULSHIFT32(int, int)": 34575695,
+            "src/third_party/libhelix_mp3/real/coder.h:clip_2n_helper(int, int)": 13639644,
+            "src/third_party/libhelix_mp3/real/dct32.hpp:fl::third_party::FDCT32(int*, int*, int, int, int)": 51799464,
+            "src/third_party/libhelix_mp3/real/dequant.hpp:fl::third_party::Dequantize(_MP3DecInfo*, int)": 26041174,
+            "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantBlock(int*, int*, int, int)": 18463953,
+            "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantChannel(int*, int*, int*, fl::third_party::_FrameHeader*, fl::third_party::_SideInfoSub*, fl::third_party::_ScaleFactorInfoSub*, fl::third_party::CriticalBandInfo*)": 20154627,
+            "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffman(_MP3DecInfo*, unsigned char const*, int*, int, int, int)": 20646623,
+            "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffmanQuads(int*, int, int, int, unsigned char const*, int)": 10927918,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::AntiAlias(int*, int)": 15353764,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::FreqInvertRescale(int*, int*, int, int)": 26233682,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::HybridTransform(int*, int*, int (*) [32], fl::third_party::_SideInfoSub*, fl::third_party::_BlockCount*)": 85424160,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT(_MP3DecInfo*, int, int)": 101035762,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT36(int*, int*, int*, int, int, int, int)": 81616669,
+            "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::idct9(int*)": 16979760,
+            "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseMono": 56829420,
+            "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseStereo": 192621420,
+            "src/third_party/libhelix_mp3/real/polyphase.hpp:fl::third_party::ClipToShort(int, int)": 12314880,
+            "src/third_party/libhelix_mp3/real/subband.hpp:fl::third_party::Subband(_MP3DecInfo*, short*)": 301950654
+          },
+          "instructions": 461845281
+        },
+        "counter_median": {
+          "branch_misses": 453948,
+          "cycles": 147513314,
+          "instructions": 461845281,
+          "ipc": 3.130872
+        },
+        "counter_source": {
+          "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+          "cycles": "Clang readcyclecounter median over 30 pinned runs",
+          "instructions": "Valgrind Callgrind deterministic Ir",
+          "ipc": "Callgrind Ir divided by median cycle counter"
+        },
+        "stage_coverage": {
+          "antialias": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "dequant": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "huffman": {
+            "instrumentation_sites": 3,
+            "mode": "dedicated"
+          },
+          "imdct": {
+            "instrumentation_sites": 3,
+            "mode": "dedicated"
+          },
+          "reorder": {
+            "fused_with": "dequant",
+            "instrumentation_sites": 0,
+            "mode": "fused"
+          },
+          "scalefactors": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "stereo": {
+            "instrumentation_sites": 3,
+            "mode": "dedicated"
+          },
+          "synthesis": {
+            "instrumentation_sites": 4,
+            "mode": "dedicated"
+          }
+        },
+        "stage_ns_median": {
+          "antialias": 2598.098,
+          "dequant": 5611.841,
+          "huffman": 6079.694,
+          "imdct": 16169.043,
+          "reorder": 0,
+          "scalefactors": 356.547,
+          "stereo": 1356.849,
+          "synthesis": 51345.789
+        }
+      },
+      "operations": {
+        "frames": 892,
+        "stages": {
+          "antialias": {
+            "macs_per_frame": 808,
+            "multiplies_per_frame": 1616,
+            "total_macs": 720736,
+            "total_multiplies": 1441472
+          },
+          "dequant": {
+            "macs_per_frame": 68.399103,
+            "multiplies_per_frame": 125.709641,
+            "total_macs": 61012,
+            "total_multiplies": 112133
+          },
+          "huffman": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "imdct": {
+            "macs_per_frame": 986.865471,
+            "multiplies_per_frame": 2559.20852,
+            "total_macs": 880284,
+            "total_multiplies": 2282814
+          },
+          "reorder": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "scalefactors": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "stereo": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "synthesis": {
+            "macs_per_frame": 21744.32287,
+            "multiplies_per_frame": 25195.802691,
+            "total_macs": 19395936,
+            "total_multiplies": 22474656
+          }
+        }
+      }
+    },
+    "minimp3-float": {
+      "codegen": {
+        "cortex-m0plus": {
+          "dct32": {
+            "inner_loop_instructions": 298,
+            "instructions": 325
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 173
+          }
+        },
+        "cortex-m4": {
+          "dct32": {
+            "inner_loop_instructions": 264,
+            "instructions": 280
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 130
+          }
+        },
+        "riscv32-esp": {
+          "dct32": {
+            "inner_loop_instructions": 0,
+            "instructions": 47
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 185
+          }
+        },
+        "xtensa-esp32": {
+          "dct32": {
+            "inner_loop_instructions": 144,
+            "instructions": 160
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 105
+          }
+        }
+      },
+      "host": {
+        "callgrind": {
+          "branch_misses": 555920,
+          "branches": 22461967,
+          "functions": {
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_antialias(float*, int)": 10067934,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_change_sign(float*)": 2097378,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_dct3_9(float*)": 10311680,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode(fl::third_party::mp3dec_t*, fl::third_party::mp3dec_scratch_internal_t*, fl::third_party::L3_gr_info_t*, int)": 71710842,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode_scalefactors(unsigned char const*, unsigned char*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float*, int)": 3008422,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_huffman(float*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float const*, int)": 17434586,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct36(float*, float*, float const*, int)": 34857040,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct_gr(float*, float*, unsigned int, unsigned int)": 35208030,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_ldexp_q2(float, int)": 897555,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_midside_stereo(float*, int)": 3644112,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_pow_43(int)": 455424,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_scalefactors(unsigned char*, unsigned char*, unsigned char const*, unsigned char const*, fl::third_party::bs_t*, int)": 1357481,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_side_info(fl::third_party::bs_t*, fl::third_party::L3_gr_info_t*, unsigned char const*)": 1053557,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::get_bits(fl::third_party::bs_t*, int)": 1425121,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_DCT_II(float*, int)": 30475052,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_scale_pcm(float)": 19588608,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth(float*, short*, int, float*)": 141205140,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_granule(float*, float*, int, int, short*)": 173353159,
+            "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_pair(short*, int, float const*)": 4473360,
+            "src/third_party/minimp3/minimp3.h:mp3dec_decode_frame_r": 252867274
+          },
+          "instructions": 261532799
+        },
+        "counter_median": {
+          "branch_misses": 555920,
+          "cycles": 54515955,
+          "instructions": 261532799,
+          "ipc": 4.797363
+        },
+        "counter_source": {
+          "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+          "cycles": "Clang readcyclecounter median over 30 pinned runs",
+          "instructions": "Valgrind Callgrind deterministic Ir",
+          "ipc": "Callgrind Ir divided by median cycle counter"
+        },
+        "stage_coverage": {
+          "antialias": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "dequant": {
+            "fused_with": "huffman",
+            "instrumentation_sites": 0,
+            "mode": "fused"
+          },
+          "huffman": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "imdct": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "reorder": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "scalefactors": {
+            "instrumentation_sites": 2,
+            "mode": "dedicated"
+          },
+          "stereo": {
+            "instrumentation_sites": 3,
+            "mode": "dedicated"
+          },
+          "synthesis": {
+            "instrumentation_sites": 2,
+            "mode": "dedicated"
+          }
+        },
+        "stage_ns_median": {
+          "antialias": 970.501,
+          "dequant": 0,
+          "huffman": 8754.614,
+          "imdct": 3791.305,
+          "reorder": 13.933,
+          "scalefactors": 614.98,
+          "stereo": 500.496,
+          "synthesis": 23522.451
+        }
+      },
+      "operations": {
+        "frames": 892,
+        "stages": {
+          "antialias": {
+            "macs_per_frame": 1178.834081,
+            "multiplies_per_frame": 2357.668161,
+            "total_macs": 1051520,
+            "total_multiplies": 2103040
+          },
+          "dequant": {
+            "macs_per_frame": 21.7287,
+            "multiplies_per_frame": 331.96861,
+            "total_macs": 19382,
+            "total_multiplies": 296116
+          },
+          "huffman": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "imdct": {
+            "macs_per_frame": 5206.529148,
+            "multiplies_per_frame": 7051.192825,
+            "total_macs": 4644224,
+            "total_multiplies": 6289664
+          },
+          "reorder": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "scalefactors": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 111.975336,
+            "total_macs": 0,
+            "total_multiplies": 99882
+          },
+          "stereo": {
+            "macs_per_frame": 0,
+            "multiplies_per_frame": 0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "synthesis": {
+            "macs_per_frame": 15306.780269,
+            "multiplies_per_frame": 29634.941704,
+            "total_macs": 13653648,
+            "total_multiplies": 26434368
+          }
+        }
+      }
+    }
+  },
+  "corpus": [
+    {
+      "bytes": 12538,
+      "path": "tests/data/codec/minimp3/l3-hecommon.bit",
+      "sha256": "21999b77716aeba047c7f55c2c1ce17b54c780b6dc007912f251b7ea189676ef"
+    },
+    {
+      "bytes": 192,
+      "path": "tests/data/codec/minimp3/l3-compl-cut.mp3",
+      "sha256": "9f5b4baaefc5403c2b55ad5a52c8d7e812ba9e25638f8b674a0d01df6008a7c7"
+    },
+    {
+      "bytes": 26645,
+      "path": "tests/data/codec/minimp3/l3-he_free.bit",
+      "sha256": "b55afc2a21492c4b3035d423f36fe87560ef34f65eb997da60af9b01f300362c"
+    },
+    {
+      "bytes": 132492,
+      "path": "tests/data/codec/minimp3/l3-lame-vbrtag.bit",
+      "sha256": "c59cc31ed4cc3556f3c1aad35ec7860a56449a3a2ca16b6f29579f0ca7684b71"
+    },
+    {
+      "bytes": 154224,
+      "path": "tests/data/codec/minimp3/M2L3_bitrate_16_all.bit",
+      "sha256": "69577544aa28b87f6217ad2060f4cec3b1835593c659683ed8437429a74d3640"
+    }
+  ],
+  "environment": {
+    "affinity_cpu": 0,
+    "compiler": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+    "cpu_model": "AMD EPYC 9V74 80-Core Processor",
+    "governor": "not-exposed",
+    "platform": "Linux-6.17.0-1022-azure-x86_64-with-glibc2.39"
+  },
+  "host_key": "AMD EPYC 9V74 80-Core Processor | Ubuntu clang version 18.1.3 (1ubuntu1) | not-exposed",
+  "profile_runs": 30,
+  "regression_tolerance": 0.05,
+  "schema_version": 2,
+  "host_baselines": {
+    "AMD EPYC 7763 64-Core Processor | Ubuntu clang version 18.1.3 (1ubuntu1) | not-exposed": {
+      "environment": {
+        "affinity_cpu": 0,
+        "compiler": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+        "cpu_model": "AMD EPYC 7763 64-Core Processor",
+        "governor": "not-exposed",
+        "platform": "Linux-6.17.0-1022-azure-x86_64-with-glibc2.39"
+      },
+      "hosts": {
+        "helix": {
+          "callgrind": {
+            "branch_misses": 453948,
+            "branches": 8294798,
+            "functions": {
+              "src/third_party/libhelix_mp3/mp3dec.hpp:fl::third_party::MP3Decode(void*, unsigned char const**, unsigned long*, short*, int)": 453016441,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MADD64(long long, int, int)": 96979680,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MULSHIFT32(int, int)": 34575695,
+              "src/third_party/libhelix_mp3/real/coder.h:clip_2n_helper(int, int)": 13639644,
+              "src/third_party/libhelix_mp3/real/dct32.hpp:fl::third_party::FDCT32(int*, int*, int, int, int)": 51799464,
+              "src/third_party/libhelix_mp3/real/dequant.hpp:fl::third_party::Dequantize(_MP3DecInfo*, int)": 26041174,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantBlock(int*, int*, int, int)": 18463953,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantChannel(int*, int*, int*, fl::third_party::_FrameHeader*, fl::third_party::_SideInfoSub*, fl::third_party::_ScaleFactorInfoSub*, fl::third_party::CriticalBandInfo*)": 20154627,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffman(_MP3DecInfo*, unsigned char const*, int*, int, int, int)": 20646623,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffmanQuads(int*, int, int, int, unsigned char const*, int)": 10927918,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::AntiAlias(int*, int)": 15353764,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::FreqInvertRescale(int*, int*, int, int)": 26233682,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::HybridTransform(int*, int*, int (*) [32], fl::third_party::_SideInfoSub*, fl::third_party::_BlockCount*)": 85424160,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT(_MP3DecInfo*, int, int)": 101035762,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT36(int*, int*, int*, int, int, int, int)": 81616669,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::idct9(int*)": 16979760,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseMono": 56829420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseStereo": 192621420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:fl::third_party::ClipToShort(int, int)": 12314880,
+              "src/third_party/libhelix_mp3/real/subband.hpp:fl::third_party::Subband(_MP3DecInfo*, short*)": 301950654
+            },
+            "instructions": 461845281
+          },
+          "counter_median": {
+            "branch_misses": 453948,
+            "cycles": 125330104.5,
+            "instructions": 461845281,
+            "ipc": 3.685031
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "huffman": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "fused_with": "dequant",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 4,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 2333.295,
+            "dequant": 5011.896,
+            "huffman": 5620.746,
+            "imdct": 15191.41,
+            "reorder": 0,
+            "scalefactors": 317.643,
+            "stereo": 1219.54,
+            "synthesis": 46696.641
+          }
+        },
+        "minimp3-float": {
+          "callgrind": {
+            "branch_misses": 555920,
+            "branches": 22461967,
+            "functions": {
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_antialias(float*, int)": 10067934,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_change_sign(float*)": 2097378,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_dct3_9(float*)": 10311680,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode(fl::third_party::mp3dec_t*, fl::third_party::mp3dec_scratch_internal_t*, fl::third_party::L3_gr_info_t*, int)": 71710842,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode_scalefactors(unsigned char const*, unsigned char*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float*, int)": 3008422,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_huffman(float*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float const*, int)": 17434586,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct36(float*, float*, float const*, int)": 34857040,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct_gr(float*, float*, unsigned int, unsigned int)": 35208030,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_ldexp_q2(float, int)": 897555,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_midside_stereo(float*, int)": 3644112,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_pow_43(int)": 455424,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_scalefactors(unsigned char*, unsigned char*, unsigned char const*, unsigned char const*, fl::third_party::bs_t*, int)": 1357481,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_side_info(fl::third_party::bs_t*, fl::third_party::L3_gr_info_t*, unsigned char const*)": 1053557,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::get_bits(fl::third_party::bs_t*, int)": 1425121,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_DCT_II(float*, int)": 30475052,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_scale_pcm(float)": 19588608,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth(float*, short*, int, float*)": 141205140,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_granule(float*, float*, int, int, short*)": 173353159,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_pair(short*, int, float const*)": 4473360,
+              "src/third_party/minimp3/minimp3.h:mp3dec_decode_frame_r": 252867274
+            },
+            "instructions": 261532799
+          },
+          "counter_median": {
+            "branch_misses": 555920,
+            "cycles": 47335274,
+            "instructions": 261532799,
+            "ipc": 5.525114
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "fused_with": "huffman",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "huffman": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 938.232,
+            "dequant": 0,
+            "huffman": 7819.434,
+            "imdct": 3692.257,
+            "reorder": 12.388,
+            "scalefactors": 586.082,
+            "stereo": 464.267,
+            "synthesis": 22360.622
+          }
+        }
+      }
+    },
+    "INTEL(R) XEON(R) PLATINUM 8573C | Ubuntu clang version 18.1.3 (1ubuntu1) | performance": {
+      "environment": {
+        "affinity_cpu": 0,
+        "compiler": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+        "cpu_model": "INTEL(R) XEON(R) PLATINUM 8573C",
+        "governor": "performance",
+        "platform": "Linux-6.17.0-1022-azure-x86_64-with-glibc2.39"
+      },
+      "hosts": {
+        "helix": {
+          "callgrind": {
+            "branch_misses": 453948,
+            "branches": 8294798,
+            "functions": {
+              "src/third_party/libhelix_mp3/mp3dec.hpp:fl::third_party::MP3Decode(void*, unsigned char const**, unsigned long*, short*, int)": 453016441,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MADD64(long long, int, int)": 96979680,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MULSHIFT32(int, int)": 34575695,
+              "src/third_party/libhelix_mp3/real/coder.h:clip_2n_helper(int, int)": 13639644,
+              "src/third_party/libhelix_mp3/real/dct32.hpp:fl::third_party::FDCT32(int*, int*, int, int, int)": 51799464,
+              "src/third_party/libhelix_mp3/real/dequant.hpp:fl::third_party::Dequantize(_MP3DecInfo*, int)": 26041174,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantBlock(int*, int*, int, int)": 18463953,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantChannel(int*, int*, int*, fl::third_party::_FrameHeader*, fl::third_party::_SideInfoSub*, fl::third_party::_ScaleFactorInfoSub*, fl::third_party::CriticalBandInfo*)": 20154627,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffman(_MP3DecInfo*, unsigned char const*, int*, int, int, int)": 20646623,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffmanQuads(int*, int, int, int, unsigned char const*, int)": 10927918,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::AntiAlias(int*, int)": 15353764,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::FreqInvertRescale(int*, int*, int, int)": 26233682,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::HybridTransform(int*, int*, int (*) [32], fl::third_party::_SideInfoSub*, fl::third_party::_BlockCount*)": 85424160,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT(_MP3DecInfo*, int, int)": 101035762,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT36(int*, int*, int*, int, int, int, int)": 81616669,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::idct9(int*)": 16979760,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseMono": 56829420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseStereo": 192621420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:fl::third_party::ClipToShort(int, int)": 12314880,
+              "src/third_party/libhelix_mp3/real/subband.hpp:fl::third_party::Subband(_MP3DecInfo*, short*)": 301950654
+            },
+            "instructions": 461845281
+          },
+          "counter_median": {
+            "branch_misses": 453948,
+            "cycles": 121774722,
+            "instructions": 461845281,
+            "ipc": 3.79262
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "huffman": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "fused_with": "dequant",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 4,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 2471.105,
+            "dequant": 3705.591,
+            "huffman": 5451.54,
+            "imdct": 13588.925,
+            "reorder": 0,
+            "scalefactors": 375.003,
+            "stereo": 1003.123,
+            "synthesis": 44669.008
+          }
+        },
+        "minimp3-float": {
+          "callgrind": {
+            "branch_misses": 555920,
+            "branches": 22461967,
+            "functions": {
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_antialias(float*, int)": 10067934,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_change_sign(float*)": 2097378,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_dct3_9(float*)": 10311680,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode(fl::third_party::mp3dec_t*, fl::third_party::mp3dec_scratch_internal_t*, fl::third_party::L3_gr_info_t*, int)": 71710842,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode_scalefactors(unsigned char const*, unsigned char*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float*, int)": 3008422,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_huffman(float*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float const*, int)": 17434586,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct36(float*, float*, float const*, int)": 34857040,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct_gr(float*, float*, unsigned int, unsigned int)": 35208030,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_ldexp_q2(float, int)": 897555,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_midside_stereo(float*, int)": 3644112,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_pow_43(int)": 455424,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_scalefactors(unsigned char*, unsigned char*, unsigned char const*, unsigned char const*, fl::third_party::bs_t*, int)": 1357481,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_side_info(fl::third_party::bs_t*, fl::third_party::L3_gr_info_t*, unsigned char const*)": 1053557,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::get_bits(fl::third_party::bs_t*, int)": 1425121,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_DCT_II(float*, int)": 30475052,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_scale_pcm(float)": 19588608,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth(float*, short*, int, float*)": 141205140,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_granule(float*, float*, int, int, short*)": 173353159,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_pair(short*, int, float const*)": 4473360,
+              "src/third_party/minimp3/minimp3.h:mp3dec_decode_frame_r": 252867274
+            },
+            "instructions": 261532799
+          },
+          "counter_median": {
+            "branch_misses": 555920,
+            "cycles": 43579998,
+            "instructions": 261532799,
+            "ipc": 6.001212
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "fused_with": "huffman",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "huffman": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 945.05,
+            "dequant": 0,
+            "huffman": 6431.265,
+            "imdct": 3277.937,
+            "reorder": 12.399,
+            "scalefactors": 592.034,
+            "stereo": 435.912,
+            "synthesis": 18897.973
+          }
+        }
+      }
+    },
+    "Intel(R) Xeon(R) 6973P-C | Ubuntu clang version 18.1.3 (1ubuntu1) | performance": {
+      "environment": {
+        "affinity_cpu": 0,
+        "compiler": "Ubuntu clang version 18.1.3 (1ubuntu1)",
+        "cpu_model": "Intel(R) Xeon(R) 6973P-C",
+        "governor": "performance",
+        "platform": "Linux-6.17.0-1022-azure-x86_64-with-glibc2.39"
+      },
+      "hosts": {
+        "helix": {
+          "callgrind": {
+            "branch_misses": 453948,
+            "branches": 8294798,
+            "functions": {
+              "src/third_party/libhelix_mp3/mp3dec.hpp:fl::third_party::MP3Decode(void*, unsigned char const**, unsigned long*, short*, int)": 453016441,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MADD64(long long, int, int)": 96979680,
+              "src/third_party/libhelix_mp3/real/assembly.h:fl::third_party::MULSHIFT32(int, int)": 34575695,
+              "src/third_party/libhelix_mp3/real/coder.h:clip_2n_helper(int, int)": 13639644,
+              "src/third_party/libhelix_mp3/real/dct32.hpp:fl::third_party::FDCT32(int*, int*, int, int, int)": 51799464,
+              "src/third_party/libhelix_mp3/real/dequant.hpp:fl::third_party::Dequantize(_MP3DecInfo*, int)": 26041174,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantBlock(int*, int*, int, int)": 18463953,
+              "src/third_party/libhelix_mp3/real/dqchan.hpp:fl::third_party::DequantChannel(int*, int*, int*, fl::third_party::_FrameHeader*, fl::third_party::_SideInfoSub*, fl::third_party::_ScaleFactorInfoSub*, fl::third_party::CriticalBandInfo*)": 20154627,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffman(_MP3DecInfo*, unsigned char const*, int*, int, int, int)": 20646623,
+              "src/third_party/libhelix_mp3/real/huffman.hpp:fl::third_party::DecodeHuffmanQuads(int*, int, int, int, unsigned char const*, int)": 10927918,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::AntiAlias(int*, int)": 15353764,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::FreqInvertRescale(int*, int*, int, int)": 26233682,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::HybridTransform(int*, int*, int (*) [32], fl::third_party::_SideInfoSub*, fl::third_party::_BlockCount*)": 85424160,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT(_MP3DecInfo*, int, int)": 101035762,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::IMDCT36(int*, int*, int*, int, int, int, int)": 81616669,
+              "src/third_party/libhelix_mp3/real/imdct.hpp:fl::third_party::idct9(int*)": 16979760,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseMono": 56829420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:PolyphaseStereo": 192621420,
+              "src/third_party/libhelix_mp3/real/polyphase.hpp:fl::third_party::ClipToShort(int, int)": 12314880,
+              "src/third_party/libhelix_mp3/real/subband.hpp:fl::third_party::Subband(_MP3DecInfo*, short*)": 301950654
+            },
+            "instructions": 461845281
+          },
+          "counter_median": {
+            "branch_misses": 453948,
+            "cycles": 86820769,
+            "instructions": 461845281,
+            "ipc": 5.319525
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "huffman": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "fused_with": "dequant",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 4,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 1717.367,
+            "dequant": 2882.306,
+            "huffman": 4053.29,
+            "imdct": 9725.711,
+            "reorder": 0,
+            "scalefactors": 276.168,
+            "stereo": 755.652,
+            "synthesis": 27702.874
+          }
+        },
+        "minimp3-float": {
+          "callgrind": {
+            "branch_misses": 555920,
+            "branches": 22461967,
+            "functions": {
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_antialias(float*, int)": 10067934,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_change_sign(float*)": 2097378,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_dct3_9(float*)": 10311680,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode(fl::third_party::mp3dec_t*, fl::third_party::mp3dec_scratch_internal_t*, fl::third_party::L3_gr_info_t*, int)": 71710842,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_decode_scalefactors(unsigned char const*, unsigned char*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float*, int)": 3008422,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_huffman(float*, fl::third_party::bs_t*, fl::third_party::L3_gr_info_t const*, float const*, int)": 17434586,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct36(float*, float*, float const*, int)": 34857040,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_imdct_gr(float*, float*, unsigned int, unsigned int)": 35208030,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_ldexp_q2(float, int)": 897555,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_midside_stereo(float*, int)": 3644112,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_pow_43(int)": 455424,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_scalefactors(unsigned char*, unsigned char*, unsigned char const*, unsigned char const*, fl::third_party::bs_t*, int)": 1357481,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::L3_read_side_info(fl::third_party::bs_t*, fl::third_party::L3_gr_info_t*, unsigned char const*)": 1053557,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::get_bits(fl::third_party::bs_t*, int)": 1425121,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_DCT_II(float*, int)": 30475052,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_scale_pcm(float)": 19588608,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth(float*, short*, int, float*)": 141205140,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_granule(float*, float*, int, int, short*)": 173353159,
+              "src/third_party/minimp3/minimp3.h:fl::third_party::mp3d_synth_pair(short*, int, float const*)": 4473360,
+              "src/third_party/minimp3/minimp3.h:mp3dec_decode_frame_r": 252867274
+            },
+            "instructions": 261532799
+          },
+          "counter_median": {
+            "branch_misses": 555920,
+            "cycles": 37331631,
+            "instructions": 261532799,
+            "ipc": 7.005662
+          },
+          "counter_source": {
+            "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+            "cycles": "Clang readcyclecounter median over 30 pinned runs",
+            "instructions": "Valgrind Callgrind deterministic Ir",
+            "ipc": "Callgrind Ir divided by median cycle counter"
+          },
+          "stage_coverage": {
+            "antialias": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "dequant": {
+              "fused_with": "huffman",
+              "instrumentation_sites": 0,
+              "mode": "fused"
+            },
+            "huffman": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "imdct": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "reorder": {
+              "instrumentation_sites": 1,
+              "mode": "dedicated"
+            },
+            "scalefactors": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            },
+            "stereo": {
+              "instrumentation_sites": 3,
+              "mode": "dedicated"
+            },
+            "synthesis": {
+              "instrumentation_sites": 2,
+              "mode": "dedicated"
+            }
+          },
+          "stage_ns_median": {
+            "antialias": 723.134,
+            "dequant": 0,
+            "huffman": 5258.724,
+            "imdct": 2449.202,
+            "reorder": 10.267,
+            "scalefactors": 483.547,
+            "stereo": 339.904,
+            "synthesis": 14113.014
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add exact per-stage multiply/MAC accounting for Helix and minimp3-float
- add pinned N=30 cycle and stage timing, deterministic Callgrind instruction/branch-miss attribution, and environment-keyed 5% trend enforcement
- add production `-Os` DCT32/polyphase codegen ledgers for Xtensa ESP32, RISC-V ESP32, Cortex-M0+, and Cortex-M4
- add fail-closed focused tests and an Ubuntu CPU-audit workflow with explicit counter provenance

## Validation
- focused CPU audit: 24 passed
- operation audit: both backends, 892 frames each
- target codegen audit: both backends across all four MCU families
- lint: passed
- broad Python: 1,070 passed, 35 skipped, 40 subtests passed; the sole cold QEMU timeout passed its immediate focused rerun
- pre-push review: clean after all accounting, scope, affinity, schema, portability, and host-profile findings were resolved

GitHub-hosted runners do not expose hardware PMU counters, so the audit records pinned Clang cycle-counter medians and scope-matched deterministic Callgrind instruction/branch-miss counts, with IPC derived from those explicitly identified sources. Because the `ubuntu-24.04` pool rotates among CPU models, host baselines are selected fail-closed by CPU/compiler/governor key; unknown hosts upload their artifact and fail for explicit onboarding. Native artifacts establish profiles for all four pool models observed across consecutive runs: AMD EPYC 9V74, AMD EPYC 7763, Intel Xeon Platinum 8573C, and Intel Xeon 6973P-C.

Closes #4053
Related: FastLED/license#14
