### PR TITLE
fix(ci): add exact USB registry lookup (#3996)

### DIFF
--- a/agents/docs/hardware-autoresearch.md
+++ b/agents/docs/hardware-autoresearch.md
@@ -145,9 +145,11 @@ driver:
 
 1. Run `fbuild port scan` and record the board identity, VID/PID, serial number,
    and port. Do not claim a board is absent without this scan. If the scan cannot
-   name the board, the identity is missing from
-   [FastLED/boards](https://github.com/FastLED/boards) — fix it there and cascade
-   the fbuild bump; never add the literal to `ci/`. See
+   name the board, check the published registry with
+   `uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>`. If that
+   reports the pair missing, fix it in
+   [FastLED/boards](https://github.com/FastLED/boards) and cascade the fbuild
+   bump; never add the literal to `ci/`. See
    [usb-vid-pid-registry.md](usb-vid-pid-registry.md).
 2. Confirm the board has an entry in `ci/boards.py` or can be detected by the
    AutoResearch/fbuild path. If the deploy backend is missing, file the gap in

--- a/agents/docs/usb-vid-pid-registry.md
+++ b/agents/docs/usb-vid-pid-registry.md
@@ -138,7 +138,15 @@ uv run python ci/util/audit_usb_registry.py
 
 It fetches the live artifact, decodes it, and reports which audited literals
 resolve. A cold or stale cache is indistinguishable from a missing record, so
-always check the published payload rather than a failed port scan.
+always check the published payload rather than a failed port scan. To check an
+observed pair directly, run:
+
+```bash
+uv run python ci/util/audit_usb_registry.py --lookup <VID:PID>
+```
+
+The lookup exits 0 and names the vendor/product when published, or exits 1 and
+reports `MISSING` when the exact pair is absent.
 
 Two lists in that script carry the state. `AUDITED_LITERALS` is the checklist —
 it should shrink to empty as literals are retired. `KNOWN_GAPS` holds gaps

--- a/ci/tests/test_audit_usb_registry.py
+++ b/ci/tests/test_audit_usb_registry.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from ci.util import audit_usb_registry
+
+
+REGISTRY = {
+    0x1234: ("Example Vendor", {0x5678: "Example Product"}),
+}
+
+
+def test_lookup_resolves_published_pair(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(audit_usb_registry, "fetch_artifact", lambda: b"registry")
+    monkeypatch.setattr(audit_usb_registry, "decode_registry", lambda raw: REGISTRY)
+
+    assert audit_usb_registry.main(["--lookup", "1234:5678"]) == 0
+    assert (
+        "FOUND 1234:5678  Example Vendor / Example Product" in capsys.readouterr().out
+    )
+
+
+def test_lookup_fails_for_absent_pair(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(audit_usb_registry, "fetch_artifact", lambda: b"registry")
+    monkeypatch.setattr(audit_usb_registry, "decode_registry", lambda raw: REGISTRY)
+
+    assert audit_usb_registry.main(["--lookup", "1234:9999"]) == 1
+    assert "MISSING 1234:9999" in capsys.readouterr().out
+
+
+def test_registry_docs_use_exact_lookup_command() -> None:
+    expected = "audit_usb_registry.py --lookup <VID:PID>"
+    doc_paths = (
+        Path("agents/docs/hardware-autoresearch.md"),
+        Path("agents/docs/usb-vid-pid-registry.md"),
+    )
+
+    for doc_path in doc_paths:
+        assert expected in doc_path.read_text()

--- a/ci/util/audit_usb_registry.py
+++ b/ci/util/audit_usb_registry.py
@@ -12,10 +12,11 @@ than trusted. It fetches the published artifact, decodes it, and reports which
 of the literals still present in `ci/` resolve from the registry.
 
     uv run python ci/util/audit_usb_registry.py
+    uv run python ci/util/audit_usb_registry.py --lookup 1234:5678
 
 Exit codes:
-    0 — every audited literal resolves, ignoring the gaps in KNOWN_GAPS
-    1 — an unfiled literal is missing, or a KNOWN_GAPS entry went stale
+    0 — every audited literal resolves, or the requested pair resolves
+    1 — an audited literal/requested pair is missing, or a known gap is stale
     2 — the artifact could not be fetched or decoded
 
 Exit 0 while a filed gap is outstanding is deliberate: it makes this safe to
@@ -29,6 +30,7 @@ FastLED/boards#60.
 
 from __future__ import annotations
 
+import argparse
 import sys
 import urllib.request
 from typing import Iterator, NamedTuple
@@ -212,7 +214,30 @@ def fetch_artifact(url: str = ARTIFACT_URL) -> bytes:
     )
 
 
-def main() -> int:
+def _vid_pid(value: str) -> tuple[int, int]:
+    """Parse a four-digit hexadecimal VID:PID command-line value."""
+    parts = value.split(":")
+    if len(parts) != 2 or any(len(part) != 4 for part in parts):
+        raise argparse.ArgumentTypeError("expected VID:PID as four hex digits each")
+    try:
+        vid, pid = (int(part, 16) for part in parts)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected VID:PID as four hex digits each"
+        ) from exc
+    return vid, pid
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lookup",
+        type=_vid_pid,
+        metavar="VID:PID",
+        help="check whether one exact hexadecimal VID:PID pair is published",
+    )
+    args = parser.parse_args(argv)
+
     try:
         raw = fetch_artifact()
         registry = decode_registry(raw)
@@ -227,6 +252,18 @@ def main() -> int:
     vendor_count = len(registry)
     product_count = sum(len(products) for _, products in registry.values())
     print(f"FastLED/boards registry: {vendor_count} vendors, {product_count} products")
+
+    if args.lookup is not None:
+        vid, pid = args.lookup
+        pair = f"{vid:04X}:{pid:04X}"
+        vendor = registry.get(vid)
+        if vendor is None or pid not in vendor[1]:
+            print(f"MISSING {pair} from FastLED/boards")
+            return 1
+        vendor_name, products = vendor
+        print(f"FOUND {pair}  {vendor_name} / {products[pid]}")
+        return 0
+
     print(f"Auditing {len(AUDITED_LITERALS)} literals from ci/\n")
 
     new_gaps: list[Literal] = []


### PR DESCRIPTION
## Summary

- add exact VID:PID lookup mode to audit_usb_registry.py
- return clear success and absent-pair results
- update registry documentation to use the implemented command

## Validation

- focused audit USB registry tests passed
- lint passed

Closes #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lookup mode for checking individual USB vendor/product identifiers.
  * Results now clearly indicate whether an identifier is published or missing, with an appropriate status code.

* **Documentation**
  * Updated hardware bring-up guidance with the new lookup workflow.
  * Documented lookup usage and result behavior.

* **Tests**
  * Added coverage for successful lookups, missing identifiers, and documented command usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->