### PR TITLE
feat(esp8266): allow clockless wait time override (#1401)

### DIFF
--- a/ci/tests/test_esp8266_clockless_wait_time.py
+++ b/ci/tests/test_esp8266_clockless_wait_time.py
@@ -1,0 +1,54 @@
+"""Compile-time regression contract for the ESP8266 clockless wait time."""
+
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+from running_process import RunningProcess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = ROOT / "src" / "platforms" / "esp" / "8266" / "clockless_esp8266.h"
+TEMPLATE_DEFAULT = re.compile(r"int WAIT_TIME = (\d+)")
+
+
+def _preprocessed_wait_time(override: int | None = None) -> int:
+    compiler = shutil.which("clang++") or shutil.which("g++") or shutil.which("c++")
+    if compiler is None:
+        pytest.skip("No C++ preprocessor is available")
+
+    command = [
+        compiler,
+        "-E",
+        "-P",
+        "-x",
+        "c++",
+        f"-I{ROOT / 'src'}",
+        "-DF_CPU=80000000",
+    ]
+    if override is not None:
+        command.append(f"-DFASTLED_ESP8266_CLOCKLESS_WAIT_TIME={override}")
+    command.append(str(HEADER))
+
+    result = RunningProcess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"preprocessing failed:\n{result.stderr}"
+    match = TEMPLATE_DEFAULT.search(result.stdout)
+    assert match is not None, "ClocklessController WAIT_TIME default was not found"
+    return int(match.group(1))
+
+
+def test_esp8266_clockless_wait_time_default_is_backward_compatible() -> None:
+    assert _preprocessed_wait_time() == 85
+
+
+def test_esp8266_clockless_wait_time_accepts_sketch_override() -> None:
+    assert _preprocessed_wait_time(10) == 10

--- a/src/platforms/esp/8266/clockless_esp8266.h
+++ b/src/platforms/esp/8266/clockless_esp8266.h
@@ -28,7 +28,11 @@ __attribute__ ((always_inline)) inline static u32 __clock_cycles() {
 
 #define FL_CLOCKLESS_CONTROLLER_DEFINED 1
 
-template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = 85>
+#ifndef FASTLED_ESP8266_CLOCKLESS_WAIT_TIME
+#define FASTLED_ESP8266_CLOCKLESS_WAIT_TIME 85
+#endif
+
+template <int DATA_PIN, typename TIMING, EOrder RGB_ORDER = RGB, int XTRA0 = 0, bool FLIP = false, int WAIT_TIME = FASTLED_ESP8266_CLOCKLESS_WAIT_TIME>
 class ClocklessController : public CPixelLEDController<RGB_ORDER> {
 	typedef typename FastPin<DATA_PIN>::port_ptr_t data_ptr_t;
 	typedef typename FastPin<DATA_PIN>::port_t data_t;


### PR DESCRIPTION
Summary:
- add FASTLED_ESP8266_CLOCKLESS_WAIT_TIME as a sketch-level compile-time override
- preserve the existing 85 microsecond default
- regression-test both default and custom values

Validation:
- uv run pytest -q ci/tests/test_esp8266_clockless_wait_time.py
- bash compile esp8266 --examples Blink --defines FASTLED_ESP8266_CLOCKLESS_WAIT_TIME=10
- bash lint
- git diff --check

Closes #1401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compile-time configuration option for ESP8266 clockless wait time.
  * The default wait time remains 85 for backward compatibility.
  * Applications can override the wait time, such as setting it to 10, when needed.

* **Tests**
  * Added coverage verifying the default value and custom override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->