### PR TITLE
fix(meson): preserve imports for external consumers

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons Learned
 
+- Host-tool selection and host-tool import context are separate concerns. When
+  Meson executes repository Python helpers for an external consumer, provide
+  the repository root through the command environment so package imports do not
+  accidentally depend on the caller's working directory.
+
 <!-- Add lessons from corrections and discoveries here -->
 
 - Before diagnosing missing functionality in a local integration checkout,

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -2,6 +2,20 @@
 
 <!-- Add tasks here as checkable items -->
 
+## Preserve FastLED imports for external Meson consumers
+
+- [x] Reproduce the foreign-working-directory `ModuleNotFoundError` in CI.
+- [x] Add a RED regression for the host Python command environment.
+- [x] Prepend the FastLED project root to `PYTHONPATH` for Meson helpers.
+- [x] Pass focused tests, full lint, and a cross-checkout Blink WASM compile.
+
+### Review
+
+- RED: the new environment regression failed and fastled-wasm DWARF smoke could
+  not import `ci.meson.cache_utils` from its checkout working directory.
+- GREEN: 3 focused tests pass, full lint passes, and fastled-wasm compiles Blink
+  successfully against this checkout from outside the FastLED project root.
+
 ## Normalize Meson host Python selection
 
 - [x] Reproduce the macOS failure caused by Meson invoking bare `python`.

--- a/ci/tests/test_meson_python_selection.py
+++ b/ci/tests/test_meson_python_selection.py
@@ -30,3 +30,15 @@ def test_meson_host_helpers_reuse_normalized_python_program() -> None:
     assert "python_exe, cache_script, '--update'" in tests_meson
     assert "find_program('python')" not in root_meson
     assert "find_program('python')" not in tests_meson
+
+
+def test_meson_host_python_commands_include_project_on_pythonpath() -> None:
+    root_meson = (ROOT / "meson.build").read_text(encoding="utf-8")
+    tests_meson = (ROOT / "tests" / "meson.build").read_text(encoding="utf-8")
+
+    assert (
+        "host_python_env.prepend('PYTHONPATH', meson.project_source_root())"
+        in root_meson
+    )
+    assert root_meson.count("env: host_python_env") >= 2
+    assert tests_meson.count("env: host_python_env") >= 3

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,8 @@ if build_machine.system() == 'windows'
   host_python_name = 'python'
 endif
 host_python = find_program(host_python_name, required: true, native: true)
+host_python_env = environment()
+host_python_env.prepend('PYTHONPATH', meson.project_source_root())
 
 # Setup cache paths
 src_cache_script = meson.project_source_root() / 'ci' / 'meson' / 'src_metadata_cache.py'
@@ -42,7 +44,8 @@ build_dir_path = meson.current_build_dir()
 # Check if cache is valid
 cache_check = run_command(
   host_python, src_cache_script, '--check', src_dir_path, build_dir_path, '--pattern', '*.cpp',
-  check: false
+  check: false,
+  env: host_python_env
 )
 
 if cache_check.returncode() == 0
@@ -64,7 +67,8 @@ else
   run_command(
     host_python, src_cache_script, '--update',
     src_dir_path, build_dir_path, all_sources_output, '--pattern', '*.cpp',
-    check: true
+    check: true,
+    env: host_python_env
   )
 endif
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -103,7 +103,8 @@ python_exe = host_python
 # Check if cache is valid
 cache_check = run_command(
   python_exe, cache_script, '--check', tests_source_dir, tests_build_dir,
-  check: false
+  check: false,
+  env: host_python_env
 )
 
 if cache_check.returncode() == 0
@@ -117,7 +118,8 @@ else
   discovery_result = run_command(
     python_exe, meson.current_source_dir() / 'organize_tests.py',
     tests_source_dir,
-    check: true
+    check: true,
+    env: host_python_env
   )
   test_metadata_output = discovery_result.stdout().strip()
 
@@ -125,7 +127,8 @@ else
   run_command(
     python_exe, cache_script, '--update',
     tests_source_dir, tests_build_dir, test_metadata_output,
-    check: true
+    check: true,
+    env: host_python_env
   )
 endif
 


### PR DESCRIPTION
## Summary
- prepend the FastLED project root to `PYTHONPATH` for host-side Meson helpers
- make metadata discovery independent of an external consumer working directory
- add regression coverage for every affected command

## Validation
- `uv run pytest ci/tests/test_meson_python_selection.py -q` (3 passed)
- `bash lint --no-rust`
- cross-checkout fastled-wasm Blink WASM compile (passes)

Follow-up to #4066. Unblocks zackees/fastled-wasm#217 DWARF smoke.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Meson-based builds and test discovery when run from outside the project directory.
  - Preserved access to project-local Python helpers and FastLED imports for external consumers.

- **Tests**
  - Added regression coverage for Python environment handling during Meson commands.
  - Verified metadata cache checks, test discovery, and cache updates use the correct project environment.

- **Documentation**
  - Documented host-tool selection and import context considerations.
  - Recorded the completed fix and validation results in project task tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->