### PR TITLE
feat(color): add opt-in Oklab blending

### DIFF
--- a/src/colorutils.h
+++ b/src/colorutils.h
@@ -13,6 +13,7 @@ using fl::fade_raw;
 using fl::nscale8;
 using fl::fadeUsingColor;
 using fl::blend;
+using fl::blend_oklab;
 using fl::CRGBPalette16;
 using fl::CRGBPalette32;
 using fl::CRGBPalette256;

--- a/src/fl/gfx/colorutils.cpp.hpp
+++ b/src/fl/gfx/colorutils.cpp.hpp
@@ -19,6 +19,71 @@
 
 namespace fl {
 
+namespace {
+
+struct Oklab {
+    float lightness;
+    float green_red;
+    float blue_yellow;
+};
+
+float signedCubeRoot(float value) {
+    const float magnitude = fl::powf(fl::abs(value), 1.0f / 3.0f);
+    return value < 0.0f ? -magnitude : magnitude;
+}
+
+Oklab rgbToOklab(const CRGB &rgb) {
+    const float red = static_cast<float>(rgb.r) / 255.0f;
+    const float green = static_cast<float>(rgb.g) / 255.0f;
+    const float blue = static_cast<float>(rgb.b) / 255.0f;
+
+    const float l = 0.4122214708f * red + 0.5363325363f * green +
+                    0.0514459929f * blue;
+    const float m = 0.2119034982f * red + 0.6806995451f * green +
+                    0.1073969566f * blue;
+    const float s = 0.0883024619f * red + 0.2817188376f * green +
+                    0.6299787005f * blue;
+
+    const float lRoot = signedCubeRoot(l);
+    const float mRoot = signedCubeRoot(m);
+    const float sRoot = signedCubeRoot(s);
+
+    return {
+        0.2104542553f * lRoot + 0.7936177850f * mRoot -
+            0.0040720468f * sRoot,
+        1.9779984951f * lRoot - 2.4285922050f * mRoot +
+            0.4505937099f * sRoot,
+        0.0259040371f * lRoot + 0.7827717662f * mRoot -
+            0.8086757660f * sRoot,
+    };
+}
+
+fl::u8 channelFromFloat(float value) {
+    const float scaled = fl::roundf(fl::clamp(value, 0.0f, 1.0f) * 255.0f);
+    return static_cast<fl::u8>(scaled);
+}
+
+CRGB oklabToRgb(const Oklab &lab) {
+    const float lRoot = lab.lightness + 0.3963377774f * lab.green_red +
+                        0.2158037573f * lab.blue_yellow;
+    const float mRoot = lab.lightness - 0.1055613458f * lab.green_red -
+                        0.0638541728f * lab.blue_yellow;
+    const float sRoot = lab.lightness - 0.0894841775f * lab.green_red -
+                        1.2914855480f * lab.blue_yellow;
+    const float l = lRoot * lRoot * lRoot;
+    const float m = mRoot * mRoot * mRoot;
+    const float s = sRoot * sRoot * sRoot;
+
+    return CRGB(channelFromFloat(4.0767416621f * l - 3.3077115913f * m +
+                                 0.2309699292f * s),
+                channelFromFloat(-1.2684380046f * l + 2.6097574011f * m -
+                                 0.3413193965f * s),
+                channelFromFloat(-0.0041960863f * l - 0.7034186147f * m +
+                                 1.7076147010f * s));
+}
+
+} // namespace
+
 CRGB &nblend(CRGB &existing, const CRGB &overlay, fract8 amountOfOverlay) {
     if (amountOfOverlay == 0) {
         return existing;
@@ -64,6 +129,21 @@ CRGB blend(const CRGB &p1, const CRGB &p2, fract8 amountOfP2) {
     CRGB nu(p1);
     nblend(nu, p2, amountOfP2);
     return nu;
+}
+
+CRGB blend_oklab(const CRGB &p1, const CRGB &p2, fract8 amountOfP2) {
+    if (amountOfP2 == 0) { return p1; }
+    if (amountOfP2 == 255) { return p2; }
+
+    const Oklab first = rgbToOklab(p1);
+    const Oklab second = rgbToOklab(p2);
+    const float amount = static_cast<float>(amountOfP2) / 255.0f;
+    const Oklab mixed = {
+        first.lightness + (second.lightness - first.lightness) * amount,
+        first.green_red + (second.green_red - first.green_red) * amount,
+        first.blue_yellow + (second.blue_yellow - first.blue_yellow) * amount,
+    };
+    return oklabToRgb(mixed);
 }
 
 CRGB *blend(const CRGB *src1, const CRGB *src2, CRGB *dest, fl::u16 count,

--- a/src/fl/gfx/colorutils.h
+++ b/src/fl/gfx/colorutils.h
@@ -152,6 +152,20 @@ inline void fadeUsingColor(fl::span<CRGB> leds, const CRGB &colormask) FL_NO_EXC
 /// @see CRGB::lerp8()
 CRGB blend(const CRGB &p1, const CRGB &p2, fract8 amountOfP2) FL_NO_EXCEPT;
 
+/// Computes a perceptual interpolation between two RGB colors in Oklab.
+///
+/// This is an opt-in alternative to blend(); existing RGB blending remains
+/// channel-wise. CRGB channel values are treated as linear-light RGB with
+/// sRGB primaries, matching the input expected by the Oklab transform.
+/// Out-of-gamut results are clipped to the CRGB channel range.
+///
+/// @param p1 the first color to blend
+/// @param p2 the second color to blend
+/// @param amountOfP2 the fraction of p2 to blend into p1
+/// @return the perceptually interpolated RGB color
+CRGB blend_oklab(const CRGB &p1, const CRGB &p2,
+                 fract8 amountOfP2) FL_NO_EXCEPT;
+
 /// @copydoc blend(const CRGB&, const CRGB&, fract8)
 ///
 /// Interpolating in HSV space preserves saturation and value far better than

--- a/tests/fl/gfx/colorutils.cpp
+++ b/tests/fl/gfx/colorutils.cpp
@@ -63,6 +63,23 @@ CRGB downconvert(const fl::CRGB16 &rgb) {
 
 FL_TEST_FILE(FL_FILEPATH) {
 
+FL_TEST_CASE("Oklab blending is opt-in and preserves endpoints") {
+    const CRGB first(12, 34, 56);
+    const CRGB second(210, 180, 90);
+
+    FL_CHECK_EQ(blend_oklab(first, second, 0), first);
+    FL_CHECK_EQ(blend_oklab(first, second, 255), second);
+
+    // In linear-light Oklab, halfway from black to white has L=0.5 and
+    // therefore RGB channels of 0.5 cubed, or approximately 32/255.
+    FL_CHECK_EQ(blend_oklab(CRGB::Black, CRGB::White, 128), CRGB(32, 32, 32));
+    // This interpolation reconstructs a negative red channel, which must be
+    // clipped to the CRGB gamut instead of wrapping during conversion.
+    FL_CHECK_EQ(blend_oklab(CRGB::Green, CRGB::Blue, 128), CRGB(0, 63, 107));
+    FL_CHECK_NE(blend_oklab(CRGB::Red, CRGB::Blue, 128),
+                blend(CRGB::Red, CRGB::Blue, 128));
+}
+
 FL_TEST_CASE("CHSV palettes upscale consistently") {
     CHSVPalette16 hsv16(
         make_hsv(0), make_hsv(1), make_hsv(2), make_hsv(3),


### PR DESCRIPTION
Fixes #4065.

Adds documented fl::blend_oklab while preserving existing channel-wise blend behavior. Includes focused endpoint and interpolation tests. Validated with lint and the focused colorutils test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in Oklab color blending for smoother, more perceptually consistent color transitions.
  * Exposed the new blending function through the public color utilities API.
  * Includes gamut clipping and consistent behavior at blend endpoints.

* **Tests**
  * Added coverage for endpoint handling, black-to-white blending, and differences from standard channel-based blending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->