### PR TITLE
fix(chrono): unify injected test clocks (#3994)

### DIFF
--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -25,7 +25,7 @@ namespace {
         return provider;
     }
 
-    bool get_injected_millis(fl::u32* value) {
+    bool get_injected_millis(fl::u32* value) FL_NO_EXCEPT {
         fl::unique_lock<fl::mutex> lock(get_time_mutex());
         const auto& provider = get_time_provider();
         if (!provider) {
@@ -72,7 +72,7 @@ fl::u32 MockTimeProvider::operator()() const {
 ///////////////////// PUBLIC API //////////////////////////////////////
 
 fl::u32 millis() {
-#ifdef FASTLED_TESTING
+#if FL_CHRONO_HAS_TEST_TIME_PROVIDER
     fl::u32 injected_millis = 0;
     if (get_injected_millis(&injected_millis)) {
         return injected_millis;
@@ -84,7 +84,7 @@ fl::u32 millis() {
 }
 
 fl::u32 micros() {
-#ifdef FASTLED_TESTING
+#if FL_CHRONO_HAS_TEST_TIME_PROVIDER
     fl::u32 injected_millis = 0;
     if (get_injected_millis(&injected_millis)) {
         return injected_millis * 1000u;

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -24,6 +24,16 @@ namespace {
         static time_provider_t provider;
         return provider;
     }
+
+    bool get_injected_millis(fl::u32* value) {
+        fl::unique_lock<fl::mutex> lock(get_time_mutex());
+        const auto& provider = get_time_provider();
+        if (!provider) {
+            return false;
+        }
+        *value = provider();
+        return true;
+    }
 }
 
 void inject_time_provider(const time_provider_t& provider) {
@@ -63,13 +73,9 @@ fl::u32 MockTimeProvider::operator()() const {
 
 fl::u32 millis() {
 #ifdef FASTLED_TESTING
-    // Check for injected time provider first
-    {
-        fl::unique_lock<fl::mutex> lock(get_time_mutex());
-        const auto& provider = get_time_provider();
-        if (provider) {
-            return provider();
-        }
+    fl::u32 injected_millis = 0;
+    if (get_injected_millis(&injected_millis)) {
+        return injected_millis;
     }
 #endif
 
@@ -78,7 +84,13 @@ fl::u32 millis() {
 }
 
 fl::u32 micros() {
-    // Note: micros() does not support time injection
+#ifdef FASTLED_TESTING
+    fl::u32 injected_millis = 0;
+    if (get_injected_millis(&injected_millis)) {
+        return injected_millis * 1000u;
+    }
+#endif
+
     return fl::platforms::micros();
 }
 

--- a/src/fl/stl/chrono.h
+++ b/src/fl/stl/chrono.h
@@ -11,8 +11,11 @@
 #include "fl/stl/ratio.h"
 
 #ifdef FASTLED_TESTING
+#define FL_CHRONO_HAS_TEST_TIME_PROVIDER 1
 #include "fl/stl/function.h"
 #include "fl/stl/noexcept.h"
+#else
+#define FL_CHRONO_HAS_TEST_TIME_PROVIDER 0
 #endif
 
 namespace fl {

--- a/src/fl/stl/chrono.h
+++ b/src/fl/stl/chrono.h
@@ -354,9 +354,9 @@ using time_provider_t = fl::function<fl::u32()>;
 
 /// Inject a custom time provider for testing
 ///
-/// This function allows unit tests to control the timing returned by fl::millis().
-/// Once injected, all calls to fl::millis() will use the provided function instead
-/// of the platform's native timing.
+/// This function allows unit tests to control the timing returned by fl::millis(),
+/// fl::micros(), and the FastLED chrono clocks. Once injected, all time views use
+/// the provided millisecond value instead of the platform's native timing.
 ///
 /// @param provider Function that returns the current time in milliseconds
 /// @note Only available in testing builds (when FASTLED_TESTING is defined)

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -166,6 +166,29 @@ FL_TEST_CASE("fl::inject_time_provider - injection and clearing") {
     }
 }
 
+FL_TEST_CASE("fl::inject_time_provider - controls all time views") {
+    MockTimeProvider mock(1234);
+    inject_time_provider([&mock]() { return mock(); });
+
+    FL_CHECK_EQ(fl::millis(), 1234);
+    FL_CHECK_EQ(fl::micros(), 1234000);
+    FL_CHECK_EQ(fl::chrono::steady_clock::now().time_since_epoch().count(),
+                1234000);
+    FL_CHECK_EQ(fl::chrono::system_clock::now().time_since_epoch().count(),
+                1234000);
+
+    mock.advance(5);
+
+    FL_CHECK_EQ(fl::millis(), 1239);
+    FL_CHECK_EQ(fl::micros(), 1239000);
+    FL_CHECK_EQ(fl::chrono::steady_clock::now().time_since_epoch().count(),
+                1239000);
+    FL_CHECK_EQ(fl::chrono::system_clock::now().time_since_epoch().count(),
+                1239000);
+
+    clear_time_provider();
+}
+
 FL_TEST_CASE("fl::time - timing scenarios with mock") {
     FL_SUBCASE("animation timing simulation") {
         MockTimeProvider mock(0);


### PR DESCRIPTION
## Summary

- make the injected millisecond provider drive millis and micros
- ensure the FastLED chrono clocks observe the same injected time
- add regression coverage for unified deterministic time

## Validation

- actual AST-backed noexcept lint passed
- bash test fl_stl_chrono --debug passed under sanitizers
- git diff --check passed

Closes #3994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency for injected test-time values across millisecond, microsecond, and chrono clock APIs.
  - Ensured microsecond readings correctly reflect injected millisecond values.
  - Ensured time-based APIs remain synchronized when mock time advances.

- **Documentation**
  - Clarified that injected time values control supported timing and chrono APIs during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->