### PR TITLE
fix(teensy4): fallback to software SPI for invalid pins (#1579)

### DIFF
--- a/src/platforms/arm/teensy/teensy4_common/spi_output_selector.h
+++ b/src/platforms/arm/teensy/teensy4_common/spi_output_selector.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// IWYU pragma: private
+
+#include "fl/stl/int.h"
+
+namespace fl {
+namespace platforms {
+namespace teensy {
+
+/// Compile-time routing for the SPI pin pairs exposed by Teensyduino.
+template <fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, bool IS_TEENSY_41>
+struct Teensy4SpiPinRoute {
+    enum {
+        is_spi = (DATA_PIN == 11 || DATA_PIN == 12) && CLOCK_PIN == 13,
+        is_spi1 = (DATA_PIN == 26 || DATA_PIN == 1) && CLOCK_PIN == 27,
+        is_spi2_40 = !IS_TEENSY_41 && (DATA_PIN == 35 || DATA_PIN == 34) &&
+                     CLOCK_PIN == 37,
+        is_spi2_41 = IS_TEENSY_41 && (DATA_PIN == 43 || DATA_PIN == 42) &&
+                     CLOCK_PIN == 45,
+        is_hardware = is_spi || is_spi1 || is_spi2_40 || is_spi2_41,
+        bus_index = is_spi ? 0 : (is_spi1 ? 1 : (is_spi2_40 || is_spi2_41 ? 2 : -1))
+    };
+};
+
+} // namespace teensy
+} // namespace platforms
+} // namespace fl

--- a/src/platforms/arm/teensy/teensy4_common/spi_output_template.h
+++ b/src/platforms/arm/teensy/teensy4_common/spi_output_template.h
@@ -7,11 +7,46 @@
 
 #include "fl/stl/int.h"
 #include "platforms/arm/mxrt1062/spi_device_proxy.h"
+#include "platforms/arm/teensy/teensy4_common/spi_output_selector.h"
+#include "platforms/shared/spi_bitbang/generic_software_spi.h"
 
 namespace fl {
 
-/// Teensy 4 hardware SPI output for all pins
-template<fl::u8 _DATA_PIN, fl::u8 _CLOCK_PIN, fl::u32 _SPI_CLOCK_DIVIDER>
-class SPIOutput : public SPIDeviceProxy<_DATA_PIN, _CLOCK_PIN, _SPI_CLOCK_DIVIDER, 0> {};
+namespace detail {
+
+template <fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::u32 SPI_CLOCK_RATE,
+          bool IS_HARDWARE, int SPI_INDEX>
+class Teensy4SPIOutputImpl
+    : public fl::GenericSoftwareSPIOutput<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE> {};
+
+template <fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::u32 SPI_CLOCK_RATE,
+          int SPI_INDEX>
+class Teensy4SPIOutputImpl<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, true, SPI_INDEX>
+    : public SPIDeviceProxy<DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE, SPI_INDEX> {};
+
+} // namespace detail
+
+/// Teensy 4 SPI output. Valid LPSPI pin pairs use hardware; all other pairs
+/// retain the legacy generic bitbang behavior.
+template <fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::u32 SPI_CLOCK_RATE>
+class SPIOutput
+    : public detail::Teensy4SPIOutputImpl<
+          DATA_PIN, CLOCK_PIN, SPI_CLOCK_RATE,
+          platforms::teensy::Teensy4SpiPinRoute<
+              DATA_PIN, CLOCK_PIN,
+#if defined(ARDUINO_TEENSY41)
+              true
+#else
+              false
+#endif
+              >::is_hardware,
+          platforms::teensy::Teensy4SpiPinRoute<
+              DATA_PIN, CLOCK_PIN,
+#if defined(ARDUINO_TEENSY41)
+              true
+#else
+              false
+#endif
+              >::bus_index> {};
 
 }  // namespace fl

--- a/tests/platforms/arm/teensy/teensy4_common/spi_output_selector.cpp
+++ b/tests/platforms/arm/teensy/teensy4_common/spi_output_selector.cpp
@@ -1,0 +1,30 @@
+#include "test.h"
+
+#include "platforms/arm/teensy/teensy4_common/spi_output_selector.h"
+
+using fl::platforms::teensy::Teensy4SpiPinRoute;
+
+FL_TEST_CASE("Teensy 4 SPI output selects hardware only for valid pin pairs") {
+    FL_CHECK((Teensy4SpiPinRoute<11, 13, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<11, 13, false>::bus_index == 0));
+    FL_CHECK((Teensy4SpiPinRoute<12, 13, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<12, 13, false>::bus_index == 0));
+    FL_CHECK((Teensy4SpiPinRoute<26, 27, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<26, 27, false>::bus_index == 1));
+    FL_CHECK((Teensy4SpiPinRoute<1, 27, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<1, 27, false>::bus_index == 1));
+    FL_CHECK((Teensy4SpiPinRoute<35, 37, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<35, 37, false>::bus_index == 2));
+    FL_CHECK((Teensy4SpiPinRoute<34, 37, false>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<34, 37, false>::bus_index == 2));
+
+    FL_CHECK((Teensy4SpiPinRoute<43, 45, true>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<43, 45, true>::bus_index == 2));
+    FL_CHECK((Teensy4SpiPinRoute<42, 45, true>::is_hardware));
+    FL_CHECK((Teensy4SpiPinRoute<42, 45, true>::bus_index == 2));
+
+    FL_CHECK_FALSE((Teensy4SpiPinRoute<1, 2, true>::is_hardware));
+    FL_CHECK_FALSE((Teensy4SpiPinRoute<11, 27, true>::is_hardware));
+    FL_CHECK_FALSE((Teensy4SpiPinRoute<35, 37, true>::is_hardware));
+    FL_CHECK_FALSE((Teensy4SpiPinRoute<50, 49, true>::is_hardware));
+}


### PR DESCRIPTION
Summary:
- detect valid Teensy 4.0 and 4.1 LPSPI pin routes at compile time
- retain hardware SPI for every currently supported primary and secondary lane
- fall back to generic software SPI for arbitrary invalid hardware pin pairs
- add focused route-selection regression coverage

Validation:
- focused debug/sanitizer test passed
- Teensy 4.1 APA102 compile passed on second hardware lane 42/45
- Teensy 4.1 APA102 compile passed on software fallback pins 1/2
- Teensy 4.0 APA102 compile passed on second hardware lane 34/37
- Teensy 4.0 APA102 compile passed on software fallback pins 1/2
- comprehensive lint and diff check passed

Closes #1579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic SPI pin routing for Teensy 4 boards.
  * Supports hardware SPI on compatible pin pairs and software SPI for unsupported combinations.
  * Added support for selecting the correct SPI bus on Teensy 4.1 devices.

* **Bug Fixes**
  * Corrected SPI handling for pin configurations that do not map to the default hardware bus.

* **Tests**
  * Added coverage for valid hardware routes, bus selection, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->