### PR TITLE
fix(samd51): recognize Metro M4 board alias (#4004)

### DIFF
--- a/ci/tests/test_samd_platform_detection.py
+++ b/ci/tests/test_samd_platform_detection.py
@@ -103,6 +103,22 @@ def _defined_macros(flags: list[str], header: str) -> set[str]:
     return macros
 
 
+def _preprocessed_header(flags: list[str], header: str) -> str:
+    """Preprocess a real FastLED header with the supplied board flags."""
+    cmd = [_compiler(), "-E", "-x", "c++", f"-I{SRC}", *flags, "-"]
+    proc = RunningProcess.run(
+        cmd,
+        input=f'#include "{header}"\n',
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+    )
+    assert proc.returncode == 0, f"preprocessing failed:\n{proc.stderr}"
+    return proc.stdout
+
+
 HEADER = "platforms/arm/samd/is_samd.h"
 
 
@@ -154,6 +170,25 @@ def test_non_samd_build_is_not_detected_as_samd() -> None:
     assert "FL_IS_SAMD" not in macros
     assert "FL_IS_SAMD21" not in macros
     assert "FL_IS_SAMD51" not in macros
+
+
+def test_arduino_metro_m4_board_macro_selects_d6_fastpin() -> None:
+    """#4004: Arduino's board macro must select the Metro M4 pin table.
+
+    ``ARDUINO_METRO_M4`` comes from ``build.board=METRO_M4`` in Adafruit
+    SAMD 1.7.17. D6 is PB15 in that release's ``variants/metro_m4`` table.
+    """
+    output = _preprocessed_header(
+        ["-DARDUINO_METRO_M4", "-D__SAMD51J19A__"],
+        "platforms/arm/d51/fastpin_arm_d51.h",
+    )
+    specialization = (
+        "template<> class FastPin<6> : public _ARMPIN<6, 15, 1ul << 15, 1> {}"
+    )
+    assert specialization in output, (
+        "ARDUINO_METRO_M4 did not select the Metro M4 table; FastPin<6> will "
+        "remain invalid instead of mapping to D6/PB15"
+    )
 
 
 def test_samd_does_not_route_into_the_arduino_spi_backend() -> None:

--- a/src/platforms/arm/d51/fastpin_arm_d51.h
+++ b/src/platforms/arm/d51/fastpin_arm_d51.h
@@ -93,7 +93,7 @@ _FL_DEFPIN(23, 23, 1); _FL_DEFPIN(24,  1, 0); _FL_DEFPIN(25,  0, 0);
 #define HAS_HARDWARE_PIN_SUPPORT 1
 
 // Actual pin definitions
-#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS)
+#elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ARDUINO_METRO_M4)
 
 // The Metro M4 Express and the Metro M4 AirLift Lite share a pinout apart from
 // A3 (pin 17), so both boards use this table.


### PR DESCRIPTION
## Summary

- recognize the canonical ARDUINO_METRO_M4 board macro
- select the existing vendor-verified Metro M4 pin table
- add a preprocessing regression contract for D6 mapping to PB15

## Validation

- SAMD platform detection tests passed
- lint passed
- the Metro M4 compile selected the correct target; upstream ARM toolchain download then returned HTTP 404 before firmware compilation

Closes #4004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hardware pin mapping for Arduino Metro M4 boards.
  * Ensured pin 6 correctly maps to the expected microcontroller pin.
  * Applied the appropriate Metro M4 SPI configuration for this board target.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->