### PR TITLE
fix(teensy): size parallel line masks for eight bits

### DIFF
--- a/src/platforms/arm/k20/clockless_block_arm_k20.h
+++ b/src/platforms/arm/k20/clockless_block_arm_k20.h
@@ -111,10 +111,11 @@ public:
 	virtual u16 getMaxRefreshRate() const { return 400; }
 
 	typedef union {
-		u8 bytes[12];
-		u16 shorts[6];
-		u32 raw[3];
+		u8 bytes[16];
+		u16 shorts[8];
+		u32 raw[4];
 	} Lines;
+	FL_STATIC_ASSERT(sizeof(Lines) >= 8 * sizeof(u16), "Lines must hold eight 16-bit output masks");
 
 	template<int BITS,int PX> __attribute__ ((always_inline)) inline static void writeBits(FASTLED_REGISTER u32 & next_mark, FASTLED_REGISTER Lines & b, PixelController<RGB_ORDER, LANES, PORT_MASK> &pixels) FL_NO_EXCEPT { // , FASTLED_REGISTER uint32_t & b2)  {
 		FASTLED_REGISTER Lines b2;

--- a/src/platforms/arm/k66/clockless_block_arm_k66.h
+++ b/src/platforms/arm/k66/clockless_block_arm_k66.h
@@ -128,10 +128,11 @@ public:
 	virtual u16 getMaxRefreshRate() const { return 400; }
 
 	typedef union {
-		u8 bytes[12];
-		u16 shorts[6];
-		u32 raw[3];
+		u8 bytes[16];
+		u16 shorts[8];
+		u32 raw[4];
 	} Lines;
+	FL_STATIC_ASSERT(sizeof(Lines) >= 8 * sizeof(u16), "Lines must hold eight 16-bit output masks");
 
 	template<int BITS,int PX> __attribute__ ((always_inline)) inline static void writeBits(FASTLED_REGISTER u32 & next_mark, FASTLED_REGISTER Lines & b, PixelController<RGB_ORDER, LANES, LANE_MASK> &pixels) FL_NO_EXCEPT { // , FASTLED_REGISTER uint32_t & b2)  {
 		FASTLED_REGISTER Lines b2;

--- a/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
+++ b/src/platforms/arm/teensy/teensy31_32/clockless_block_arm_k20.h
@@ -99,10 +99,11 @@ public:
 	virtual u16 getMaxRefreshRate() const { return 400; }
 
 	typedef union {
-		u8 bytes[12];
-		u16 shorts[6];
-		u32 raw[3];
+		u8 bytes[16];
+		u16 shorts[8];
+		u32 raw[4];
 	} Lines;
+	FL_STATIC_ASSERT(sizeof(Lines) >= 8 * sizeof(u16), "Lines must hold eight 16-bit output masks");
 
 	template<int BITS,int PX> __attribute__ ((always_inline)) inline static void writeBits(FASTLED_REGISTER u32 & next_mark, FASTLED_REGISTER Lines & b, PixelController<RGB_ORDER, LANES, PORT_MASK> &pixels) FL_NO_EXCEPT { // , FASTLED_REGISTER uint32_t & b2)  {
 		FASTLED_REGISTER Lines b2;

--- a/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
+++ b/src/platforms/arm/teensy/teensy36/clockless_block_arm_k66.h
@@ -114,10 +114,11 @@ public:
 	virtual u16 getMaxRefreshRate() const { return 400; }
 
 	typedef union {
-		u8 bytes[12];
-		u16 shorts[6];
-		u32 raw[3];
+		u8 bytes[16];
+		u16 shorts[8];
+		u32 raw[4];
 	} Lines;
+	FL_STATIC_ASSERT(sizeof(Lines) >= 8 * sizeof(u16), "Lines must hold eight 16-bit output masks");
 
 	template<int BITS,int PX> __attribute__ ((always_inline)) inline static void writeBits(FASTLED_REGISTER u32 & next_mark, FASTLED_REGISTER Lines & b, PixelController<RGB_ORDER, LANES, LANE_MASK> &pixels) FL_NO_EXCEPT { // , FASTLED_REGISTER uint32_t & b2)  {
 		FASTLED_REGISTER Lines b2;


### PR DESCRIPTION
Fixes #1201.\n\nExpands the K20/K66 parallel controller line-mask storage to safely cover all eight 16-bit masks, including compatibility headers. Validated with [0;34mFAST FastLED TypeScript Linting (ESLint + TypeScript Type Checking - FAST!)[0m
[0;34mChecking if TypeScript files need linting...[0m
All checks passed!
1.14 ⚠️  Changes detected in JavaScript/TypeScript directories
[0;34mTypeScript files changed - proceeding with linting[0m
[0;34mFound WASM TypeScript files:[0m
  src/platforms/wasm/compiler/types/index.ts
  src/platforms/wasm/compiler/app.ts
  src/platforms/wasm/compiler/index.ts
  src/platforms/wasm/compiler/modules/ui/column_validator.ts
  src/platforms/wasm/compiler/modules/ui/layout_state_manager.ts
  src/platforms/wasm/compiler/modules/ui/ui_layout_placement_manager.ts
  src/platforms/wasm/compiler/modules/ui/ui_manager.ts
  src/platforms/wasm/compiler/modules/ui/resize_coordinator.ts
  src/platforms/wasm/compiler/modules/core/fastled_async_controller.ts
  src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
  src/platforms/wasm/compiler/modules/core/fastled_callbacks.ts
  src/platforms/wasm/compiler/modules/core/fastled_debug_logger.ts
  src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
  src/platforms/wasm/compiler/modules/core/fastled_events.ts
  src/platforms/wasm/compiler/modules/recording/video_recorder.ts
  src/platforms/wasm/compiler/modules/recording/ui_playback.ts
  src/platforms/wasm/compiler/modules/recording/ui_recorder_test.ts
  src/platforms/wasm/compiler/modules/recording/ui_recorder.ts
  src/platforms/wasm/compiler/modules/utils/json_inspector.ts
  src/platforms/wasm/compiler/modules/audio/audio_manager.ts
  src/platforms/wasm/compiler/modules/graphics/graphics_manager.ts
  src/platforms/wasm/compiler/modules/graphics/graphics_utils.ts
  src/platforms/wasm/compiler/modules/graphics/graphics_manager_threejs.ts
[0;34mFound WASM JavaScript files:[0m
  src/platforms/wasm/compiler/js_library.js
  src/platforms/wasm/compiler/modules/audio/audio_worklet_processor.js
[0;34mFound avr8js TypeScript files:[0m
  ci/docker_utils/avr8js/main.ts
  ci/docker_utils/avr8js/intelhex.ts
  ci/docker_utils/avr8js/format-time.ts
  ci/docker_utils/avr8js/execute.ts
[0;34mRunning ESLint...[0m
🚀 Running FastLED Comprehensive Linting Suite
==============================================

⚡ PARALLEL LINTING (4 stages)
================================
Running ruff check (linting + import sorting)
  Started python_pipeline (PID 14538)

🔧 C++ LINTING
---------------
  Started cpp_linting (PID 14538)

🌐 JAVASCRIPT LINTING & TYPE CHECKING
--------------------------------------
  Started javascript_linting (PID 14538)
  Started meson_linting (PID 14538)

[0;34m🚀 Using fast JavaScript linting (Node.js + ESLint)[0m
2.74 ⚠️  C++ files changed - running linting
All checks passed!
1 file left unchanged
403 files left unchanged

/Users/zacharyvorhies/dev/fastled/src/platforms/wasm/compiler/modules/graphics/graphics_manager.ts
  400:15  warning  Method 'updateCanvas' has a complexity of 43. Maximum allowed is 35  complexity

✖ 1 problem (0 errors, 1 warning)

[0;32mESLint completed successfully[0m
[0;34mRunning TypeScript Type Checking...[0m
[0;34mUsing TypeScript for type checking: /Users/zacharyvorhies/dev/fastled/.cache/js-tools/node_modules/.bin/tsc[0m
ci/autoresearch/driver_sweep.py:261:21: error[invalid-argument-type] Argument to bound method `RpcClient.send` is incorrect: Expected `list[Any] | None`, found `dict[str, Any]`
ci/autoresearch_agent.py:433:31: error[invalid-assignment] Object of type `dict[str, Any]` is not assignable to `list[Any]`
ci/meson/runner.py:812:17: error[unresolved-attribute] Unresolved attribute `kill_all` on type `def test_callback(test_path: Path) -> TestResult`
ci/meson/streaming.py:581:9: error[unresolved-attribute] Unresolved attribute `_test_file_filter` on type `(Path, /) -> TestResult`
ci/util/boot_wait.py:59:15: error[invalid-type-form] Invalid subscript of object of type `def callable(obj: object, /) -> TypeIs[Top[(...) -> object]]` in a parameter annotation
ci/util/console_utf8.py:23:13: error[call-non-callable] Object of type `object` is not callable
ci/util/console_utf8.py:27:13: error[call-non-callable] Object of type `object` is not callable
ci/util/pio_process_killer.py:112:17: error[call-top-callable] Object of type `Top[(...) -> object]` is not safe to call; its signature is not known
ci/util/pio_process_killer.py:372:39: error[invalid-argument-type] Argument to bound method `Popen.communicate` is incorrect: Expected `str | None`, found `bytes | str | None`
Found 9 diagnostics
[0;32mTypeScript type checking completed successfully[0m
[0;32mSUCCESS: TypeScript linting and type checking completed successfully[0m
📝 Lint success fingerprint updated
Running unified C++ linting checks...
Project root: /Users/zacharyvorhies/dev/fastled


================================================================================
✅ All C++ linting checks passed!
================================================================================
✅ All platform headers have IWYU pragma markings

🔍 C++ CUSTOM LINTERS (UNIFIED)
-------------------------------
Running unified C++ checker (all linters + unity build + cpp_lint in one pass)
Running ruff format (formatting)
Running KeyboardInterrupt handler checks
Running sys.path.insert/append checks
Running dict type annotation checks
✅ ruff passed
Running ty (fast type check)
❌ ty failed
  ❌ python_pipeline FAILED
🔧 C++ lint success fingerprint updated
✅ C++ linting passed

🔍 IWYU PRAGMA CHECK
--------------------

🔍 INCLUDE-WHAT-YOU-USE ANALYSIS
---------------------------------
⏭️  IWYU skipped (use --full or --iwyu to enable)

🔍 CLANG-TIDY STATIC ANALYSIS
------------------------------
⏭️  clang-tidy skipped (use --tidy to enable)

🔍 FL_NOEXCEPT PLATFORMS CHECK
-------------------------------
⏭️  noexcept check skipped (use --tidy to enable)
  ✅ cpp_linting completed
  ✅ javascript_linting completed
  ✅ meson_linting completed

  Parallel phase completed in 22s

🎉 All linting completed!

Linting Execution Summary:
-------------------+-------------------------
Linter Name        |                 Duration
-------------------+-------------------------
python_pipeline    |                       8s
cpp_linting        |                      22s
javascript_linting |                      11s
meson_linting      |                       1s
-------------------+-------------------------

💡 FOR AI AGENTS:
  - Use 'bash lint' for comprehensive linting (Python, C++, and JavaScript)
  - Use 'bash lint --strict' to also run pyright + IWYU (strict type & include checking)
  - Use 'bash lint --js' for JavaScript linting only
  - Use 'bash lint --cpp' for C++ linting only
  - Use 'bash lint --full' to include IWYU (Include-What-You-Use) analysis
  - Use 'bash lint --iwyu' to run IWYU analysis only
  - Use 'bash lint --iwyu --fix' to auto-fix IWYU violations
  - Use 'bash lint --tidy' to run clang-tidy static analysis on src/fl
  - Python linting includes: ruff (lint + format) + KBI checker + ty
  - Use --strict to also run pyright (strict type checking)
  - C++ linting includes: clang-format and custom checkers
  - IWYU runs with --full, --iwyu, or --strict flags
  - clang-tidy runs with --tidy flag
  - JavaScript linting: FAST ONLY (no slow fallback)
  - To enable fast JavaScript linting: uv run ci/setup-js-linting-fast.py
  - Use 'bash lint --help' for usage information and a Teensy 3.6 Blink compile; root C++ suite is blocked by an unrelated host-only ESP32 example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LED output reliability for supported ARM-based controllers by increasing internal output capacity.
  * Added safeguards to ensure sufficient storage for multiple output masks, helping prevent configuration-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->