### PR TITLE
fix(esp32): default unsupported SPI channels to bit bang

### DIFF
--- a/src/fl/channels/bus.h
+++ b/src/fl/channels/bus.h
@@ -67,6 +67,10 @@ template<> struct DefaultBus<ClocklessChipset> {
 template<> struct DefaultBus<SpiChipsetConfig> {
     static constexpr Bus value = Bus::FLEX_IO;
 };
+#else
+template<> struct DefaultBus<SpiChipsetConfig> {
+    static constexpr Bus value = Bus::BIT_BANG;
+};
 #endif
 
 #elif defined(FL_IS_TEENSY_4X)

--- a/src/platforms/esp/32/core/fastled_esp32.h
+++ b/src/platforms/esp/32/core/fastled_esp32.h
@@ -15,6 +15,7 @@
 #include "platforms/esp/32/drivers/i2s_spi/bus_traits.h"
 #include "platforms/esp/32/drivers/lcd_spi/bus_traits.h"
 #include "platforms/esp/32/drivers/parlio/bus_traits.h"
+#include "platforms/shared/bitbang/bus_traits.h"
 // IWYU pragma: end_keep
 
 

--- a/src/platforms/esp/compile_test.hpp
+++ b/src/platforms/esp/compile_test.hpp
@@ -112,6 +112,13 @@ void esp32_compile_tests() {
 #error "FASTLED_HAS_MILLIS should be defined for ESP32"
 #endif
 
+// ESP32 variants without a true-SPI Channel driver must keep AUTO usable for
+// clocked chipsets through the portable GPIO fallback.
+#if defined(FL_IS_ESP_32C2) || defined(FL_IS_ESP_32C3) || defined(FL_IS_ESP_32S2)
+FL_STATIC_ASSERT(DefaultBus<SpiChipsetConfig>::value == Bus::BIT_BANG,
+                 "ESP32 variants without true-SPI Channel support must default to BIT_BANG");
+#endif
+
 // Check for ESP32 driver capabilities
 #if !defined(FASTLED_ESP32_HAS_RMT) && !defined(FASTLED_ESP32_HAS_CLOCKLESS_SPI)
 #warning "No clockless drivers defined - you may not be able to drive WS2812 and similar chipsets"


### PR DESCRIPTION
## Summary

- give ESP32-C2/C3/S2 a portable `BIT_BANG` default for clocked SPI chipsets
- expose the shared bit-bang bus traits through the ESP32 public aggregator
- add a platform compile-time assertion for the AUTO SPI contract

## Failure evidence

- repeated ESP32-C2 failure: https://github.com/FastLED/FastLED/actions/runs/33345692796
- the same incomplete `DefaultBus<SpiChipsetConfig>` signature repeated on ESP32-C3 and ESP32-S2

## Validation

- RED: `bash compile esp32c2 --examples Apa102` failed in `channel_typed.h`
- GREEN: the same ESP32-C2 command built firmware successfully (365.36 KB flash, 57.95 KB RAM)
- ESP32-C3 also reached a successful firmware build (457.05 KB flash, 71.66 KB RAM)
- `bash lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation for supported ESP32 variants that lack dedicated SPI channel drivers.
  * Added a reliable bit-banged GPIO fallback for clocked chipset communication on these targets.
  * Added compile-time validation to ensure the correct fallback is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->