### PR TITLE
feat(esp32): select SPI host per controller (#1516)

### DIFF
--- a/examples/MultipleEsp32SpiBuses/MultipleEsp32SpiBuses.ino
+++ b/examples/MultipleEsp32SpiBuses/MultipleEsp32SpiBuses.ino
@@ -1,0 +1,19 @@
+#include <FastLED.h>
+
+#if !defined(ESP32)
+#error "This example requires ESP32"
+#endif
+
+CRGB spi2Leds[8];
+CRGB spi3Leds[8];
+
+void setup() {
+    FastLED.addLeds<APA102, 11, 12, RGB, DATA_RATE_MHZ(20)>(
+        spi2Leds, 8, fl::Esp32SpiBus::SPI2);
+    FastLED.addLeds<APA102, 13, 14, RGB, DATA_RATE_MHZ(20)>(
+        spi3Leds, 8, fl::Esp32SpiBus::SPI3);
+}
+
+void loop() {
+    FastLED.show();
+}

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -1115,6 +1115,23 @@ public:
 		return *sChannel;
 	}
 
+	/// Add an SPI controller with an explicit ESP-IDF SPI host.
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO, fl::u8 B_WHICH = 0>
+	::CLEDController &addLeds(CRGB *data, int nLeds, fl::Esp32SpiBus spiBus) {
+		fl::SpiEncoder encoder = fl::SpiEncoder::spiEncoderForChipset(
+			static_cast<fl::SpiChipset>(CHIPSET), SPI_DATA_RATE);
+		fl::SpiChipsetConfig spiCfg(DATA_PIN, CLOCK_PIN, encoder, spiBus);
+		fl::ChannelConfig config(spiCfg, fl::span<CRGB>(data, nLeds), RGB_ORDER);
+		config.options.mBus = B;
+		config.options.mBusWhich = B_WHICH;
+		static fl::ChannelPtr sChannel;
+		if (!sChannel) {
+			sChannel = fl::TypedChannel<B, fl::SpiChipsetConfig, B_WHICH>::create(config);
+			add(sChannel);
+		}
+		return *sChannel;
+	}
+
 	/// Add an SPI based CLEDController via Channel API (default RGB order and speed).
 	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::Bus B = fl::Bus::AUTO, fl::u8 B_WHICH = 0>
 	static ::CLEDController &addLeds(CRGB *data, int nLedsOrOffset, int nLedsIfOffset = 0) {
@@ -1168,6 +1185,19 @@ public:
 		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER_AND_FREQ<RGB_ORDER, SPI_DATA_RATE>::ControllerType ControllerTypeWithFreq;
 		static ControllerTypeWithFreq c;
 		return addLeds(&c, data, nLedsOrOffset, nLedsIfOffset);
+	}
+
+	/// Add an SPI controller on a selected ESP-IDF host.
+	/// @note SPI1 is reserved for flash/PSRAM; use SPI2 or SPI3.
+	template<ESPIChipsets CHIPSET, fl::u8 DATA_PIN, fl::u8 CLOCK_PIN, fl::EOrder RGB_ORDER, fl::u32 SPI_DATA_RATE, fl::Bus B = fl::Bus::AUTO>
+	::CLEDController &addLeds(CRGB *data, int nLeds, fl::Esp32SpiBus spiBus) {
+		fl::busKeepAlive<B>();
+		typedef ClockedChipsetHelper<CHIPSET, DATA_PIN, CLOCK_PIN> CHIP;
+		FL_STATIC_ASSERT(CHIP::IS_VALID, "Unsupported chipset");
+		typedef typename CHIP::template CONTROLLER_CLASS_WITH_ORDER_AND_FREQ<RGB_ORDER, SPI_DATA_RATE>::ControllerType ControllerTypeWithFreq;
+		static ControllerTypeWithFreq c;
+		c.setSpiBus(spiBus);
+		return addLeds(&c, data, nLeds, 0);
 	}
 
 	/// Add an SPI based CLEDController instance to the world (legacy path).

--- a/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
+++ b/src/fl/channels/adapters/spi_channel_adapter.cpp.hpp
@@ -96,10 +96,10 @@ int SpiChannelEngineAdapter::getPriority() const {
     return maxPriority;
 }
 
-int SpiChannelEngineAdapter::selectControllerForClockPin(int clockPin) {
+int SpiChannelEngineAdapter::selectControllerForClockPin(int clockPin, Esp32SpiBus requestedBus) {
     // Check if clock pin already assigned
     for (const auto& assignment : mClockPinAssignments) {
-        if (assignment.clockPin == clockPin) {
+        if (assignment.clockPin == clockPin && assignment.requestedBus == requestedBus) {
             return assignment.controllerIndex;
         }
     }
@@ -109,6 +109,10 @@ int SpiChannelEngineAdapter::selectControllerForClockPin(int clockPin) {
     int bestPriority = -1;
 
     for (size_t i = 0; i < mControllers.size(); i++) {
+        if (requestedBus != Esp32SpiBus::AUTO &&
+            mControllers[i].controller->getBusId() != static_cast<int>(requestedBus)) {
+            continue;
+        }
         if (!canControllerHandleClockPin(mControllers[i], clockPin)) {
             continue;
         }
@@ -121,7 +125,7 @@ int SpiChannelEngineAdapter::selectControllerForClockPin(int clockPin) {
 
     // Record assignment
     if (bestIndex >= 0) {
-        mClockPinAssignments.push_back({clockPin, static_cast<size_t>(bestIndex)});
+        mClockPinAssignments.push_back({clockPin, requestedBus, static_cast<size_t>(bestIndex)});
     }
 
     return bestIndex;
@@ -311,7 +315,7 @@ fl::vector<SpiChannelEngineAdapter::ClockPinGroup> SpiChannelEngineAdapter::grou
         // Find existing group for this clock pin
         ClockPinGroup* existingGroup = nullptr;
         for (size_t i = 0; i < groups.size(); i++) {
-            if (groups[i].clockPin == clockPin) {
+            if (groups[i].clockPin == clockPin && groups[i].requestedBus == spiConfig.spiBus) {
                 existingGroup = &groups[i];
                 break;
             }
@@ -323,6 +327,7 @@ fl::vector<SpiChannelEngineAdapter::ClockPinGroup> SpiChannelEngineAdapter::grou
         } else {
             ClockPinGroup newGroup;
             newGroup.clockPin = clockPin;
+            newGroup.requestedBus = spiConfig.spiBus;
             newGroup.channels.push_back(channel);
             groups.push_back(newGroup);
         }
@@ -348,7 +353,7 @@ bool SpiChannelEngineAdapter::transmitBatch(fl::span<const ChannelDataPtr> chann
     int dataPin = channels[0]->getPin();  // MOSI pin from channel config
 
     // Select controller for this clock pin
-    int controllerIndex = selectControllerForClockPin(clockPin);
+    int controllerIndex = selectControllerForClockPin(clockPin, spiConfig.spiBus);
     if (controllerIndex < 0) {
         FL_WARN_F("SpiChannelEngineAdapter: No available controller for clock pin %s", clockPin);
         return false;

--- a/src/fl/channels/adapters/spi_channel_adapter.h
+++ b/src/fl/channels/adapters/spi_channel_adapter.h
@@ -137,13 +137,14 @@ private:
 
     struct ClockPinAssignment {
         int clockPin;
+        Esp32SpiBus requestedBus;
         size_t controllerIndex;  ///< Index into mControllers
     };
 
     /// @brief Select best controller for a given clock pin
     /// @param clockPin Clock pin number to route
     /// @returns Controller index, or -1 if none available
-    int selectControllerForClockPin(int clockPin);
+    int selectControllerForClockPin(int clockPin, Esp32SpiBus requestedBus);
 
     /// @brief Check if controller can handle this clock pin
     /// @param ctrl Controller to check
@@ -161,6 +162,7 @@ private:
     /// @brief Group data structure for channels with same clock pin
     struct ClockPinGroup {
         int clockPin;
+        Esp32SpiBus requestedBus = Esp32SpiBus::AUTO;
         fl::vector<ChannelDataPtr> channels;
     };
 

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -15,6 +15,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/span.h"
 #include "fl/stl/noexcept.h"
+#include "fl/spi_bus.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -84,6 +85,12 @@ protected:
     }
 
 public:
+    /// Select an ESP-IDF SPI host for this clocked controller before init().
+    /// Non-ESP32 and non-SPI controllers ignore this setting.
+    virtual CLEDController &setSpiBus(Esp32SpiBus bus) FL_NO_EXCEPT {
+        (void)bus;
+        return *this;
+    }
     /// @brief Add this controller to the linked list
     /// @note Used with DeferRegister mode to explicitly add controller to list
     /// @note Safe to call multiple times - won't add if already in list

--- a/src/fl/channels/config.h
+++ b/src/fl/channels/config.h
@@ -12,6 +12,7 @@
 #include "fl/chipsets/spi.h"
 #include "fl/gfx/eorder.h"
 #include "fl/channels/options.h"
+#include "fl/spi_bus.h"
 #include "fl/stl/optional.h"
 #include "fl/stl/string.h"  // fl::string must be complete for Optional<fl::string> below  // IWYU pragma: keep
 #include "color.h"  // IWYU pragma: keep
@@ -103,14 +104,16 @@ struct SpiChipsetConfig {
     int dataPin;                    ///< GPIO data pin (MOSI)
     int clockPin;                   ///< GPIO clock pin (SCK)
     SpiEncoder timing;              ///< SPI encoder configuration
+    Esp32SpiBus spiBus;             ///< ESP-IDF host override, or AUTO
 
     /// @brief Constructor
-    SpiChipsetConfig(int dataPin, int clockPin, const SpiEncoder& timing) FL_NO_EXCEPT
-        : dataPin(dataPin), clockPin(clockPin), timing(timing) {}
+    SpiChipsetConfig(int dataPin, int clockPin, const SpiEncoder& timing,
+                     Esp32SpiBus spiBus = Esp32SpiBus::AUTO) FL_NO_EXCEPT
+        : dataPin(dataPin), clockPin(clockPin), timing(timing), spiBus(spiBus) {}
 
     /// @brief Default constructor (requires explicit protocol specification)
     /// @note Protocol defaults to APA102 as a reasonable fallback
-    SpiChipsetConfig() FL_NO_EXCEPT : dataPin(-1), clockPin(-1), timing{fl::SpiChipset::APA102, 6000000} {}
+    SpiChipsetConfig() FL_NO_EXCEPT : dataPin(-1), clockPin(-1), timing{fl::SpiChipset::APA102, 6000000}, spiBus(Esp32SpiBus::AUTO) {}
 
     /// @brief Copy constructor
     SpiChipsetConfig(const SpiChipsetConfig&) FL_NO_EXCEPT = default;
@@ -128,7 +131,8 @@ struct SpiChipsetConfig {
     bool operator==(const SpiChipsetConfig& other) const FL_NO_EXCEPT {
         return dataPin == other.dataPin &&
                clockPin == other.clockPin &&
-               timing == other.timing;
+               timing == other.timing &&
+               spiBus == other.spiBus;
     }
 
     /// @brief Inequality operator

--- a/src/fl/chipsets/apa102.h
+++ b/src/fl/chipsets/apa102.h
@@ -87,6 +87,12 @@ class APA102Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	APA102Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	virtual void init() override {
 		mSPI.init();

--- a/src/fl/chipsets/hd108.h
+++ b/src/fl/chipsets/hd108.h
@@ -44,6 +44,12 @@ class HD108Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	HD108Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	void init() override { mSPI.init(); }
 

--- a/src/fl/chipsets/lpd880x.h
+++ b/src/fl/chipsets/lpd880x.h
@@ -44,6 +44,12 @@ class LPD8806Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	LPD8806Controller() FL_NO_EXCEPT  {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 	virtual void init() {
 		mSPI.init();
 	}
@@ -109,6 +115,12 @@ class LPD6803Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	LPD6803Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	virtual void init() {
 		mSPI.init();

--- a/src/fl/chipsets/p9813.h
+++ b/src/fl/chipsets/p9813.h
@@ -36,6 +36,12 @@ class P9813Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	P9813Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	virtual void init() {
 		mSPI.init();

--- a/src/fl/chipsets/sm16716.h
+++ b/src/fl/chipsets/sm16716.h
@@ -45,6 +45,12 @@ class SM16716Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	SM16716Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	virtual void init() {
 		mSPI.init();

--- a/src/fl/chipsets/ws2801.h
+++ b/src/fl/chipsets/ws2801.h
@@ -29,6 +29,12 @@ class WS2801Controller : public CPixelLEDController<RGB_ORDER> {
 
 public:
 	WS2801Controller() FL_NO_EXCEPT {}
+	#if defined(FL_IS_ESP32)
+	CLEDController &setSpiBus(fl::Esp32SpiBus bus) FL_NO_EXCEPT override {
+		mSPI.setBus(bus);
+		return *this;
+	}
+	#endif
 
 	/// Initialize the controller
 	virtual void init() {

--- a/src/fl/spi_bus.h
+++ b/src/fl/spi_bus.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+/// ESP-IDF SPI host selection for an individual clocked LED controller.
+/// SPI1 is intentionally unavailable because ESP-IDF reserves it for flash/PSRAM.
+enum class Esp32SpiBus : u8 {
+    AUTO = 0,
+    SPI2 = 2,
+    SPI3 = 3,
+};
+
+} // namespace fl

--- a/src/platforms/esp/32/README.md
+++ b/src/platforms/esp/32/README.md
@@ -89,6 +89,11 @@ Additional I2S defines and guidance:
   - **`FASTLED_ALL_PINS_HARDWARE_SPI`**: **DEPRECATED**. Hardware SPI is now the unconditional default. This define is accepted for backwards compatibility but no longer required.
   - **`FASTLED_FORCE_SOFTWARE_SPI`**: Force software bit-banging SPI instead of hardware SPI. The SPI bus manager will still handle device registration and conflict detection, but all data transmission uses software bit-banging. Use only if hardware SPI causes issues.
   - **`FASTLED_ESP32_SPI_BUS`**: Select SPI bus: `VSPI`, `HSPI`, or `FSPI`. Defaults per target: S2/S3 use `FSPI`, others default to `VSPI` (see `fastspi_esp32.h`).
+  - For independent per-controller selection with the ESP-IDF backend, pass
+    `fl::Esp32SpiBus::SPI2` or `fl::Esp32SpiBus::SPI3` as the final argument:
+    `FastLED.addLeds<APA102, DATA, CLOCK, RGB, DATA_RATE_MHZ(20)>(leds, count, fl::Esp32SpiBus::SPI3);`.
+    An omitted override remains `AUTO` and preserves the existing automatic
+    host allocation order.
   - **`FASTLED_ESP32_SPI_BULK_TRANSFER`**: When `1`, batches pixels into blocks to reduce transfer overhead and improve throughput at the cost of RAM. Default `0`.
   - **`FASTLED_ESP32_SPI_BULK_TRANSFER_SIZE`**: Bulk block size (CRGBs) when bulk mode is enabled. Default `64`.
 

--- a/src/platforms/esp/32/core/fastspi_esp32_idf.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_idf.h
@@ -24,6 +24,7 @@ FL_EXTERN_C_BEGIN
 #include "esp_heap_caps.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/noexcept.h"
+#include "fl/spi_bus.h"
 
 FL_DISABLE_WARNING_PUSH
 FL_DISABLE_WARNING_DEPRECATED_REGISTER
@@ -58,7 +59,7 @@ public:
 
     ESP32SPIOutput()
         : mSPIHandle(nullptr)
-        , mHost(FASTLED_ESP32_DEFAULT_SPI_HOST)
+        , mHost(defaultHost())
         , mPSelect(nullptr)
         , mInitialized(false)
         , mInTransaction(false)
@@ -68,7 +69,7 @@ public:
 
     ESP32SPIOutput(Selectable* pSelect)
         : mSPIHandle(nullptr)
-        , mHost(FASTLED_ESP32_DEFAULT_SPI_HOST)
+        , mHost(defaultHost())
         , mPSelect(pSelect)
         , mInitialized(false)
         , mInTransaction(false)
@@ -89,6 +90,33 @@ public:
 
     void setSelect(Selectable* pSelect) FL_NO_EXCEPT {
         mPSelect = pSelect;
+    }
+
+    void setBus(Esp32SpiBus bus) FL_NO_EXCEPT {
+        switch (bus) {
+            case Esp32SpiBus::SPI2:
+                mHost = SPI2_HOST;
+                break;
+            case Esp32SpiBus::SPI3:
+#if SOC_SPI_PERIPH_NUM > 2
+                mHost = SPI3_HOST;
+#else
+                FL_WARN_F("SPI3 is unavailable on this ESP32 target; using the default SPI host");
+                mHost = defaultHost();
+#endif
+                break;
+            case Esp32SpiBus::AUTO:
+                mHost = defaultHost();
+                break;
+        }
+    }
+
+    static spi_host_device_t defaultHost() FL_NO_EXCEPT {
+#ifdef FASTLED_ESP32_SPI_BUS
+        return static_cast<spi_host_device_t>(FASTLED_ESP32_SPI_BUS);
+#else
+        return FASTLED_ESP32_DEFAULT_SPI_HOST;
+#endif
     }
 
     void init() FL_NO_EXCEPT {

--- a/src/platforms/esp/32/drivers/spi/spi_device_proxy.h
+++ b/src/platforms/esp/32/drivers/spi/spi_device_proxy.h
@@ -49,6 +49,7 @@ private:
     bool mInitialized;                       // Whether init() was called
     bool mBusInitialized;                    // Whether bus manager has been initialized
     bool mInTransaction;                     // Whether select() was called
+    Esp32SpiBus mRequestedBus;
 
 public:
     /// Constructor - just stores pins, actual setup happens in init()
@@ -58,8 +59,11 @@ public:
         , mInitialized(false)
         , mBusInitialized(false)
         , mInTransaction(false)
+        , mRequestedBus(Esp32SpiBus::AUTO)
     {
     }
+
+    void setBus(Esp32SpiBus bus) FL_NO_EXCEPT { mRequestedBus = bus; }
 
     /// Destructor - cleanup owned resources and unregister from bus manager
     ~SPIDeviceProxy() {
@@ -85,7 +89,7 @@ public:
         // Register with bus manager
         // NOTE: Bus manager will determine if we use Single/Quad/Soft SPI
         // based on how many devices share our clock pin
-        mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_SPEED, this);
+        mHandle = mBusManager->registerDevice(CLOCK_PIN, DATA_PIN, SPI_SPEED, this, mRequestedBus);
 
         if (!mHandle.is_valid) {
             FL_LOG_SPI_F("Failed to register with bus manager (pin %s:%s)", CLOCK_PIN, DATA_PIN);
@@ -118,6 +122,7 @@ public:
         if (bus && bus->bus_type == SPIBusType::SINGLE_SPI && !mSingleSPI) {
             // We're using single-SPI - create owned ESP32SPIOutput instance
             mSingleSPI = fl::make_unique<ESP32SPIOutput<DATA_PIN, CLOCK_PIN, SPI_SPEED>>();
+            mSingleSPI->setBus(mRequestedBus);
             mSingleSPI->init();
         }
         // For Quad-SPI, bus manager handles hardware - we just buffer writes

--- a/src/platforms/shared/spi_manager.cpp.hpp
+++ b/src/platforms/shared/spi_manager.cpp.hpp
@@ -46,14 +46,15 @@ SPIBusManager::~SPIBusManager() {
     // Device destructors already handle cleanup via unregisterDevice(), so this is safe.
 }
 
-SPIBusHandle SPIBusManager::registerDevice(u8 clock_pin, u8 data_pin, u32 requested_speed_hz, void* controller) FL_NO_EXCEPT {
+SPIBusHandle SPIBusManager::registerDevice(u8 clock_pin, u8 data_pin, u32 requested_speed_hz, void* controller,
+                                           Esp32SpiBus requested_bus) FL_NO_EXCEPT {
     if (!controller) {
         FL_WARN_F("SPIBusManager: nullptr controller pointer");
         return SPIBusHandle();
     }
 
     // Find or create bus for this clock pin
-    SPIBusInfo* bus = getOrCreateBus(clock_pin);
+    SPIBusInfo* bus = getOrCreateBus(clock_pin, requested_bus);
     if (!bus) {
         FL_WARN_F("SPIBusManager: Too many different clock pins (max %s)", static_cast<int>(MAX_BUSES));
         return SPIBusHandle();
@@ -543,6 +544,7 @@ void SPIBusManager::reset() FL_NO_EXCEPT {
         mBuses[i].bus_type = SPIBusType::SOFT_SPI;
         mBuses[i].num_devices = 0;
         mBuses[i].spi_bus_num = 0xFF;
+        mBuses[i].requested_bus = Esp32SpiBus::AUTO;
         mBuses[i].hw_controller = nullptr;
         mBuses[i].is_initialized = false;
         mBuses[i].error_message = nullptr;
@@ -570,10 +572,10 @@ const SPIBusInfo* SPIBusManager::getBusInfo(u8 bus_id) const FL_NO_EXCEPT {
 // Private Methods
 // ============================================================================
 
-SPIBusInfo* SPIBusManager::getOrCreateBus(u8 clock_pin) FL_NO_EXCEPT {
+SPIBusInfo* SPIBusManager::getOrCreateBus(u8 clock_pin, Esp32SpiBus requested_bus) FL_NO_EXCEPT {
     // Search for existing bus with this clock pin
     for (u8 i = 0; i < mNumBuses; i++) {
-        if (mBuses[i].clock_pin == clock_pin) {
+        if (mBuses[i].clock_pin == clock_pin && mBuses[i].requested_bus == requested_bus) {
             return &mBuses[i];
         }
     }
@@ -584,6 +586,7 @@ SPIBusInfo* SPIBusManager::getOrCreateBus(u8 clock_pin) FL_NO_EXCEPT {
     }
 
     mBuses[mNumBuses].clock_pin = clock_pin;
+    mBuses[mNumBuses].requested_bus = requested_bus;
     mBuses[mNumBuses].num_devices = 0;
     mBuses[mNumBuses].bus_type = SPIBusType::SOFT_SPI;
     return &mBuses[mNumBuses++];
@@ -655,7 +658,9 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NO_EXCEPT {
         // Try each controller until we find one that works
         fl::shared_ptr<SpiHw2> dual_ctrl;
         for (const auto& ctrl : controllers) {
-            if (!ctrl->isInitialized()) {
+            const bool host_matches = bus.requested_bus == Esp32SpiBus::AUTO ||
+                ctrl->getBusId() == static_cast<int>(bus.requested_bus);
+            if (host_matches && !ctrl->isInitialized()) {
                 dual_ctrl = ctrl;
                 break;
             }
@@ -706,7 +711,9 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NO_EXCEPT {
         // Try each controller until we find one that works
         fl::shared_ptr<SpiHw4> quad_ctrl;
         for (const auto& ctrl : controllers) {
-            if (!ctrl->isInitialized()) {
+            const bool host_matches = bus.requested_bus == Esp32SpiBus::AUTO ||
+                ctrl->getBusId() == static_cast<int>(bus.requested_bus);
+            if (host_matches && !ctrl->isInitialized()) {
                 quad_ctrl = ctrl;
                 break;
             }
@@ -761,7 +768,9 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NO_EXCEPT {
         // Try each controller until we find one that works
         fl::shared_ptr<SpiHw8> octal_ctrl;
         for (const auto& ctrl : controllers) {
-            if (!ctrl->isInitialized()) {
+            const bool host_matches = bus.requested_bus == Esp32SpiBus::AUTO ||
+                ctrl->getBusId() == static_cast<int>(bus.requested_bus);
+            if (host_matches && !ctrl->isInitialized()) {
                 octal_ctrl = ctrl;
                 break;
             }
@@ -820,7 +829,9 @@ bool SPIBusManager::promoteToMultiSPI(SPIBusInfo& bus) FL_NO_EXCEPT {
         // Try each controller until we find one that works
         fl::shared_ptr<SpiHw16> hexadeca_ctrl;
         for (const auto& ctrl : controllers) {
-            if (!ctrl->isInitialized()) {
+            const bool host_matches = bus.requested_bus == Esp32SpiBus::AUTO ||
+                ctrl->getBusId() == static_cast<int>(bus.requested_bus);
+            if (host_matches && !ctrl->isInitialized()) {
                 hexadeca_ctrl = ctrl;
                 break;
             }

--- a/src/platforms/shared/spi_manager.h
+++ b/src/platforms/shared/spi_manager.h
@@ -4,6 +4,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/vector.h"
+#include "fl/spi_bus.h"
 
 // Shared SPI type definitions
 #include "platforms/shared/spi_types.h"
@@ -69,6 +70,7 @@ struct SPIBusInfo {
     u8 num_devices;            ///< Number of devices on this bus
     SPIDeviceInfo devices[16];      ///< Device list (max 16 for I2S parallel mode)
     u8 spi_bus_num;            ///< Hardware SPI bus number (2 or 3)
+    Esp32SpiBus requested_bus; ///< Explicit ESP32 host, or AUTO
     fl::shared_ptr<SpiHwBase> hw_controller;  ///< Polymorphic hardware controller (SpiHw1/2/4/8/16)
     bool is_initialized;            ///< Whether hardware is initialized
     const char* error_message;      ///< Error message if initialization failed
@@ -79,7 +81,7 @@ struct SPIBusInfo {
 
     SPIBusInfo()
  FL_NO_EXCEPT : clock_pin(0xFF), bus_type(SPIBusType::SOFT_SPI), num_devices(0),
-          spi_bus_num(0xFF), hw_controller(nullptr), is_initialized(false),
+          spi_bus_num(0xFF), requested_bus(Esp32SpiBus::AUTO), hw_controller(nullptr), is_initialized(false),
           error_message(nullptr) {}
 };
 
@@ -105,7 +107,8 @@ public:
     /// @param requested_speed_hz User-requested SPI speed in Hz (from DATA_RATE_MHZ)
     /// @param controller Pointer to controller instance
     /// @returns Handle to use for transmit operations
-    SPIBusHandle registerDevice(u8 clock_pin, u8 data_pin, u32 requested_speed_hz, void* controller) FL_NO_EXCEPT;
+    SPIBusHandle registerDevice(u8 clock_pin, u8 data_pin, u32 requested_speed_hz, void* controller,
+                                Esp32SpiBus requested_bus = Esp32SpiBus::AUTO) FL_NO_EXCEPT;
 
     /// Unregister a device (LED strip) from the manager
     /// Called by LED controller destructors
@@ -151,7 +154,7 @@ private:
     /// Find or create bus for a clock pin
     /// @param clock_pin Clock pin number
     /// @returns Pointer to bus, or nullptr if MAX_BUSES exceeded
-    SPIBusInfo* getOrCreateBus(u8 clock_pin) FL_NO_EXCEPT;
+    SPIBusInfo* getOrCreateBus(u8 clock_pin, Esp32SpiBus requested_bus) FL_NO_EXCEPT;
 
     /// Initialize a specific bus (promotes to multi-SPI if needed)
     /// @param bus Bus to initialize

--- a/tests/fl/channels/adapters/spi_channel_adapter.cpp
+++ b/tests/fl/channels/adapters/spi_channel_adapter.cpp
@@ -137,9 +137,10 @@ private:
 };
 
 /// @brief Create SPI channel data (APA102, SK9822, etc.)
-ChannelDataPtr createSpiChannelData(int dataPin = 5, int clockPin = 18) {
+ChannelDataPtr createSpiChannelData(int dataPin = 5, int clockPin = 18,
+                                    Esp32SpiBus spiBus = Esp32SpiBus::AUTO) {
     SpiEncoder encoder = SpiEncoder::apa102();
-    SpiChipsetConfig spiConfig{dataPin, clockPin, encoder};
+    SpiChipsetConfig spiConfig{dataPin, clockPin, encoder, spiBus};
     fl::vector_psram<uint8_t> data = {0x00, 0xFF, 0xAA, 0x55};
     return ChannelData::create(spiConfig, fl::move(data));
 }
@@ -536,6 +537,44 @@ FL_TEST_CASE("SpiChannelEngineAdapter - Multiple channels same clock pin") {
     // Both channels should be transmitted (batched together)
     // Mock transmit called once per channel in batch
     FL_CHECK_GT(spiHw1->getTransmitCount(), 0);
+}
+
+FL_TEST_CASE("SpiChannelEngineAdapter - explicit SPI host selects matching controller") {
+    auto spi2 = fl::make_shared<MockSpiHw>(1, "SPI2", 10);
+    auto spi3 = fl::make_shared<MockSpiHw>(1, "SPI3", 5);
+    spi2->setBusId(2);
+    spi3->setBusId(3);
+
+    fl::vector<fl::shared_ptr<SpiHwBase>> controllers = {spi2, spi3};
+    fl::vector<int> priorities = {10, 5};
+    fl::vector<const char*> names = {"SPI2", "SPI3"};
+    auto adapter = SpiChannelEngineAdapter::create(
+        controllers, priorities, names, "SPI_UNIFIED");
+
+    adapter->enqueue(createSpiChannelData(5, 18, Esp32SpiBus::SPI3));
+    adapter->show();
+
+    FL_CHECK_FALSE(spi2->wasTransmitCalled());
+    FL_CHECK_TRUE(spi3->wasTransmitCalled());
+}
+
+FL_TEST_CASE("SpiChannelEngineAdapter - AUTO preserves controller priority") {
+    auto preferred = fl::make_shared<MockSpiHw>(1, "preferred", 10);
+    auto fallback = fl::make_shared<MockSpiHw>(1, "fallback", 5);
+    preferred->setBusId(2);
+    fallback->setBusId(3);
+
+    fl::vector<fl::shared_ptr<SpiHwBase>> controllers = {preferred, fallback};
+    fl::vector<int> priorities = {10, 5};
+    fl::vector<const char*> names = {"preferred", "fallback"};
+    auto adapter = SpiChannelEngineAdapter::create(
+        controllers, priorities, names, "SPI_UNIFIED");
+
+    adapter->enqueue(createSpiChannelData());
+    adapter->show();
+
+    FL_CHECK_TRUE(preferred->wasTransmitCalled());
+    FL_CHECK_FALSE(fallback->wasTransmitCalled());
 }
 
 } // FL_TEST_FILE

--- a/tests/platforms/shared/spi_manager.cpp
+++ b/tests/platforms/shared/spi_manager.cpp
@@ -10,6 +10,34 @@
 
 using namespace fl;
 
+namespace {
+
+class TestSpiHw2 : public SpiHw2 {
+  public:
+    explicit TestSpiHw2(int busId) : mBusId(busId) {}
+    bool begin(const Config& config) FL_NO_EXCEPT override {
+        mInitialized = true;
+        mConfiguredBus = config.bus_num;
+        return true;
+    }
+    void end() FL_NO_EXCEPT override { mInitialized = false; }
+    DMABuffer acquireDMABuffer(size_t size) FL_NO_EXCEPT override { return DMABuffer(size); }
+    bool transmit(TransmitMode) FL_NO_EXCEPT override { return true; }
+    bool waitComplete(u32) FL_NO_EXCEPT override { return true; }
+    bool isBusy() const FL_NO_EXCEPT override { return false; }
+    bool isInitialized() const FL_NO_EXCEPT override { return mInitialized; }
+    int getBusId() const FL_NO_EXCEPT override { return mBusId; }
+    const char* getName() const FL_NO_EXCEPT override { return "test-spi"; }
+    int configuredBus() const { return mConfiguredBus; }
+
+  private:
+    int mBusId;
+    int mConfiguredBus = -1;
+    bool mInitialized = false;
+};
+
+} // namespace
+
 FL_TEST_CASE("SPIBusManager - device registration and bus type") {
     SPIBusManager& manager = getSPIBusManager();
     manager.reset();
@@ -41,4 +69,83 @@ FL_TEST_CASE("SPIBusManager - device registration and bus type") {
 #endif
 
     manager.reset();
+}
+
+FL_TEST_CASE("SPIBusManager - explicit ESP32 hosts are independent") {
+    SPIBusManager& manager = getSPIBusManager();
+    manager.reset();
+
+    SPIBusHandle spi2 = manager.registerDevice(18, 23, 1000000,
+                                                (void*)0x1234,
+                                                Esp32SpiBus::SPI2);
+    SPIBusHandle spi3 = manager.registerDevice(18, 19, 1000000,
+                                                (void*)0x5678,
+                                                Esp32SpiBus::SPI3);
+
+    FL_REQUIRE_TRUE(spi2.is_valid);
+    FL_REQUIRE_TRUE(spi3.is_valid);
+    FL_CHECK_NE(spi2.bus_id, spi3.bus_id);
+    FL_CHECK_EQ(manager.getBusInfo(spi2.bus_id)->requested_bus, Esp32SpiBus::SPI2);
+    FL_CHECK_EQ(manager.getBusInfo(spi3.bus_id)->requested_bus, Esp32SpiBus::SPI3);
+    manager.reset();
+}
+
+FL_TEST_CASE("SPIBusManager - AUTO preserves clock-pin grouping") {
+    SPIBusManager& manager = getSPIBusManager();
+    manager.reset();
+
+    SPIBusHandle first = manager.registerDevice(18, 23, 1000000, (void*)0x1234);
+    SPIBusHandle second = manager.registerDevice(18, 19, 1000000, (void*)0x5678);
+
+    FL_REQUIRE_TRUE(first.is_valid);
+    FL_REQUIRE_TRUE(second.is_valid);
+    FL_CHECK_EQ(first.bus_id, second.bus_id);
+    FL_CHECK_EQ(manager.getBusInfo(first.bus_id)->requested_bus, Esp32SpiBus::AUTO);
+    manager.reset();
+}
+
+FL_TEST_CASE("SPIBusManager - explicit host controls multi-lane allocation") {
+    (void)SpiHw2::getAll();
+    SpiHw2::clearInstances();
+    auto spi2 = fl::make_shared<TestSpiHw2>(2);
+    auto spi3 = fl::make_shared<TestSpiHw2>(3);
+    SpiHw2::registerInstance(spi2);
+    SpiHw2::registerInstance(spi3);
+
+    SPIBusManager& manager = getSPIBusManager();
+    manager.reset();
+    manager.registerDevice(18, 23, 1000000, (void*)0x1234, Esp32SpiBus::SPI3);
+    SPIBusHandle handle = manager.registerDevice(
+        18, 19, 1000000, (void*)0x5678, Esp32SpiBus::SPI3);
+
+    FL_REQUIRE_TRUE(manager.initialize());
+    FL_CHECK_FALSE(spi2->isInitialized());
+    FL_CHECK_TRUE(spi3->isInitialized());
+    FL_CHECK_EQ(spi3->configuredBus(), 3);
+    FL_CHECK_EQ(manager.getBusInfo(handle.bus_id)->spi_bus_num, 3);
+
+    manager.reset();
+    SpiHw2::clearInstances();
+}
+
+FL_TEST_CASE("SPIBusManager - AUTO keeps first-available allocation") {
+    (void)SpiHw2::getAll();
+    SpiHw2::clearInstances();
+    auto first = fl::make_shared<TestSpiHw2>(7);
+    auto second = fl::make_shared<TestSpiHw2>(8);
+    SpiHw2::registerInstance(first);
+    SpiHw2::registerInstance(second);
+
+    SPIBusManager& manager = getSPIBusManager();
+    manager.reset();
+    manager.registerDevice(18, 23, 1000000, (void*)0x1234);
+    SPIBusHandle handle = manager.registerDevice(18, 19, 1000000, (void*)0x5678);
+
+    FL_REQUIRE_TRUE(manager.initialize());
+    FL_CHECK_TRUE(first->isInitialized());
+    FL_CHECK_FALSE(second->isInitialized());
+    FL_CHECK_EQ(manager.getBusInfo(handle.bus_id)->spi_bus_num, 7);
+
+    manager.reset();
+    SpiHw2::clearInstances();
 }


### PR DESCRIPTION
Summary:
- add typed per-controller ESP32 SPI2/SPI3 host selection to both Channel and legacy APIs
- carry the selected host through channel configuration, grouping, and controller allocation
- preserve AUTO priority behavior and isolate same-clock groups requested on different hosts
- guard SPI3 on one-host ESP32 variants
- add behavioral allocation regressions and a two-bus ESP32-S3 example

Validation:
- spi_manager debug/sanitizer suite passed
- spi_channel_adapter debug/sanitizer suite passed
- ESP32-S3 MultipleEsp32SpiBuses exact public-API compile passed
- ESP32-C3 APA102 single-host portability compile passed
- comprehensive lint passed
- diff check passed

Closes #1516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting ESP32 SPI2 or SPI3 independently for each LED controller.
  * Added an example showing two APA102 strips running on separate SPI buses.
  * Automatic bus selection remains available when no bus is specified.

* **Documentation**
  * Updated ESP32 guidance with instructions for configuring per-controller SPI buses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->