### PR TITLE
fix: keep test time provider alive through teardown (#3995)

### DIFF
--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -14,36 +14,41 @@ namespace fl {
 #ifdef FASTLED_TESTING
 
 namespace {
-    // Thread-safe storage for injected time provider
-    fl::mutex& get_time_mutex() {
-        static fl::mutex mutex;
-        return mutex;
-    }
+    struct TimeProviderState {
+        fl::mutex mutex;
+        time_provider_t provider;
+    };
 
-    time_provider_t& get_time_provider() {
-        static time_provider_t provider;
-        return provider;
+    TimeProviderState& get_time_provider_state() {
+        // millis() may be called by background threads and static destructors
+        // after ordinary function-local statics have been destroyed. Retain this
+        // one bounded state object for the process lifetime so both its mutex and
+        // installed provider remain valid throughout teardown.
+        static TimeProviderState* const state = new TimeProviderState(); // ok bare allocation - intentionally retained for safe process teardown
+        return *state;
     }
 
     bool get_injected_millis(fl::u32* value) FL_NO_EXCEPT {
-        fl::unique_lock<fl::mutex> lock(get_time_mutex());
-        const auto& provider = get_time_provider();
-        if (!provider) {
+        TimeProviderState& state = get_time_provider_state();
+        fl::unique_lock<fl::mutex> lock(state.mutex);
+        if (!state.provider) {
             return false;
         }
-        *value = provider();
+        *value = state.provider();
         return true;
     }
 }
 
 void inject_time_provider(const time_provider_t& provider) {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_time_provider() = provider;
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.provider = provider;
 }
 
 void clear_time_provider() {
-    fl::unique_lock<fl::mutex> lock(get_time_mutex());
-    get_time_provider() = time_provider_t{}; // Clear the function
+    TimeProviderState& state = get_time_provider_state();
+    fl::unique_lock<fl::mutex> lock(state.mutex);
+    state.provider = time_provider_t{}; // Clear the function
 }
 
 // MockTimeProvider implementation

--- a/src/fl/stl/chrono.cpp.hpp
+++ b/src/fl/stl/chrono.cpp.hpp
@@ -19,7 +19,7 @@ namespace {
         time_provider_t provider;
     };
 
-    TimeProviderState& get_time_provider_state() {
+    TimeProviderState& get_time_provider_state() FL_NO_EXCEPT {
         // millis() may be called by background threads and static destructors
         // after ordinary function-local statics have been destroyed. Retain this
         // one bounded state object for the process lifetime so both its mutex and

--- a/tests/fl/stl/chrono.cpp
+++ b/tests/fl/stl/chrono.cpp
@@ -5,9 +5,28 @@
 #include "fl/stl/move.h"
 #include "fl/stl/int.h"
 
+#include <atomic>  // okay std namespace - host-only concurrency regression
+#include <thread>  // ok include - host-only concurrency regression
+
 FL_TEST_FILE(FL_FILEPATH) {
 
 using namespace fl;
+
+#ifdef FASTLED_TESTING
+namespace {
+
+// Constructed before main and destroyed after function-local time-provider
+// state. Calling millis() here exercises the process-teardown access pattern
+// that originally attempted to lock an already-destroyed mutex.
+struct LateMillisCaller {
+    ~LateMillisCaller() { sink = fl::millis(); }
+    volatile fl::u32 sink = 0;
+};
+
+LateMillisCaller gLateMillisCaller;
+
+} // namespace
+#endif
 
 FL_TEST_CASE("fl::time - basic functionality") {
     FL_SUBCASE("time returns non-zero values") {
@@ -207,6 +226,39 @@ FL_TEST_CASE("fl::inject_time_provider - controls all time views") {
                 1239000);
 
     clear_time_provider();
+}
+
+FL_TEST_CASE("fl::time provider remains valid during concurrent replacement") {
+    constexpr int iterations = 2000;
+    std::atomic<bool> start{false}; // okay std namespace
+    std::atomic<bool> invalid{false}; // okay std namespace
+
+    inject_time_provider([]() { return 0x11111111u; });
+
+    std::thread reader([&]() { // okay std namespace
+        while (!start.load()) {
+            std::this_thread::yield(); // okay std namespace
+        }
+        for (int i = 0; i < iterations; ++i) {
+            const fl::u32 value = fl::millis();
+            if (value != 0x11111111u && value != 0x22222222u) {
+                invalid.store(true);
+            }
+        }
+    });
+
+    start.store(true);
+    for (int i = 0; i < iterations; ++i) {
+        if ((i & 1) == 0) {
+            inject_time_provider([]() { return 0x22222222u; });
+        } else {
+            inject_time_provider([]() { return 0x11111111u; });
+        }
+    }
+
+    reader.join();
+    clear_time_provider();
+    FL_CHECK_FALSE(invalid.load());
 }
 
 FL_TEST_CASE("fl::time - timing scenarios with mock") {


### PR DESCRIPTION
## Summary

- retain the test time-provider state for process lifetime
- keep its mutex and provider valid during static destruction and concurrent access
- add late-static and concurrent replacement regression coverage

## Validation

- reproduced the teardown abort before the fix
- actual AST-backed noexcept lint passed
- bash test fl_stl_chrono --debug passed under sanitizers
- git diff --check passed

Closes #3995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-provider reliability during application shutdown.
  * Prevented potential failures when reading time while the provider is being replaced concurrently.

* **Tests**
  * Added coverage for concurrent time-provider access and replacement.
  * Added shutdown-focused regression coverage for late time reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->