### PR TITLE
fix(sdfat): remove Teensy Arduino SPI hatch (#3980)

### DIFF
--- a/ci/tests/test_teensy_sdfat_spi_transport.py
+++ b/ci/tests/test_teensy_sdfat_spi_transport.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SDFAT_ROOT = PROJECT_ROOT / "src/platforms/arm/teensy/sdfat"
+
+
+def test_teensy_sdfat_has_no_arduino_spi_fallback() -> None:
+    forbidden = (
+        "FL_SDFAT_USE_ARDUINO_SPI",
+        "SPIClass",
+        "SPISettings",
+        "m_spi = &SPI",
+    )
+    violations: list[str] = []
+
+    for path in SDFAT_ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for token in forbidden:
+            if token in text:
+                violations.append(f"{path.relative_to(PROJECT_ROOT)}: {token}")
+
+    assert not violations, "Arduino SPI fallback remains:\n" + "\n".join(violations)

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiArduinoDriver.h
@@ -46,11 +46,6 @@ typedef fl::platforms::teensy::LpspiSettings SpiPortSettings_t;
 typedef fl::platforms::teensy::DspiBus SpiPort_t;
 /** Transaction settings for the FastLED DSPI hardware driver (Teensy 3.x / LC). */
 typedef fl::platforms::teensy::DspiSettings SpiPortSettings_t;
-#else
-/** Port type for Arduino SPI hardware driver. */
-typedef SPIClass SpiPort_t;
-/** Transaction settings for Arduino SPI hardware driver. */
-typedef SPISettings SpiPortSettings_t;
 #endif
 class SdSpiConfig;
 /**
@@ -94,7 +89,7 @@ class SdSpiArduinoDriver {
    * \param[in] count Number of bytes to send.
    */
   void send(const fl::u8* buf, fl::size count);
-  /** Save high speed SPISettings after SD initialization.
+  /** Save high speed SPI settings after SD initialization.
    *
    * \param[in] maxSck Maximum SCK frequency.
    */
@@ -105,8 +100,7 @@ class SdSpiArduinoDriver {
  private:
   // SpiPort_t / SpiPortSettings_t are selected just above, driven by the
   // transport macro SdSpiDriver.h defines before including this header:
-  // fl LpspiBus on Teensy 4, fl DspiBus on Teensy 3.x/LC, and SPIClass only
-  // when FL_SDFAT_USE_ARDUINO_SPI forces the framework path back on.
+  // fl LpspiBus on Teensy 4 and fl DspiBus on Teensy 3.x/LC.
   SpiPort_t *mSpi;
   SpiPortSettings_t mSpiSettings;
 };

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiDriver.h
@@ -33,32 +33,20 @@
 #include "fl/stl/int.h"
 #include "platforms/arm/teensy/is_teensy.h"  // ok platform headers
 
-// Transport selection for the Arduino-shaped hardware driver.
-//
-// On Teensy 4 (IMXRT1062) SdFat's SPI port is FastLED's own `LpspiBus` rather
-// than the framework's `SPIClass`. This is not a preference: the Teensyduino
-// `SPI` library is only *compiled* when the library finder selects it from an
-// unconditional sketch-level `#include <SPI.h>`, so `SPIClass::begin`,
-// `SPIClass::transfer` and the global `SPI` object resolve as headers but
-// never link (FastLED #3970). The library also cannot be vendored -- it is
-// GPLv2/LGPLv2.1 and FastLED is MIT. `LpspiBus` (#3802) already owns the
-// registers, so the port type is simply retargeted at it.
+// Transport selection for the Arduino-shaped hardware driver. Teensy 4 uses
+// FastLED's LPSPI bus and Teensy 3.x/LC use FastLED's DSPI bus. These buses own
+// the peripheral registers directly, avoiding a dependency on the framework
+// SPI library (FastLED #3970, #3972).
 //
 // The Kinetis Teensys (3.x and LC) get the same treatment through
-// `DspiBus`, which owns SPI0's DSPI registers directly (FastLED #3972). That
-// also retires the `SPISettings::ctar_clock_table` / `ctar_div_table`
-// dependency: the frequency-to-CTAR mapping is computed from the K20/K64/K66
-// reference manual instead of transcribed from the GPL/LGPL tables.
-//
-// Define `FL_SDFAT_USE_ARDUINO_SPI` to force the Arduino path back on as an
-// escape hatch. Nothing links in that configuration unless the sketch also
-// carries an unconditional `#include <SPI.h>`.
-#if !defined(FL_SDFAT_USE_ARDUINO_SPI)
+// `DspiBus`, which owns SPI0's DSPI registers directly. Its frequency-to-CTAR
+// mapping is computed from the K20/K64/K66 reference manual.
 #if defined(FL_IS_TEENSY_4X)
 #define FL_SDFAT_HAS_LPSPI_BUS
 #elif defined(FL_IS_TEENSY_3X) || defined(FL_IS_TEENSY_LC)
 #define FL_SDFAT_HAS_DSPI_BUS
-#endif
+#else
+#error "Teensy SdFat requires a supported FastLED SPI bus"
 #endif
 
 #if SPI_DRIVER_SELECT < 2
@@ -66,8 +54,6 @@
 #include "platforms/arm/teensy/teensy4_common/lpspi/lpspi_bus.h"  // ok platform headers
 #elif defined(FL_SDFAT_HAS_DSPI_BUS)
 #include "platforms/arm/teensy/kinetis_spi/dspi_bus.h"  // ok platform headers
-#else
-#include "SPI.h"
 #endif
 #endif
 
@@ -114,9 +100,9 @@ inline bool spiOptionDedicated(fl::u8 opt) {return opt & DEDICATED_SPI;}
 inline bool spiOptionDedicated(fl::u8 opt) {(void)opt; return false;}
 #endif  // ENABLE_DEDICATED_SPI
 //------------------------------------------------------------------------------
-/** SPISettings for SCK frequency in Hz. */
+/** SPI setting for SCK frequency in Hz. */
 #define SD_SCK_HZ(maxSpeed) (maxSpeed)
-/** SPISettings for SCK frequency in MHz. */
+/** SPI setting for SCK frequency in MHz. */
 #define SD_SCK_MHZ(maxMhz) (1000000UL*(maxMhz))
 // SPI divisor constants - obsolete.
 /** Set SCK to max rate. */

--- a/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
+++ b/src/platforms/arm/teensy/sdfat/SpiDriver/SdSpiTeensy3.cpp.hpp
@@ -52,8 +52,6 @@ void SdSpiArduinoDriver::begin(SdSpiConfig spiConfig) {
 #elif defined(FL_SDFAT_HAS_DSPI_BUS)
     // Bus 0 is SPI0, the peripheral the Arduino global `SPI` wraps.
     m_spi = &fl::platforms::teensy::DspiBus::get(0);
-#else
-    m_spi = &SPI;
 #endif
   }
   m_spi->begin();

--- a/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
+++ b/src/platforms/arm/teensy/sdfat/fs_sdfat_teensy.h
@@ -6,10 +6,9 @@
 // Deliberately no `#include <SPI.h>` here. Every Teensy now routes SdFat
 // through a FastLED-owned bus -- `LpspiBus` on Teensy 4 (FastLED#3971),
 // `DspiBus` on Teensy 3.x/LC (FastLED#3972) -- and pulling the framework
-// header in would keep the GPL/LGPL `SPI.h` in the translation unit and
-// re-expose the undefined `SPIClass`/`SPI` symbols the moment anything
-// referenced them again. `SdSpiDriver.h` supplies whichever transport header
-// the platform actually needs.
+// header in would keep the GPL/LGPL SPI implementation in the translation
+// unit. `SdSpiDriver.h` supplies whichever transport header the platform
+// actually needs.
 
 // IWYU pragma: begin_keep
 #include "platforms/arm/teensy/sdfat/SdFat.h"


### PR DESCRIPTION
Summary:
- remove the broken FL_SDFAT_USE_ARDUINO_SPI escape hatch and framework SPI types
- route supported Teensy 4.x and Teensy 3.x/LC builds exclusively through FastLED-owned LPSPI/DSPI transports
- reject unsupported Teensy variants at compile time and lock out residual Arduino SPI fallback code

Validation:
- uv run pytest -q ci/tests/test_teensy_sdfat_spi_transport.py
- bash compile teensy31 --examples Blink
- bash compile teensy41 --examples Blink (revalidated after rebase)
- bash lint
- git diff --check

Closes #3980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teensy SD card communication now uses the supported, platform-specific SPI transport.
  * Removed unsupported Arduino SPI fallback behavior.
  * Unsupported Teensy platforms now fail clearly during compilation instead of selecting an incompatible SPI path.

* **Tests**
  * Added automated checks to prevent unsupported Arduino SPI references from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->