### PR TITLE
fix(ci): pin SparkFun XRP Arduino-Pico framework

### DIFF
--- a/ci/boards.py
+++ b/ci/boards.py
@@ -764,6 +764,8 @@ SPARKFUN_XRP_CONTROLLER_2350B = Board(
     board_name="sparkfun_xrp_controller",
     platform="https://github.com/maxgerhardt/platform-raspberrypi",
     platform_needs_install=True,
+    platform_packages="framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip",
+    board_build_core="earlephilhower",
 )
 
 APOLLO3_RED_BOARD = Board(

--- a/ci/tests/test_board_to_platformio_ini.py
+++ b/ci/tests/test_board_to_platformio_ini.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ci.boards import Board
+from ci.boards import SPARKFUN_XRP_CONTROLLER_2350B, Board
 
 
 class TestBoardToPlatformioIni(unittest.TestCase):
@@ -55,6 +55,13 @@ class TestBoardToPlatformioIni(unittest.TestCase):
 
         self.assertEqual(ini.count("lib_deps ="), 1)
         self.assertIn("lib_deps = board-lib,extra-lib", ini)
+
+    def test_sparkfun_xrp_uses_supported_arduino_pico_framework(self) -> None:
+        ini = SPARKFUN_XRP_CONTROLLER_2350B.to_platformio_ini()
+
+        self.assertIn("framework-arduinopico", ini)
+        self.assertIn("rp2040-5.7.0.zip", ini)
+        self.assertIn("board_build.core = earlephilhower", ini)
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_board_to_platformio_ini.py
+++ b/ci/tests/test_board_to_platformio_ini.py
@@ -56,7 +56,9 @@ class TestBoardToPlatformioIni(unittest.TestCase):
         self.assertEqual(ini.count("lib_deps ="), 1)
         self.assertIn("lib_deps = board-lib,extra-lib", ini)
 
-    def test_sparkfun_xrp_uses_supported_arduino_pico_framework(self) -> None:
+    def test_sparkfun_xrp_uses_supported_arduino_pico_framework(
+        self: "TestBoardToPlatformioIni",
+    ) -> None:
         ini = SPARKFUN_XRP_CONTROLLER_2350B.to_platformio_ini()
 
         self.assertIn("framework-arduinopico", ini)


### PR DESCRIPTION
## Summary

- pin the SparkFun XRP controller to Arduino-Pico 5.7.0
- explicitly select the Earle Philhower core
- add regression coverage for the generated PlatformIO configuration

## Why

The stock RP2350 framework selected the bundled Adafruit TinyUSB library without selecting TinyUSB, failing with `#error TinyUSB is not selected`. The same 5.7.0 framework pin is already used by the repository’s canonical RP2350 board entries.

Failed default-branch run: https://github.com/FastLED/FastLED/actions/runs/33345693324

## Validation

- RED: stock configuration reproduced the TinyUSB compile failure
- rejected `board_build.usbstack=tinyusb` because it caused duplicate TinyUSB symbols against `libpico.a`
- rejected `lib_ignore` because framework LDF still selected the bundled library
- GREEN: `bash compile sparkfun_xrp_controller --examples Blink` (189/189 sources; linked successfully; flash 568.56 KB, RAM 56.71 KB)
- focused generated-configuration regression test passed
- `bash lint` passed
- `git diff --check` passed

Note: the trusted PR board workflow does not copy `ci/**`, so the XRP board compile is verified locally here and will be exercised again by the default-branch board workflow after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SparkFun XRP Controller 2350B builds to use the Arduino-Pico 5.7.0 framework.
  * Improved build compatibility by selecting the appropriate RP2040 core configuration.
  * Board builds now use a consistent, pinned framework release for more predictable results.

* **Tests**
  * Added validation confirming the board uses the expected framework version and core settings.
  * Expanded configuration checks to help prevent future build setup regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->