### PR TITLE
fix(lpc): use LPC804 watchdog clock registers

### DIFF
--- a/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
@@ -17,9 +17,10 @@
 /// `platforms/watchdog.impl.cpp.hpp`).
 ///
 /// Uses the internal Watchdog Oscillator (WDOSC) — nominally 525 kHz after
-/// DIVSEL, divided by 4 inside the WWDT to give a ~131 kHz tick (we budget
-/// 125 kHz), so the 24-bit TC register lets us program timeouts from ~32 µs
-/// to ~134 s. The defaults in `begin()` clamp to a 1-second nominal window.
+/// DIVSEL, divided by 4 inside the WWDT to give a 131.25 kHz tick. LPC804's
+/// fixed 500 kHz LPOSC gives a 125 kHz WWDT tick. The 24-bit TC register lets
+/// us program timeouts from ~32 µs to ~134 s. The defaults in `begin()` clamp
+/// to a 1-second nominal window.
 ///
 /// **WDOSC accuracy:** the watchdog oscillator on LPC8xx is uncalibrated
 /// silicon and can drift ±40% across voltage/temperature corners (per
@@ -98,10 +99,14 @@ namespace platforms {
 namespace lpc_wwdt {
     // LPC845: WDOSC nominal tick after the WWDT-internal /4 prescaler. Per
     // UM11029 §4.6.7 Table 51, FREQSEL=0x2 selects a nominal 1.05 MHz
-    // source; DIVSEL=0x00 produces 525 kHz. LPC804 instead has a fixed
-    // 500 kHz LPOSC selected through LPOSCCLKEN (UM11065 §4.5.17). Both
-    // yield approximately 125 kHz after the WWDT prescaler.
+    // source; DIVSEL=0x00 produces 525 kHz, or 131.25 kHz after the WWDT
+    // prescaler. LPC804 instead has a fixed 500 kHz LPOSC selected through
+    // LPOSCCLKEN (UM11065 §4.5.17), yielding a 125 kHz WWDT tick.
+#if defined(FL_IS_ARM_LPC_845)
+    constexpr fl::u32 kTickHz = 131250u;
+#else
     constexpr fl::u32 kTickHz = 125000u;
+#endif
 #if defined(FL_IS_ARM_LPC_845)
     constexpr fl::u32 kWdtoscCtrl =
         SYSCON_WDTOSCCTRL_FREQSEL(0x2u) | SYSCON_WDTOSCCTRL_DIVSEL(0x00u);

--- a/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
@@ -96,17 +96,16 @@ namespace fl {
 namespace platforms {
 
 namespace lpc_wwdt {
-    // WDOSC nominal tick after the WWDT-internal /4 prescaler. Per
+    // LPC845: WDOSC nominal tick after the WWDT-internal /4 prescaler. Per
     // UM11029 §4.6.7 Table 51, FREQSEL=0x2 selects a nominal 1.05 MHz
-    // WDOSC source; with DIVSEL=0x00 the WDOSC output is 1.05/2 = 525 kHz
-    // and the WWDT-internal /4 brings the tick to ~131 kHz. We budget
-    // kTickHz at 125 kHz (4-5% conservative) so TC values overshoot
-    // slightly rather than undershoot, biasing the watchdog toward
-    // "fires a little late" rather than "fires while legit code runs."
-    // Either direction is within the ±40% silicon corner anyway.
+    // source; DIVSEL=0x00 produces 525 kHz. LPC804 instead has a fixed
+    // 500 kHz LPOSC selected through LPOSCCLKEN (UM11065 §4.5.17). Both
+    // yield approximately 125 kHz after the WWDT prescaler.
     constexpr fl::u32 kTickHz = 125000u;
+#if defined(FL_IS_ARM_LPC_845)
     constexpr fl::u32 kWdtoscCtrl =
         SYSCON_WDTOSCCTRL_FREQSEL(0x2u) | SYSCON_WDTOSCCTRL_DIVSEL(0x00u);
+#endif
 
     constexpr fl::u32 kModWden    = WWDT_MOD_WDEN_MASK;
     constexpr fl::u32 kModWdreset = WWDT_MOD_WDRESET_MASK;
@@ -159,15 +158,18 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
     if (timeout_ms > FL_WATCHDOG_MAX_TIMEOUT_MS) timeout_ms = FL_WATCHDOG_MAX_TIMEOUT_MS;
 
     // Power up the watchdog oscillator and turn on the WWDT AHB clock. The
-    // WDTOSC powerdown bit is *cleared* to enable (PDRUNCFG is an
+    // oscillator powerdown bit is *cleared* to enable (PDRUNCFG is an
     // active-low powerdown register).
-    SYSCON->PDRUNCFG      &= ~SYSCON_PDRUNCFG_WDTOSC_PD_MASK;
-    SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_WWDT_MASK;
-
-    // Set WDOSC frequency band. Per UM11029 §4.6 the WDOSC frequency is
-    // somewhere between the FREQSEL/DIVSEL nominal and a ±40% corner — we
-    // want a round number so the math here matches WWDT->TC units.
+    // LPC845 exposes a configurable WDOSC. LPC804's vendor PAL instead
+    // exposes the fixed LPOSC and a dedicated WWDT clock-enable bit.
+#if defined(FL_IS_ARM_LPC_845)
+    SYSCON->PDRUNCFG &= ~SYSCON_PDRUNCFG_WDTOSC_PD_MASK;
     SYSCON->WDTOSCCTRL = kWdtoscCtrl;
+#else
+    SYSCON->PDRUNCFG &= ~SYSCON_PDRUNCFG_LPOSC_PD_MASK;
+    SYSCON->LPOSCCLKEN |= SYSCON_LPOSCCLKEN_WDT_MASK;
+#endif
+    SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_WWDT_MASK;
 
     // TC is in WWDT ticks; we are at ~125 kHz after the internal /4. Round
     // up so we never timeout EARLY (timeout_ms is the maximum allowed

--- a/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
@@ -174,9 +174,9 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
 #endif
     SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_WWDT_MASK;
 
-    // TC is in WWDT ticks at the chip-specific divided oscillator rate. Round
-    // up so we never timeout EARLY (timeout_ms is the maximum allowed
-    // silence between feeds, undershooting it would crash live code).
+    // TC is in WWDT ticks at the chip-specific nominal oscillator rate. Round
+    // up so integer conversion does not shorten the nominal timeout. Actual
+    // timing remains subject to the oscillator tolerance documented above.
     // 64-bit intermediate: timeout_ms * kTickHz overflows u32 above
     // ~34.3 s, and the cap is 60 s — a wrapped product would program a
     // much SHORTER window than requested (CodeRabbit finding, PR #3550).
@@ -188,8 +188,8 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
 
 #if FL_LPC_WATCHDOG_NMI_BACKTRACE
     // Warning threshold: fire the WDT interrupt when the counter reaches
-    // the 10-bit maximum (1023 ticks ≈ 8 ms at 125 kHz) so the NMI hook
-    // below gets a window to print the wedged PC before the hard reset.
+    // the 10-bit maximum (nominally ~7.8 ms on LPC845 and ~4.1 ms on LPC804)
+    // so the NMI hook gets a window to print the wedged PC before hard reset.
     WWDT->WARNINT = WWDT_WARNINT_WARNINT_MASK;
 #endif
 

--- a/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
+++ b/src/platforms/arm/lpc/watchdog_lpc.impl.hpp
@@ -16,22 +16,21 @@
 /// different SYSCON layouts; they fall through to the no-op backend (see
 /// `platforms/watchdog.impl.cpp.hpp`).
 ///
-/// Uses the internal Watchdog Oscillator (WDOSC) — nominally 525 kHz after
-/// DIVSEL, divided by 4 inside the WWDT to give a 131.25 kHz tick. LPC804's
-/// fixed 500 kHz LPOSC gives a 125 kHz WWDT tick. The 24-bit TC register lets
-/// us program timeouts from ~32 µs to ~134 s. The defaults in `begin()` clamp
-/// to a 1-second nominal window.
+/// LPC845 uses the internal Watchdog Oscillator (WDOSC) — nominally 525 kHz
+/// after DIVSEL, divided by 4 inside the WWDT to give a 131.25 kHz tick.
+/// LPC804's fixed 1 MHz LPOSC gives a 250 kHz WWDT tick. The 24-bit TC register
+/// allows nominal windows up to ~128 s on LPC845 and ~67 s on LPC804;
+/// `begin()` caps the requested timeout at 60 s.
 ///
-/// **WDOSC accuracy:** the watchdog oscillator on LPC8xx is uncalibrated
-/// silicon and can drift ±40% across voltage/temperature corners (per
-/// UM11029 §4.6). That is fine for "panic reset after N seconds of hang" —
-/// the failure mode is "device reboots a bit early or late" — but is not
-/// a precision timer. Anyone needing accurate scheduling should NOT use
-/// this as a wakeup source.
+/// **Oscillator accuracy:** LPC845's WDOSC is uncalibrated silicon and can
+/// drift ±40% across voltage/temperature corners (UM11029 §4.6). LPC804's
+/// LPOSC is specified at 1 MHz ±3% (LPC804 data sheet, Table 17). This is fine
+/// for "panic reset after N seconds of hang" but is not a precision timer.
+/// Anyone needing accurate scheduling should NOT use this as a wakeup source.
 ///
 /// **Wedge backtrace (NMI warning hook):** `begin()` programs the WWDT
-/// warning threshold (WARNINT, 10-bit → fires ~8 ms before the reset at
-/// the 125 kHz tick) and routes the WDT interrupt line to the Cortex-M0+
+/// warning threshold (WARNINT, 10-bit → nominally ~7.8 ms before reset on
+/// LPC845 and ~4.1 ms on LPC804) and routes the WDT interrupt line to the Cortex-M0+
 /// NMI via `SYSCON->NMISRC`. The ACLPC startup file's `NMI_Handler` is a
 /// STRONG alias of `HardFault_Handler` (not overridable from here — a
 /// weak-alias upstreaming is possible later), and that shared handler
@@ -87,10 +86,9 @@ FL_IS_ARM_LPC_804 (LPC11xx/LPC15xx take the no-op backend)."
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 8
-// 24-bit TC at the divided WDOSC rate. Even at the slowest realistic
-// WDOSC corner (~280 kHz / 4 = 70 kHz tick) the TC ceiling is ~239 s;
-// at the nominal 125 kHz tick it is ~134 s. Cap at 60 s so we stay
-// comfortably inside the worst-case silicon corner.
+// 24-bit TC at the divided oscillator rate. At the nominal rates the TC
+// ceiling is ~128 s on LPC845 and ~67 s on LPC804. Cap at 60 s so both chips
+// remain below the register ceiling across their specified oscillator range.
 #define FL_WATCHDOG_MAX_TIMEOUT_MS 60000u
 
 namespace fl {
@@ -100,12 +98,12 @@ namespace lpc_wwdt {
     // LPC845: WDOSC nominal tick after the WWDT-internal /4 prescaler. Per
     // UM11029 §4.6.7 Table 51, FREQSEL=0x2 selects a nominal 1.05 MHz
     // source; DIVSEL=0x00 produces 525 kHz, or 131.25 kHz after the WWDT
-    // prescaler. LPC804 instead has a fixed 500 kHz LPOSC selected through
-    // LPOSCCLKEN (UM11065 §4.5.17), yielding a 125 kHz WWDT tick.
+    // prescaler. LPC804 instead has a fixed 1 MHz LPOSC selected through
+    // LPOSCCLKEN (UM11065 §4.5.17), yielding a 250 kHz WWDT tick.
 #if defined(FL_IS_ARM_LPC_845)
     constexpr fl::u32 kTickHz = 131250u;
 #else
-    constexpr fl::u32 kTickHz = 125000u;
+    constexpr fl::u32 kTickHz = 250000u;
 #endif
 #if defined(FL_IS_ARM_LPC_845)
     constexpr fl::u32 kWdtoscCtrl =
@@ -176,7 +174,7 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
 #endif
     SYSCON->SYSAHBCLKCTRL0 |= SYSCON_SYSAHBCLKCTRL0_WWDT_MASK;
 
-    // TC is in WWDT ticks; we are at ~125 kHz after the internal /4. Round
+    // TC is in WWDT ticks at the chip-specific divided oscillator rate. Round
     // up so we never timeout EARLY (timeout_ms is the maximum allowed
     // silence between feeds, undershooting it would crash live code).
     // 64-bit intermediate: timeout_ms * kTickHz overflows u32 above


### PR DESCRIPTION
## Summary

- preserve the LPC845 configurable watchdog oscillator path
- use LPC804's vendor-defined LPOSC power and watchdog clock-enable registers
- restore LPC804/LPCXpresso804 compilation without register shims

## Failure evidence

- repeated default-branch failure: https://github.com/FastLED/FastLED/actions/runs/33345693303
- compiler rejected LPC845-only `WDTOSCCTRL` symbols against the LPC804 CMSIS PAL

## Validation

- pinned LPC804 and LPC845 vendor headers reviewed against the exact framework commit
- `bash lint`
- `git diff --check`
- local board compile was blocked before compilation by an unrelated missing macOS ARM toolchain artifact; the Linux `lpcxpresso804` PR workflow is the required GREEN gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LPC804 watchdog timing to use the 1 MHz low-power oscillator and a 250 kHz watchdog tick.
  * Preserved LPC845 watchdog timing using its dedicated oscillator configuration.
  * Improved watchdog timeout calculations and clock setup across supported LPC devices.
  * Updated documented timeout limits, oscillator accuracy, warning intervals, and maximum timeout values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->