### PR TITLE
fix(compiler): apply asset build defines (#4020)

### DIFF
--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -530,11 +530,9 @@ def embedded_fs_defines(scan: AssetScanResult) -> list[str]:
     `platforms/embedded_fs.h` -- so on the platform people actually use for
     LittleFS, an asset declaring `storage=littlefs` already works.
 
-    Nothing applies these yet: build defines are assembled per-board in
-    `ci/boards.py`, and this is per-sketch. Applying them would also currently
-    break the ESP8266 builds it targets, because that backend cannot compile
-    until FastLED/fbuild#1380 ships the core's littlefs submodule. Tracked in
-    FastLED#4020.
+    ``copy_example_source`` carries these per-sketch requirements into the
+    generated compile configuration. fbuild#1380 supplies the ESP8266 core's
+    LittleFS submodule, so opting into that backend is now safe.
     """
     return ["FL_ESP8266_EMBEDDED_FS"] if scan.embedded_fs_assets() else []
 
@@ -547,12 +545,9 @@ def announce_storage_requirements(scan: AssetScanResult) -> None:
     prints, in green, which assets asked for it and where that requirement is
     already met.
 
-    It does not claim the build enabled anything. ESP32 genuinely is automatic
-    -- `platforms/embedded_fs.h` selects LittleFS with no flag -- but ESP8266
-    still needs `FL_ESP8266_EMBEDDED_FS`, and `embedded_fs_defines` is not yet
-    consumed by any build layer (FastLED#4020). Saying "enabled automatically"
-    on ESP8266 would report work that did not happen, which is worse than
-    saying nothing: the user would stop looking.
+    ESP32 is automatic -- `platforms/embedded_fs.h` selects LittleFS with no
+    flag -- while ESP8266 receives `FL_ESP8266_EMBEDDED_FS` through the staged
+    example's build requirements.
 
     Green because it is neither a warning nor an error. An unrecognised target
     is the yellow case -- a typo like `littleFS` would otherwise behave exactly

--- a/ci/compiler/compiler.py
+++ b/ci/compiler/compiler.py
@@ -7,7 +7,7 @@ Defines the interface that all FastLED compiler implementations must follow.
 
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -24,6 +24,8 @@ class CompilerResult:
 @dataclass
 class InitResult(CompilerResult):
     """Result from compiler initialization."""
+
+    sketch_build_defines: list[str] = field(default_factory=list)
 
     @property
     def platformio_ini(self) -> Path:

--- a/ci/compiler/pio.py
+++ b/ci/compiler/pio.py
@@ -48,6 +48,7 @@ from ci.compiler.package_manager import (
 )
 from ci.compiler.path_manager import FastLEDPaths, resolve_project_root
 from ci.compiler.source_manager import (
+    CopyExampleResult,
     copy_boards_directory,
     copy_example_source,
     copy_fastled_library,
@@ -96,6 +97,43 @@ def _probe_root_platformio_build_flags(
             f"Warning: failed to probe root platformio.ini for env '{board_name}': {e}"
         )
         return []
+
+
+def _update_generated_build_defines(
+    platformio_ini_path: Path,
+    board_name: str,
+    previous_defines: list[str],
+    copy_result: CopyExampleResult,
+) -> None:
+    """Replace per-sketch defines in an already-generated compile config."""
+    from ci.compiler.platformio_ini import PlatformIOIni
+
+    platformio_ini = PlatformIOIni.parseFile(platformio_ini_path)
+    section = platformio_ini.config[f"env:{board_name}"]
+    previous_flags = {f"-D{define}" for define in previous_defines}
+    build_flags: list[str] = []
+    for raw_flag in section.get("build_flags", "").splitlines():
+        flag = raw_flag.strip()
+        if flag and flag not in previous_flags:
+            build_flags.append(flag)
+    for define in copy_result.build_defines:
+        flag = f"-D{define}"
+        if flag not in build_flags:
+            build_flags.append(flag)
+    section["build_flags"] = "\n" + "\n".join(build_flags)
+    platformio_ini.dump(platformio_ini_path)
+
+
+def _owned_sketch_build_defines(
+    discovered_defines: list[str], persistent_defines: list[str] | None
+) -> list[str]:
+    """Return asset defines that the compiler may remove on sketch changes."""
+    persistent = set(persistent_defines or [])
+    owned: list[str] = []
+    for define in discovered_defines:
+        if define not in persistent:
+            owned.append(define)
+    return owned
 
 
 def _init_platformio_build(
@@ -242,32 +280,36 @@ def _init_platformio_build(
                 f"(see #3274 / #3278 / #3279)."
             )
 
+    # Stage first because asset declarations contribute per-sketch build defines.
+    print(create_building_banner(example))
+    copy_result = copy_example_source(project_root, build_dir, example)
+    if not copy_result.success:
+        error_msg = get_example_error_message(project_root, example)
+        warnings.warn(error_msg)
+        return InitResult(
+            success=False,
+            output=error_msg,
+            build_dir=build_dir,
+        )
+
+    merged_defines = list(additional_defines or [])
+    merged_defines.extend(
+        define for define in copy_result.build_defines if define not in merged_defines
+    )
+
     # Apply board-specific configuration
     if not apply_board_specific_config(
         board_with_sketch_include,
         platformio_ini,
         example,
         paths,
-        additional_defines,
+        merged_defines,
         merged_include_dirs,
         additional_libs,
     ):
         return InitResult(
             success=False,
             output=f"Failed to apply board configuration for {board.board_name}",
-            build_dir=build_dir,
-        )
-
-    # Print building banner first
-    print(create_building_banner(example))
-
-    ok_copy_src = copy_example_source(project_root, build_dir, example)
-    if not ok_copy_src:
-        error_msg = get_example_error_message(project_root, example)
-        warnings.warn(error_msg)
-        return InitResult(
-            success=False,
-            output=error_msg,
             build_dir=build_dir,
         )
 
@@ -329,7 +371,12 @@ def _init_platformio_build(
                 print(ini_content)
                 print("=" * 60)
                 print()
-        return InitResult(success=True, output="", build_dir=build_dir)
+        return InitResult(
+            success=True,
+            output="",
+            build_dir=build_dir,
+            sketch_build_defines=copy_result.build_defines,
+        )
 
     # Run initial build with LDF enabled to set up the environment
     run_cmd: list[str] = ["pio", "run", "--project-dir", str(build_dir)]
@@ -387,7 +434,12 @@ def _init_platformio_build(
     # Pass example name to generate example-specific build_info_{example}.json
     generate_build_info_json_from_existing_build(build_dir, board, example)
 
-    return InitResult(success=True, output="", build_dir=build_dir)
+    return InitResult(
+        success=True,
+        output="",
+        build_dir=build_dir,
+        sketch_build_defines=copy_result.build_defines,
+    )
 
 
 def init_fbuild_project(
@@ -465,6 +517,7 @@ class PioCompiler(Compiler):
         # No per-board lock needed
 
         self.initialized = False
+        self._sketch_build_defines: list[str] = []
         self.executor = ThreadPoolExecutor(max_workers=1)
 
     def _internal_init_build_no_lock(self, example: str) -> InitResult:
@@ -487,6 +540,10 @@ class PioCompiler(Compiler):
             use_fbuild=self.use_fbuild,
         )
         if result.success:
+            self._sketch_build_defines = _owned_sketch_build_defines(
+                result.sketch_build_defines,
+                self.additional_defines,
+            )
             self.initialized = True
         return result
 
@@ -851,8 +908,8 @@ class PioCompiler(Compiler):
             # Copy example source for subsequent examples
             if self.initialized:
                 project_root = resolve_project_root()
-                ok_copy_src = copy_example_source(project_root, self.build_dir, example)
-                if not ok_copy_src:
+                copy_result = copy_example_source(project_root, self.build_dir, example)
+                if not copy_result.success:
                     error_msg = get_example_error_message(project_root, example)
                     result = SketchResult(
                         success=False,
@@ -864,6 +921,16 @@ class PioCompiler(Compiler):
                     future.set_result(result)
                     futures.append(future)
                     continue
+                _update_generated_build_defines(
+                    self.build_dir / "platformio.ini",
+                    self.board.board_name,
+                    self._sketch_build_defines,
+                    copy_result,
+                )
+                self._sketch_build_defines = _owned_sketch_build_defines(
+                    copy_result.build_defines,
+                    self.additional_defines,
+                )
 
             # Run fbuild on main thread — Ctrl+C works directly
             result = self._build_with_fbuild(example)
@@ -884,8 +951,8 @@ class PioCompiler(Compiler):
 
         # Copy example source to build directory
         project_root = resolve_project_root()
-        ok_copy_src = copy_example_source(project_root, self.build_dir, example)
-        if not ok_copy_src:
+        copy_result = copy_example_source(project_root, self.build_dir, example)
+        if not copy_result.success:
             error_msg = get_example_error_message(project_root, example)
             return SketchResult(
                 success=False,
@@ -893,6 +960,16 @@ class PioCompiler(Compiler):
                 build_dir=self.build_dir,
                 example=example,
             )
+        _update_generated_build_defines(
+            self.build_dir / "platformio.ini",
+            self.board.board_name,
+            self._sketch_build_defines,
+            copy_result,
+        )
+        self._sketch_build_defines = _owned_sketch_build_defines(
+            copy_result.build_defines,
+            self.additional_defines,
+        )
 
         # Cache configuration is handled through build flags during initialization
 

--- a/ci/compiler/source_manager.py
+++ b/ci/compiler/source_manager.py
@@ -6,13 +6,30 @@ import shutil
 import sys
 import time
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 
+from typeguard import typechecked
+
+from ci.compiler.asset_scanner import (
+    announce_storage_requirements,
+    embedded_fs_defines,
+    scan_sketch_assets,
+)
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
 _GENERATED_EXAMPLE_DIRS = frozenset({".build", ".fbuild", ".pio", "fastled_js"})
 _GENERATED_EXAMPLE_FILES = frozenset({"compile_commands.json"})
+
+
+@typechecked
+@dataclass
+class CopyExampleResult:
+    """Result of staging an example and discovering its build requirements."""
+
+    success: bool
+    build_defines: list[str]
 
 
 def _scandir_sync(
@@ -181,7 +198,9 @@ __attribute__((weak)) int main() {{
     return main_cpp_content
 
 
-def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bool:
+def copy_example_source(
+    project_root: Path, build_dir: Path, example: str
+) -> CopyExampleResult:
     """Copy example source to the build directory with sketch subdirectory structure.
 
     Args:
@@ -190,7 +209,7 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
         example: Name of the example to copy, or path to example directory
 
     Returns:
-        True if successful, False if example not found
+        Staging status and preprocessor defines required by the example.
     """
     # Configure example source - handle both names and paths
     example_path = Path(example)
@@ -198,12 +217,12 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     if example_path.is_absolute():
         # Absolute path - use as-is
         if not example_path.exists():
-            return False
+            return CopyExampleResult(success=False, build_defines=[])
     else:
         # Relative path (including nested paths like Fx/FxWave2d) - resolve to examples directory
         example_path = project_root / "examples" / example
         if not example_path.exists():
-            return False
+            return CopyExampleResult(success=False, build_defines=[])
 
     # Create src and sketch directories (PlatformIO requirement with sketch subdirectory)
     src_dir = build_dir / "src"
@@ -284,17 +303,14 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     # leaving the user to discover it -- see announce_storage_requirements.
     # The example directory is scanned, not the copy: identical content, and it
     # is the path the user recognises if something is misdeclared.
-    from ci.compiler.asset_scanner import (
-        announce_storage_requirements,
-        scan_sketch_assets,
-    )
-
     # Not wrapped in a broad except: a storage declaration is build
     # configuration, and a build that cannot read it should say so rather than
     # continue as if the sketch had declared nothing. Malformed individual
     # `.lnk` files are already non-fatal -- scan_sketch_assets collects those as
     # warnings -- so reaching an exception here means something genuinely wrong.
-    announce_storage_requirements(scan_sketch_assets(example_path))
+    asset_scan = scan_sketch_assets(example_path)
+    announce_storage_requirements(asset_scan)
+    build_defines = embedded_fs_defines(asset_scan)
 
     # Create or update stub main.cpp that includes the .ino files
     main_cpp_content = generate_main_cpp(ino_files)
@@ -313,7 +329,7 @@ def copy_example_source(project_root: Path, build_dir: Path, example: str) -> bo
     if should_write:
         main_cpp_path.write_text(main_cpp_content, encoding="utf-8")
 
-    return True
+    return CopyExampleResult(success=True, build_defines=build_defines)
 
 
 def copy_boards_directory(project_root: Path, build_dir: Path) -> bool:

--- a/ci/tests/test_embedded_fs_build_defines.py
+++ b/ci/tests/test_embedded_fs_build_defines.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+from ci.boards import create_board
+from ci.compiler.compiler import InitResult
+from ci.compiler.path_manager import FastLEDPaths
+from ci.compiler.pio import PioCompiler, init_fbuild_project
+
+
+@pytest.mark.parametrize(
+    ("storage_declaration", "expects_define"),
+    [("storage=littlefs\n", True), ("", False)],
+)
+def test_asset_requirement_reaches_generated_compile_configuration(
+    tmp_path: Path, storage_declaration: str, expects_define: bool
+) -> None:
+    example_dir = tmp_path / "example"
+    example_dir.mkdir()
+    (example_dir / "Example.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    (example_dir / "data").mkdir()
+    (example_dir / "data" / "asset.rgb.lnk").write_text(
+        f"https://example.com/asset.rgb\n{storage_declaration}"
+    )
+    build_dir = tmp_path / "build"
+    paths = FastLEDPaths("esp8266", project_root=tmp_path)
+    paths.home_dir = tmp_path / "home"
+    paths.fastled_root = paths.home_dir / ".fastled"
+    paths._global_platformio_cache_dir = tmp_path / "pio-cache"
+
+    result = init_fbuild_project(
+        board=create_board("esp8266"),
+        verbose=False,
+        example=str(example_dir),
+        paths=paths,
+        build_dir=build_dir,
+    )
+
+    assert result.success
+    generated_ini = (build_dir / "platformio.ini").read_text()
+    assert ("-DFL_ESP8266_EMBEDDED_FS" in generated_ini) is expects_define
+
+
+@pytest.mark.parametrize(
+    ("additional_defines", "expected_managed"),
+    [([], ["FL_ESP8266_EMBEDDED_FS"]), (["FL_ESP8266_EMBEDDED_FS"], [])],
+)
+def test_compiler_seeds_owned_defines_from_first_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    additional_defines: list[str],
+    expected_managed: list[str],
+) -> None:
+    compiler = object.__new__(PioCompiler)
+    compiler.initialized = False
+    compiler.board = create_board("esp8266")
+    compiler.verbose = False
+    compiler.paths = FastLEDPaths("esp8266", project_root=tmp_path)
+    compiler.build_dir = tmp_path / "build"
+    compiler.additional_defines = additional_defines
+    compiler.additional_include_dirs = None
+    compiler.additional_libs = None
+    compiler.use_fbuild = True
+    compiler._sketch_build_defines = []
+
+    monkeypatch.setattr(
+        "ci.compiler.pio._init_platformio_build",
+        lambda *_args, **_kwargs: InitResult(
+            success=True,
+            output="",
+            build_dir=compiler.build_dir,
+            sketch_build_defines=["FL_ESP8266_EMBEDDED_FS"],
+        ),
+    )
+
+    result = compiler._internal_init_build_no_lock("Assets")
+
+    assert result.success
+    assert compiler._sketch_build_defines == expected_managed

--- a/ci/tests/test_root_platformio_sever.py
+++ b/ci/tests/test_root_platformio_sever.py
@@ -98,7 +98,13 @@ class TestRootPlatformioSever(unittest.TestCase):
             mock.patch.object(
                 pio_module, "apply_board_specific_config", side_effect=fake_apply
             ),
-            mock.patch.object(pio_module, "copy_example_source", return_value=True),
+            mock.patch.object(
+                pio_module,
+                "copy_example_source",
+                return_value=pio_module.CopyExampleResult(
+                    success=True, build_defines=[]
+                ),
+            ),
             mock.patch.object(pio_module, "copy_fastled_library", return_value=True),
             mock.patch.object(pio_module, "copy_boards_directory", return_value=True),
         ):

--- a/ci/tests/test_source_manager.py
+++ b/ci/tests/test_source_manager.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from ci.compiler.source_manager import copy_example_source
+from ci.compiler.source_manager import CopyExampleResult, copy_example_source
 
 
 @pytest.mark.parametrize("generated_dir", [".build", ".fbuild", ".pio", "fastled_js"])
@@ -19,7 +19,9 @@ def test_copy_example_source_skips_generated_directories(
 
     build_dir = tmp_path / "output"
     build_dir.mkdir()
-    assert copy_example_source(project_root, build_dir, "Blink")
+    result = copy_example_source(project_root, build_dir, "Blink")
+    assert result.success
+    assert result.build_defines == []
 
     staged_sketch = build_dir / "src" / "sketch"
     assert (staged_sketch / "Blink.ino").is_file()
@@ -35,8 +37,29 @@ def test_copy_example_source_skips_generated_files(tmp_path: Path) -> None:
 
     build_dir = tmp_path / "output"
     build_dir.mkdir()
-    assert copy_example_source(project_root, build_dir, "Blink")
+    assert copy_example_source(project_root, build_dir, "Blink").success
 
     staged_sketch = build_dir / "src" / "sketch"
     assert (staged_sketch / "Blink.ino").is_file()
     assert not (staged_sketch / "compile_commands.json").exists()
+
+
+def test_copy_example_source_returns_embedded_fs_build_requirements(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    example_dir = project_root / "examples" / "Assets"
+    example_dir.mkdir(parents=True)
+    (example_dir / "Assets.ino").write_text("void setup() {}\nvoid loop() {}\n")
+    (example_dir / "data").mkdir()
+    (example_dir / "data" / "video.rgb.lnk").write_text(
+        "https://example.com/video.rgb\nstorage=littlefs\n"
+    )
+
+    build_dir = tmp_path / "output"
+    build_dir.mkdir()
+    result = copy_example_source(project_root, build_dir, "Assets")
+
+    assert isinstance(result, CopyExampleResult)
+    assert result.success
+    assert result.build_defines == ["FL_ESP8266_EMBEDDED_FS"]


### PR DESCRIPTION
## Summary

- carry asset-declared build defines through CopyExampleResult
- apply embedded filesystem defines to generated compile configuration
- preserve the defines on subsequent configuration generation paths

## Validation

- 51 focused tests passed
- lint passed
- ESP8266 compile confirmed the generated embedded filesystem define

Closes #4020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded filesystem settings are now automatically applied to per-sketch builds.
  * ESP8266 projects using LittleFS receive the required build configuration automatically.
  * Build staging now reports both success status and detected build settings.

* **Bug Fixes**
  * Prevented build settings from one sketch from carrying over to another.

* **Tests**
  * Added coverage for LittleFS configuration and per-sketch build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->