### PR TITLE
fix(avr): keep SPI defaults off UART TX

### DIFF
--- a/src/platforms/avr/atmega/m328p/fastpin_m328p.h
+++ b/src/platforms/avr/atmega/m328p/fastpin_m328p.h
@@ -48,6 +48,16 @@ _FL_DEFPIN( 8, 0, B); _FL_DEFPIN( 9, 1, B); _FL_DEFPIN(10, 2, B); _FL_DEFPIN(11,
 _FL_DEFPIN(12, 4, B); _FL_DEFPIN(13, 5, B); _FL_DEFPIN(14, 0, C); _FL_DEFPIN(15, 1, C);
 _FL_DEFPIN(16, 2, C); _FL_DEFPIN(17, 3, C); _FL_DEFPIN(18, 4, C); _FL_DEFPIN(19, 5, C);
 
+// D1 is the hardware UART TX pin used by Serial on Arduino Uno, Nano, and
+// Pro Mini boards. Keep the clocked-example default off the console and use
+// this family's established hardware SPI pair instead.
+#ifndef FL_PIN_SPI_DATA_1
+#define FL_PIN_SPI_DATA_1 11
+#endif
+#ifndef FL_PIN_SPI_CLOCK_1
+#define FL_PIN_SPI_CLOCK_1 13
+#endif
+
 #define SPI_DATA 11
 #define SPI_CLOCK 13
 #define SPI_SELECT 10


### PR DESCRIPTION
Refs #4018.

Sets ATmega328P-family default SPI data and clock pins to D11/D13, preserving user overrides and avoiding inherited D1 UART TX. Validated with lint and an Uno APA102 compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default SPI data and clock pin mappings for ATmega328P-based boards.
  * Preserves custom pin assignments when externally configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->