### PR TITLE
fix(ci): label ESP32-S3 build shards clearly

### DIFF
--- a/.github/workflows/build_esp32s3.yml
+++ b/.github/workflows/build_esp32s3.yml
@@ -46,6 +46,7 @@ on:
 
 jobs:
   build:
+    name: ESP32-S3 examples shard ${{ matrix.shard_index }} (8 total)
     # Hard-block external-fork pull requests (no exceptions per #2757).
     # `github.event.pull_request == null` lets push / workflow_dispatch / etc.
     # pass; the equality clause only matches when the PR head repo IS the base.

--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -1,11 +1,26 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ci.compiler.argument_parser import CompilationArgumentParser
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_esp32s3_workflow_names_each_shard_explicitly() -> None:
+    workflow_path = ROOT / ".github/workflows/build_esp32s3.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    build_job = workflow["jobs"]["build"]
+
+    assert build_job["name"] == (
+        "ESP32-S3 examples shard ${{ matrix.shard_index }} (8 total)"
+    )
+    assert build_job["strategy"]["matrix"]["shard_index"] == list(range(8))
+    assert build_job["with"]["args"] == (
+        "esp32s3 all --shard-index ${{ matrix.shard_index }} --shard-count 8"
+    )
 
 
 def test_all_example_shards_are_disjoint_and_exhaustive() -> None:


### PR DESCRIPTION
## What

- Give each ESP32-S3 matrix job an explicit shard-aware check name.
- Lock the eight-way matrix and compiler arguments with a regression test.

## Why

The workflow intentionally partitions the all-example sweep into eight disjoint shards so each reusable build stays below its 45-minute limit. GitHub currently renders those jobs as generic `build (0)` through `build (7)` checks, which makes them look like accidental duplicate builds—especially when several issue branches are open at once.

This keeps full coverage while making the purpose of every check visible.

## Validation

- `uv run pytest -q ci/tests/test_compile_example_sharding.py` (6 passed)
- `bash lint`