### PR TITLE
fix(meson): normalize host Python selection

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -2,6 +2,11 @@
 
 <!-- Add lessons from corrections and discoveries here -->
 
+- Before diagnosing missing functionality in a local integration checkout,
+  fetch and compare it with its upstream branch; a stale checkout can omit the
+  entire subsystem under test. For Meson host tools in a cross-build, branch on
+  `build_machine.system()`, never `host_machine.system()`.
+
 - QEMU CI must use fbuild's native `test-emu` runner as the owner of the
   build, flash-image preparation, and emulation lifecycle. Do not repair or
   extend PlatformIO-shaped merged-bin artifact plumbing while PlatformIO is

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -2,6 +2,24 @@
 
 <!-- Add tasks here as checkable items -->
 
+## Normalize Meson host Python selection
+
+- [x] Reproduce the macOS failure caused by Meson invoking bare `python`.
+- [x] Add a RED source-contract test for Windows versus macOS/Linux selection.
+- [x] Define one build-machine Python program and reuse it in Meson helpers.
+- [x] Run the focused regression test and Meson lint checks.
+- [x] Validate the WASM Blink compile through fastled-wasm's Tauri test mode.
+
+### Review
+
+- RED: `ci/tests/test_meson_python_selection.py` failed both assertions before
+  the normalized build-machine program was introduced.
+- GREEN: the focused regression test passes (2 tests), and the dependent
+  macOS Tauri run finds `python3`, compiles Blink, starts the pthread worker,
+  and captures a non-black WebGL frame.
+- Review: selection is intentionally based on `build_machine`, because these
+  Python helpers execute during configuration even for an Emscripten cross-build.
+
 ## minimp3 Phase 0 (#4051)
 
 - [x] Capture the missing minimp3 backend as a focused RED test.

--- a/ci/tests/test_meson_python_selection.py
+++ b/ci/tests/test_meson_python_selection.py
@@ -12,7 +12,10 @@ def test_meson_selects_host_python_from_build_machine() -> None:
     assert "build_machine.system() == 'windows'" in root_meson
     assert "host_python_name = 'python'" in root_meson
     assert "host_python_name = 'python3'" in root_meson
-    assert "host_python = find_program(host_python_name, required: true)" in root_meson
+    assert (
+        "host_python = find_program(host_python_name, required: true, native: true)"
+        in root_meson
+    )
 
 
 def test_meson_host_helpers_reuse_normalized_python_program() -> None:
@@ -22,5 +25,8 @@ def test_meson_host_helpers_reuse_normalized_python_program() -> None:
     assert "host_python, src_cache_script, '--check'" in root_meson
     assert "host_python, src_cache_script, '--update'" in root_meson
     assert "python_exe = host_python" in tests_meson
+    assert "python_exe, cache_script, '--check'" in tests_meson
+    assert "python_exe, meson.current_source_dir() / 'organize_tests.py'" in tests_meson
+    assert "python_exe, cache_script, '--update'" in tests_meson
     assert "find_program('python')" not in root_meson
     assert "find_program('python')" not in tests_meson

--- a/ci/tests/test_meson_python_selection.py
+++ b/ci/tests/test_meson_python_selection.py
@@ -1,0 +1,26 @@
+"""Regression coverage for build-host Python selection in Meson."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_meson_selects_host_python_from_build_machine() -> None:
+    root_meson = (ROOT / "meson.build").read_text(encoding="utf-8")
+
+    assert "build_machine.system() == 'windows'" in root_meson
+    assert "host_python_name = 'python'" in root_meson
+    assert "host_python_name = 'python3'" in root_meson
+    assert "host_python = find_program(host_python_name, required: true)" in root_meson
+
+
+def test_meson_host_helpers_reuse_normalized_python_program() -> None:
+    root_meson = (ROOT / "meson.build").read_text(encoding="utf-8")
+    tests_meson = (ROOT / "tests" / "meson.build").read_text(encoding="utf-8")
+
+    assert "host_python, src_cache_script, '--check'" in root_meson
+    assert "host_python, src_cache_script, '--update'" in root_meson
+    assert "python_exe = host_python" in tests_meson
+    assert "find_program('python')" not in root_meson
+    assert "find_program('python')" not in tests_meson

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,15 @@ project('fastled', 'cpp',
 # the right #if-def guard in it to prevent compilation
 uv_prog = find_program('uv', required: true)
 
+# Host-side helpers must use the build machine's Python executable. During a
+# WASM cross-build host_machine.system() is 'emscripten', so it cannot identify
+# whether the command is running on Windows or a Unix-like build host.
+host_python_name = 'python3'
+if build_machine.system() == 'windows'
+  host_python_name = 'python'
+endif
+host_python = find_program(host_python_name, required: true)
+
 # Setup cache paths
 src_cache_script = meson.project_source_root() / 'ci' / 'meson' / 'src_metadata_cache.py'
 rglob_script = meson.project_source_root() / 'ci' / 'meson' / 'rglob.py'
@@ -32,7 +41,7 @@ build_dir_path = meson.current_build_dir()
 
 # Check if cache is valid
 cache_check = run_command(
-  'python', src_cache_script, '--check', src_dir_path, build_dir_path, '--pattern', '*.cpp',
+  host_python, src_cache_script, '--check', src_dir_path, build_dir_path, '--pattern', '*.cpp',
   check: false
 )
 
@@ -53,7 +62,7 @@ else
 
   # Update cache
   run_command(
-    'python', src_cache_script, '--update',
+    host_python, src_cache_script, '--update',
     src_dir_path, build_dir_path, all_sources_output, '--pattern', '*.cpp',
     check: true
   )

--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ host_python_name = 'python3'
 if build_machine.system() == 'windows'
   host_python_name = 'python'
 endif
-host_python = find_program(host_python_name, required: true)
+host_python = find_program(host_python_name, required: true, native: true)
 
 # Setup cache paths
 src_cache_script = meson.project_source_root() / 'ci' / 'meson' / 'src_metadata_cache.py'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -97,10 +97,12 @@ runner_exe = executable('runner',
 cache_script = meson.current_source_dir() / 'test_metadata_cache.py'
 tests_source_dir = meson.current_source_dir()
 tests_build_dir = meson.current_build_dir()
+# Find Python once for configuration helpers and test wrappers.
+python_exe = host_python
 
 # Check if cache is valid
 cache_check = run_command(
-  'python', cache_script, '--check', tests_source_dir, tests_build_dir,
+  python_exe, cache_script, '--check', tests_source_dir, tests_build_dir,
   check: false
 )
 
@@ -113,7 +115,7 @@ else
   message('Running test discovery (cache invalid or missing)')
 
   discovery_result = run_command(
-    'python', meson.current_source_dir() / 'organize_tests.py',
+    python_exe, meson.current_source_dir() / 'organize_tests.py',
     tests_source_dir,
     check: true
   )
@@ -121,7 +123,7 @@ else
 
   # Update cache
   run_command(
-    'python', cache_script, '--update',
+    python_exe, cache_script, '--update',
     tests_source_dir, tests_build_dir, test_metadata_output,
     check: true
   )
@@ -160,9 +162,6 @@ test_env.prepend('PATH', fastled_lib_dir)
 # upstream-blessed replacement. If ASan/MinGW DLLs go missing in CI,
 # revert this hunk + ci/meson/native/meson.build to re-enable the
 # belt-and-suspenders injection.
-
-# Find python once for test wrapper (avoid 245 find_program calls inside loop)
-python_exe = host_python
 
 # ============================================================================
 # SHARED TEST OBJECTS (compiled once, reused by all test DLLs)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -162,7 +162,7 @@ test_env.prepend('PATH', fastled_lib_dir)
 # belt-and-suspenders injection.
 
 # Find python once for test wrapper (avoid 245 find_program calls inside loop)
-python_exe = find_program('python')
+python_exe = host_python
 
 # ============================================================================
 # SHARED TEST OBJECTS (compiled once, reused by all test DLLs)


### PR DESCRIPTION
## Summary
- select `python` on Windows and `python3` on macOS/Linux using Meson `build_machine.system()`
- reuse the normalized host interpreter for metadata-cache helpers and test wrappers
- add regression coverage for selection and reuse

## Validation
- `uv run pytest ci/tests/test_meson_python_selection.py -q` (2 passed)
- `bash lint --no-rust`
- dependent macOS Tauri Blink build and screenshot test (passes)

Coordinated with zackees/fastled-wasm#217.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform and cross-compilation builds by selecting the appropriate Python executable.
  * Updated build checks and test tooling to consistently use the selected interpreter.
  * Added regression coverage to prevent failures caused by incorrect Python selection.

* **Documentation**
  * Added guidance for diagnosing stale integration checkouts and choosing the correct Meson machine context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->