### PR TITLE
fix: resolve eight focused platform and tooling issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ See `agents/docs/build-system.md` for full command execution rules and forbidden
 ### USB VID/PID identities live in FastLED/boards — ALWAYS
 - **Never introduce a board/device USB VID:PID into this repo as the place it first exists.** [FastLED/boards](https://github.com/FastLED/boards) is the source of truth; it publishes a zstd-compressed protobuf (`usb-vids.proto.zstd`) that fbuild ingests at build time and falls back to from its cache root. FastLED consumes it through `fbuild port scan` / `fbuild deploy`.
 - **Missing identity ⇒ fix the registry, then cascade.** Add it on the FastLED/boards data branch, let the `site.yml` workflow republish, cut an fbuild release, then move the `fbuild==X.Y.Z` pin in `pyproject.toml` and run `uv sync` to pick it up. `uv.lock` is gitignored here, so the pin is the only committed half of the cascade — but you must still relock/sync locally or you keep running the old wheel.
-- **The legacy tables are frozen.** `ENVIRONMENT_TO_VCOM_VID_PIDS` (`ci/util/port_utils.py`) and `BOARD_FINGERPRINTS` (`ci/util/serial_probe.py`) must not gain entries. Test fixtures may use concrete literals; they must never become runtime defaults.
+- **The legacy tables are retired.** Runtime USB identities and environment-aware port selection come from FastLED/boards through fbuild. Test fixtures may use concrete literals; they must never become runtime defaults.
 - Full rule, pipeline diagram, and cascade procedure: `agents/docs/usb-vid-pid-registry.md`. fbuild mirrors it in its own `CLAUDE.md` → "USB VID/PID source of truth" and `docs/usb-vidpid-audit.md`.
 
 ### Deployment (flash / upload) is fbuild's job — ALWAYS

--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -145,9 +145,11 @@ driver:
 
 1. Run `fbuild port scan` and record the board identity, VID/PID, serial number,
    and port. Do not claim a board is absent without this scan. If the scan cannot
-   name the board, the identity is missing from
-   [FastLED/boards](https://github.com/FastLED/boards) — fix it there and cascade
-   the fbuild bump; never add the literal to `ci/`. See
+   name the board, check the published registry with
+   `uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>`. If that
+   reports the pair missing, fix it in
+   [FastLED/boards](https://github.com/FastLED/boards) and cascade the fbuild
+   bump; never add the literal to `ci/`. See
    [usb-vid-pid-registry.md](usb-vid-pid-registry.md).
 2. Confirm the board has an entry in `ci/boards.py` or can be detected by the
    AutoResearch/fbuild path. If the deploy backend is missing, file the gap in

--- a/agents/docs/usb-vid-pid-registry.md
+++ b/agents/docs/usb-vid-pid-registry.md
@@ -13,8 +13,8 @@ version cascade — not a new literal in `ci/`.
 
 A local table forks on the first board that behaves differently, and the fork
 is invisible until hardware is attached. Three consumers had already drifted
-before this rule was written: `ci/util/port_utils.py`, `ci/util/serial_probe.py`,
-and fbuild's former generated Rust tables all carried overlapping,
+before this rule was written: FastLED's now-retired CI tables and fbuild's
+former generated Rust tables all carried overlapping,
 independently-edited copies of the same identities. FastLED/boards ends that by
 publishing one artifact that every consumer ingests.
 
@@ -101,45 +101,13 @@ uv run fbuild --version
 relock anyway: without it your local environment keeps running the previous
 wheel and any verification you do is against the old registry snapshot.
 
-## Migration status (audited 2026-08-22)
+## Migration status
 
-Every VID:PID literal in this repo's `ci/` tree was checked against the live
-`usb-vids.proto.zstd` (36 vendors / 1056 products). **14 of 15 resolve from the
-registry**:
+The legacy runtime VID:PID tables were retired after all 15 identities resolved
+from FastLED/boards. The catalogue fetch/decode utility remains for the exact
+VID:PID query mode tracked in FastLED #3996.
 
-| VID:PID | Identity | Registry |
-| --- | --- | --- |
-| `2E8A:000A` | rp2040 / rpipico application CDC | resolved |
-| `2E8A:F00A` | rpipicow application CDC | resolved |
-| `2E8A:000F` | rp2350 / rpipico2 application CDC | resolved |
-| `2E8A:F00F` | rp2350w / rpipico2w application CDC | resolved |
-| `2E8A:0003` | RP2 ROM BOOTSEL | resolved |
-| `16C0:0483` | LPCXpresso VCOM (LPC11U35) | resolved |
-| `16C0:0486` | PJRC / Teensy USB-Serial (alt) | resolved |
-| `1FC9:0132` | NXP LPC-Link2 CMSIS-DAP | resolved |
-| `303A:1001` | Espressif native USB CDC | resolved |
-| `10C4:EA60` | Silicon Labs CP2102 | resolved |
-| `1A86:7523` | WCH CH340 | resolved |
-| `1A86:55D4` | WCH CH343 | resolved |
-| `0403:6001` | FTDI FT232R | resolved |
-| `0403:6010` | FTDI FT2232 | resolved |
-| `0403:6014` | FTDI FT232H | **GAP** — FastLED/boards#60 |
-
-The FTDI vendor entry exists but enumerates only `6001` and `6010`; `6014` is
-absent registry-wide. It is the sole blocker to deleting the local tables
-outright rather than freezing them. Do not close that gap by keeping the
-literal — track it in FastLED/boards#60.
-
-Re-run the audit at any time:
-
-```bash
-uv run python ci/util/audit_usb_registry.py
-```
-
-It fetches the live artifact, decodes it, and reports which audited literals
-resolve. A cold or stale cache is indistinguishable from a missing record, so
-always check the published payload rather than a failed port scan. To check an
-observed pair directly, run:
+Check an observed identity against the published catalogue directly:
 
 ```bash
 uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>
@@ -148,20 +116,12 @@ uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>
 The lookup exits 0 and names the vendor/product when published, or exits 1 and
 reports `MISSING` when the exact pair is absent.
 
-Two lists in that script carry the state. `AUDITED_LITERALS` is the checklist —
-it should shrink to empty as literals are retired. `KNOWN_GAPS` holds gaps
-already filed upstream; those print as `GAP*` with their tracking issue and do
-**not** fail the run, so the audit can be wired into CI without going
-permanently red. It exits 1 on a gap that is *not* filed, and also when a
-`KNOWN_GAPS` entry has since been published — that is the prompt to drop the
-allowlist entry and delete the local literal.
-
-## Existing local tables (legacy, do not extend)
+## Runtime ownership
 
 | Location | Status |
 | --- | --- |
-| `ci/util/port_utils.py` → `ENVIRONMENT_TO_VCOM_VID_PIDS` | Legacy. Frozen — every pair is already published in FastLED/boards. Do not add entries; see FastLED#3836. |
-| `ci/util/serial_probe.py` → `BOARD_FINGERPRINTS` | Legacy display/diagnostic hints only. Never a selection authority. Do not add entries. |
+| `fbuild deploy` | Environment-aware port selection, including boards with multiple accepted probe identities. |
+| `fbuild port scan` | FastLED/boards-backed vendor/product diagnostics. |
 | `ci/tests/**` | Test fixtures may use concrete literals to exercise parsing and selection. They must not become runtime defaults. |
 
 Tests are the one sanctioned home for concrete USB literals in this repo —

--- a/agents/docs/usb-vid-pid-registry.md
+++ b/agents/docs/usb-vid-pid-registry.md
@@ -138,7 +138,15 @@ uv run python ci/util/audit_usb_registry.py
 
 It fetches the live artifact, decodes it, and reports which audited literals
 resolve. A cold or stale cache is indistinguishable from a missing record, so
-always check the published payload rather than a failed port scan.
+always check the published payload rather than a failed port scan. To check an
+observed pair directly, run:
+
+```bash
+uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>
+```
+
+The lookup exits 0 and names the vendor/product when published, or exits 1 and
+reports `MISSING` when the exact pair is absent.
 
 Two lists in that script carry the state. `AUDITED_LITERALS` is the checklist —
 it should shrink to empty as literals are retired. `KNOWN_GAPS` holds gaps

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1324,7 +1324,16 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
     )
 
     upload_port = args.upload_port
-    if not upload_port and not stock_rp2xxx_transport:
+    # Every board build selects FbuildDriver below. When the environment is
+    # known, passing no port is intentional: fbuild resolves every accepted
+    # identity for that environment from FastLED/boards and reports the
+    # post-deploy application port through FBUILD_DEPLOY_PORT.
+    defer_port_selection_to_fbuild = bool(ctx.final_environment)
+    if (
+        not upload_port
+        and not stock_rp2xxx_transport
+        and not defer_port_selection_to_fbuild
+    ):
         expected_environment = None if is_teensy else ctx.final_environment
         max_wait_s = 60
         poll_interval_s = 1.0
@@ -1395,10 +1404,10 @@ async def _resolve_port_and_environment(ctx: RunContext) -> int | None:
 
         upload_port = result.selected_port
 
-    if stock_rp2xxx_transport and not upload_port:
+    if (stock_rp2xxx_transport or defer_port_selection_to_fbuild) and not upload_port:
         print(
-            f"📦 Stock {rp2xxx_environment} transport: no pre-deploy serial port required; "
-            "fbuild will discover RPI-RP2 and return the application CDC port."
+            f"📦 {ctx.final_environment} port selection deferred to fbuild; "
+            "deploy will use the FastLED/boards registry and return the application port."
         )
     else:
         assert upload_port is not None, "upload_port should be set by auto-detection"
@@ -1632,47 +1641,28 @@ async def _run_build_deploy(ctx: RunContext, qctx: QuietContext) -> int | None:
 
     print(f"\U0001f4e6 Using {build_driver.name}")
 
-    if final_environment_norm in LPC_BRING_UP_ENVS:
-        # Deployment is fbuild's responsibility — autoresearch never invokes
-        # flash tools (pyocd/lpc21isp/etc.) directly. The nxplpc deploy
-        # backend (LpcDeployer, lpc21isp UART ISP path) landed in
-        # FastLED/fbuild#595; if the pinned fbuild predates it, this fails
-        # loudly with a clear pointer rather than bringing a probe wedge
-        # here. See agents/docs/build-system.md.
-        if not _build_and_deploy_nxplpc(
-            build_dir,
-            environment=build_environment
-            or final_environment_norm
-            or final_environment,
-            upload_port=upload_port,
-            verbose=args.verbose,
-        ):
-            qctx.emit("BUILD+DEPLOY FAIL (nxplpc)")
-            qctx.emit_log_path()
-            return 1
-    else:
-        deploy_result = build_driver.deploy(
-            build_dir,
-            environment=build_environment,
-            upload_port=upload_port,
-            verbose=args.verbose,
-            clean=args.clean,
-            quiet=args.quiet,
-            log_file=qctx.log_file,
-        )
-        deploy_success = (
-            deploy_result.success
-            if isinstance(deploy_result, DeployResult)
-            else bool(deploy_result)
-        )
-        if isinstance(deploy_result, DeployResult) and deploy_result.port:
-            ctx.upload_port = deploy_result.port
-            upload_port = deploy_result.port
-            print(f"✅ fbuild returned application port: {deploy_result.port}")
-        if not deploy_success:
-            qctx.emit("BUILD+FLASH FAIL")
-            qctx.emit_log_path()
-            return 1
+    deploy_result = build_driver.deploy(
+        build_dir,
+        environment=build_environment,
+        upload_port=upload_port,
+        verbose=args.verbose,
+        clean=args.clean,
+        quiet=args.quiet,
+        log_file=qctx.log_file,
+    )
+    deploy_success = (
+        deploy_result.success
+        if isinstance(deploy_result, DeployResult)
+        else bool(deploy_result)
+    )
+    if isinstance(deploy_result, DeployResult) and deploy_result.port:
+        ctx.upload_port = deploy_result.port
+        upload_port = deploy_result.port
+        print(f"✅ fbuild returned application port: {deploy_result.port}")
+    if not deploy_success:
+        qctx.emit("BUILD+FLASH FAIL")
+        qctx.emit_log_path()
+        return 1
 
     if ctx.net_peer_mode:
         # A peer run must remain entirely on fbuild's deploy path.  In
@@ -1810,42 +1800,13 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     """
     args = ctx.args
     upload_port = ctx.upload_port
-    rp2xxx_environment = _active_rp2xxx_environment(ctx.final_environment)
-    port_detection_error: str | None = None
-    if (
-        upload_port is None
-        and (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode)
-        and ctx.use_fbuild
-        and rp2xxx_environment is not None
-    ):
-        # Stock RP2xxx deployment starts from BOOTSEL mass-storage and may
-        # return before Windows has published the application CDC endpoint.
-        # Poll by USB identity instead of asserting on the pre-deploy port.
-        wait_seconds = min(10.0, ctx.remaining_seconds())
-        deadline = time.monotonic() + max(0.0, wait_seconds)
-        while True:
-            result = await asyncio.to_thread(
-                auto_detect_upload_port,
-                expected_environment=rp2xxx_environment,
-                require_unique_match=True,
-            )
-            port_detection_error = result.error_message
-            if result.selected_port:
-                upload_port = result.selected_port
-                ctx.upload_port = upload_port
-                print(
-                    f"✅ Discovered {rp2xxx_environment} application port: "
-                    f"{upload_port}"
-                )
-                break
-            if time.monotonic() >= deadline:
-                break
-            await asyncio.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
     if upload_port is None:
-        message = "No application serial port was returned after fbuild deployment"
-        if port_detection_error:
-            message += f": {port_detection_error}"
-        print(f"❌ {message}")
+        print(
+            "❌ No application serial port was returned after fbuild deployment; "
+            "refusing identity-only recovery because multiple identical boards "
+            "cannot be distinguished. Fix the fbuild deploy result or pass "
+            "--upload-port explicitly."
+        )
         return 1
     use_fbuild = ctx.use_fbuild
     final_environment = ctx.final_environment

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -1811,6 +1811,7 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
     args = ctx.args
     upload_port = ctx.upload_port
     rp2xxx_environment = _active_rp2xxx_environment(ctx.final_environment)
+    port_detection_error: str | None = None
     if (
         upload_port is None
         and (ctx.rpc_smoke_mode or ctx.watchdog_soak_mode)
@@ -1826,7 +1827,9 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
             result = await asyncio.to_thread(
                 auto_detect_upload_port,
                 expected_environment=rp2xxx_environment,
+                require_unique_match=True,
             )
+            port_detection_error = result.error_message
             if result.selected_port:
                 upload_port = result.selected_port
                 ctx.upload_port = upload_port
@@ -1839,7 +1842,10 @@ async def _run_schema_and_pin_setup(ctx: RunContext) -> int | None:
                 break
             await asyncio.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
     if upload_port is None:
-        print("❌ No application serial port was returned after fbuild deployment")
+        message = "No application serial port was returned after fbuild deployment"
+        if port_detection_error:
+            message += f": {port_detection_error}"
+        print(f"❌ {message}")
         return 1
     use_fbuild = ctx.use_fbuild
     final_environment = ctx.final_environment

--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -530,11 +530,9 @@ def embedded_fs_defines(scan: AssetScanResult) -> list[str]:
     `platforms/embedded_fs.h` -- so on the platform people actually use for
     LittleFS, an asset declaring `storage=littlefs` already works.
 
-    Nothing applies these yet: build defines are assembled per-board in
-    `ci/boards.py`, and this is per-sketch. Applying them would also currently
-    break the ESP8266 builds it targets, because that backend cannot compile
-    until FastLED/fbuild#1380 ships the core's littlefs submodule. Tracked in
-    FastLED#4020.
+    ``copy_example_source`` carries these per-sketch requirements into the
+    generated compile configuration. fbuild#1380 supplies the ESP8266 core's
+    LittleFS submodule, so opting into that backend is now safe.
     """
     return ["FL_ESP8266_EMBEDDED_FS"] if scan.embedded_fs_assets() else []
 
@@ -547,12 +545,9 @@ def announce_storage_requirements(scan: AssetScanResult) -> None:
     prints, in green, which assets asked for it and where that requirement is
     already met.
 
-    It does not claim the build enabled anything. ESP32 genuinely is automatic
-    -- `platforms/embedded_fs.h` selects LittleFS with no flag -- but ESP8266
-    still needs `FL_ESP8266_EMBEDDED_FS`, and `embedded_fs_defines` is not yet
-    consumed by any build layer (FastLED#4020). Saying "enabled automatically"
-    on ESP8266 would report work that did not happen, which is worse than
-    saying nothing: the user would stop looking.
+    ESP32 is automatic -- `platforms/embedded_fs.h` selects LittleFS with no
+    flag -- while ESP8266 receives `FL_ESP8266_EMBEDDED_FS` through the staged
+    example's build requirements.
 
     Green because it is neither a warning nor an error. An unrecognised target
     is the yellow case -- a typo like `littleFS` would otherwise behave exactly

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -48,6 +48,7 @@ from ci.compiler.package_manager import (
 )
 from ci.compiler.path_manager import FastLEDPaths, resolve_project_root
 from ci.compiler.source_manager import (
+    CopyExampleResult,
     copy_boards_directory,
     copy_example_source,
     copy_fastled_library,
@@ -96,6 +97,32 @@ def _probe_root_platformio_build_flags(
             f"Warning: failed to probe root platformio.ini for env '{board_name}': {e}"
         )
         return []
+
+
+def _update_generated_build_defines(
+    platformio_ini_path: Path,
+    board_name: str,
+    previous_defines: list[str],
+    copy_result: CopyExampleResult,
+) -> None:
+    """Replace per-sketch defines in an already-generated compile config."""
+    from ci.compiler.platformio_ini import PlatformIOIni
+
+    platformio_ini = PlatformIOIni.parseFile(platformio_ini_path)
+    section = platformio_ini.config[f"env:{board_name}"]
+    previous_flags = {f"-D{define}" for define in previous_defines}
+    build_flags = [
+        flag.strip()
+        for flag in section.get("build_flags", "").splitlines()
+        if flag.strip() and flag.strip() not in previous_flags
+    ]
+    build_flags.extend(
+        f"-D{define}"
+        for define in copy_result.build_defines
+        if f"-D{define}" not in build_flags
+    )
+    section["build_flags"] = "\n" + "\n".join(build_flags)
+    platformio_ini.dump(platformio_ini_path)
 
 
 def _init_platformio_build(
@@ -242,32 +269,36 @@ def _init_platformio_build(
                 f"(see #3274 / #3278 / #3279)."
             )
 
+    # Stage first because asset declarations contribute per-sketch build defines.
+    print(create_building_banner(example))
+    copy_result = copy_example_source(project_root, build_dir, example)
+    if not copy_result.success:
+        error_msg = get_example_error_message(project_root, example)
+        warnings.warn(error_msg)
+        return InitResult(
+            success=False,
+            output=error_msg,
+            build_dir=build_dir,
+        )
+
+    merged_defines = list(additional_defines or [])
+    merged_defines.extend(
+        define for define in copy_result.build_defines if define not in merged_defines
+    )
+
     # Apply board-specific configuration
     if not apply_board_specific_config(
         board_with_sketch_include,
         platformio_ini,
         example,
         paths,
-        additional_defines,
+        merged_defines,
         merged_include_dirs,
         additional_libs,
     ):
         return InitResult(
             success=False,
             output=f"Failed to apply board configuration for {board.board_name}",
-            build_dir=build_dir,
-        )
-
-    # Print building banner first
-    print(create_building_banner(example))
-
-    ok_copy_src = copy_example_source(project_root, build_dir, example)
-    if not ok_copy_src:
-        error_msg = get_example_error_message(project_root, example)
-        warnings.warn(error_msg)
-        return InitResult(
-            success=False,
-            output=error_msg,
             build_dir=build_dir,
         )
 
@@ -465,6 +496,7 @@ class PioCompiler(Compiler):
         # No per-board lock needed
 
         self.initialized = False
+        self._sketch_build_defines: list[str] = []
         self.executor = ThreadPoolExecutor(max_workers=1)
 
     def _internal_init_build_no_lock(self, example: str) -> InitResult:
@@ -851,8 +883,8 @@ class PioCompiler(Compiler):
             # Copy example source for subsequent examples
             if self.initialized:
                 project_root = resolve_project_root()
-                ok_copy_src = copy_example_source(project_root, self.build_dir, example)
-                if not ok_copy_src:
+                copy_result = copy_example_source(project_root, self.build_dir, example)
+                if not copy_result.success:
                     error_msg = get_example_error_message(project_root, example)
                     result = SketchResult(
                         success=False,
@@ -864,6 +896,13 @@ class PioCompiler(Compiler):
                     future.set_result(result)
                     futures.append(future)
                     continue
+                _update_generated_build_defines(
+                    self.build_dir / "platformio.ini",
+                    self.board.board_name,
+                    self._sketch_build_defines,
+                    copy_result,
+                )
+                self._sketch_build_defines = copy_result.build_defines
 
             # Run fbuild on main thread — Ctrl+C works directly
             result = self._build_with_fbuild(example)
@@ -884,8 +923,8 @@ class PioCompiler(Compiler):
 
         # Copy example source to build directory
         project_root = resolve_project_root()
-        ok_copy_src = copy_example_source(project_root, self.build_dir, example)
-        if not ok_copy_src:
+        copy_result = copy_example_source(project_root, self.build_dir, example)
+        if not copy_result.success:
             error_msg = get_example_error_message(project_root, example)
             return SketchResult(
                 success=False,
@@ -893,6 +932,13 @@ class PioCompiler(Compiler):
                 build_dir=self.build_dir,
                 example=example,
             )
+        _update_generated_build_defines(
+            self.build_dir / "platformio.ini",
+            self.board.board_name,
+            self._sketch_build_defines,
+            copy_result,
+        )
+        self._sketch_build_defines = copy_result.build_defines
 
         # Cache configuration is handled through build flags during initialization
 

--- a/ci/compiler/source_manager.py
+++ b/ci/compiler/source_manager.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import time
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
@@ -13,6 +14,14 @@ from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 _GENERATED_EXAMPLE_DIRS = frozenset({".build", ".fbuild", ".pio", "fastled_js"})
 _GENERATED_EXAMPLE_FILES = frozenset({"compile_commands.json"})
+
+
+@dataclass
+class CopyExampleResult:
+    """Result of staging an example and discovering its build requirements."""
+
+    success: bool
+    build_defines: list[str]
 
 
 def _scandir_sync(
@@ -181,7 +190,9 @@ __attribute__((weak)) int main() {{
     return main_cpp_content
 
 
-def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bool:
+def copy_example_source(
+    project_root: Path, build_dir: Path, example: str
+) -> CopyExampleResult:
     """Copy example source to the build directory with sketch subdirectory structure.
 
     Args:
@@ -190,7 +201,7 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
         example: Name of the example to copy, or path to example directory
 
     Returns:
-        True if successful, False if example not found
+        Staging status and preprocessor defines required by the example.
     """
     # Configure example source - handle both names and paths
     example_path = Path(example)
@@ -198,12 +209,12 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     if example_path.is_absolute():
         # Absolute path - use as-is
         if not example_path.exists():
-            return False
+            return CopyExampleResult(success=False, build_defines=[])
     else:
         # Relative path (including nested paths like Fx/FxWave2d) - resolve to examples directory
         example_path = project_root / "examples" / example
         if not example_path.exists():
-            return False
+            return CopyExampleResult(success=False, build_defines=[])
 
     # Create src and sketch directories (PlatformIO requirement with sketch subdirectory)
     src_dir = build_dir / "src"
@@ -286,6 +297,7 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     # is the path the user recognises if something is misdeclared.
     from ci.compiler.asset_scanner import (
         announce_storage_requirements,
+        embedded_fs_defines,
         scan_sketch_assets,
     )
 
@@ -294,7 +306,9 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     # continue as if the sketch had declared nothing. Malformed individual
     # `.lnk` files are already non-fatal -- scan_sketch_assets collects those as
     # warnings -- so reaching an exception here means something genuinely wrong.
-    announce_storage_requirements(scan_sketch_assets(example_path))
+    asset_scan = scan_sketch_assets(example_path)
+    announce_storage_requirements(asset_scan)
+    build_defines = embedded_fs_defines(asset_scan)
 
     # Create or update stub main.cpp that includes the .ino files
     main_cpp_content = generate_main_cpp(ino_files)
@@ -313,7 +327,7 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     if should_write:
         main_cpp_path.write_text(main_cpp_content, encoding="utf-8")
 
-    return True
+    return CopyExampleResult(success=True, build_defines=build_defines)
 
 
 def copy_boards_directory(project_root: Path, build_dir: Path) -> bool:

--- a/ci/tests/test_audit_usb_registry.py
+++ b/ci/tests/test_audit_usb_registry.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from ci.util import audit_usb_registry
+
+
+REGISTRY = {
+    0x1234: ("Example Vendor", {0x5678: "Example Product"}),
+}
+
+
+def test_lookup_resolves_published_pair(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(audit_usb_registry, "fetch_artifact", lambda: b"registry")
+    monkeypatch.setattr(audit_usb_registry, "decode_registry", lambda raw: REGISTRY)
+
+    assert audit_usb_registry.main(["--lookup", "1234:5678"]) == 0
+    assert (
+        "FOUND 1234:5678  Example Vendor / Example Product" in capsys.readouterr().out
+    )
+
+
+def test_lookup_fails_for_absent_pair(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(audit_usb_registry, "fetch_artifact", lambda: b"registry")
+    monkeypatch.setattr(audit_usb_registry, "decode_registry", lambda raw: REGISTRY)
+
+    assert audit_usb_registry.main(["--lookup", "1234:9999"]) == 1
+    assert "MISSING 1234:9999" in capsys.readouterr().out
+
+
+def test_registry_docs_use_exact_lookup_command() -> None:
+    expected = "audit_usb_registry.py --lookup <VID:PID>"
+    doc_paths = (
+        Path("agents/docs/hardware-autoresearch.md"),
+        Path("agents/docs/usb-vid-pid-registry.md"),
+    )
+
+    for doc_path in doc_paths:
+        assert expected in doc_path.read_text()

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1550,14 +1550,17 @@ class TestResolvePortAndEnvironment:
         assert ctx.drivers == ["UART1"]
         assert ctx.json_rpc_commands[0]["params"]["driver"] == "UART1"
 
-    def test_auto_detect_port_success(self) -> None:
-        ctx = _make_ctx(upload_port=None)
-        ctx.args = _make_args(upload_port=None)
-        mock_result = MagicMock(ok=True, selected_port="COM5")
+    @pytest.mark.parametrize(
+        "environment",
+        ("esp32s3", "lpc845brk", "lpc845", "lpcxpresso845max", "lpcxpresso804"),
+    )
+    def test_known_environment_defers_port_selection_to_fbuild(
+        self, environment: str
+    ) -> None:
+        ctx = _make_ctx(upload_port=None, final_environment=environment)
+        ctx.args = _make_args(upload_port=None, environment=environment)
         with (
-            patch(
-                f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result
-            ) as auto_detect,
+            patch(f"{_PATCH_MOD}.auto_detect_upload_port") as auto_detect,
             patch(
                 f"{_PATCH_MOD}.select_build_driver", return_value=_make_mock_driver()
             ),
@@ -1568,30 +1571,8 @@ class TestResolvePortAndEnvironment:
         ):
             rc = asyncio.run(_resolve_port_and_environment(ctx))
         assert rc is None
-        assert ctx.upload_port == "COM5"
-        assert ctx.final_environment == "esp32s3"
-        auto_detect.assert_called_once_with(expected_environment="esp32s3")
-
-    def test_auto_detect_port_uses_requested_environment(self) -> None:
-        ctx = _make_ctx(upload_port=None, final_environment="esp32c6")
-        ctx.args = _make_args(upload_port=None, environment="esp32c6")
-        mock_result = MagicMock(ok=True, selected_port="COM9")
-        with (
-            patch(
-                f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result
-            ) as auto_detect,
-            patch(
-                f"{_PATCH_MOD}.select_build_driver", return_value=_make_mock_driver()
-            ),
-            patch(
-                "ci.util.pio_package_daemon.get_default_environment",
-                return_value=None,
-            ),
-        ):
-            rc = asyncio.run(_resolve_port_and_environment(ctx))
-        assert rc is None
-        assert ctx.upload_port == "COM9"
-        auto_detect.assert_called_once_with(expected_environment="esp32c6")
+        assert ctx.upload_port is None
+        auto_detect.assert_not_called()
 
     @pytest.mark.parametrize(
         "environment", ("rp2350", "rpipico2", "rp2350w", "rpipico2w")
@@ -1747,56 +1728,6 @@ class TestResolvePortAndEnvironment:
             rc = asyncio.run(_resolve_port_and_environment(ctx))
         assert rc == 1
 
-    def test_teensy_port_detection_never_uploads_stale_pio_hex(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        stale_hex = tmp_path / ".pio" / "build" / "teensy41" / "firmware.hex"
-        stale_hex.parent.mkdir(parents=True)
-        stale_hex.write_text("", encoding="utf-8")
-
-        ctx = _make_ctx(
-            upload_port=None,
-            final_environment="teensy41",
-            build_dir=tmp_path,
-        )
-        ctx.args = _make_args(
-            upload_port=None,
-            environment="teensy41",
-            object_fled=True,
-            parlio=False,
-            use_root_platformio_ini=False,
-            project_dir=tmp_path,
-        )
-        mock_result = MagicMock(
-            ok=False,
-            selected_port=None,
-            error_message="No USB",
-            all_ports=[],
-        )
-        call_count = [0]
-        original_monotonic = __import__("time").monotonic
-
-        def fake_monotonic() -> float:
-            call_count[0] += 1
-            if call_count[0] <= 2:
-                return original_monotonic()
-            return original_monotonic() + 999
-
-        with (
-            patch(f"{_PATCH_MOD}.auto_detect_upload_port", return_value=mock_result),
-            patch(f"{_PATCH_MOD}.time") as mock_time,
-            patch(f"{_PATCH_MOD}.subprocess.run") as mock_subprocess_run,
-        ):
-            mock_time.monotonic = fake_monotonic
-            mock_time.sleep = MagicMock()
-            rc = asyncio.run(_resolve_port_and_environment(ctx))
-
-        output = capsys.readouterr().out
-        assert rc == 1
-        mock_subprocess_run.assert_not_called()
-        assert "AutoResearch will not pre-upload stale .pio firmware" in output
-        assert "Firmware uploaded via Teensy bootloader" not in output
-
 
 class TestAutoDetectUploadPort:
     """Test USB port detection edge cases used by autoresearch."""
@@ -1857,310 +1788,6 @@ class TestAutoDetectUploadPort:
         assert "No USB serial port matched expected environment" in (
             result.error_message or ""
         )
-
-    def test_lpc845brk_lpcxpresso_vcom_fingerprint_matches(self) -> None:
-        """LPC845-BRK with LPCXpresso VCOM firmware (16C0:0483) is accepted."""
-        port = ListPortInfo("COM12")
-        port.description = "USB Serial Device"
-        port.hwid = "USB VID:PID=16C0:0483"
-        port.vid = 0x16C0
-        port.pid = 0x0483
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("lpc845brk")
-
-        assert result.ok is True
-        assert result.selected_port == "COM12"
-
-    def test_rp2040_requires_application_cdc_fingerprint(self) -> None:
-        """A nearby CP210x must never be selected for an RP2040 run."""
-        port = ListPortInfo("COM11")
-        port.description = "Silicon Labs CP210x USB to UART Bridge"
-        port.hwid = "USB VID:PID=10C4:EA60"
-        port.vid = 0x10C4
-        port.pid = 0xEA60
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("rp2040")
-        assert result.ok is False
-        assert result.selected_port is None
-        assert "2E8A:000A" in (result.error_message or "")
-
-    def test_rp2040_application_cdc_fingerprint_matches(self) -> None:
-        port = ListPortInfo("COM11")
-        port.description = "USB Serial Device"
-        port.hwid = "USB VID:PID=2E8A:000A"
-        port.vid = 0x2E8A
-        port.pid = 0x000A
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("rp2040")
-        assert result.ok is True
-        assert result.selected_port == "COM11"
-
-    def test_rp2040_unique_match_rejects_identical_boards(self) -> None:
-        ports = []
-        for device in ("COM11", "COM12"):
-            port = ListPortInfo(device)
-            port.description = "USB Serial Device"
-            port.hwid = "USB VID:PID=2E8A:000A"
-            port.vid = 0x2E8A
-            port.pid = 0x000A
-            ports.append(port)
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=ports,
-        ):
-            result = auto_detect_upload_port("rp2040", require_unique_match=True)
-
-        assert result.ok is False
-        assert result.selected_port is None
-        assert "multiple" in (result.error_message or "").lower()
-        assert "--upload-port" in (result.error_message or "")
-
-    def test_rp2040_rejects_rp2350_application_cdc_fingerprint(self) -> None:
-        rp2350 = ListPortInfo("COM12")
-        rp2350.description = "USB Serial Device"
-        rp2350.hwid = "USB VID:PID=2E8A:000F"
-        rp2350.vid = 0x2E8A
-        rp2350.pid = 0x000F
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[rp2350],
-        ):
-            result = auto_detect_upload_port("rp2040")
-
-        assert result.ok is False
-        assert result.selected_port is None
-
-    def test_rpipicow_uses_its_board_exact_application_identity(
-        self: "TestAutoDetectUploadPort",
-    ) -> None:
-        pico = ListPortInfo("COM11")
-        pico.description = "USB Serial Device"
-        pico.hwid = "USB VID:PID=2E8A:000A"
-        pico.vid = 0x2E8A
-        pico.pid = 0x000A
-
-        pico_w = ListPortInfo("COM12")
-        pico_w.description = "USB Serial Device"
-        pico_w.hwid = "USB VID:PID=2E8A:F00A"
-        pico_w.vid = 0x2E8A
-        pico_w.pid = 0xF00A
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[pico, pico_w],
-        ):
-            result = auto_detect_upload_port("rpipicow")
-
-        assert result.ok is True
-        assert result.selected_port == "COM12"
-
-    def test_rpipico2_application_cdc_fingerprint_matches(self) -> None:
-        port = ListPortInfo("COM12")
-        port.description = "USB Serial Device"
-        port.hwid = "USB VID:PID=2E8A:000F"
-        port.vid = 0x2E8A
-        port.pid = 0x000F
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("rpipico2")
-        assert result.ok is True
-        assert result.selected_port == "COM12"
-
-    @pytest.mark.parametrize(
-        ("environment", "pid"),
-        (
-            ("rp2350", 0x000F),
-            ("rpipico2", 0x000F),
-            ("rp2350w", 0xF00F),
-            ("rpipico2w", 0xF00F),
-        ),
-    )
-    def test_rp2350_aliases_accept_board_exact_application_cdc_fingerprint(
-        self, environment: str, pid: int
-    ) -> None:
-        port = ListPortInfo("COM17")
-        port.description = "USB Serial Device"
-        port.hwid = f"USB VID:PID=2E8A:{pid:04X}"
-        port.vid = 0x2E8A
-        port.pid = pid
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port(environment)
-
-        assert result.ok is True
-        assert result.selected_port == "COM17"
-
-    @pytest.mark.parametrize(
-        ("environment", "wrong_pid"),
-        (("rp2350", 0xF00F), ("rp2350w", 0x000F)),
-    )
-    def test_rp2350_variants_reject_each_others_application_identity(
-        self, environment: str, wrong_pid: int
-    ) -> None:
-        other_variant = ListPortInfo("COM12")
-        other_variant.description = "USB Serial Device"
-        other_variant.hwid = f"USB VID:PID=2E8A:{wrong_pid:04X}"
-        other_variant.vid = 0x2E8A
-        other_variant.pid = wrong_pid
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[other_variant],
-        ):
-            result = auto_detect_upload_port(environment)
-
-        assert result.ok is False
-        assert result.selected_port is None
-
-    def test_rp2350w_strict_fingerprint_skips_unrelated_usb_serial(self) -> None:
-        unrelated = ListPortInfo("COM11")
-        unrelated.description = "Silicon Labs CP210x USB to UART Bridge"
-        unrelated.hwid = "USB VID:PID=10C4:EA60"
-        unrelated.vid = 0x10C4
-        unrelated.pid = 0xEA60
-
-        rp2350 = ListPortInfo("COM17")
-        rp2350.description = "USB Serial Device"
-        rp2350.hwid = "USB VID:PID=2E8A:F00F"
-        rp2350.vid = 0x2E8A
-        rp2350.pid = 0xF00F
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[unrelated, rp2350],
-        ):
-            result = auto_detect_upload_port("rp2350w")
-
-        assert result.ok is True
-        assert result.selected_port == "COM17"
-
-    def test_rp2350_strict_fingerprint_skips_attached_esp32c6(self) -> None:
-        esp32c6 = ListPortInfo("COM9")
-        esp32c6.description = "USB JTAG/serial debug unit"
-        esp32c6.hwid = "USB VID:PID=303A:1001"
-        esp32c6.vid = 0x303A
-        esp32c6.pid = 0x1001
-
-        rp2350 = ListPortInfo("COM17")
-        rp2350.description = "USB Serial Device"
-        rp2350.hwid = "USB VID:PID=2E8A:F00F"
-        rp2350.vid = 0x2E8A
-        rp2350.pid = 0xF00F
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[esp32c6, rp2350],
-        ):
-            result = auto_detect_upload_port("rp2350w")
-
-        assert result.ok is True
-        assert result.selected_port == "COM17"
-
-    def test_rp2350_strict_fingerprint_rejects_unrelated_usb_serial(self) -> None:
-        unrelated = ListPortInfo("COM11")
-        unrelated.description = "Silicon Labs CP210x USB to UART Bridge"
-        unrelated.hwid = "USB VID:PID=10C4:EA60"
-        unrelated.vid = 0x10C4
-        unrelated.pid = 0xEA60
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[unrelated],
-        ):
-            result = auto_detect_upload_port("rp2350")
-
-        assert result.ok is False
-        assert result.selected_port is None
-        assert "2E8A:000F" in (result.error_message or "")
-
-    def test_rp2350w_serial_identity_selects_original_board(self) -> None:
-        replacement = ListPortInfo("COM18")
-        replacement.description = "USB Serial Device"
-        replacement.hwid = "USB VID:PID=2E8A:F00F"
-        replacement.vid = 0x2E8A
-        replacement.pid = 0xF00F
-        replacement.serial_number = "OTHER-RP2350W"
-
-        original = ListPortInfo("COM19")
-        original.description = "USB Serial Device"
-        original.hwid = "USB VID:PID=2E8A:F00F"
-        original.vid = 0x2E8A
-        original.pid = 0xF00F
-        original.serial_number = "2DCB876B587EA334"
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[replacement, original],
-        ):
-            result = auto_detect_upload_port(
-                "rp2350w",
-                expected_serial_number="2DCB876B587EA334",
-                require_unique_match=True,
-            )
-
-        assert result.ok is True
-        assert result.selected_port == "COM19"
-
-    def test_lpc845brk_lpc_link2_cmsis_dap_fingerprint_matches(self) -> None:
-        """LPC845-BRK with LPC-Link2 CMSIS-DAP firmware (1FC9:0132) is accepted.
-
-        FastLED #3468 follow-up: newer LPC845-BRK boards ship with NXP's own
-        LPC-Link2 CMSIS-DAP firmware pre-flashed on the debug probe. The
-        probe still exposes the LPC845's USART0 as a VCOM alongside the
-        CMSIS-DAP HID interface — VID:PID 1FC9:0132 belongs to NXP rather
-        than the community "V-USB" pool. Both firmwares are valid for
-        AutoResearch.
-        """
-        port = ListPortInfo("COM10")
-        port.description = "USB Serial Device"
-        port.hwid = "USB VID:PID=1FC9:0132"
-        port.vid = 0x1FC9
-        port.pid = 0x0132
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("lpc845brk")
-
-        assert result.ok is True
-        assert result.selected_port == "COM10"
-
-    def test_lpc845brk_neither_fingerprint_matches_reports_both(self) -> None:
-        """Error message lists BOTH accepted VID:PIDs when neither is found."""
-        port = ListPortInfo("COM7")
-        port.description = "USB Serial Device"
-        port.hwid = "USB VID:PID=303A:1001"
-        port.vid = 0x303A
-        port.pid = 0x1001
-
-        with patch(
-            "ci.util.port_utils.serial.tools.list_ports.comports",
-            return_value=[port],
-        ):
-            result = auto_detect_upload_port("lpc845brk")
-
-        assert result.ok is False
-        assert result.selected_port is None
-        assert "16C0:0483" in (result.error_message or "")
-        assert "1FC9:0132" in (result.error_message or "")
 
 
 # ============================================================
@@ -2274,18 +1901,16 @@ class TestRunBuildDeploy:
             ieee754_test_mode=True,
         )
         qctx = QuietContext(quiet=False)
-        with patch(
-            f"{_PATCH_MOD}._build_and_deploy_nxplpc", return_value=True
-        ) as flash:
-            rc = asyncio.run(_run_build_deploy(ctx, qctx))
+        rc = asyncio.run(_run_build_deploy(ctx, qctx))
         assert rc is None
         assert _build_environment_for_mode(ctx) == "lpc845brk_ieee754"
         mock_driver.install_packages.assert_called_once_with(
             Path("/fake/project"), "lpc845brk_ieee754"
         )
-        flash.assert_called_once()
-        assert flash.call_args.kwargs["environment"] == "lpc845brk_ieee754"
-        mock_driver.deploy.assert_not_called()
+        mock_driver.deploy.assert_called_once()
+        assert mock_driver.deploy.call_args.kwargs["environment"] == (
+            "lpc845brk_ieee754"
+        )
 
     def test_stopping_host_watchdog_signals_and_clears_the_runner_handle(self) -> None:
         ctx = _make_ctx()
@@ -2306,35 +1931,22 @@ class TestRunBuildDeploy:
 class TestRunSchemaAndPinSetup:
     """Test _run_schema_and_pin_setup (mocks RPC client)."""
 
-    def test_rp2350_postdeploy_rescan_polls_until_cdc_appears(self) -> None:
+    def test_rp2350_missing_deploy_port_fails_closed(self, capsys) -> None:
         ctx = _make_ctx(
             final_environment="rp2350",
             upload_port=None,
             use_fbuild=True,
             rpc_smoke_mode=True,
         )
-        missed = MagicMock(selected_port=None)
-        discovered = MagicMock(selected_port="COM17")
-
-        with (
-            patch(
-                f"{_PATCH_MOD}.auto_detect_upload_port",
-                side_effect=[missed, missed, discovered],
-            ) as auto_detect,
-            patch(
-                "ci.util.serial_interface.create_serial_interface",
-                return_value=MagicMock(),
-            ),
-            patch(f"{_PATCH_MOD}.CrashTraceDecoder", return_value=MagicMock()),
-        ):
+        with patch(f"{_PATCH_MOD}.auto_detect_upload_port") as auto_detect:
             rc = asyncio.run(_run_schema_and_pin_setup(ctx))
 
-        assert rc is None
-        assert ctx.upload_port == "COM17"
-        assert auto_detect.call_count == 3
-        auto_detect.assert_called_with(
-            expected_environment="rp2350", require_unique_match=True
-        )
+        assert rc == 1
+        assert ctx.upload_port is None
+        auto_detect.assert_not_called()
+        output = capsys.readouterr().out
+        assert "refusing identity-only recovery" in output
+        assert "--upload-port" in output
 
     def test_cli_pin_override(self) -> None:
         args = _make_args(tx_pin=3, rx_pin=4, skip_schema=True)

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -1905,6 +1905,27 @@ class TestAutoDetectUploadPort:
         assert result.ok is True
         assert result.selected_port == "COM11"
 
+    def test_rp2040_unique_match_rejects_identical_boards(self) -> None:
+        ports = []
+        for device in ("COM11", "COM12"):
+            port = ListPortInfo(device)
+            port.description = "USB Serial Device"
+            port.hwid = "USB VID:PID=2E8A:000A"
+            port.vid = 0x2E8A
+            port.pid = 0x000A
+            ports.append(port)
+
+        with patch(
+            "ci.util.port_utils.serial.tools.list_ports.comports",
+            return_value=ports,
+        ):
+            result = auto_detect_upload_port("rp2040", require_unique_match=True)
+
+        assert result.ok is False
+        assert result.selected_port is None
+        assert "multiple" in (result.error_message or "").lower()
+        assert "--upload-port" in (result.error_message or "")
+
     def test_rp2040_rejects_rp2350_application_cdc_fingerprint(self) -> None:
         rp2350 = ListPortInfo("COM12")
         rp2350.description = "USB Serial Device"
@@ -2089,7 +2110,9 @@ class TestAutoDetectUploadPort:
             return_value=[replacement, original],
         ):
             result = auto_detect_upload_port(
-                "rp2350w", expected_serial_number="2DCB876B587EA334"
+                "rp2350w",
+                expected_serial_number="2DCB876B587EA334",
+                require_unique_match=True,
             )
 
         assert result.ok is True
@@ -2309,7 +2332,9 @@ class TestRunSchemaAndPinSetup:
         assert rc is None
         assert ctx.upload_port == "COM17"
         assert auto_detect.call_count == 3
-        auto_detect.assert_called_with(expected_environment="rp2350")
+        auto_detect.assert_called_with(
+            expected_environment="rp2350", require_unique_match=True
+        )
 
     def test_cli_pin_override(self) -> None:
         args = _make_args(tx_pin=3, rx_pin=4, skip_schema=True)

--- a/ci/tests/test_embedded_fs_build_defines.py
+++ b/ci/tests/test_embedded_fs_build_defines.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from ci.boards import create_board
+from ci.compiler.path_manager import FastLEDPaths
+from ci.compiler.pio import init_fbuild_project
+
+
+@pytest.mark.parametrize(
+    ("storage_declaration", "expects_define"),
+    [("storage=littlefs\n", True), ("", False)],
+)
+def test_asset_requirement_reaches_generated_compile_configuration(
+    tmp_path: Path, storage_declaration: str, expects_define: bool
+) -> None:
+    example_dir = tmp_path / "example"
+    example_dir.mkdir()
+    (example_dir / "Example.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    (example_dir / "data").mkdir()
+    (example_dir / "data" / "asset.rgb.lnk").write_text(
+        f"https://example.com/asset.rgb\n{storage_declaration}"
+    )
+    build_dir = tmp_path / "build"
+    paths = FastLEDPaths("esp8266")
+    paths._global_platformio_cache_dir = tmp_path / "pio-cache"
+
+    result = init_fbuild_project(
+        board=create_board("esp8266"),
+        verbose=False,
+        example=str(example_dir),
+        paths=paths,
+        build_dir=build_dir,
+    )
+
+    assert result.success
+    generated_ini = (build_dir / "platformio.ini").read_text()
+    assert ("-DFL_ESP8266_EMBEDDED_FS" in generated_ini) is expects_define

--- a/ci/tests/test_root_platformio_sever.py
+++ b/ci/tests/test_root_platformio_sever.py
@@ -98,7 +98,13 @@ class TestRootPlatformioSever(unittest.TestCase):
             mock.patch.object(
                 pio_module, "apply_board_specific_config", side_effect=fake_apply
             ),
-            mock.patch.object(pio_module, "copy_example_source", return_value=True),
+            mock.patch.object(
+                pio_module,
+                "copy_example_source",
+                return_value=pio_module.CopyExampleResult(
+                    success=True, build_defines=[]
+                ),
+            ),
             mock.patch.object(pio_module, "copy_fastled_library", return_value=True),
             mock.patch.object(pio_module, "copy_boards_directory", return_value=True),
         ):

--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -103,6 +103,22 @@ def _defined_macros(flags: list[str], header: str) -> set[str]:
     return macros
 
 
+def _preprocessed_header(flags: list[str], header: str) -> str:
+    """Preprocess a real FastLED header with the supplied board flags."""
+    cmd = [_compiler(), "-E", "-x", "c++", f"-I{SRC}", *flags, "-"]
+    proc = RunningProcess.run(
+        cmd,
+        input=f'#include "{header}"\n',
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+    )
+    assert proc.returncode == 0, f"preprocessing failed:\n{proc.stderr}"
+    return proc.stdout
+
+
 HEADER = "platforms/arm/samd/is_samd.h"
 
 
@@ -154,6 +170,25 @@ def test_non_samd_build_is_not_detected_as_samd() -> None:
     assert "FL_IS_SAMD" not in macros
     assert "FL_IS_SAMD21" not in macros
     assert "FL_IS_SAMD51" not in macros
+
+
+def test_arduino_metro_m4_board_macro_selects_d6_fastpin() -> None:
+    """#4004: Arduino's board macro must select the Metro M4 pin table.
+
+    ``ARDUINO_METRO_M4`` comes from ``build.board=METRO_M4`` in Adafruit
+    SAMD 1.7.17. D6 is PB15 in that release's ``variants/metro_m4`` table.
+    """
+    output = _preprocessed_header(
+        ["-DARDUINO_METRO_M4", "-D__SAMD51J19A__"],
+        "platforms/arm/d51/fastpin_arm_d51.h",
+    )
+    specialization = (
+        "template<> class FastPin<6> : public _ARMPIN<6, 15, 1ul << 15, 1> {}"
+    )
+    assert specialization in output, (
+        "ARDUINO_METRO_M4 did not select the Metro M4 table; FastPin<6> will "
+        "remain invalid instead of mapping to D6/PB15"
+    )
 
 
 def test_samd_does_not_route_into_the_arduino_spi_backend() -> None:

--- a/ci/tests/test_source_manager.py
+++ b/ci/tests/test_source_manager.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ci.compiler.source_manager import copy_example_source
+from ci.compiler.source_manager import CopyExampleResult, copy_example_source
 
 
 @pytest.mark.parametrize("generated_dir", [".build", ".fbuild", ".pio", "fastled_js"])
@@ -19,7 +19,9 @@ def test_copy_example_source_skips_generated_directories(
 
     build_dir = tmp_path / "output"
     build_dir.mkdir()
-    assert copy_example_source(project_root, build_dir, "Blink")
+    result = copy_example_source(project_root, build_dir, "Blink")
+    assert result.success
+    assert result.build_defines == []
 
     staged_sketch = build_dir / "src" / "sketch"
     assert (staged_sketch / "Blink.ino").is_file()
@@ -35,8 +37,29 @@ def test_copy_example_source_skips_generated_files(tmp_path: Path) -> None:
 
     build_dir = tmp_path / "output"
     build_dir.mkdir()
-    assert copy_example_source(project_root, build_dir, "Blink")
+    assert copy_example_source(project_root, build_dir, "Blink").success
 
     staged_sketch = build_dir / "src" / "sketch"
     assert (staged_sketch / "Blink.ino").is_file()
     assert not (staged_sketch / "compile_commands.json").exists()
+
+
+def test_copy_example_source_returns_embedded_fs_build_requirements(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    example_dir = project_root / "examples" / "Assets"
+    example_dir.mkdir(parents=True)
+    (example_dir / "Assets.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    (example_dir / "data").mkdir()
+    (example_dir / "data" / "video.rgb.lnk").write_text(
+        "https://example.com/video.rgb\nstorage=littlefs\n"
+    )
+
+    build_dir = tmp_path / "output"
+    build_dir.mkdir()
+    result = copy_example_source(project_root, build_dir, "Assets")
+
+    assert isinstance(result, CopyExampleResult)
+    assert result.success
+    assert result.build_defines == ["FL_ESP8266_EMBEDDED_FS"]

--- a/ci/tests/test_usb_registry_retirement.py
+++ b/ci/tests/test_usb_registry_retirement.py
@@ -1,0 +1,32 @@
+"""Regression tests for retiring FastLED's local USB identity tables."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_legacy_usb_identity_tables_are_gone() -> None:
+    """Runtime USB selection and labels must come from fbuild's registry."""
+    port_utils = (ROOT / "ci/util/port_utils.py").read_text(encoding="utf-8")
+    serial_probe = (ROOT / "ci/util/serial_probe.py").read_text(encoding="utf-8")
+
+    assert "ENVIRONMENT_TO_VCOM_VID_PIDS" not in port_utils
+    assert "ENVIRONMENT_TO_VCOM_VID_PID" not in port_utils
+    assert "BOARD_FINGERPRINTS" not in serial_probe
+
+
+def test_audit_is_a_registry_query_tool_not_a_retirement_checklist() -> None:
+    """Keep the query implementation needed by #3996, but drop old literals."""
+    audit = (ROOT / "ci/util/audit_usb_registry.py").read_text(encoding="utf-8")
+
+    assert "AUDITED_LITERALS: tuple[Literal, ...] = ()" in audit
+    assert "fetch_artifact" in audit
+    assert "decode_registry" in audit
+
+
+def test_autoresearch_defers_known_board_port_selection_to_fbuild() -> None:
+    """Known environments, including LPC845, must not be locally fingerprinted."""
+    phases = (ROOT / "ci/autoresearch/phases.py").read_text(encoding="utf-8")
+
+    assert "defer_port_selection_to_fbuild" in phases

--- a/ci/util/README.md
+++ b/ci/util/README.md
@@ -4,25 +4,18 @@ Shared Python utilities for the FastLED CI/build system.
 
 ## USB VID/PID identities are not owned here
 
-`port_utils.py` and `serial_probe.py` each carry a legacy VID:PID table. Both
-are **frozen**. USB board identity is owned by
+USB board identity is owned by
 [FastLED/boards](https://github.com/FastLED/boards) and reaches this repo
 through fbuild's ingestion of the published `usb-vids.proto.zstd` archive.
 
-Do not add entries to either table. If a board cannot be identified, add the
-record upstream, let fbuild ingest it, then cascade the `fbuild==X.Y.Z` pin in
-`pyproject.toml` and relock locally (`uv lock && uv sync`; `uv.lock` itself is
-gitignored here).
+Use `fbuild port scan` for registry-backed USB diagnostics and let `fbuild
+deploy` select a port for a known environment. If a board cannot be identified,
+add the record upstream, let fbuild ingest it, then cascade the `fbuild==X.Y.Z`
+pin in `pyproject.toml` and relock locally (`uv lock && uv sync`; `uv.lock`
+itself is gitignored here).
 
-Check the migration status at any time:
-
-```bash
-uv run python ci/util/audit_usb_registry.py
-```
-
-It exits 0 while the only outstanding gaps are ones already filed upstream
-(listed in `KNOWN_GAPS`, shown as `GAP*`), so it is safe to wire into CI. It
-exits 1 on an unfiled gap, or when a `KNOWN_GAPS` entry has been published and
-the literal can finally be retired.
+`ci/util/audit_usb_registry.py` retains the catalogue fetch/decode support used
+by the exact VID:PID lookup tracked in FastLED #3996. It no longer audits a
+local retirement checklist because the runtime tables have been removed.
 
 Full rule and cascade procedure: `agents/docs/usb-vid-pid-registry.md`.

--- a/ci/util/audit_usb_registry.py
+++ b/ci/util/audit_usb_registry.py
@@ -12,10 +12,11 @@ than trusted. It fetches the published artifact, decodes it, and reports which
 of the literals still present in `ci/` resolve from the registry.
 
     uv run python ci/util/audit_usb_registry.py
+    uv run python ci/util/audit_usb_registry.py --lookup 1234:5678
 
 Exit codes:
-    0 — every audited literal resolves, ignoring the gaps in KNOWN_GAPS
-    1 — an unfiled literal is missing, or a KNOWN_GAPS entry went stale
+    0 — every audited literal resolves, or the requested pair resolves
+    1 — an audited literal/requested pair is missing, or a known gap is stale
     2 — the artifact could not be fetched or decoded
 
 Exit 0 while a filed gap is outstanding is deliberate: it makes this safe to
@@ -29,6 +30,7 @@ FastLED/boards#60.
 
 from __future__ import annotations
 
+import argparse
 import sys
 import urllib.request
 from typing import Iterator, NamedTuple
@@ -212,7 +214,30 @@ def fetch_artifact(url: str = ARTIFACT_URL) -> bytes:
     )
 
 
-def main() -> int:
+def _vid_pid(value: str) -> tuple[int, int]:
+    """Parse a four-digit hexadecimal VID:PID command-line value."""
+    parts = value.split(":")
+    if len(parts) != 2 or any(len(part) != 4 for part in parts):
+        raise argparse.ArgumentTypeError("expected VID:PID as four hex digits each")
+    try:
+        vid, pid = (int(part, 16) for part in parts)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected VID:PID as four hex digits each"
+        ) from exc
+    return vid, pid
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lookup",
+        type=_vid_pid,
+        metavar="VID:PID",
+        help="check whether one exact hexadecimal VID:PID pair is published",
+    )
+    args = parser.parse_args(argv)
+
     try:
         raw = fetch_artifact()
         registry = decode_registry(raw)
@@ -227,6 +252,18 @@ def main() -> int:
     vendor_count = len(registry)
     product_count = sum(len(products) for _, products in registry.values())
     print(f"FastLED/boards registry: {vendor_count} vendors, {product_count} products")
+
+    if args.lookup is not None:
+        vid, pid = args.lookup
+        pair = f"{vid:04X}:{pid:04X}"
+        vendor = registry.get(vid)
+        if vendor is None or pid not in vendor[1]:
+            print(f"MISSING {pair} from FastLED/boards")
+            return 1
+        vendor_name, products = vendor
+        print(f"FOUND {pair}  {vendor_name} / {products[pid]}")
+        return 0
+
     print(f"Auditing {len(AUDITED_LITERALS)} literals from ci/\n")
 
     new_gaps: list[Literal] = []

--- a/ci/util/audit_usb_registry.py
+++ b/ci/util/audit_usb_registry.py
@@ -58,32 +58,14 @@ class Literal(NamedTuple):
 
 # Every VID:PID literal in the ci/ tree. Keep in sync when a literal is
 # retired — the point of this list is that it shrinks to empty.
-AUDITED_LITERALS: tuple[Literal, ...] = (
-    Literal(0x2E8A, 0x000A, "rp2040 / rpipico application CDC", "port_utils.py"),
-    Literal(0x2E8A, 0xF00A, "rpipicow application CDC", "port_utils.py"),
-    Literal(0x2E8A, 0x000F, "rp2350 / rpipico2 application CDC", "port_utils.py"),
-    Literal(0x2E8A, 0xF00F, "rp2350w / rpipico2w application CDC", "port_utils.py"),
-    Literal(0x2E8A, 0x0003, "RP2 ROM BOOTSEL", "port_utils.py (comment)"),
-    Literal(0x16C0, 0x0483, "LPCXpresso VCOM (LPC11U35)", "port_utils.py"),
-    Literal(0x1FC9, 0x0132, "NXP LPC-Link2 CMSIS-DAP", "port_utils.py"),
-    Literal(0x16C0, 0x0486, "PJRC / Teensy USB-Serial (alt)", "serial_probe.py"),
-    Literal(0x303A, 0x1001, "Espressif native USB CDC", "serial_probe.py"),
-    Literal(0x10C4, 0xEA60, "Silicon Labs CP2102", "serial_probe.py"),
-    Literal(0x1A86, 0x7523, "WCH CH340", "serial_probe.py"),
-    Literal(0x1A86, 0x55D4, "WCH CH343", "serial_probe.py"),
-    Literal(0x0403, 0x6001, "FTDI FT232R", "serial_probe.py"),
-    Literal(0x0403, 0x6010, "FTDI FT2232", "serial_probe.py"),
-    Literal(0x0403, 0x6014, "FTDI FT232H", "serial_probe.py"),
-)
+AUDITED_LITERALS: tuple[Literal, ...] = ()
 
 
 # Gaps already filed upstream and accepted as outstanding. A known gap keeps
 # the exit code green so this script can be wired into CI or a pre-commit hook
 # without going permanently red; an *unknown* gap still fails. Delete an entry
 # once the registry publishes it — the audit then fails loudly if it regresses.
-KNOWN_GAPS: dict[tuple[int, int], str] = {
-    (0x0403, 0x6014): "FastLED/boards#60",
-}
+KNOWN_GAPS: dict[tuple[int, int], str] = {}
 
 
 def _read_varint(buf: bytes, pos: int) -> tuple[int, int]:

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -177,6 +177,7 @@ def auto_detect_upload_port(
     expected_environment: str | None,
     *,
     expected_serial_number: str | None = None,
+    require_unique_match: bool = False,
 ) -> ComportResult:
     """Auto-detect the upload port from available serial ports.
 
@@ -194,6 +195,8 @@ def auto_detect_upload_port(
         expected_environment: Board environment used for strict fingerprinting.
         expected_serial_number: Optional stable USB identity that a matching
             board must retain across re-enumeration.
+        require_unique_match: Reject fingerprint detection when multiple ports
+            match instead of silently selecting the first one.
 
     Returns:
         ComportResult with detection status and diagnostics
@@ -260,18 +263,33 @@ def auto_detect_upload_port(
     )
     if expected_vid_pids:
         accepted = set(expected_vid_pids)
-        for port in usb_ports:
-            serial_matches = (
+        matching_ports = [
+            port
+            for port in usb_ports
+            if (port.vid, port.pid) in accepted
+            and (
                 expected_serial_number is None
                 or port.serial_number == expected_serial_number
             )
-            if (port.vid, port.pid) in accepted and serial_matches:
-                return ComportResult(
-                    ok=True,
-                    selected_port=port.device,
-                    error_message=None,
-                    all_ports=all_ports,
-                )
+        ]
+        if require_unique_match and len(matching_ports) > 1:
+            devices = ", ".join(port.device for port in matching_ports)
+            return ComportResult(
+                ok=False,
+                selected_port=None,
+                error_message=(
+                    f"Multiple USB serial ports match '{expected_environment}' "
+                    f"({devices}); pass --upload-port to select the deployed board."
+                ),
+                all_ports=all_ports,
+            )
+        if matching_ports:
+            return ComportResult(
+                ok=True,
+                selected_port=matching_ports[0].device,
+                error_message=None,
+                all_ports=all_ports,
+            )
         # Fingerprint expected but no port matched. Don't fall through to the
         # ESP probe — the wrong port will fail later with PermissionError or
         # silent timeout. Report explicitly so the user can plug the board in.

--- a/ci/util/port_utils.py
+++ b/ci/util/port_utils.py
@@ -43,73 +43,6 @@ CHIP_TO_ENVIRONMENT: dict[str, str] = {
 # ESP32 variants that lack WiFi hardware
 NO_WIFI_ENVIRONMENTS: set[str] = {"esp32h2", "esp32p4"}
 
-# PlatformIO environments → expected USB VID:PID(s) for the data-bearing
-# VCOM port. This bypasses the description-string heuristic for boards
-# whose USB descriptors are too generic to disambiguate (e.g. "USB Serial
-# Device" on Windows for both the LPC845-BRK VCOM and any other Microsoft
-# CDC device).
-#
-# Each entry is a **tuple of accepted VID:PID pairs** — the first port
-# whose (vid, pid) matches any pair is selected. Some boards ship one of
-# several debug-probe firmwares that expose different VID:PIDs; listing
-# them all here lets the same PlatformIO env work regardless of which
-# firmware is on the on-board probe (see the LPC845-BRK note below).
-#
-# FROZEN — DO NOT ADD ENTRIES. USB VID:PID identity is owned by
-# https://github.com/FastLED/boards and reaches this repo through fbuild's
-# ingestion of the published `usb-vids.proto.zstd` archive. Every pair below
-# is already published there; this map survives only as a legacy fast path
-# for default-port selection (see FastLED #3300 for the LPC845-BRK case that
-# motivated it, and FastLED #3836 for its retirement).
-#
-# A board that cannot be identified is a FastLED/boards gap: add the record
-# on the appropriate data branch, let fbuild ingest it, then cascade the
-# `fbuild==X.Y.Z` pin in pyproject.toml and relock locally. Full procedure:
-# agents/docs/usb-vid-pid-registry.md.
-#
-# ci/util/serial_probe.py has a richer fingerprint table; it is likewise
-# frozen and is display/diagnostic only.
-ENVIRONMENT_TO_VCOM_VID_PIDS: dict[str, tuple[tuple[int, int], ...]] = {
-    # RP2040 Pico application CDC (the ROM BOOTSEL interface is 2E8A:0003
-    # and is intentionally not a serial port). Keep this fingerprint strict:
-    # falling back to an arbitrary CP210x/CH340 port can run RPC against a
-    # different attached board.
-    "rp2040": ((0x2E8A, 0x000A),),
-    "rpipico": ((0x2E8A, 0x000A),),
-    "rpipicow": ((0x2E8A, 0xF00A),),
-    # Arduino-Pico assigns distinct application CDC identities to Pico 2
-    # and Pico 2 W. Keep them board-exact so a non-W RP2350 cannot be
-    # selected for an rp2350w run when both variants are attached.
-    "rp2350": ((0x2E8A, 0x000F),),
-    "rpipico2": ((0x2E8A, 0x000F),),
-    "rp2350w": ((0x2E8A, 0xF00F),),
-    "rpipico2w": ((0x2E8A, 0xF00F),),
-    # LPC8xx family: the on-board debug probe can be either
-    #   * LPC11U35 running the LPCXpresso VCOM firmware — 16C0:0483
-    #     (the community "V-USB" VID:PID; shared with PJRC Teensy).
-    #   * LPC-Link2 CMSIS-DAP firmware — 1FC9:0132
-    #     (NXP's own VID:PID; the debug probe presents a single COM
-    #     port that carries the LPC845's USART0 as a virtual serial
-    #     bridge alongside the CMSIS-DAP HID interface).
-    # Newer LPC845-BRK / LPCXpresso boards ship with the LPC-Link2
-    # CMSIS-DAP firmware pre-flashed; either variant is acceptable for
-    # AutoResearch as long as the VCOM stream reaches the host.
-    "lpc845brk": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
-    "lpc845": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
-    "lpc804": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
-    "lpcxpresso845max": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
-    "lpcxpresso804": ((0x16C0, 0x0483), (0x1FC9, 0x0132)),
-}
-
-# Backwards-compatibility shim — the old single-VID:PID map is derived
-# from the first entry of the new plural form so any external caller
-# that still reads `ENVIRONMENT_TO_VCOM_VID_PID` gets the primary
-# (LPCXpresso VCOM) fingerprint. Deprecated; update callers to consume
-# the plural form and drop this once no in-repo callers remain.
-ENVIRONMENT_TO_VCOM_VID_PID: dict[str, tuple[int, int]] = {
-    env: pids[0] for env, pids in ENVIRONMENT_TO_VCOM_VID_PIDS.items()
-}
-
 
 def environment_has_wifi(environment: str) -> bool:
     """Check if a PlatformIO environment has WiFi hardware."""
@@ -177,7 +110,6 @@ def auto_detect_upload_port(
     expected_environment: str | None,
     *,
     expected_serial_number: str | None = None,
-    require_unique_match: bool = False,
 ) -> ComportResult:
     """Auto-detect the upload port from available serial ports.
 
@@ -195,8 +127,6 @@ def auto_detect_upload_port(
         expected_environment: Board environment used for strict fingerprinting.
         expected_serial_number: Optional stable USB identity that a matching
             board must retain across re-enumeration.
-        require_unique_match: Reject fingerprint detection when multiple ports
-            match instead of silently selecting the first one.
 
     Returns:
         ComportResult with detection status and diagnostics
@@ -249,75 +179,6 @@ def auto_detect_upload_port(
         )
 
     expected_env = expected_environment.lower() if expected_environment else None
-
-    # VID:PID-based detection takes precedence over chip-probe and description
-    # heuristics. For boards whose VCOM bridges have well-known IDs (LPC845-BRK
-    # via LPC11U35 or LPC-Link2 CMSIS-DAP, see FastLED #3300), this is the only
-    # reliable signal on Windows where multiple boards report a generic "USB
-    # Serial Device" name. An environment may map to more than one accepted
-    # VID:PID (e.g. LPC845-BRK boards ship with either LPCXpresso VCOM
-    # firmware 16C0:0483 or LPC-Link2 CMSIS-DAP firmware 1FC9:0132 on the
-    # debug probe) — the first port matching ANY of the entry's pairs wins.
-    expected_vid_pids = (
-        ENVIRONMENT_TO_VCOM_VID_PIDS.get(expected_env) if expected_env else None
-    )
-    if expected_vid_pids:
-        accepted = set(expected_vid_pids)
-        matching_ports = [
-            port
-            for port in usb_ports
-            if (port.vid, port.pid) in accepted
-            and (
-                expected_serial_number is None
-                or port.serial_number == expected_serial_number
-            )
-        ]
-        if require_unique_match and len(matching_ports) > 1:
-            devices = ", ".join(port.device for port in matching_ports)
-            return ComportResult(
-                ok=False,
-                selected_port=None,
-                error_message=(
-                    f"Multiple USB serial ports match '{expected_environment}' "
-                    f"({devices}); pass --upload-port to select the deployed board."
-                ),
-                all_ports=all_ports,
-            )
-        if matching_ports:
-            return ComportResult(
-                ok=True,
-                selected_port=matching_ports[0].device,
-                error_message=None,
-                all_ports=all_ports,
-            )
-        # Fingerprint expected but no port matched. Don't fall through to the
-        # ESP probe — the wrong port will fail later with PermissionError or
-        # silent timeout. Report explicitly so the user can plug the board in.
-        formatted_expected = " or ".join(
-            f"{vid:04X}:{pid:04X}" for vid, pid in expected_vid_pids
-        )
-        return ComportResult(
-            ok=False,
-            selected_port=None,
-            error_message=(
-                f"No USB serial port matched expected VCOM fingerprint for "
-                f"'{expected_environment}' (VID:PID {formatted_expected}"
-                + (
-                    f", serial {expected_serial_number}"
-                    if expected_serial_number
-                    else ""
-                )
-                + "). "
-                f"Detected USB ports: "
-                + ", ".join(
-                    f"{p.device}={p.vid:04X}:{p.pid:04X}"
-                    if p.vid and p.pid
-                    else f"{p.device}=----:----"
-                    for p in usb_ports
-                )
-            ),
-            all_ports=all_ports,
-        )
 
     esp_environments = {env.lower() for env in CHIP_TO_ENVIRONMENT.values()}
     if expected_env in esp_environments:

--- a/ci/util/serial_probe.py
+++ b/ci/util/serial_probe.py
@@ -46,51 +46,6 @@ import serial  # type: ignore[import-not-found]
 import serial.tools.list_ports  # type: ignore[import-not-found]
 
 
-# Known board USB VID:PID fingerprints — display/diagnostic hints only.
-#
-# FROZEN — DO NOT ADD ENTRIES. USB VID:PID identity is owned by
-# https://github.com/FastLED/boards and reaches this repo through fbuild's
-# ingestion of the published `usb-vids.proto.zstd` archive; `fbuild port scan`
-# is the authority for naming an attached board. This table is never a
-# selection authority — it only labels ports that have already been chosen.
-#
-# A board that cannot be identified is a FastLED/boards gap: add the record
-# there, let fbuild ingest it, then cascade the `fbuild==X.Y.Z` pin in
-# pyproject.toml and relock locally. Full procedure:
-# agents/docs/usb-vid-pid-registry.md.
-BOARD_FINGERPRINTS: dict[tuple[int, int], str] = {
-    # NXP LPC845-BRK ships with an LPC11U35 carrying both the CMSIS-DAP
-    # debug interface AND a USB-VCOM bridge for the LPC845's USART0.
-    (0x1FC9, 0x0132): "NXP CMSIS-DAP debug (LPC845-BRK / LPC11U35)",
-    # 16C0:0483 is shared between the LPC11U35 VCOM bridge (when used on
-    # LPC845-BRK) and PJRC Teensy USB-Serial. Disambiguation requires
-    # additional signal — e.g. presence of a sibling CMSIS-DAP port for
-    # LPC, or `manufacturer.startswith("Teensyduino")` for PJRC. The
-    # fingerprint table only carries the joint hint; callers that need
-    # to act on the difference must inspect `manufacturer` / `serial_number`
-    # or the companion-port heuristic in `find_lpc845brk_vcom`.
-    (
-        0x16C0,
-        0x0483,
-    ): "LPC11U35 VCOM bridge (LPC845-BRK USART0) OR PJRC Teensy USB-Serial",
-    # Espressif native USB CDC across ESP32-S3/C3/C6/H2/P4 variants.
-    (0x303A, 0x1001): "Espressif native USB CDC (ESP32-S3/C3/C6/H2/P4)",
-    # CP2102 from Silicon Labs — common on ESP32-WROOM dev kits.
-    (0x10C4, 0xEA60): "Silicon Labs CP2102 USB-UART (ESP32 dev kit)",
-    # CH340/CH341 from WCH — common on cheaper ESP32/Arduino clones.
-    (0x1A86, 0x7523): "WCH CH340 USB-Serial",
-    (0x1A86, 0x55D4): "WCH CH343 USB-Serial",
-    # FTDI FT232R — older Arduinos, some shields.
-    (0x0403, 0x6001): "FTDI FT232R USB-UART",
-    (0x0403, 0x6010): "FTDI FT2232 dual UART",
-    # Only literal here not yet resolvable from FastLED/boards --
-    # tracked as FastLED/boards#60. Remove once the registry publishes it.
-    (0x0403, 0x6014): "FTDI FT232H USB-UART",
-    # Teensy 3.x/4.x.
-    (0x16C0, 0x0486): "PJRC / Teensy USB-Serial (alt)",
-}
-
-
 @dataclass(frozen=True)
 class PortInfo:
     device: str
@@ -105,18 +60,10 @@ class PortInfo:
     def vid_pid(self) -> tuple[int, int] | None:
         return (self.vid, self.pid) if (self.vid and self.pid) else None
 
-    @property
-    def board_hint(self) -> str | None:
-        vp = self.vid_pid
-        if vp is None:
-            return None
-        return BOARD_FINGERPRINTS.get(vp)
-
     def format(self) -> str:
         vp = f"{self.vid:04X}:{self.pid:04X}" if self.vid and self.pid else "----:----"
-        hint = f"  [{self.board_hint}]" if self.board_hint else ""
         ser = f"  ser={self.serial_number}" if self.serial_number else ""
-        return f"{self.device:8s}  {vp}{ser}  {self.description}{hint}"
+        return f"{self.device:8s}  {vp}{ser}  {self.description}"
 
 
 def list_ports() -> list[PortInfo]:

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -24,6 +24,11 @@ namespace {
         static time_provider_t provider;
         return provider;
     }
+
+    fl::function<fl::u64()>& get_micros64_time_provider() {
+        static fl::function<fl::u64()> provider;
+        return provider;
+    }
 }
 
 void inject_time_provider(const time_provider_t& provider) {
@@ -34,6 +39,16 @@ void inject_time_provider(const time_provider_t& provider) {
 void clear_time_provider() {
     fl::unique_lock<fl::mutex> lock(get_time_mutex());
     get_time_provider() = time_provider_t{}; // Clear the function
+}
+
+void inject_micros64_time_provider(const fl::function<fl::u64()>& provider) {
+    fl::unique_lock<fl::mutex> lock(get_time_mutex());
+    get_micros64_time_provider() = provider;
+}
+
+void clear_micros64_time_provider() {
+    fl::unique_lock<fl::mutex> lock(get_time_mutex());
+    get_micros64_time_provider() = fl::function<fl::u64()>{};
 }
 
 // MockTimeProvider implementation
@@ -80,6 +95,38 @@ fl::u32 millis() {
 fl::u32 micros() {
     // Note: micros() does not support time injection
     return fl::platforms::micros();
+}
+
+fl::u64 micros64() {
+#ifdef FASTLED_TESTING
+    {
+        fl::unique_lock<fl::mutex> lock(get_time_mutex());
+        const auto& provider = get_micros64_time_provider();
+        if (provider) {
+            return provider();
+        }
+    }
+#endif
+
+    struct Micros64State {
+        fl::u64 accumulated = 0;
+        fl::u32 last_micros = 0;
+        bool initialized = false;
+        fl::mutex mutex;
+    };
+    static Micros64State state;
+
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    const fl::u32 current = fl::micros();
+    if (!state.initialized) {
+        state.accumulated = current;
+        state.last_micros = current;
+        state.initialized = true;
+        return state.accumulated;
+    }
+    state.accumulated += static_cast<fl::u32>(current - state.last_micros);
+    state.last_micros = current;
+    return state.accumulated;
 }
 
 namespace {

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -14,51 +14,64 @@ namespace fl {
 #ifdef FASTLED_TESTING
 
 namespace {
-    // Thread-safe storage for injected time provider
-    fl::mutex& get_time_mutex() {
-        static fl::mutex mutex;
-        return mutex;
-    }
+    struct TimeProviderState {
+        fl::mutex mutex;
+        time_provider_t provider;
+        fl::function<fl::u64()> micros64Provider;
+    };
 
-    time_provider_t& get_time_provider() {
-        static time_provider_t provider;
-        return provider;
-    }
-
-    fl::function<fl::u64()>& get_micros64_time_provider() {
-        static fl::function<fl::u64()> provider;
-        return provider;
+    TimeProviderState& get_time_provider_state() {
+        // millis() may be called by background threads and static destructors
+        // after ordinary function-local statics have been destroyed. Retain this
+        // one bounded state object for the process lifetime so both its mutex and
+        // installed provider remain valid throughout teardown.
+        static TimeProviderState* const state = new TimeProviderState(); // ok bare allocation - intentionally retained for safe process teardown
+        return *state;
     }
 
     bool get_injected_millis(fl::u32* value) {
-        fl::unique_lock<fl::mutex> lock(get_time_mutex());
-        const auto& provider = get_time_provider();
-        if (!provider) {
+        TimeProviderState& state = get_time_provider_state();
+        fl::unique_lock<fl::mutex> lock(state.mutex);
+        if (!state.provider) {
             return false;
         }
-        *value = provider();
+        *value = state.provider();
+        return true;
+    }
+
+    bool get_injected_micros64(fl::u64* value) {
+        TimeProviderState& state = get_time_provider_state();
+        fl::unique_lock<fl::mutex> lock(state.mutex);
+        if (!state.micros64Provider) {
+            return false;
+        }
+        *value = state.micros64Provider();
         return true;
     }
 }
 
 void inject_time_provider(const time_provider_t& provider) {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_time_provider() = provider;
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.provider = provider;
 }
 
 void clear_time_provider() {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_time_provider() = time_provider_t{}; // Clear the function
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.provider = time_provider_t{}; // Clear the function
 }
 
 void inject_micros64_time_provider(const fl::function<fl::u64()>& provider) {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_micros64_time_provider() = provider;
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.micros64Provider = provider;
 }
 
 void clear_micros64_time_provider() {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_micros64_time_provider() = fl::function<fl::u64()>{};
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.micros64Provider = fl::function<fl::u64()>{};
 }
 
 // MockTimeProvider implementation
@@ -111,12 +124,9 @@ fl::u32 micros() {
 
 fl::u64 micros64() {
 #ifdef FASTLED_TESTING
-    {
-        fl::unique_lock<fl::mutex> lock(get_time_mutex());
-        const auto& provider = get_micros64_time_provider();
-        if (provider) {
-            return provider();
-        }
+    fl::u64 injected_micros = 0;
+    if (get_injected_micros64(&injected_micros)) {
+        return injected_micros;
     }
     fl::u32 injected_millis = 0;
     if (get_injected_millis(&injected_millis)) {

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -20,7 +20,7 @@ namespace {
         fl::function<fl::u64()> micros64Provider;
     };
 
-    TimeProviderState& get_time_provider_state() {
+    TimeProviderState& get_time_provider_state() FL_NO_EXCEPT {
         // millis() may be called by background threads and static destructors
         // after ordinary function-local statics have been destroyed. Retain this
         // one bounded state object for the process lifetime so both its mutex and
@@ -29,7 +29,7 @@ namespace {
         return *state;
     }
 
-    bool get_injected_millis(fl::u32* value) {
+    bool get_injected_millis(fl::u32* value) FL_NO_EXCEPT {
         TimeProviderState& state = get_time_provider_state();
         fl::unique_lock<fl::mutex> lock(state.mutex);
         if (!state.provider) {
@@ -39,7 +39,7 @@ namespace {
         return true;
     }
 
-    bool get_injected_micros64(fl::u64* value) {
+    bool get_injected_micros64(fl::u64* value) FL_NO_EXCEPT {
         TimeProviderState& state = get_time_provider_state();
         fl::unique_lock<fl::mutex> lock(state.mutex);
         if (!state.micros64Provider) {
@@ -62,13 +62,13 @@ void clear_time_provider() {
     state.provider = time_provider_t{}; // Clear the function
 }
 
-void inject_micros64_time_provider(const fl::function<fl::u64()>& provider) {
+void inject_micros64_time_provider(const fl::function<fl::u64()>& provider) FL_NO_EXCEPT {
     TimeProviderState& state = get_time_provider_state();
     fl::unique_lock<fl::mutex> lock(state.mutex);
     state.micros64Provider = provider;
 }
 
-void clear_micros64_time_provider() {
+void clear_micros64_time_provider() FL_NO_EXCEPT {
     TimeProviderState& state = get_time_provider_state();
     fl::unique_lock<fl::mutex> lock(state.mutex);
     state.micros64Provider = fl::function<fl::u64()>{};
@@ -122,7 +122,7 @@ fl::u32 micros() {
     return fl::platforms::micros();
 }
 
-fl::u64 micros64() {
+fl::u64 micros64() FL_NO_EXCEPT {
 #ifdef FASTLED_TESTING
     fl::u64 injected_micros = 0;
     if (get_injected_micros64(&injected_micros)) {

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -29,6 +29,16 @@ namespace {
         static fl::function<fl::u64()> provider;
         return provider;
     }
+
+    bool get_injected_millis(fl::u32* value) {
+        fl::unique_lock<fl::mutex> lock(get_time_mutex());
+        const auto& provider = get_time_provider();
+        if (!provider) {
+            return false;
+        }
+        *value = provider();
+        return true;
+    }
 }
 
 void inject_time_provider(const time_provider_t& provider) {
@@ -78,13 +88,9 @@ fl::u32 MockTimeProvider::operator()() const {
 
 fl::u32 millis() {
 #ifdef FASTLED_TESTING
-    // Check for injected time provider first
-    {
-        fl::unique_lock<fl::mutex> lock(get_time_mutex());
-        const auto& provider = get_time_provider();
-        if (provider) {
-            return provider();
-        }
+    fl::u32 injected_millis = 0;
+    if (get_injected_millis(&injected_millis)) {
+        return injected_millis;
     }
 #endif
 
@@ -93,7 +99,13 @@ fl::u32 millis() {
 }
 
 fl::u32 micros() {
-    // Note: micros() does not support time injection
+#ifdef FASTLED_TESTING
+    fl::u32 injected_millis = 0;
+    if (get_injected_millis(&injected_millis)) {
+        return injected_millis * 1000u;
+    }
+#endif
+
     return fl::platforms::micros();
 }
 
@@ -105,6 +117,10 @@ fl::u64 micros64() {
         if (provider) {
             return provider();
         }
+    }
+    fl::u32 injected_millis = 0;
+    if (get_injected_millis(&injected_millis)) {
+        return static_cast<fl::u64>(injected_millis) * 1000u;
     }
 #endif
 

--- a/src/fl/stl/chrono.h
+++ b/src/fl/stl/chrono.h
@@ -360,9 +360,9 @@ using time_provider_t = fl::function<fl::u32()>;
 
 /// Inject a custom time provider for testing
 ///
-/// This function allows unit tests to control the timing returned by fl::millis().
-/// Once injected, all calls to fl::millis() will use the provided function instead
-/// of the platform's native timing.
+/// This function allows unit tests to control the timing returned by fl::millis(),
+/// fl::micros(), and the FastLED chrono clocks. Once injected, all time views use
+/// the provided millisecond value instead of the platform's native timing.
 ///
 /// @param provider Function that returns the current time in milliseconds
 /// @note Only available in testing builds (when FASTLED_TESTING is defined)

--- a/src/fl/stl/chrono.h
+++ b/src/fl/stl/chrono.h
@@ -294,13 +294,19 @@ fl::u32 millis() FL_NO_EXCEPT;
 /// @endcode
 fl::u32 micros() FL_NO_EXCEPT;
 
-// Now that fl::micros() is declared, implement clock::now() methods
+/// 64-bit monotonic microsecond timer.
+///
+/// Extends the platform's 32-bit microsecond counter using unsigned elapsed
+/// deltas, so the returned value never wraps in practical use.
+fl::u64 micros64() FL_NO_EXCEPT;
+
+// Now that fl::micros64() is declared, implement clock::now() methods
 inline chrono::steady_clock::time_point chrono::steady_clock::now() FL_NO_EXCEPT {
-    return time_point(duration(static_cast<fl::i64>(fl::micros())));
+    return time_point(duration(static_cast<fl::i64>(fl::micros64())));
 }
 
 inline chrono::system_clock::time_point chrono::system_clock::now() FL_NO_EXCEPT {
-    return time_point(duration(static_cast<fl::i64>(fl::micros())));
+    return time_point(duration(static_cast<fl::i64>(fl::micros64())));
 }
 
 /// 64-bit millisecond timer - returns milliseconds since system startup without wraparound
@@ -385,6 +391,12 @@ void inject_time_provider(const time_provider_t& provider) FL_NO_EXCEPT;
 /// @note Thread-safe: Uses appropriate locking in multi-threaded environments
 /// @note Safe to call multiple times or when no provider is injected
 void clear_time_provider() FL_NO_EXCEPT;
+
+/// Inject a 64-bit microsecond source for deterministic clock tests.
+void inject_micros64_time_provider(const fl::function<fl::u64()>& provider) FL_NO_EXCEPT;
+
+/// Restore the platform-backed 64-bit microsecond source.
+void clear_micros64_time_provider() FL_NO_EXCEPT;
 
 /// Reset the millis64() internal state for testing
 ///

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -93,7 +93,7 @@ _FL_DEFPIN(23, 23, 1); _FL_DEFPIN(24,  1, 0); _FL_DEFPIN(25,  0, 0);
 #define HAS_HARDWARE_PIN_SUPPORT 1
 
 // Actual pin definitions
-#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
+#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ARDUINO_METRO_M4)
 
 // The Metro M4 Express and the Metro M4 AirLift Lite share a pinout apart from
 // A3 (pin 17), so both boards use this table.

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -184,6 +184,29 @@ FL_TEST_CASE("fl::inject_time_provider - injection and clearing") {
     }
 }
 
+FL_TEST_CASE("fl::inject_time_provider - controls all time views") {
+    MockTimeProvider mock(1234);
+    inject_time_provider([&mock]() { return mock(); });
+
+    FL_CHECK_EQ(fl::millis(), 1234);
+    FL_CHECK_EQ(fl::micros(), 1234000);
+    FL_CHECK_EQ(fl::chrono::steady_clock::now().time_since_epoch().count(),
+                1234000);
+    FL_CHECK_EQ(fl::chrono::system_clock::now().time_since_epoch().count(),
+                1234000);
+
+    mock.advance(5);
+
+    FL_CHECK_EQ(fl::millis(), 1239);
+    FL_CHECK_EQ(fl::micros(), 1239000);
+    FL_CHECK_EQ(fl::chrono::steady_clock::now().time_since_epoch().count(),
+                1239000);
+    FL_CHECK_EQ(fl::chrono::system_clock::now().time_since_epoch().count(),
+                1239000);
+
+    clear_time_provider();
+}
+
 FL_TEST_CASE("fl::time - timing scenarios with mock") {
     FL_SUBCASE("animation timing simulation") {
         MockTimeProvider mock(0);

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -55,6 +55,24 @@ FL_TEST_CASE("fl::time - basic functionality") {
 
 #ifdef FASTLED_TESTING
 
+FL_TEST_CASE("fl::chrono clocks remain monotonic across micros rollover") {
+    fl::u64 now_us = 0xFFFFFFF0ULL;
+    fl::inject_micros64_time_provider([&now_us]() { return now_us; });
+
+    const auto steady_before = fl::chrono::steady_clock::now();
+    const auto system_before = fl::chrono::system_clock::now();
+    now_us += 0x20;
+    const auto steady_after = fl::chrono::steady_clock::now();
+    const auto system_after = fl::chrono::system_clock::now();
+
+    FL_CHECK(steady_after > steady_before);
+    FL_CHECK(system_after > system_before);
+    FL_CHECK_EQ((steady_after - steady_before).count(), 0x20);
+    FL_CHECK_EQ((system_after - system_before).count(), 0x20);
+
+    fl::clear_micros64_time_provider();
+}
+
 FL_TEST_CASE("fl::MockTimeProvider - basic functionality") {
     FL_SUBCASE("constructor with initial time") {
         MockTimeProvider mock(1000);

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -5,9 +5,28 @@
 #include "fl/stl/move.h"
 #include "fl/stl/int.h"
 
+#include <atomic>  // okay std namespace - host-only concurrency regression
+#include <thread>  // ok include - host-only concurrency regression
+
 FL_TEST_FILE(FL_FILEPATH) {
 
 using namespace fl;
+
+#ifdef FASTLED_TESTING
+namespace {
+
+// Constructed before main and destroyed after function-local time-provider
+// state. Calling millis() here exercises the process-teardown access pattern
+// that originally attempted to lock an already-destroyed mutex.
+struct LateMillisCaller {
+    ~LateMillisCaller() { sink = fl::millis(); }
+    volatile fl::u32 sink = 0;
+};
+
+LateMillisCaller gLateMillisCaller;
+
+} // namespace
+#endif
 
 FL_TEST_CASE("fl::time - basic functionality") {
     FL_SUBCASE("time returns non-zero values") {
@@ -205,6 +224,39 @@ FL_TEST_CASE("fl::inject_time_provider - controls all time views") {
                 1239000);
 
     clear_time_provider();
+}
+
+FL_TEST_CASE("fl::time provider remains valid during concurrent replacement") {
+    constexpr int iterations = 2000;
+    std::atomic<bool> start{false}; // okay std namespace
+    std::atomic<bool> invalid{false}; // okay std namespace
+
+    inject_time_provider([]() { return 0x11111111u; });
+
+    std::thread reader([&]() { // okay std namespace
+        while (!start.load()) {
+            std::this_thread::yield(); // okay std namespace
+        }
+        for (int i = 0; i < iterations; ++i) {
+            const fl::u32 value = fl::millis();
+            if (value != 0x11111111u && value != 0x22222222u) {
+                invalid.store(true);
+            }
+        }
+    });
+
+    start.store(true);
+    for (int i = 0; i < iterations; ++i) {
+        if ((i & 1) == 0) {
+            inject_time_provider([]() { return 0x22222222u; });
+        } else {
+            inject_time_provider([]() { return 0x11111111u; });
+        }
+    }
+
+    reader.join();
+    clear_time_provider();
+    FL_CHECK_FALSE(invalid.load());
 }
 
 FL_TEST_CASE("fl::time - timing scenarios with mock") {


### PR DESCRIPTION
## Summary

This combines eight independently implemented and reviewed fixes:

- extend microsecond time across 32-bit rollover for monotonic chrono clocks
- unify injected millis, micros, steady_clock, and system_clock test time
- keep the injected time-provider state alive through static teardown
- add exact VID:PID lookup support to the USB registry audit tool
- retire the legacy local USB VID/PID and board fingerprint tables
- fail closed when RP deploy does not return an unambiguous application port
- recognize the canonical ARDUINO_METRO_M4 macro for the Metro M4 pin table
- propagate asset-declared embedded filesystem defines into generated builds

## Validation

- bash lint
- bash test --cpp: 369/369 unit and example targets passed
- bash test fastled_core --debug: passed with sanitizers
- targeted chrono, USB registry, AutoResearch, asset define, and SAMD detection tests passed
- broad Python suite: 1068 passed, 41 skipped; two unrelated local infrastructure failures reproduced under verbose rerun (ESP32 QEMU fixture missing setup/loop and native WASM launcher missing the cctype toolchain header)
- independent combined-diff review found no concrete issues and verified all eight issue outcomes

Closes #3993
Closes #3994
Closes #3995
Closes #3996
Closes #3997
Closes #3998
Closes #4004
Closes #4020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact VID:PID lookup for published USB board identities, reporting whether a match is found.
  * Added 64-bit microsecond timing with improved monotonic behavior across timer rollovers.
  * Added support for Metro M4 board pin mapping.
  * Embedded filesystem build settings are now applied automatically when required by sketches.

* **Bug Fixes**
  * Improved deployment and port handling with clearer failure reporting.

* **Documentation**
  * Updated USB registry and hardware bring-up guidance for the current workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->