### PR TITLE
fix(color): prevent rgb2hsv channel overflow (#1074)

### DIFF
--- a/src/hsv2rgb.cpp.hpp
+++ b/src/hsv2rgb.cpp.hpp
@@ -558,9 +558,11 @@ void hsv2rgb_fullspectrum( const CHSV* phsv, CRGB * prgb, int numLeds) {
 // See extended notes in the .h file.
 CHSV rgb2hsv_approximate( const CRGB& rgb)
 {
-    fl::u8 r = rgb.r;
-    fl::u8 g = rgb.g;
-    fl::u8 b = rgb.b;
+    // These channels can exceed 255 while saturation is being undone. Keep
+    // the intermediate values wide until they are normalized below.
+    fl::u16 r = rgb.r;
+    fl::u16 g = rgb.g;
+    fl::u16 b = rgb.b;
     fl::u8 h, s, v;
 
     // find desaturation
@@ -616,8 +618,10 @@ CHSV rgb2hsv_approximate( const CRGB& rgb)
 
     //Serial.print("total="); Serial.print(total); Serial.println("");
 
-    // scale all channels up to compensate for low values
-    if( total < 255) {
+    // Normalize the channels to the range expected by the hue approximation.
+    // This scales low totals up as before, and also scales high totals down
+    // instead of letting wide intermediates wrap when stored in u8 channels.
+    if( total != 255) {
         if( total == 0) total = 1;
         fl::u32 scaleup = 65535 / (total);
         r = ((fl::u32)(r) * scaleup) / 256;
@@ -670,7 +674,7 @@ CHSV rgb2hsv_approximate( const CRGB& rgb)
 
     // start with which channel is highest
     // (ties don't matter)
-    fl::u8 highest = r;
+    fl::u16 highest = r;
     if( g > highest) highest = g;
     if( b > highest) highest = b;
 

--- a/tests/fl/hsv2rgb_accuracy.cpp
+++ b/tests/fl/hsv2rgb_accuracy.cpp
@@ -229,6 +229,20 @@ FL_TEST_CASE("rgb2hsv_approximate - orange is not reported as green (issue #436)
     }
 }
 
+FL_TEST_CASE("rgb2hsv_approximate - scaling does not wrap channels (issue #1074)") {
+    const CRGB original(218, 137, 48);
+    const CHSV hsv = rgb2hsv_approximate(original);
+    const CRGB roundtrip = hsv2rgb_rainbow(hsv);
+
+    // Scaling the desaturated channels produces an intermediate red value of
+    // 299. It must be normalized, not truncated to 43, which incorrectly
+    // makes green the dominant channel and moves this orange into green hues.
+    FL_CHECK_LE((int)hsv.hue, (int)HUE_YELLOW);
+    FL_CHECK_EQ((int)hsv.value, 255);
+    FL_CHECK_GT((int)roundtrip.r, (int)roundtrip.g);
+    FL_CHECK_GT((int)roundtrip.g, (int)roundtrip.b);
+}
+
 FL_TEST_CASE("rgb2hsv_approximate - hue stays in the red..yellow arc red -> yellow") {
     // Sweeping green up at full red walks hue from red toward yellow. The
     // underflow made this jump out into the greens partway through (46 -> 115


### PR DESCRIPTION
Summary:
- keep saturation-undo RGB intermediates wide enough to avoid 8-bit rollover
- normalize both low and high channel totals before hue approximation
- add a regression for RGB(218,137,48) preserving the red/yellow hue arc and channel order

Validation:
- focused release test passed
- focused debug/sanitizer test passed
- comprehensive lint passed
- diff check passed
- full C++ suite compiled all targets; the macOS runner then returned permission denied for every test executable

Closes #1074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color conversion accuracy for desaturated colors, preventing channel values from wrapping or being truncated during normalization.
  * Preserved more accurate hue, brightness, and dominant-color results when converting colors between HSV and RGB.

* **Tests**
  * Added coverage for high-value desaturated colors and verified accurate round-trip conversion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->