### PR TITLE
test(wdt): make feed timing deterministic (#3978)

### DIFF
--- a/src/platforms/stub/watchdog_stub.h
+++ b/src/platforms/stub/watchdog_stub.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/chrono.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace platforms {
+
+using StubWatchdogClock = fl::chrono::steady_clock::time_point (*)();
+
+void setStubWatchdogClockForTesting(StubWatchdogClock clock) FL_NO_EXCEPT;
+void clearStubWatchdogClockForTesting() FL_NO_EXCEPT;
+
+} // namespace platforms
+} // namespace fl

--- a/src/platforms/stub/watchdog_stub.impl.hpp
+++ b/src/platforms/stub/watchdog_stub.impl.hpp
@@ -30,6 +30,7 @@
 #include "fl/stl/cstring.h"
 #include "fl/stl/mutex.h"
 #include "fl/stl/thread.h"
+#include "platforms/stub/watchdog_stub.h"
 
 #define FL_WATCHDOG_HAS_HARDWARE
 #define FL_WATCHDOG_PERSIST_BYTES 16
@@ -39,6 +40,24 @@
 
 namespace fl {
 namespace platforms {
+
+inline fl::atomic<StubWatchdogClock>& stubWatchdogClock() FL_NO_EXCEPT {
+    static fl::atomic<StubWatchdogClock> clock{nullptr};
+    return clock;
+}
+
+inline fl::chrono::steady_clock::time_point stubWatchdogNow() FL_NO_EXCEPT {
+    StubWatchdogClock clock = stubWatchdogClock().load();
+    return clock ? clock() : fl::chrono::steady_clock::now();
+}
+
+void setStubWatchdogClockForTesting(StubWatchdogClock clock) FL_NO_EXCEPT {
+    stubWatchdogClock().store(clock);
+}
+
+void clearStubWatchdogClockForTesting() FL_NO_EXCEPT {
+    stubWatchdogClock().store(nullptr);
+}
 
 // Persistent storage layout — survives within a single process. Magic word at
 // the front separates first-run garbage from genuine persisted state.
@@ -156,7 +175,7 @@ inline void stubWatchdogTimerLoop() FL_NO_EXCEPT {
             fl::lock_guard<fl::mutex> g(s.mu);
             dl = s.deadline;
         }
-        if (fl::chrono::steady_clock::now() >= dl) {
+        if (stubWatchdogNow() >= dl) {
             WatchdogTimeoutCallback cb;
             void* user;
             fl::function<void()> cb_fn_copy;
@@ -203,7 +222,7 @@ void Watchdog::begin(fl::u32 timeout_ms) FL_NO_EXCEPT {
     auto& s = platforms::stubWatchdogState();
     fl::lock_guard<fl::mutex> g(s.mu);
     s.timeout_ms.store(timeout_ms);
-    s.deadline = fl::chrono::steady_clock::now() + fl::chrono::milliseconds(timeout_ms);
+    s.deadline = platforms::stubWatchdogNow() + fl::chrono::milliseconds(timeout_ms);
     s.enabled.store(true);
 }
 
@@ -211,7 +230,7 @@ void Watchdog::feed() FL_NO_EXCEPT {
     auto& s = platforms::stubWatchdogState();
     if (!s.enabled.load()) return;
     fl::lock_guard<fl::mutex> g(s.mu);
-    s.deadline = fl::chrono::steady_clock::now() + fl::chrono::milliseconds(s.timeout_ms.load());
+    s.deadline = platforms::stubWatchdogNow() + fl::chrono::milliseconds(s.timeout_ms.load());
 }
 
 void Watchdog::disable() FL_NO_EXCEPT {

--- a/tests/fl/wdt/watchdog.cpp
+++ b/tests/fl/wdt/watchdog.cpp
@@ -10,6 +10,7 @@
 #define FASTLED_STUB_WATCHDOG_NO_ABORT 1
 
 #include "fl/wdt/watchdog.h"
+#include "platforms/stub/watchdog_stub.h"
 #include "fl/stl/atomic.h"
 #include "fl/stl/chrono.h"
 #include "fl/stl/thread.h"
@@ -162,9 +163,24 @@ FL_TEST_CASE("fl::Watchdog — feeding before timeout prevents fire") {
     fired.store(false);
     dog.onTimeout([](void*) { fired.store(true); }, nullptr);
 
+    static fl::atomic<fl::u64> now_ms;
+    now_ms.store(1000);
+    struct ClockGuard {
+        ClockGuard() {
+            fl::platforms::setStubWatchdogClockForTesting(+[]() {
+                return fl::chrono::steady_clock::time_point(
+                    fl::chrono::milliseconds(now_ms.load()));
+            });
+        }
+        ~ClockGuard() { fl::platforms::clearStubWatchdogClockForTesting(); }
+    } clock_guard;
+
     dog.begin(200);
     for (int i = 0; i < 10; ++i) {
-        fl::this_thread::sleep_for(fl::chrono::milliseconds(50));  // ok sleep for
+        now_ms.store(now_ms.load() + 50);
+        // Give the worker a chance to observe each deterministic clock step.
+        // Wall-clock overshoot is harmless because it cannot advance now_ms.
+        fl::this_thread::sleep_for(fl::chrono::milliseconds(15));  // ok sleep for
         dog.feed();
     }
     dog.disable();


### PR DESCRIPTION
Summary:
- add a stub-only injectable watchdog clock with the real steady clock as the default
- make the feed-before-timeout regression advance deterministic mock time
- preserve worker-thread observation without allowing scheduler overshoot to create false failures

Validation:
- bash test watchdog (repeated focused passes)
- bash test --cpp (284 unit tests and 84 examples passed)
- bash lint
- git diff --check

Closes #3978