### PR TITLE
fix(chrono): prevent microsecond clock rollover (#3993)

### DIFF
--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -95,6 +95,53 @@ fl::u32 micros() {
 }
 
 namespace {
+    struct Micros64State {
+        fl::u64 accumulated = 0;
+        fl::u32 last_micros = 0;
+        bool initialized = false;
+        fl::mutex mutex;
+    };
+
+    Micros64State& get_micros64_state() FL_NO_EXCEPT {
+        static Micros64State state;
+        return state;
+    }
+}
+
+#if FL_CHRONO_HAS_TEST_TIME_PROVIDER
+void micros64_reset() FL_NO_EXCEPT {
+    Micros64State& state = get_micros64_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.accumulated = 0;
+    state.last_micros = 0;
+    state.initialized = false;
+}
+#endif
+
+fl::u64 micros64() FL_NO_EXCEPT {
+    Micros64State& state = get_micros64_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    const fl::u32 current = fl::micros();
+    if (!state.initialized) {
+        state.accumulated = current;
+        state.last_micros = current;
+        state.initialized = true;
+        return state.accumulated;
+    }
+    state.accumulated += static_cast<fl::u32>(current - state.last_micros);
+    state.last_micros = current;
+    return state.accumulated;
+}
+
+chrono::steady_clock::time_point chrono::steady_clock::now() FL_NO_EXCEPT {
+    return time_point(duration(static_cast<fl::i64>(fl::micros64())));
+}
+
+chrono::system_clock::time_point chrono::system_clock::now() FL_NO_EXCEPT {
+    return time_point(duration(static_cast<fl::i64>(fl::micros64())));
+}
+
+namespace {
     // Thread-safe 64-bit millisecond counter state
     struct Millis64State {
         fl::u64 accumulated = 0;

--- a/src/fl/stl/chrono.h
+++ b/src/fl/stl/chrono.h
@@ -178,13 +178,13 @@ private:
     Duration mDuration;
 };
 
-// Forward declarations for clock types (now() implemented after fl::micros() declaration)
+// Forward declarations for clock types (now() is implemented in chrono.cpp.hpp)
 struct steady_clock;  // IWYU pragma: keep
 struct system_clock;  // IWYU pragma: keep
 
 /// @brief Monotonic clock that never goes backwards
 ///
-/// Uses fl::micros() as the underlying time source, providing microsecond
+/// Uses fl::micros64() as the underlying time source, providing microsecond
 /// resolution across all FastLED platforms.
 struct steady_clock {
     using duration = microseconds;
@@ -193,14 +193,14 @@ struct steady_clock {
     using time_point = fl::chrono::time_point<steady_clock>;
     static constexpr bool is_steady = true;
 
-    /// Returns the current time point (implemented after fl::micros() declaration)
+    /// Returns the current time point.
     static time_point now() FL_NO_EXCEPT;
 };
 
 /// @brief Wall clock (may not be monotonic)
 ///
 /// On embedded platforms this behaves identically to steady_clock since
-/// there is no real-time clock available. Uses fl::micros() as the
+/// there is no real-time clock available. Uses fl::micros64() as the
 /// underlying time source.
 struct system_clock {
     using duration = microseconds;
@@ -209,7 +209,7 @@ struct system_clock {
     using time_point = fl::chrono::time_point<system_clock>;
     static constexpr bool is_steady = false;
 
-    /// Returns the current time point (implemented after fl::micros() declaration)
+    /// Returns the current time point.
     static time_point now() FL_NO_EXCEPT;
 };
 
@@ -297,14 +297,11 @@ fl::u32 millis() FL_NO_EXCEPT;
 /// @endcode
 fl::u32 micros() FL_NO_EXCEPT;
 
-// Now that fl::micros() is declared, implement clock::now() methods
-inline chrono::steady_clock::time_point chrono::steady_clock::now() FL_NO_EXCEPT {
-    return time_point(duration(static_cast<fl::i64>(fl::micros())));
-}
-
-inline chrono::system_clock::time_point chrono::system_clock::now() FL_NO_EXCEPT {
-    return time_point(duration(static_cast<fl::i64>(fl::micros())));
-}
+/// 64-bit monotonic microsecond timer.
+///
+/// Extends the platform's 32-bit microsecond counter using unsigned elapsed
+/// deltas, so the returned value never wraps in practical use.
+fl::u64 micros64() FL_NO_EXCEPT;
 
 /// 64-bit millisecond timer - returns milliseconds since system startup without wraparound
 ///
@@ -388,6 +385,9 @@ void inject_time_provider(const time_provider_t& provider) FL_NO_EXCEPT;
 /// @note Thread-safe: Uses appropriate locking in multi-threaded environments
 /// @note Safe to call multiple times or when no provider is injected
 void clear_time_provider() FL_NO_EXCEPT;
+
+/// Reset the micros64() rollover extender for deterministic clock tests.
+void micros64_reset() FL_NO_EXCEPT;
 
 /// Reset the millis64() internal state for testing
 ///

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -55,6 +55,26 @@ FL_TEST_CASE("fl::time - basic functionality") {
 
 #ifdef FASTLED_TESTING
 
+FL_TEST_CASE("fl::chrono clocks remain monotonic across micros rollover") {
+    MockTimeProvider mock(0xFFFFFFFFu / 1000u);
+    inject_time_provider([&mock]() { return mock(); });
+    micros64_reset();
+
+    const auto steady_before = fl::chrono::steady_clock::now();
+    const auto system_before = fl::chrono::system_clock::now();
+    mock.advance(1);
+    const auto steady_after = fl::chrono::steady_clock::now();
+    const auto system_after = fl::chrono::system_clock::now();
+
+    FL_CHECK(steady_after > steady_before);
+    FL_CHECK(system_after > system_before);
+    FL_CHECK_EQ((steady_after - steady_before).count(), 1000);
+    FL_CHECK_EQ((system_after - system_before).count(), 1000);
+
+    clear_time_provider();
+    micros64_reset();
+}
+
 FL_TEST_CASE("fl::MockTimeProvider - basic functionality") {
     FL_SUBCASE("constructor with initial time") {
         MockTimeProvider mock(1000);


### PR DESCRIPTION
## Summary

- add a monotonic 64-bit microsecond counter over the platform 32-bit source
- route steady_clock and system_clock through the extended counter
- add rollover regression coverage and deterministic microsecond injection

## Validation

- actual AST-backed noexcept lint passed
- bash test fl_stl_chrono --debug passed under sanitizers
- git diff --check passed

Closes #3993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 64-bit microsecond timer for long-term monotonic timing.
  * Updated steady and system clocks to use the extended timer.

* **Bug Fixes**
  * Prevented clock values from moving backward when the underlying timer rolls over.

* **Tests**
  * Added coverage for monotonic clock behavior across timer rollover boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->