### PR TITLE
fix(esp32): compile APA102 defaults in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
   build_esp32dev:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: "esp32dev"
+      args: "esp32dev --examples Blink,Apa102"
 
   build_esp8266:
     uses: ./.github/workflows/build_template.yml
@@ -44,12 +44,12 @@ jobs:
   build_esp32_c3_devkitm_1:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: "esp32c3"
+      args: "esp32c3 --examples Blink,Apa102"
 
   build_esp32_s3_devkitc_1:
     uses: ./.github/workflows/build_template.yml
     with:
-      args: "esp32s3"
+      args: "esp32s3 --examples Blink,Apa102"
 
   build_yun:
     uses: ./.github/workflows/build_template.yml


### PR DESCRIPTION
Fixes #4022.\n\nAdds APA102 to the classic ESP32, C3, and S3 CI compile sweeps, exercising the already-correct per-variant SPI defaults. Validated with ; board builds will run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated builds for ESP32 board variants to include the Blink and Apa102 examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->