### PR TITLE
perf(mp3): integer SIMD for the fixed-point decoder (#4055)

### DIFF
--- a/.github/workflows/mp3_cpu_audit.yml
+++ b/.github/workflows/mp3_cpu_audit.yml
@@ -12,6 +12,8 @@ on:
       - 'src/third_party/libhelix_mp3/**'
       - 'src/third_party/minimp3/**'
       - 'ci/codec_tables/**'
+      - 'tests/fl/codec/mp3*'
+      - 'tests/fl/codec/minimp3_variants.hpp'
       - 'tests/data/codec/minimp3/**'
       - 'ci/codec_cpu/**'
       - 'ci/codec_memory/*_audit.cpp'
@@ -26,6 +28,8 @@ on:
       - 'src/third_party/libhelix_mp3/**'
       - 'src/third_party/minimp3/**'
       - 'ci/codec_tables/**'
+      - 'tests/fl/codec/mp3*'
+      - 'tests/fl/codec/minimp3_variants.hpp'
       - 'tests/data/codec/minimp3/**'
       - 'ci/codec_cpu/**'
       - 'ci/codec_memory/*_audit.cpp'
@@ -72,6 +76,17 @@ jobs:
           uv run pio pkg install -g -t 'espressif/toolchain-xtensa-esp32@8.4.0+2021r2-patch3'
           uv run pio pkg install -g -t 'espressif/toolchain-riscv32-esp@12.2.0+20230208'
           uv run pio pkg install -g -t 'platformio/toolchain-gccarmnoneeabi@1.120301.0'
+
+      # The fixed-point SIMD kernels must not be slower than the scalar ones
+      # they replace (FastLED/FastLED#4055). That comparison lives in the codec
+      # unit tests, which measure both variants in one process so the result is
+      # same-host by construction and needs no baseline -- but it only asserts
+      # in an optimised build, because -O0 punishes intrinsics far more than
+      # scalar integer code and would measure the compiler instead of the
+      # kernel. The default unit-test build is -O0, so it is run here in
+      # release explicitly.
+      - name: Verify the fixed-point SIMD is not slower than scalar
+        run: bash test fl_codec --cpp --build-mode release
 
       - name: Verify the focused CPU gate
         env:

--- a/ci/codec_memory/minimp3_fixed_audit.cpp
+++ b/ci/codec_memory/minimp3_fixed_audit.cpp
@@ -15,10 +15,20 @@
 
 #include "platforms/new.h"
 
+// Scalar deliberately. The 2 KiB decode-stack budget this audit enforces is an
+// MCU budget, and no FastLED MCU target compiles the integer SIMD kernels --
+// Xtensa, RISC-V and Cortex-M have neither SSE nor NEON. Auditing the host's
+// vectorised build would measure a configuration that never ships to the
+// targets the budget exists for, and the vector kernels legitimately need more
+// stack (the DCT-32 holds its 4x8 scratch as 16-byte vectors rather than
+// int32). The SIMD build's own footprint is covered by the bit-exactness and
+// perf gates in tests/fl/codec/mp3_fixed_point.hpp.
 #define MINIMP3_FIXED_POINT 1
+#define MINIMP3_NO_SIMD
 #define MINIMP3_IMPLEMENTATION
 #define MINIMP3_NO_STDIO
 #include "third_party/minimp3/minimp3.h" // ok cpp include
 #undef MINIMP3_NO_STDIO
 #undef MINIMP3_IMPLEMENTATION
+#undef MINIMP3_NO_SIMD
 #undef MINIMP3_FIXED_POINT

--- a/src/third_party/minimp3/FASTLED.patch
+++ b/src/third_party/minimp3/FASTLED.patch
@@ -1,8 +1,8 @@
 diff --git a/minimp3.h b/minimp3.h
-index 9fbd4d2..eb0397a 100644
+index 9fbd4d2..0add0fd 100644
 --- a/minimp3.h
 +++ b/minimp3.h
-@@ -1,50 +1,198 @@
+@@ -1,50 +1,200 @@
  #ifndef MINIMP3_H
  #define MINIMP3_H
 +// SPDX-License-Identifier: CC0-1.0
@@ -33,7 +33,9 @@ index 9fbd4d2..eb0397a 100644
 +#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
 +    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
 +#include <immintrin.h>
-+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
++#if defined(_MSC_VER)
++#include <intrin.h> /* __cpuid, for the SSE4.1 run-time check */
++#elif defined(__GNUC__) || defined(__clang__)
 +#include <cpuid.h>
 +#endif
 +#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
@@ -213,7 +215,7 @@ index 9fbd4d2..eb0397a 100644
  
  #define MAX_FREE_FORMAT_FRAME_SIZE  2304    /* more than ISO spec's */
  #ifndef MAX_FRAME_SYNC_MATCHES
-@@ -84,7 +232,181 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -84,7 +234,180 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  #define MINIMP3_MIN(a, b)           ((a) > (b) ? (b) : (a))
  #define MINIMP3_MAX(a, b)           ((a) < (b) ? (b) : (a))
  
@@ -315,19 +317,18 @@ index 9fbd4d2..eb0397a 100644
 +    return mp3d_sat64((acc + ((int64_t)1 << 29)) >> 30);
 +}
 +
-+/* Saturating add/subtract, computed entirely in 32 bits.
++/* Saturating add/subtract, via a 64-bit intermediate.
 +
-+   These run tens of times per butterfly in the DCT-32 and IMDCT, which is the
-+   hot path on exactly the 32-bit MCUs this path exists for, and there a 64-bit
-+   add costs a register pair and a carry chain. The overflow test is the
-+   standard one: a signed add overflows exactly when both operands share a sign
-+   that the result does not, which is what `(a ^ sum) & (b ^ sum) < 0` says. The
-+   wrapping sum is computed on unsigned operands, where wraparound is defined
-+   rather than UB.
++   These run tens of times per butterfly in the DCT-32 and IMDCT, so a 32-bit
++   branchless form is tempting -- a 64-bit add is a register pair and a carry
++   chain on the MCUs this path targets. It was tried and reverted: on the one
++   target that could actually be measured it cost 6,265 bytes of text (+24%)
++   and 48 bytes of decode stack for ~3% of decode time, and the MCU argument for
++   it was never verified on an MCU. Revisit only with cross-compiled codegen
++   numbers; codec_cpu_trend.json has the rig.
 +
-+   The trailing check preserves the previous behaviour exactly: the saturation
-+   range is symmetric (see MP3D_SAT_MIN), so INT32_MIN is out of range even
-+   though it does not overflow a 32-bit add. */
++   Note the saturation range is symmetric (see MP3D_SAT_MIN), which the vector
++   forms of these must reproduce exactly. */
 +static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 +{
 +    return mp3d_sat64((int64_t)a + (int64_t)b);
@@ -396,7 +397,7 @@ index 9fbd4d2..eb0397a 100644
  
  #if !defined(MINIMP3_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__) || defined(_M_ARM64))
  /* x64 always have SSE2, arm64 always have neon, no need for generic code */
-@@ -136,7 +458,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
+@@ -136,7 +459,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
  #endif /* defined(__PIC__)*/
  }
  #endif /* defined(_MSC_VER) || defined(MINIMP3_ONLY_SIMD) */
@@ -405,7 +406,7 @@ index 9fbd4d2..eb0397a 100644
  {
  #ifdef MINIMP3_ONLY_SIMD
      return 1;
-@@ -187,9 +509,37 @@ static int have_simd()
+@@ -187,9 +510,37 @@ static int have_simd()
  #error MINIMP3_ONLY_SIMD used, but SSE/NEON not enabled
  #endif /* MINIMP3_ONLY_SIMD */
  #endif /* SIMD checks... */
@@ -445,7 +446,7 @@ index 9fbd4d2..eb0397a 100644
  
  #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
  #define HAVE_ARMV6 1
-@@ -211,7 +561,21 @@ typedef struct
+@@ -211,7 +562,21 @@ typedef struct
  
  typedef struct
  {
@@ -467,7 +468,7 @@ index 9fbd4d2..eb0397a 100644
      uint8_t total_bands, stereo_bands, bitalloc[64], scfcod[64];
  } L12_scale_info;
  
-@@ -234,18 +598,34 @@ typedef struct
+@@ -234,18 +599,34 @@ typedef struct
      bs_t bs;
      uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
      L3_gr_info_t gr_info[4];
@@ -506,7 +507,7 @@ index 9fbd4d2..eb0397a 100644
  {
      uint32_t next, cache = 0, s = bs->pos & 7;
      int shl = n + s;
-@@ -261,7 +641,7 @@ static uint32_t get_bits(bs_t *bs, int n)
+@@ -261,7 +642,7 @@ static uint32_t get_bits(bs_t *bs, int n)
      return cache | (next >> -shl);
  }
  
@@ -515,7 +516,7 @@ index 9fbd4d2..eb0397a 100644
  {
      return h[0] == 0xff &&
          ((h[1] & 0xF0) == 0xf0 || (h[1] & 0xFE) == 0xe2) &&
-@@ -270,7 +650,7 @@ static int hdr_valid(const uint8_t *h)
+@@ -270,7 +651,7 @@ static int hdr_valid(const uint8_t *h)
          (HDR_GET_SAMPLE_RATE(h) != 3);
  }
  
@@ -524,7 +525,7 @@ index 9fbd4d2..eb0397a 100644
  {
      return hdr_valid(h2) &&
          ((h1[1] ^ h2[1]) & 0xFE) == 0 &&
-@@ -278,7 +658,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
+@@ -278,7 +659,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
          !(HDR_IS_FREE_FORMAT(h1) ^ HDR_IS_FREE_FORMAT(h2));
  }
  
@@ -533,7 +534,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const uint8_t halfrate[2][3][15] = {
          { { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,16,24,28,32,40,48,56,64,72,80,88,96,112,128 } },
-@@ -287,18 +667,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
+@@ -287,18 +668,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
      return 2*halfrate[!!HDR_TEST_MPEG1(h)][HDR_GET_LAYER(h) - 1][HDR_GET_BITRATE(h)];
  }
  
@@ -555,7 +556,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int frame_bytes = hdr_frame_samples(h)*hdr_bitrate_kbps(h)*125/hdr_sample_rate_hz(h);
      if (HDR_IS_LAYER_1(h))
-@@ -308,13 +688,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
+@@ -308,13 +689,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
      return frame_bytes ? frame_bytes : free_format_size;
  }
  
@@ -571,7 +572,7 @@ index 9fbd4d2..eb0397a 100644
  {
      const L12_subband_alloc_t *alloc;
      int mode = HDR_GET_STEREO_MODE(hdr);
-@@ -359,7 +739,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
+@@ -359,7 +740,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
      return alloc;
  }
  
@@ -630,7 +631,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const float g_deq_L12[18*3] = {
  #define DQ(x) 9.53674316e-07f/x, 7.56931807e-07f/x, 6.00777173e-07f/x
-@@ -382,8 +812,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
+@@ -382,8 +813,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
          }
      }
  }
@@ -641,7 +642,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const uint8_t g_bitalloc_code_tab[] = {
          0,17, 3, 4, 5,6,7, 8,9,10,11,12,13,14,15,16,
-@@ -423,7 +854,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -423,7 +855,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
          sci->scfcod[i] = sci->bitalloc[i] ? HDR_IS_LAYER_1(hdr) ? 2 : get_bits(bs, 2) : 6;
      }
  
@@ -653,7 +654,7 @@ index 9fbd4d2..eb0397a 100644
  
      for (i = sci->stereo_bands; i < sci->total_bands; i++)
      {
-@@ -431,12 +866,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -431,12 +867,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
      }
  }
  
@@ -672,7 +673,7 @@ index 9fbd4d2..eb0397a 100644
          for (i = 0; i < 2*sci->total_bands; i++)
          {
              int ba = sci->bitalloc[i];
-@@ -447,7 +886,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -447,7 +887,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      int half = (1 << (ba - 1)) - 1;
                      for (k = 0; k < group_size; k++)
                      {
@@ -681,7 +682,7 @@ index 9fbd4d2..eb0397a 100644
                      }
                  } else
                  {
-@@ -455,7 +894,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -455,7 +895,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      unsigned code = get_bits(bs, mod + 2 - (mod >> 3));  /* 5, 7, 10 */
                      for (k = 0; k < group_size; k++, code /= mod)
                      {
@@ -690,7 +691,7 @@ index 9fbd4d2..eb0397a 100644
                      }
                  }
              }
-@@ -466,7 +905,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -466,7 +906,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
      return group_size*4;
  }
  
@@ -714,7 +715,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, k;
      memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
-@@ -479,9 +933,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
+@@ -479,9 +934,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
          }
      }
  }
@@ -726,7 +727,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const uint8_t g_scf_long[8][23] = {
          { 6,6,6,6,6,6,8,10,12,14,16,20,24,28,32,38,46,52,60,68,58,54,0 },
-@@ -606,7 +1061,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
+@@ -606,7 +1062,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
      return main_data_begin;
  }
  
@@ -735,7 +736,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, k;
      for (i = 0; i < 4 && scf_count[i]; i++, scfsi *= 2)
-@@ -639,7 +1094,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
+@@ -639,7 +1095,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
      scf[0] = scf[1] = scf[2] = 0;
  }
  
@@ -836,7 +837,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const float g_expfrac[4] = { 9.31322575e-10f,7.83145814e-10f,6.58544508e-10f,5.53767716e-10f };
      int e;
-@@ -650,8 +1197,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
+@@ -650,8 +1198,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
      } while ((exp_q2 -= e) > 0);
      return y;
  }
@@ -857,7 +858,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const uint8_t g_scf_partitions[3][28] = {
          { 6,5,5, 5,6,5,5,5,6,5, 7,3,11,10,0,0, 7, 7, 7,0, 6, 6,6,3, 8, 8,5,0 },
-@@ -661,7 +1218,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -661,7 +1219,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      const uint8_t *scf_partition = g_scf_partitions[!!gr->n_short_sfb + !gr->n_long_sfb];
      uint8_t scf_size[4], iscf[40];
      int i, scf_shift = gr->scalefac_scale + 1, gain_exp, scfsi = gr->scfsi;
@@ -867,7 +868,7 @@ index 9fbd4d2..eb0397a 100644
  
      if (HDR_TEST_MPEG1(hdr))
      {
-@@ -706,19 +1265,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -706,19 +1266,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      }
  
      gain_exp = gr->global_gain + BITS_DEQUANTIZER_OUT*4 - 210 - (HDR_IS_MS_STEREO(hdr) ? 2 : 0);
@@ -942,7 +943,7 @@ index 9fbd4d2..eb0397a 100644
  {
      float frac;
      int sign, mult = 256;
-@@ -738,8 +1351,9 @@ static float L3_pow_43(int x)
+@@ -738,8 +1352,9 @@ static float L3_pow_43(int x)
      frac = (float)((x & 63) - sign) / ((x & ~63) + sign);
      return g_pow43[16 + ((x + sign) >> 6)]*(1.f + frac*((4.f/3) + frac*(2.f/9)))*mult;
  }
@@ -953,7 +954,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const int16_t tabs[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          785,785,785,785,784,784,784,784,513,513,513,513,513,513,513,513,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,
-@@ -767,7 +1381,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -767,7 +1382,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
  #define CHECK_BITS    while (bs_sh >= 0) { bs_cache |= (uint32_t)*bs_next_ptr++ << bs_sh; bs_sh -= 8; }
  #define BSPOS         ((bs_next_ptr - bs->buf)*8 - 24 + bs_sh)
  
@@ -962,7 +963,7 @@ index 9fbd4d2..eb0397a 100644
      int ireg = 0, big_val_cnt = gr_info->big_values;
      const uint8_t *sfb = gr_info->sfbtab;
      const uint8_t *bs_next_ptr = bs->buf + bs->pos/8;
-@@ -787,7 +1401,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -787,7 +1402,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -971,7 +972,7 @@ index 9fbd4d2..eb0397a 100644
                  do
                  {
                      int j, w = 5;
-@@ -808,10 +1422,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -808,10 +1423,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                              lsb += PEEK_BITS(linbits);
                              FLUSH_BITS(linbits);
                              CHECK_BITS;
@@ -984,7 +985,7 @@ index 9fbd4d2..eb0397a 100644
                          }
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
-@@ -824,7 +1438,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -824,7 +1439,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -993,7 +994,7 @@ index 9fbd4d2..eb0397a 100644
                  do
                  {
                      int j, w = 5;
-@@ -840,7 +1454,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -840,7 +1455,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                      for (j = 0; j < 2; j++, dst++, leaf >>= 4)
                      {
                          int lsb = leaf & 0x0F;
@@ -1002,7 +1003,7 @@ index 9fbd4d2..eb0397a 100644
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
                      CHECK_BITS;
-@@ -862,8 +1476,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -862,8 +1477,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
          {
              break;
          }
@@ -1013,7 +1014,7 @@ index 9fbd4d2..eb0397a 100644
          RELOAD_SCALEFACTOR;
          DEQ_COUNT1(0);
          DEQ_COUNT1(1);
-@@ -876,10 +1490,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -876,10 +1491,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
      bs->pos = layer3gr_limit;
  }
  
@@ -1026,7 +1027,7 @@ index 9fbd4d2..eb0397a 100644
  #if HAVE_SIMD
      if (have_simd())
      {
-@@ -901,24 +1515,47 @@ static void L3_midside_stereo(float *left, int n)
+@@ -901,24 +1516,47 @@ static void L3_midside_stereo(float *left, int n)
  #endif /* HAVE_SIMD */
      for (; i < n; i++)
      {
@@ -1076,7 +1077,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, k;
  
-@@ -938,9 +1575,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
+@@ -938,9 +1576,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
      }
  }
  
@@ -1102,7 +1103,7 @@ index 9fbd4d2..eb0397a 100644
      unsigned i, max_pos = HDR_TEST_MPEG1(hdr) ? 7 : 64;
  
      for (i = 0; sfb[i]; i++)
-@@ -948,6 +1600,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -948,6 +1601,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
          unsigned ipos = ist_pos[i];
          if ((int)i > max_band[i % 3] && ipos < max_pos)
          {
@@ -1130,7 +1131,7 @@ index 9fbd4d2..eb0397a 100644
              float kl, kr, s = HDR_TEST_MS_STEREO(hdr) ? 1.41421356f : 1;
              if (HDR_TEST_MPEG1(hdr))
              {
-@@ -964,6 +1637,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -964,6 +1638,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
                  }
              }
              L3_intensity_stereo_band(left, sfb[i], kl*s, kr*s);
@@ -1138,7 +1139,7 @@ index 9fbd4d2..eb0397a 100644
          } else if (HDR_TEST_MS_STEREO(hdr))
          {
              L3_midside_stereo(left, sfb[i]);
-@@ -972,7 +1646,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -972,7 +1647,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
      }
  }
  
@@ -1147,7 +1148,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int max_band[3], n_sfb = gr->n_long_sfb + gr->n_short_sfb;
      int i, max_blocks = gr->n_short_sfb ? 3 : 1;
-@@ -992,10 +1666,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
+@@ -992,10 +1667,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
      L3_stereo_process(left, ist_pos, gr->sfbtab, hdr, max_band, gr[1].scalefac_compress & 1);
  }
  
@@ -1160,7 +1161,7 @@ index 9fbd4d2..eb0397a 100644
  
      for (;0 != (len = *sfb); sfb += 3, src += 2*len)
      {
-@@ -1006,15 +1680,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
+@@ -1006,15 +1681,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
              *dst++ = src[2*len];
          }
      }
@@ -1180,7 +1181,7 @@ index 9fbd4d2..eb0397a 100644
  
      for (; nbands > 0; nbands--, grbuf += 18)
      {
-@@ -1035,16 +1711,193 @@ static void L3_antialias(float *grbuf, int nbands)
+@@ -1035,16 +1712,193 @@ static void L3_antialias(float *grbuf, int nbands)
  #ifndef MINIMP3_ONLY_SIMD
          for(; i < 8; i++)
          {
@@ -1375,7 +1376,7 @@ index 9fbd4d2..eb0397a 100644
  {
      float s0, s1, s2, s3, s4, s5, s6, s7, s8, t0, t2, t4;
  
-@@ -1084,7 +1937,7 @@ static void L3_dct3_9(float *y)
+@@ -1084,7 +1938,7 @@ static void L3_dct3_9(float *y)
      y[8] = s4 + s7;
  }
  
@@ -1384,7 +1385,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, j;
      static const float g_twid9[18] = {
-@@ -1141,7 +1994,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
+@@ -1141,7 +1995,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
      }
  }
  
@@ -1393,7 +1394,7 @@ index 9fbd4d2..eb0397a 100644
  {
      float m1 = x1*0.86602540f;
      float a1 = x0 - x2*0.5f;
-@@ -1150,7 +2003,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
+@@ -1150,7 +2004,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
      dst[2] = a1 - m1;
  }
  
@@ -1402,7 +1403,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const float g_twid3[6] = { 0.79335334f,0.92387953f,0.99144486f, 0.60876143f,0.38268343f,0.13052619f };
      float co[3], si[3];
-@@ -1170,7 +2023,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
+@@ -1170,7 +2024,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
      }
  }
  
@@ -1411,7 +1412,7 @@ index 9fbd4d2..eb0397a 100644
  {
      for (;nbands > 0; nbands--, overlap += 9, grbuf += 18)
      {
-@@ -1183,7 +2036,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
+@@ -1183,7 +2037,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
      }
  }
  
@@ -1420,7 +1421,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int b, i;
      for (b = 0, grbuf += 18; b < 32; b += 2, grbuf += 36)
-@@ -1191,7 +2044,7 @@ static void L3_change_sign(float *grbuf)
+@@ -1191,7 +2045,7 @@ static void L3_change_sign(float *grbuf)
              grbuf[i] = -grbuf[i];
  }
  
@@ -1429,7 +1430,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const float g_mdct_window[2][18] = {
          { 0.99904822f,0.99144486f,0.97629601f,0.95371695f,0.92387953f,0.88701083f,0.84339145f,0.79335334f,0.73727734f,0.04361938f,0.13052619f,0.21643961f,0.30070580f,0.38268343f,0.46174861f,0.53729961f,0.60876143f,0.67559021f },
-@@ -1208,8 +2061,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
+@@ -1208,8 +2062,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
      else
          L3_imdct36(grbuf, overlap, g_mdct_window[block_type == STOP_BLOCK_TYPE], 32 - n_long_bands);
  }
@@ -1441,7 +1442,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int pos = (s->bs.pos + 7)/8u;
      int remains = s->bs.limit/8u - pos;
-@@ -1225,7 +2080,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
+@@ -1225,7 +2081,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
      h->reserv = remains;
  }
  
@@ -1450,7 +1451,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int frame_bytes = (bs->limit - bs->pos)/8;
      int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-@@ -1235,15 +2090,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
+@@ -1235,15 +2091,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
      return h->reserv >= main_data_begin;
  }
  
@@ -1479,7 +1480,7 @@ index 9fbd4d2..eb0397a 100644
      }
  
      if (HDR_TEST_I_STEREO(h->header))
-@@ -1253,6 +2118,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1253,6 +2119,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
      {
          L3_midside_stereo(s->grbuf[0], 576);
      }
@@ -1487,7 +1488,7 @@ index 9fbd4d2..eb0397a 100644
  
      for (ch = 0; ch < nch; ch++, gr_info++)
      {
-@@ -1262,16 +2128,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1262,16 +2129,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
          if (gr_info->n_short_sfb)
          {
              aa_bands = n_long_bands - 1;
@@ -1502,10 +1503,9 @@ index 9fbd4d2..eb0397a 100644
          L3_imdct_gr(s->grbuf[ch], h->mdct_overlap[ch], gr_info->block_type, n_long_bands);
          L3_change_sign(s->grbuf[ch]);
 +        MP3D_STAGE(MINIMP3_STAGE_IMDCT, ch, s->grbuf[ch], 576);
-     }
- }
- 
--static void mp3d_DCT_II(float *grbuf, int n)
++    }
++}
++
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* DCT-32. Same factorisation as the float build. The secants reach 10.19 so
 +   they are Q27; the rotation constants are Q31 and the output scalings Q29,
@@ -1860,9 +1860,10 @@ index 9fbd4d2..eb0397a 100644
 +        y[1*18] = mp3d_add_sat(t[2][7], t[3][7]);
 +        y[2*18] = t[1][7];
 +        y[3*18] = t[3][7];
-+    }
-+}
-+
+     }
+ }
+ 
+-static void mp3d_DCT_II(float *grbuf, int n)
 +/* Q(MINIMP3_FRAC_BITS) accumulator to int16, reproducing the float build's
 +   rounding exactly: add a half, truncate toward zero, then step away from zero
 +   for negatives ("away from zero, to be compliant"). Matching it matters --
@@ -2085,7 +2086,7 @@ index 9fbd4d2..eb0397a 100644
  {
      static const float g_sec[24] = {
          10.19000816f,0.50060302f,0.50241929f,3.40760851f,0.50547093f,0.52249861f,2.05778098f,0.51544732f,0.56694406f,1.48416460f,0.53104258f,0.64682180f,1.16943991f,0.55310392f,0.78815460f,0.97256821f,0.58293498f,1.06067765f,0.83934963f,0.62250412f,1.72244716f,0.74453628f,0.67480832f,5.10114861f
-@@ -1427,7 +2872,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
+@@ -1427,7 +2873,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
  }
  
  #ifndef MINIMP3_FLOAT_OUTPUT
@@ -2094,7 +2095,7 @@ index 9fbd4d2..eb0397a 100644
  {
  #if HAVE_ARMV6
      int32_t s32 = (int32_t)(sample + .5f);
-@@ -1448,7 +2893,7 @@ static float mp3d_scale_pcm(float sample)
+@@ -1448,7 +2894,7 @@ static float mp3d_scale_pcm(float sample)
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
  
@@ -2103,7 +2104,7 @@ index 9fbd4d2..eb0397a 100644
  {
      float a;
      a  = (z[14*64] - z[    0]) * 29;
-@@ -1473,7 +2918,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
+@@ -1473,7 +2919,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
      pcm[16*nch] = mp3d_scale_pcm(a);
  }
  
@@ -2112,7 +2113,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i;
      float *xr = xl + 576*(nch - 1);
-@@ -1626,16 +3071,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
+@@ -1626,16 +3072,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
  #endif /* MINIMP3_ONLY_SIMD */
  }
  
@@ -2133,7 +2134,7 @@ index 9fbd4d2..eb0397a 100644
      for (i = 0; i < nbands; i += 2)
      {
          mp3d_synth(grbuf + i, pcm + 32*nch*i, nch, lins + i*64);
-@@ -1650,11 +3096,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
+@@ -1650,11 +3097,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
      } else
  #endif /* MINIMP3_NONSTANDARD_BUT_LOGICAL */
      {
@@ -2149,7 +2150,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, nmatch;
      for (i = 0, nmatch = 0; nmatch < MAX_FRAME_SYNC_MATCHES; nmatch++)
-@@ -1668,7 +3116,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
+@@ -1668,7 +3117,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
      return 1;
  }
  
@@ -2158,7 +2159,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i, k;
      for (i = 0; i < mp3_bytes - HDR_SIZE; i++, mp3++)
-@@ -1705,17 +3153,36 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
+@@ -1705,17 +3154,46 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
      return mp3_bytes;
  }
  
@@ -2175,7 +2176,17 @@ index 9fbd4d2..eb0397a 100644
 +
 +int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT
 +{
-+    return MP3D_SIMD_KERNELS_LIVE;
++#if MP3D_SIMD_KERNELS_LIVE
++    /* Compile-time availability is not the question -- on x86 the kernels are
++       compiled for any SSE2 build but only reached when the run-time SSE4.1
++       check passes. Reporting the compile-time answer would make the
++       bit-exactness gate compare a scalar decode against another scalar decode
++       and call it a pass, and would make the perf gate assert a ratio on two
++       identical runs, i.e. on timer noise. */
++    return MP3D_SIMD_AVAILABLE();
++#else
++    return 0;
++#endif
 +}
 +
 +void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT
@@ -2198,7 +2209,7 @@ index 9fbd4d2..eb0397a 100644
  
      if (mp3_bytes > 4 && dec->header[0] == 0xff && hdr_compare(dec->header, mp3))
      {
-@@ -1758,23 +3225,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1758,23 +3236,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  
      if (info->layer == 3)
      {
@@ -2228,7 +2239,7 @@ index 9fbd4d2..eb0397a 100644
      } else
      {
  #ifdef MINIMP3_ONLY_MP3
-@@ -1783,15 +3250,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1783,15 +3261,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
          L12_scale_info sci[1];
          L12_read_scale_info(hdr, bs_frame, sci);
  
@@ -2253,7 +2264,7 @@ index 9fbd4d2..eb0397a 100644
                  pcm += 384*info->channels;
              }
              if (bs_frame->pos > bs_frame->limit)
-@@ -1806,7 +3277,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1806,7 +3288,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  }
  
  #ifdef MINIMP3_FLOAT_OUTPUT
@@ -2262,7 +2273,7 @@ index 9fbd4d2..eb0397a 100644
  {
      int i = 0;
  #if HAVE_SIMD
-@@ -1862,4 +3333,114 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
+@@ -1862,4 +3344,115 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
      }
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
@@ -2303,7 +2314,6 @@ index 9fbd4d2..eb0397a 100644
 +#undef MP3D_V_SUB64
 +#undef MP3D_V_GET64
 +#undef MP3D_V_PREP
-+#undef MP3D_V_SIGN
 +#undef MP3D_V_ADDSAT
 +#undef MP3D_V_SUBSAT
 +#undef MP3D_V_MULSHIFT
@@ -2312,6 +2322,8 @@ index 9fbd4d2..eb0397a 100644
 +#undef MP3D_INT_SIMD_SSE
 +#undef MP3D_INT_SIMD_NEON
 +#undef MP3D_SIMD_KERNELS_LIVE
++#undef MP3D_SIMD_AVAILABLE
++#undef MP3D_SIMD_TARGET
 +#undef BITS_DEQUANTIZER_OUT
 +#undef BSPOS
 +#undef CHECK_BITS

--- a/src/third_party/minimp3/FASTLED.patch
+++ b/src/third_party/minimp3/FASTLED.patch
@@ -1,8 +1,8 @@
 diff --git a/minimp3.h b/minimp3.h
-index 9fbd4d2..c43c40a 100644
+index 9fbd4d2..588d897 100644
 --- a/minimp3.h
 +++ b/minimp3.h
-@@ -1,50 +1,173 @@
+@@ -1,50 +1,178 @@
  #ifndef MINIMP3_H
  #define MINIMP3_H
 +// SPDX-License-Identifier: CC0-1.0
@@ -156,6 +156,11 @@ index 9fbd4d2..c43c40a 100644
 +int mp3dec_is_fixed_point(void) FL_NO_EXCEPT;
 +/* 1 when this instantiation actually decodes with integer arithmetic. */
 +int mp3dec_dsp_is_integer(void) FL_NO_EXCEPT;
++/* 1 when this instantiation compiled integer SIMD kernels. Reported
++   separately from the two above for the same reason they are separate from
++   each other: "the build accepted the flag" and "the build actually vectorised"
++   are different claims, and only the second is worth gating on. */
++int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT;
  #ifndef MINIMP3_FLOAT_OUTPUT
  typedef int16_t mp3d_sample_t;
  #else /* MINIMP3_FLOAT_OUTPUT */
@@ -188,10 +193,11 @@ index 9fbd4d2..c43c40a 100644
  
  #define MAX_FREE_FORMAT_FRAME_SIZE  2304    /* more than ISO spec's */
  #ifndef MAX_FRAME_SYNC_MATCHES
-@@ -84,6 +207,163 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -84,7 +212,191 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  #define MINIMP3_MIN(a, b)           ((a) > (b) ? (b) : (a))
  #define MINIMP3_MAX(a, b)           ((a) < (b) ? (b) : (a))
  
+-#if !defined(MINIMP3_NO_SIMD)
 +#if MINIMP3_HAVE_FIXED_POINT
 +#if defined(MINIMP3_FLOAT_OUTPUT)
 +#error "MINIMP3_FIXED_POINT and MINIMP3_FLOAT_OUTPUT are mutually exclusive"
@@ -289,14 +295,37 @@ index 9fbd4d2..c43c40a 100644
 +    return mp3d_sat64((acc + ((int64_t)1 << 29)) >> 30);
 +}
 +
++/* Saturating add/subtract, computed entirely in 32 bits.
++
++   These run tens of times per butterfly in the DCT-32 and IMDCT, which is the
++   hot path on exactly the 32-bit MCUs this path exists for, and there a 64-bit
++   add costs a register pair and a carry chain. The overflow test is the
++   standard one: a signed add overflows exactly when both operands share a sign
++   that the result does not, which is what `(a ^ sum) & (b ^ sum) < 0` says. The
++   wrapping sum is computed on unsigned operands, where wraparound is defined
++   rather than UB.
++
++   The trailing check preserves the previous behaviour exactly: the saturation
++   range is symmetric (see MP3D_SAT_MIN), so INT32_MIN is out of range even
++   though it does not overflow a 32-bit add. */
 +static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 +{
-+    return mp3d_sat64((int64_t)a + (int64_t)b);
++    const int32_t sum = (int32_t)((uint32_t)a + (uint32_t)b);
++    if (((a ^ sum) & (b ^ sum)) < 0)
++    {
++        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
++    }
++    return sum < MP3D_SAT_MIN ? MP3D_SAT_MIN : sum;
 +}
 +
 +static int32_t mp3d_sub_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 +{
-+    return mp3d_sat64((int64_t)a - (int64_t)b);
++    const int32_t diff = (int32_t)((uint32_t)a - (uint32_t)b);
++    if (((a ^ b) & (a ^ diff)) < 0)
++    {
++        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
++    }
++    return diff < MP3D_SAT_MIN ? MP3D_SAT_MIN : diff;
 +}
 +
 +/* One Q26 unit of 1.0, and the clamp applied to dequantised samples.
@@ -341,18 +370,23 @@ index 9fbd4d2..c43c40a 100644
 +#define MP3D_STAGE(stage, ch, buf, n) ((void)0)
 +#endif
 +
-+/* FastLED: the SIMD kernels below are float-only. Integer SSE2/NEON kernels
-+   are Phase 4 (FastLED/FastLED#4055); until then the fixed-point build is
-+   scalar, and says so rather than silently compiling float vector code. */
-+#if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
-+#define MINIMP3_NO_SIMD
-+#define MP3D_OWNS_NO_SIMD
++/* FastLED: the vector kernels come in two families that must not be confused.
++   The `HAVE_SIMD` block below is the float one, and it stays exactly as
++   upstream wrote it -- the fixed-point build must never compile float vector
++   code. The integer kernels live in their own MP3D_HAVE_INT_SIMD block and are
++   selected only for the fixed build. */
++#if MINIMP3_HAVE_FIXED_POINT
++/* Keep upstream's float SIMD out of the fixed build without disturbing the
++   caller's own MINIMP3_NO_SIMD, which still has to mean "scalar everywhere"
++   and is what the Phase 4 opt-out proof relies on. */
++#define MP3D_FLOAT_SIMD_OFF
 +#endif
 +
- #if !defined(MINIMP3_NO_SIMD)
++#if !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF)
  
  #if !defined(MINIMP3_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__) || defined(_M_ARM64))
-@@ -136,7 +416,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
+ /* x64 always have SSE2, arm64 always have neon, no need for generic code */
+@@ -136,7 +448,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
  #endif /* defined(__PIC__)*/
  }
  #endif /* defined(_MSC_VER) || defined(MINIMP3_ONLY_SIMD) */
@@ -361,7 +395,52 @@ index 9fbd4d2..c43c40a 100644
  {
  #ifdef MINIMP3_ONLY_SIMD
      return 1;
-@@ -211,7 +491,21 @@ typedef struct
+@@ -187,9 +499,42 @@ static int have_simd()
+ #error MINIMP3_ONLY_SIMD used, but SSE/NEON not enabled
+ #endif /* MINIMP3_ONLY_SIMD */
+ #endif /* SIMD checks... */
+-#else /* !defined(MINIMP3_NO_SIMD) */
++#else /* !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF) */
+ #define HAVE_SIMD 0
+-#endif /* !defined(MINIMP3_NO_SIMD) */
++#endif /* !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF) */
++
++/* FastLED: integer SIMD for the fixed-point path (FastLED/FastLED#4055).
++   Deliberately a separate detection block from upstream's float one above --
++   the two select different instruction sets and must never both be live.
++   MINIMP3_NO_SIMD suppresses this as well, which is what makes the scalar
++   opt-out proof meaningful. */
++#if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
++#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
++    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
++#include <immintrin.h>
++#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
++#include <cpuid.h>
++#endif
++#define MP3D_HAVE_INT_SIMD 1
++#define MP3D_INT_SIMD_SSE  1
++typedef __m128i mp3d_i32x4;
++#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
++#include <arm_neon.h>
++#define MP3D_HAVE_INT_SIMD 1
++#define MP3D_INT_SIMD_NEON 1
++typedef int32x4_t mp3d_i32x4;
++#endif
++#endif /* MINIMP3_HAVE_FIXED_POINT && !MINIMP3_NO_SIMD */
++
++#ifndef MP3D_HAVE_INT_SIMD
++#define MP3D_HAVE_INT_SIMD 0
++#endif
++
++/* 1 once integer kernels actually replace scalar ones. Separate from
++   MP3D_HAVE_INT_SIMD -- having the intrinsics available is not the same as
++   using them, and the gate is on the second. */
++#undef MP3D_SIMD_KERNELS_LIVE
++#define MP3D_SIMD_KERNELS_LIVE MP3D_HAVE_INT_SIMD
+ 
+ #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
+ #define HAVE_ARMV6 1
+@@ -211,7 +556,21 @@ typedef struct
  
  typedef struct
  {
@@ -383,7 +462,7 @@ index 9fbd4d2..c43c40a 100644
      uint8_t total_bands, stereo_bands, bitalloc[64], scfcod[64];
  } L12_scale_info;
  
-@@ -234,18 +528,34 @@ typedef struct
+@@ -234,18 +593,34 @@ typedef struct
      bs_t bs;
      uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
      L3_gr_info_t gr_info[4];
@@ -401,15 +480,15 @@ index 9fbd4d2..c43c40a 100644
      uint8_t ist_pos[2][39];
 -} mp3dec_scratch_t;
 +} mp3dec_scratch_internal_t;
- 
--static void bs_init(bs_t *bs, const uint8_t *data, int bytes)
++
 +#ifdef __cplusplus
 +static_assert(sizeof(mp3dec_scratch_internal_t) <= MINIMP3_SCRATCH_SIZE,
 +              "MINIMP3_SCRATCH_SIZE is too small");
 +static_assert(alignof(mp3dec_scratch_internal_t) <= alignof(mp3dec_scratch_t),
 +              "mp3dec_scratch_t alignment is too small");
 +#endif
-+
+ 
+-static void bs_init(bs_t *bs, const uint8_t *data, int bytes)
 +static void bs_init(bs_t *bs, const uint8_t *data, int bytes) FL_NO_EXCEPT
  {
      bs->buf   = data;
@@ -422,7 +501,7 @@ index 9fbd4d2..c43c40a 100644
  {
      uint32_t next, cache = 0, s = bs->pos & 7;
      int shl = n + s;
-@@ -261,7 +571,7 @@ static uint32_t get_bits(bs_t *bs, int n)
+@@ -261,7 +636,7 @@ static uint32_t get_bits(bs_t *bs, int n)
      return cache | (next >> -shl);
  }
  
@@ -431,7 +510,7 @@ index 9fbd4d2..c43c40a 100644
  {
      return h[0] == 0xff &&
          ((h[1] & 0xF0) == 0xf0 || (h[1] & 0xFE) == 0xe2) &&
-@@ -270,7 +580,7 @@ static int hdr_valid(const uint8_t *h)
+@@ -270,7 +645,7 @@ static int hdr_valid(const uint8_t *h)
          (HDR_GET_SAMPLE_RATE(h) != 3);
  }
  
@@ -440,7 +519,7 @@ index 9fbd4d2..c43c40a 100644
  {
      return hdr_valid(h2) &&
          ((h1[1] ^ h2[1]) & 0xFE) == 0 &&
-@@ -278,7 +588,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
+@@ -278,7 +653,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
          !(HDR_IS_FREE_FORMAT(h1) ^ HDR_IS_FREE_FORMAT(h2));
  }
  
@@ -449,7 +528,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const uint8_t halfrate[2][3][15] = {
          { { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,16,24,28,32,40,48,56,64,72,80,88,96,112,128 } },
-@@ -287,18 +597,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
+@@ -287,18 +662,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
      return 2*halfrate[!!HDR_TEST_MPEG1(h)][HDR_GET_LAYER(h) - 1][HDR_GET_BITRATE(h)];
  }
  
@@ -471,7 +550,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int frame_bytes = hdr_frame_samples(h)*hdr_bitrate_kbps(h)*125/hdr_sample_rate_hz(h);
      if (HDR_IS_LAYER_1(h))
-@@ -308,13 +618,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
+@@ -308,13 +683,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
      return frame_bytes ? frame_bytes : free_format_size;
  }
  
@@ -487,7 +566,7 @@ index 9fbd4d2..c43c40a 100644
  {
      const L12_subband_alloc_t *alloc;
      int mode = HDR_GET_STEREO_MODE(hdr);
-@@ -359,7 +669,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
+@@ -359,7 +734,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
      return alloc;
  }
  
@@ -546,7 +625,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const float g_deq_L12[18*3] = {
  #define DQ(x) 9.53674316e-07f/x, 7.56931807e-07f/x, 6.00777173e-07f/x
-@@ -382,8 +742,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
+@@ -382,8 +807,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
          }
      }
  }
@@ -557,7 +636,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const uint8_t g_bitalloc_code_tab[] = {
          0,17, 3, 4, 5,6,7, 8,9,10,11,12,13,14,15,16,
-@@ -423,7 +784,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -423,7 +849,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
          sci->scfcod[i] = sci->bitalloc[i] ? HDR_IS_LAYER_1(hdr) ? 2 : get_bits(bs, 2) : 6;
      }
  
@@ -569,7 +648,7 @@ index 9fbd4d2..c43c40a 100644
  
      for (i = sci->stereo_bands; i < sci->total_bands; i++)
      {
-@@ -431,12 +796,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -431,12 +861,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
      }
  }
  
@@ -588,7 +667,7 @@ index 9fbd4d2..c43c40a 100644
          for (i = 0; i < 2*sci->total_bands; i++)
          {
              int ba = sci->bitalloc[i];
-@@ -447,7 +816,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -447,7 +881,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      int half = (1 << (ba - 1)) - 1;
                      for (k = 0; k < group_size; k++)
                      {
@@ -597,7 +676,7 @@ index 9fbd4d2..c43c40a 100644
                      }
                  } else
                  {
-@@ -455,7 +824,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -455,7 +889,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      unsigned code = get_bits(bs, mod + 2 - (mod >> 3));  /* 5, 7, 10 */
                      for (k = 0; k < group_size; k++, code /= mod)
                      {
@@ -606,7 +685,7 @@ index 9fbd4d2..c43c40a 100644
                      }
                  }
              }
-@@ -466,7 +835,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -466,7 +900,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
      return group_size*4;
  }
  
@@ -630,7 +709,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, k;
      memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
-@@ -479,9 +863,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
+@@ -479,9 +928,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
          }
      }
  }
@@ -642,7 +721,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const uint8_t g_scf_long[8][23] = {
          { 6,6,6,6,6,6,8,10,12,14,16,20,24,28,32,38,46,52,60,68,58,54,0 },
-@@ -606,7 +991,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
+@@ -606,7 +1056,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
      return main_data_begin;
  }
  
@@ -651,7 +730,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, k;
      for (i = 0; i < 4 && scf_count[i]; i++, scfsi *= 2)
-@@ -639,7 +1024,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
+@@ -639,7 +1089,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
      scf[0] = scf[1] = scf[2] = 0;
  }
  
@@ -752,7 +831,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const float g_expfrac[4] = { 9.31322575e-10f,7.83145814e-10f,6.58544508e-10f,5.53767716e-10f };
      int e;
-@@ -650,8 +1127,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
+@@ -650,8 +1192,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
      } while ((exp_q2 -= e) > 0);
      return y;
  }
@@ -773,7 +852,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const uint8_t g_scf_partitions[3][28] = {
          { 6,5,5, 5,6,5,5,5,6,5, 7,3,11,10,0,0, 7, 7, 7,0, 6, 6,6,3, 8, 8,5,0 },
-@@ -661,7 +1148,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -661,7 +1213,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      const uint8_t *scf_partition = g_scf_partitions[!!gr->n_short_sfb + !gr->n_long_sfb];
      uint8_t scf_size[4], iscf[40];
      int i, scf_shift = gr->scalefac_scale + 1, gain_exp, scfsi = gr->scfsi;
@@ -783,7 +862,7 @@ index 9fbd4d2..c43c40a 100644
  
      if (HDR_TEST_MPEG1(hdr))
      {
-@@ -706,19 +1195,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -706,19 +1260,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      }
  
      gain_exp = gr->global_gain + BITS_DEQUANTIZER_OUT*4 - 210 - (HDR_IS_MS_STEREO(hdr) ? 2 : 0);
@@ -809,8 +888,8 @@ index 9fbd4d2..c43c40a 100644
          scf[i] = L3_ldexp_q2(gain, iscf[i] << scf_shift);
      }
 +#endif
-+}
-+
+ }
+ 
 +#if MINIMP3_HAVE_FIXED_POINT
 +static int32_t mp3d_huff_escape(int32_t gain_mant, int gain_exp, int lsb,
 +                                int negative) FL_NO_EXCEPT
@@ -819,8 +898,8 @@ index 9fbd4d2..c43c40a 100644
 +    const int32_t pow_mant = mp3d_pow43(lsb, &pow_exp);
 +    const int32_t value = mp3d_dequant(gain_mant, gain_exp, pow_mant, pow_exp);
 +    return negative ? -value : value;
- }
- 
++}
++
 +static int32_t mp3d_huff_one(int32_t gain_mant, int gain_exp,
 +                             int negative) FL_NO_EXCEPT
 +{
@@ -858,7 +937,7 @@ index 9fbd4d2..c43c40a 100644
  {
      float frac;
      int sign, mult = 256;
-@@ -738,8 +1281,9 @@ static float L3_pow_43(int x)
+@@ -738,8 +1346,9 @@ static float L3_pow_43(int x)
      frac = (float)((x & 63) - sign) / ((x & ~63) + sign);
      return g_pow43[16 + ((x + sign) >> 6)]*(1.f + frac*((4.f/3) + frac*(2.f/9)))*mult;
  }
@@ -869,7 +948,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const int16_t tabs[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          785,785,785,785,784,784,784,784,513,513,513,513,513,513,513,513,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,
-@@ -767,7 +1311,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -767,7 +1376,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
  #define CHECK_BITS    while (bs_sh >= 0) { bs_cache |= (uint32_t)*bs_next_ptr++ << bs_sh; bs_sh -= 8; }
  #define BSPOS         ((bs_next_ptr - bs->buf)*8 - 24 + bs_sh)
  
@@ -878,7 +957,7 @@ index 9fbd4d2..c43c40a 100644
      int ireg = 0, big_val_cnt = gr_info->big_values;
      const uint8_t *sfb = gr_info->sfbtab;
      const uint8_t *bs_next_ptr = bs->buf + bs->pos/8;
-@@ -787,7 +1331,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -787,7 +1396,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -887,7 +966,7 @@ index 9fbd4d2..c43c40a 100644
                  do
                  {
                      int j, w = 5;
-@@ -808,10 +1352,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -808,10 +1417,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                              lsb += PEEK_BITS(linbits);
                              FLUSH_BITS(linbits);
                              CHECK_BITS;
@@ -900,7 +979,7 @@ index 9fbd4d2..c43c40a 100644
                          }
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
-@@ -824,7 +1368,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -824,7 +1433,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -909,7 +988,7 @@ index 9fbd4d2..c43c40a 100644
                  do
                  {
                      int j, w = 5;
-@@ -840,7 +1384,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -840,7 +1449,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                      for (j = 0; j < 2; j++, dst++, leaf >>= 4)
                      {
                          int lsb = leaf & 0x0F;
@@ -918,7 +997,7 @@ index 9fbd4d2..c43c40a 100644
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
                      CHECK_BITS;
-@@ -862,8 +1406,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -862,8 +1471,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
          {
              break;
          }
@@ -929,7 +1008,7 @@ index 9fbd4d2..c43c40a 100644
          RELOAD_SCALEFACTOR;
          DEQ_COUNT1(0);
          DEQ_COUNT1(1);
-@@ -876,10 +1420,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -876,10 +1485,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
      bs->pos = layer3gr_limit;
  }
  
@@ -942,7 +1021,7 @@ index 9fbd4d2..c43c40a 100644
  #if HAVE_SIMD
      if (have_simd())
      {
-@@ -901,24 +1445,47 @@ static void L3_midside_stereo(float *left, int n)
+@@ -901,24 +1510,47 @@ static void L3_midside_stereo(float *left, int n)
  #endif /* HAVE_SIMD */
      for (; i < n; i++)
      {
@@ -992,7 +1071,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, k;
  
-@@ -938,9 +1505,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
+@@ -938,9 +1570,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
      }
  }
  
@@ -1002,7 +1081,7 @@ index 9fbd4d2..c43c40a 100644
 +   is always <= 0 here, so this is the same quarter-power split the scalefactor
 +   gains use, collapsed by a right shift instead of carried. */
 +static int32_t mp3d_ist_gain_q30(int quarters) FL_NO_EXCEPT
-+{
+ {
 +    int32_t mant;
 +    int exp;
 +    mp3d_gain_from_quarters(-quarters, &mant, &exp);
@@ -1011,14 +1090,14 @@ index 9fbd4d2..c43c40a 100644
 +#endif
 +
 +static void L3_stereo_process(mp3d_dsp_t *left, const uint8_t *ist_pos, const uint8_t *sfb, const uint8_t *hdr, int max_band[3], int mpeg2_sh) FL_NO_EXCEPT // ok array parameter
- {
++{
 +#if !MINIMP3_HAVE_FIXED_POINT
      static const float g_pan[7*2] = { 0,1,0.21132487f,0.78867513f,0.36602540f,0.63397460f,0.5f,0.5f,0.63397460f,0.36602540f,0.78867513f,0.21132487f,1,0 };
 +#endif
      unsigned i, max_pos = HDR_TEST_MPEG1(hdr) ? 7 : 64;
  
      for (i = 0; sfb[i]; i++)
-@@ -948,6 +1530,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -948,6 +1595,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
          unsigned ipos = ist_pos[i];
          if ((int)i > max_band[i % 3] && ipos < max_pos)
          {
@@ -1046,7 +1125,7 @@ index 9fbd4d2..c43c40a 100644
              float kl, kr, s = HDR_TEST_MS_STEREO(hdr) ? 1.41421356f : 1;
              if (HDR_TEST_MPEG1(hdr))
              {
-@@ -964,6 +1567,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -964,6 +1632,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
                  }
              }
              L3_intensity_stereo_band(left, sfb[i], kl*s, kr*s);
@@ -1054,7 +1133,7 @@ index 9fbd4d2..c43c40a 100644
          } else if (HDR_TEST_MS_STEREO(hdr))
          {
              L3_midside_stereo(left, sfb[i]);
-@@ -972,7 +1576,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -972,7 +1641,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
      }
  }
  
@@ -1063,7 +1142,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int max_band[3], n_sfb = gr->n_long_sfb + gr->n_short_sfb;
      int i, max_blocks = gr->n_short_sfb ? 3 : 1;
-@@ -992,10 +1596,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
+@@ -992,10 +1661,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
      L3_stereo_process(left, ist_pos, gr->sfbtab, hdr, max_band, gr[1].scalefac_compress & 1);
  }
  
@@ -1076,7 +1155,7 @@ index 9fbd4d2..c43c40a 100644
  
      for (;0 != (len = *sfb); sfb += 3, src += 2*len)
      {
-@@ -1006,15 +1610,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
+@@ -1006,15 +1675,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
              *dst++ = src[2*len];
          }
      }
@@ -1096,7 +1175,7 @@ index 9fbd4d2..c43c40a 100644
  
      for (; nbands > 0; nbands--, grbuf += 18)
      {
-@@ -1035,16 +1641,193 @@ static void L3_antialias(float *grbuf, int nbands)
+@@ -1035,16 +1706,193 @@ static void L3_antialias(float *grbuf, int nbands)
  #ifndef MINIMP3_ONLY_SIMD
          for(; i < 8; i++)
          {
@@ -1291,7 +1370,7 @@ index 9fbd4d2..c43c40a 100644
  {
      float s0, s1, s2, s3, s4, s5, s6, s7, s8, t0, t2, t4;
  
-@@ -1084,7 +1867,7 @@ static void L3_dct3_9(float *y)
+@@ -1084,7 +1932,7 @@ static void L3_dct3_9(float *y)
      y[8] = s4 + s7;
  }
  
@@ -1300,7 +1379,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, j;
      static const float g_twid9[18] = {
-@@ -1141,7 +1924,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
+@@ -1141,7 +1989,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
      }
  }
  
@@ -1309,7 +1388,7 @@ index 9fbd4d2..c43c40a 100644
  {
      float m1 = x1*0.86602540f;
      float a1 = x0 - x2*0.5f;
-@@ -1150,7 +1933,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
+@@ -1150,7 +1998,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
      dst[2] = a1 - m1;
  }
  
@@ -1318,7 +1397,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const float g_twid3[6] = { 0.79335334f,0.92387953f,0.99144486f, 0.60876143f,0.38268343f,0.13052619f };
      float co[3], si[3];
-@@ -1170,7 +1953,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
+@@ -1170,7 +2018,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
      }
  }
  
@@ -1327,7 +1406,7 @@ index 9fbd4d2..c43c40a 100644
  {
      for (;nbands > 0; nbands--, overlap += 9, grbuf += 18)
      {
-@@ -1183,7 +1966,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
+@@ -1183,7 +2031,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
      }
  }
  
@@ -1336,7 +1415,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int b, i;
      for (b = 0, grbuf += 18; b < 32; b += 2, grbuf += 36)
-@@ -1191,7 +1974,7 @@ static void L3_change_sign(float *grbuf)
+@@ -1191,7 +2039,7 @@ static void L3_change_sign(float *grbuf)
              grbuf[i] = -grbuf[i];
  }
  
@@ -1345,19 +1424,19 @@ index 9fbd4d2..c43c40a 100644
  {
      static const float g_mdct_window[2][18] = {
          { 0.99904822f,0.99144486f,0.97629601f,0.95371695f,0.92387953f,0.88701083f,0.84339145f,0.79335334f,0.73727734f,0.04361938f,0.13052619f,0.21643961f,0.30070580f,0.38268343f,0.46174861f,0.53729961f,0.60876143f,0.67559021f },
-@@ -1208,8 +1991,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
+@@ -1208,8 +2056,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
      else
          L3_imdct36(grbuf, overlap, g_mdct_window[block_type == STOP_BLOCK_TYPE], 32 - n_long_bands);
  }
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
-+
  
 -static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
++
 +static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_internal_t *s) FL_NO_EXCEPT
  {
      int pos = (s->bs.pos + 7)/8u;
      int remains = s->bs.limit/8u - pos;
-@@ -1225,7 +2010,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
+@@ -1225,7 +2075,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
      h->reserv = remains;
  }
  
@@ -1366,7 +1445,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int frame_bytes = (bs->limit - bs->pos)/8;
      int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-@@ -1235,15 +2020,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
+@@ -1235,15 +2085,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
      return h->reserv >= main_data_begin;
  }
  
@@ -1395,7 +1474,7 @@ index 9fbd4d2..c43c40a 100644
      }
  
      if (HDR_TEST_I_STEREO(h->header))
-@@ -1253,6 +2048,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1253,6 +2113,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
      {
          L3_midside_stereo(s->grbuf[0], 576);
      }
@@ -1403,7 +1482,7 @@ index 9fbd4d2..c43c40a 100644
  
      for (ch = 0; ch < nch; ch++, gr_info++)
      {
-@@ -1262,16 +2058,243 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1262,16 +2123,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
          if (gr_info->n_short_sfb)
          {
              aa_bands = n_long_bands - 1;
@@ -1418,9 +1497,10 @@ index 9fbd4d2..c43c40a 100644
          L3_imdct_gr(s->grbuf[ch], h->mdct_overlap[ch], gr_info->block_type, n_long_bands);
          L3_change_sign(s->grbuf[ch]);
 +        MP3D_STAGE(MINIMP3_STAGE_IMDCT, ch, s->grbuf[ch], 576);
-+    }
-+}
-+
+     }
+ }
+ 
+-static void mp3d_DCT_II(float *grbuf, int n)
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* DCT-32. Same factorisation as the float build. The secants reach 10.19 so
 +   they are Q27; the rotation constants are Q31 and the output scalings Q29,
@@ -1431,9 +1511,292 @@ index 9fbd4d2..c43c40a 100644
 +   can drive dequantised samples to the +/-1 clamp, and this butterfly stacks
 +   three levels of adds on top of a 10.19x multiply. Saturating there turns a
 +   signed-overflow UB report into a bounded, audible-at-worst result. */
++#if MP3D_HAVE_INT_SIMD
++/* FastLED: integer vector helpers for the polyphase back-end.
++
++   The polyphase filter is the one kernel where vectorising is bit-exact for
++   free: it is a pure int32 x int32 -> int64 multiply-accumulate with no
++   intermediate rounding or saturation, and int64 addition is exact and
++   associative, so any lane arrangement reproduces the scalar result exactly.
++   Every other kernel rounds and saturates per operation, which is why they are
++   not vectorised -- see the disposition note on mp3d_synth below.
++
++   The MUL_LO/MUL_HI pair takes two int32 lanes and returns two int64 products
++   -- `LO` for lanes 0 and 1, `HI` for lanes 2 and 3. ADDSAT/SUBSAT/MULSHIFT are
++   the four-lane forms of the scalar helpers of the same name and must match
++   them exactly, including the symmetric saturation range. */
++#if MP3D_INT_SIMD_NEON
++typedef int64x2_t mp3d_i64x2;
++#define MP3D_V_ZERO64()        vdupq_n_s64(0)
++#define MP3D_V_LOAD4(p)        vld1q_s32((const int32_t *)(p))
++#define MP3D_V_SPLAT(x)        vdupq_n_s32(x)
++#define MP3D_V_PREP(v)         (v)
++#define MP3D_V_STORE4(p, v)    vst1q_s32((int32_t *)(p), (v))
++#define MP3D_V_MUL_LO(v, s)    vmull_s32(vget_low_s32(v), vget_low_s32(s))
++#define MP3D_V_MUL_HI(v, s)    vmull_s32(vget_high_s32(v), vget_high_s32(s))
++#define MP3D_V_ADD64(x, y)     vaddq_s64((x), (y))
++#define MP3D_V_SUB64(x, y)     vsubq_s64((x), (y))
++#define MP3D_V_GET64(x, lane)  ((lane) ? vgetq_lane_s64((x), 1) : vgetq_lane_s64((x), 0))
++/* NEON multiplies signed 32x32 -> 64 natively and is in the ARM64 baseline, so
++   there is nothing to detect. */
++#define MP3D_SIMD_AVAILABLE()  1
++#define MP3D_SIMD_TARGET
++
++/* Saturating add/subtract. vqaddq_s32 saturates to INT32_MIN/MAX; the decoder's
++   range is symmetric, so the extra vmaxq_s32 pulls INT32_MIN up to
++   MP3D_SAT_MIN exactly as the scalar helper does. */
++#define MP3D_V_ADDSAT(a, b)                                                    \
++    vmaxq_s32(vqaddq_s32((a), (b)), vdupq_n_s32(MP3D_SAT_MIN))
++#define MP3D_V_SUBSAT(a, b)                                                    \
++    vmaxq_s32(vqsubq_s32((a), (b)), vdupq_n_s32(MP3D_SAT_MIN))
++
++/* value * Q`bits` coefficient, rounded and saturated -- the vector form of
++   mp3d_mulshift, and it must round the same way: add half, then shift right
++   with sign extension (round half toward +infinity). */
++static int32x4_t mp3d_v_mulshift(int32x4_t v, int32_t coef,
++                                 int64x2_t round, int shift) FL_NO_EXCEPT
++{
++    const int32x2_t c = vdup_n_s32(coef);
++    int64x2_t lo = vaddq_s64(vmull_s32(vget_low_s32(v), c), round);
++    int64x2_t hi = vaddq_s64(vmull_s32(vget_high_s32(v), c), round);
++    lo = vshlq_s64(lo, vdupq_n_s64(-shift));
++    hi = vshlq_s64(hi, vdupq_n_s64(-shift));
++    return vmaxq_s32(vcombine_s32(vqmovn_s64(lo), vqmovn_s64(hi)),
++                     vdupq_n_s32(MP3D_SAT_MIN));
++}
++#define MP3D_V_MULSHIFT(v, coef, bits)                                         \
++    mp3d_v_mulshift((v), (coef), vdupq_n_s64((int64_t)1 << ((bits) - 1)),      \
++                    (bits))
++#else /* MP3D_INT_SIMD_SSE */
++typedef __m128i mp3d_i64x2;
++#define MP3D_V_ZERO64()        _mm_setzero_si128()
++#define MP3D_V_LOAD4(p)        _mm_loadu_si128((const __m128i *)(const void *)(p))
++#define MP3D_V_SPLAT(x)        _mm_set1_epi32(x)
++/* _mm_mul_epi32 multiplies the even int32 lanes; shuffling to (0,1),(2,3) once
++   per vector lets both architectures share the accumulator bookkeeping. */
++#define MP3D_V_PREP(v)         _mm_shuffle_epi32((v), _MM_SHUFFLE(3, 1, 2, 0))
++#define MP3D_V_STORE4(p, v)    _mm_storeu_si128((__m128i *)(void *)(p), (v))
++#define MP3D_V_MUL_LO(v, s)    _mm_mul_epi32((v), (s))
++#define MP3D_V_MUL_HI(v, s)    _mm_mul_epi32(_mm_srli_si128((v), 4), (s))
++#define MP3D_V_ADD64(x, y)     _mm_add_epi64((x), (y))
++#define MP3D_V_SUB64(x, y)     _mm_sub_epi64((x), (y))
++
++static int64_t mp3d_get_i64(__m128i v, int lane) FL_NO_EXCEPT
++{
++    int64_t out[2];
++    _mm_storeu_si128((__m128i *)(void *)out, v);
++    return out[lane];
++}
++#define MP3D_V_GET64(x, lane)  mp3d_get_i64((x), (lane))
++
++/* Signed 32x32 -> 64 needs SSE4.1. SSE2 can emulate it with an unsigned
++   multiply plus a sign correction, and that was measured rather than assumed:
++   0.66x of scalar in a standalone harness, 0.95x inside the decoder. Slower is
++   not worth shipping, so SSE2-only hardware stays on the scalar kernel and the
++   vector path is chosen at run time -- the same shape as upstream's
++   have_simd() dispatch for the float kernels. The same harness measures 1.71x
++   once _mm_mul_epi32 is available. */
++#if defined(__GNUC__) || defined(__clang__)
++#define MP3D_SIMD_TARGET __attribute__((target("sse4.1")))
++#else
++#define MP3D_SIMD_TARGET
++#endif
++
++/* Self-contained: upstream's minimp3_cpuid lives inside the float SIMD block,
++   which the fixed build switches off, so this path cannot borrow it. */
++static int mp3d_have_sse41(void) FL_NO_EXCEPT
++{
++#if defined(__SSE4_1__)
++    return 1;
++#elif defined(_MSC_VER)
++    static int cached;
++    int info[4];
++    if (!cached)
++    {
++        __cpuid(info, 1);
++        cached = ((info[2] & (1 << 19)) != 0) + 1; /* ECX.SSE4_1 */
++    }
++    return cached - 1;
++#elif defined(__GNUC__) || defined(__clang__)
++    static int cached;
++    unsigned eax, ebx, ecx, edx;
++    if (!cached)
++    {
++        cached = (__get_cpuid(1, &eax, &ebx, &ecx, &edx) &&
++                  (ecx & (1u << 19))) + 1;
++    }
++    return cached - 1;
++#else
++    return 0;
++#endif
++}
++#define MP3D_SIMD_AVAILABLE()  mp3d_have_sse41()
++
++/* Saturating add/subtract on four int32 lanes. SSE has saturating add only for
++   8- and 16-bit lanes, so the 32-bit form is the classic branchless test: a
++   signed add overflows exactly when both operands share a sign the result does
++   not. The trailing _mm_max_epi32 enforces the decoder's symmetric range, the
++   same trailing clamp the scalar helper carries. */
++MP3D_SIMD_TARGET static __m128i mp3d_v_addsat(__m128i a, __m128i b) FL_NO_EXCEPT
++{
++    const __m128i sum = _mm_add_epi32(a, b);
++    /* _mm_blendv_epi8 selects per byte on that byte's high bit, so every mask
++       here is broadcast to a full lane with _mm_srai_epi32(.., 31) first --
++       handing it a raw value blends bytes independently and silently produces
++       a wrong answer in the low bits. */
++    const __m128i overflow = _mm_srai_epi32(
++        _mm_and_si128(_mm_xor_si128(a, sum), _mm_xor_si128(b, sum)), 31);
++    const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
++                                         _mm_set1_epi32(MP3D_SAT_MIN),
++                                         _mm_srai_epi32(a, 31));
++    return _mm_max_epi32(_mm_blendv_epi8(sum, rail, overflow),
++                         _mm_set1_epi32(MP3D_SAT_MIN));
++}
++
++MP3D_SIMD_TARGET static __m128i mp3d_v_subsat(__m128i a, __m128i b) FL_NO_EXCEPT
++{
++    const __m128i diff = _mm_sub_epi32(a, b);
++    const __m128i overflow = _mm_srai_epi32(
++        _mm_and_si128(_mm_xor_si128(a, b), _mm_xor_si128(a, diff)), 31);
++    const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
++                                         _mm_set1_epi32(MP3D_SAT_MIN),
++                                         _mm_srai_epi32(a, 31));
++    return _mm_max_epi32(_mm_blendv_epi8(diff, rail, overflow),
++                         _mm_set1_epi32(MP3D_SAT_MIN));
++}
++
++/* value * Q`bits` coefficient, rounded and saturated. SSE has no arithmetic
++   64-bit shift before AVX-512, so the sign bits are folded back in by hand;
++   and no 64-bit compare before SSE4.2, so the narrow detects out-of-range by
++   checking that the high word is the sign extension of the low one. */
++MP3D_SIMD_TARGET static __m128i mp3d_v_mulshift(__m128i v, int32_t coef,
++                                                int bits) FL_NO_EXCEPT
++{
++    const __m128i c = _mm_set1_epi32(coef);
++    const __m128i round = _mm_set1_epi64x((int64_t)1 << (bits - 1));
++    const __m128i s = _mm_shuffle_epi32(v, _MM_SHUFFLE(3, 1, 2, 0));
++    __m128i p01 = _mm_add_epi64(_mm_mul_epi32(s, c), round);
++    __m128i p23 = _mm_add_epi64(_mm_mul_epi32(_mm_srli_si128(s, 4), c), round);
++    const __m128i sign01 =
++        _mm_srai_epi32(_mm_shuffle_epi32(p01, _MM_SHUFFLE(3, 3, 1, 1)), 31);
++    const __m128i sign23 =
++        _mm_srai_epi32(_mm_shuffle_epi32(p23, _MM_SHUFFLE(3, 3, 1, 1)), 31);
++    p01 = _mm_or_si128(_mm_srli_epi64(p01, bits),
++                       _mm_slli_epi64(sign01, 64 - bits));
++    p23 = _mm_or_si128(_mm_srli_epi64(p23, bits),
++                       _mm_slli_epi64(sign23, 64 - bits));
++    {
++        const __m128i lo = _mm_castps_si128(
++            _mm_shuffle_ps(_mm_castsi128_ps(p01), _mm_castsi128_ps(p23),
++                           _MM_SHUFFLE(2, 0, 2, 0)));
++        const __m128i hi = _mm_castps_si128(
++            _mm_shuffle_ps(_mm_castsi128_ps(p01), _mm_castsi128_ps(p23),
++                           _MM_SHUFFLE(3, 1, 3, 1)));
++        const __m128i in_range = _mm_cmpeq_epi32(hi, _mm_srai_epi32(lo, 31));
++        const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
++                                             _mm_set1_epi32(MP3D_SAT_MIN),
++                                             _mm_srai_epi32(hi, 31));
++        return _mm_max_epi32(_mm_blendv_epi8(rail, lo, in_range),
++                             _mm_set1_epi32(MP3D_SAT_MIN));
++    }
++}
++#define MP3D_V_ADDSAT(a, b)            mp3d_v_addsat((a), (b))
++#define MP3D_V_SUBSAT(a, b)            mp3d_v_subsat((a), (b))
++#define MP3D_V_MULSHIFT(v, coef, bits) mp3d_v_mulshift((v), (coef), (bits))
++#endif
++
++#endif /* MP3D_HAVE_INT_SIMD */
++
++#if MP3D_HAVE_INT_SIMD
++/* Four bands of the DCT-32 at once.
++
++   grbuf is laid out band-major, so `y[i*18]` for four consecutive k values is
++   four consecutive int32 -- the same property upstream's float kernel relies
++   on, and the reason this vectorises without gathers.
++
++   Transcribed operation for operation from the scalar version below rather
++   than re-associated. That matters here in a way it did not for the polyphase:
++   every add saturates and every multiply rounds, so reordering them is
++   observable, and #4055's gate is exact equality with the scalar path. */
++MP3D_SIMD_TARGET static void mp3d_dct2_bands4(int32_t *grbuf, int k) FL_NO_EXCEPT
++{
++    mp3d_i32x4 t[4][8], *x;
++    int32_t *y = grbuf + k;
++    int i;
++
++    for (x = t[0], i = 0; i < 8; i++, x++)
++    {
++        const mp3d_i32x4 x0 = MP3D_V_LOAD4(&y[i*18]);
++        const mp3d_i32x4 x1 = MP3D_V_LOAD4(&y[(15 - i)*18]);
++        const mp3d_i32x4 x2 = MP3D_V_LOAD4(&y[(16 + i)*18]);
++        const mp3d_i32x4 x3 = MP3D_V_LOAD4(&y[(31 - i)*18]);
++        const mp3d_i32x4 t0 = MP3D_V_ADDSAT(x0, x3);
++        const mp3d_i32x4 t1 = MP3D_V_ADDSAT(x1, x2);
++        const mp3d_i32x4 t2 =
++            MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x1, x2), g_sec_q27[3*i + 0], 27);
++        const mp3d_i32x4 t3 =
++            MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x3), g_sec_q27[3*i + 1], 27);
++        x[0]  = MP3D_V_ADDSAT(t0, t1);
++        x[8]  = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(t0, t1), g_sec_q27[3*i + 2], 27);
++        x[16] = MP3D_V_ADDSAT(t3, t2);
++        x[24] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(t3, t2), g_sec_q27[3*i + 2], 27);
++    }
++    for (x = t[0], i = 0; i < 4; i++, x += 8)
++    {
++        mp3d_i32x4 x0 = x[0], x1 = x[1], x2 = x[2], x3 = x[3];
++        mp3d_i32x4 x4 = x[4], x5 = x[5], x6 = x[6], x7 = x[7], xt;
++        xt = MP3D_V_SUBSAT(x0, x7); x0 = MP3D_V_ADDSAT(x0, x7);
++        x7 = MP3D_V_SUBSAT(x1, x6); x1 = MP3D_V_ADDSAT(x1, x6);
++        x6 = MP3D_V_SUBSAT(x2, x5); x2 = MP3D_V_ADDSAT(x2, x5);
++        x5 = MP3D_V_SUBSAT(x3, x4); x3 = MP3D_V_ADDSAT(x3, x4);
++        x4 = MP3D_V_SUBSAT(x0, x3); x0 = MP3D_V_ADDSAT(x0, x3);
++        x3 = MP3D_V_SUBSAT(x1, x2); x1 = MP3D_V_ADDSAT(x1, x2);
++        x[0] = MP3D_V_ADDSAT(x0, x1);
++        x[4] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x1), MP3D_Q31_COS_PI_4, 31);
++        x5 = MP3D_V_ADDSAT(x5, x6);
++        x6 = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x6, x7), MP3D_Q31_COS_PI_4, 31);
++        x7 = MP3D_V_ADDSAT(x7, xt);
++        x3 = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x3, x4), MP3D_Q31_COS_PI_4, 31);
++        x5 = MP3D_V_SUBSAT(x5, MP3D_V_MULSHIFT(x7, MP3D_Q31_TAN_PI_16, 31));
++        x7 = MP3D_V_ADDSAT(x7, MP3D_V_MULSHIFT(x5, MP3D_Q31_SIN_PI_8, 31));
++        x5 = MP3D_V_SUBSAT(x5, MP3D_V_MULSHIFT(x7, MP3D_Q31_TAN_PI_16, 31));
++        x0 = MP3D_V_SUBSAT(xt, x6); xt = MP3D_V_ADDSAT(xt, x6);
++        x[1] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(xt, x7), MP3D_Q29_SEC_PI_16, 29);
++        x[2] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x4, x3), MP3D_Q29_SEC_PI_8, 29);
++        x[3] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x5), MP3D_Q29_SEC_3PI_16, 29);
++        x[5] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x0, x5), MP3D_Q29_SEC_5PI_16, 29);
++        x[6] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x4, x3), MP3D_Q29_SEC_3PI_8, 29);
++        x[7] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(xt, x7), MP3D_Q29_SEC_7PI_16, 29);
++    }
++    for (i = 0; i < 7; i++, y += 4*18)
++    {
++        MP3D_V_STORE4(&y[0*18], t[0][i]);
++        MP3D_V_STORE4(&y[1*18], MP3D_V_ADDSAT(MP3D_V_ADDSAT(t[2][i], t[3][i]),
++                                              t[3][i + 1]));
++        MP3D_V_STORE4(&y[2*18], MP3D_V_ADDSAT(t[1][i], t[1][i + 1]));
++        MP3D_V_STORE4(&y[3*18],
++                      MP3D_V_ADDSAT(MP3D_V_ADDSAT(t[2][i + 1], t[3][i]),
++                                    t[3][i + 1]));
++    }
++    MP3D_V_STORE4(&y[0*18], t[0][7]);
++    MP3D_V_STORE4(&y[1*18], MP3D_V_ADDSAT(t[2][7], t[3][7]));
++    MP3D_V_STORE4(&y[2*18], t[1][7]);
++    MP3D_V_STORE4(&y[3*18], t[3][7]);
++}
++#endif /* MP3D_HAVE_INT_SIMD */
++
 +static void mp3d_DCT_II(int32_t *grbuf, int n) FL_NO_EXCEPT
 +{
 +    int i, k = 0;
++#if MP3D_HAVE_INT_SIMD
++    if (MP3D_SIMD_AVAILABLE())
++    {
++        for (; k + 4 <= n; k += 4)
++        {
++            mp3d_dct2_bands4(grbuf, k);
++        }
++    }
++#endif
 +    for (; k < n; k++)
 +    {
 +        int32_t t[4][8], *x, *y = grbuf + k;
@@ -1544,6 +1907,62 @@ index 9fbd4d2..c43c40a 100644
 +   up to int16, and it is the one place a 64-bit accumulator is genuinely
 +   required: the window coefficients reach 75038, so a single product already
 +   needs 48 bits before sixteen of them are summed. */
++#if MP3D_HAVE_INT_SIMD
++/* One iteration's eight window taps.
++
++   Factored into its own function so the x86 build can put the SSE4.1 target
++   attribute on exactly this code and reach it through a run-time check,
++   without forcing the whole file to be compiled for a baseline the project
++   does not require. The tap order and the arithmetic are identical to the
++   scalar S0/S1/S2 chain: taps 1,3,5,7 accumulate `a` with the operands
++   swapped, which is what S2 does, and the rest follow S0/S1. Starting the
++   accumulators at zero makes S0's assignment and S1's accumulation the same
++   operation. */
++MP3D_SIMD_TARGET static void mp3d_synth_taps(const int32_t *zlin,
++                                             const int32_t *w, int i,
++                                             int64_t *a, int64_t *b) FL_NO_EXCEPT
++{
++    mp3d_i64x2 alo = MP3D_V_ZERO64(), ahi = MP3D_V_ZERO64();
++    mp3d_i64x2 blo = MP3D_V_ZERO64(), bhi = MP3D_V_ZERO64();
++    int k;
++
++    for (k = 0; k < 8; k++)
++    {
++        const int32_t w0 = *w++;
++        const int32_t w1 = *w++;
++        const mp3d_i32x4 vz = MP3D_V_PREP(MP3D_V_LOAD4(&zlin[4*i - k*64]));
++        const mp3d_i32x4 vy =
++            MP3D_V_PREP(MP3D_V_LOAD4(&zlin[4*i - (15 - k)*64]));
++        const mp3d_i32x4 s0 = MP3D_V_SPLAT(w0);
++        const mp3d_i32x4 s1 = MP3D_V_SPLAT(w1);
++
++        blo = MP3D_V_ADD64(blo, MP3D_V_ADD64(MP3D_V_MUL_LO(vz, s1),
++                                             MP3D_V_MUL_LO(vy, s0)));
++        bhi = MP3D_V_ADD64(bhi, MP3D_V_ADD64(MP3D_V_MUL_HI(vz, s1),
++                                             MP3D_V_MUL_HI(vy, s0)));
++        if (k & 1)
++        {
++            alo = MP3D_V_ADD64(alo, MP3D_V_SUB64(MP3D_V_MUL_LO(vy, s1),
++                                                 MP3D_V_MUL_LO(vz, s0)));
++            ahi = MP3D_V_ADD64(ahi, MP3D_V_SUB64(MP3D_V_MUL_HI(vy, s1),
++                                                 MP3D_V_MUL_HI(vz, s0)));
++        }
++        else
++        {
++            alo = MP3D_V_ADD64(alo, MP3D_V_SUB64(MP3D_V_MUL_LO(vz, s0),
++                                                 MP3D_V_MUL_LO(vy, s1)));
++            ahi = MP3D_V_ADD64(ahi, MP3D_V_SUB64(MP3D_V_MUL_HI(vz, s0),
++                                                 MP3D_V_MUL_HI(vy, s1)));
++        }
++    }
++
++    a[0] = MP3D_V_GET64(alo, 0); a[1] = MP3D_V_GET64(alo, 1);
++    a[2] = MP3D_V_GET64(ahi, 0); a[3] = MP3D_V_GET64(ahi, 1);
++    b[0] = MP3D_V_GET64(blo, 0); b[1] = MP3D_V_GET64(blo, 1);
++    b[2] = MP3D_V_GET64(bhi, 0); b[3] = MP3D_V_GET64(bhi, 1);
++}
++#endif /* MP3D_HAVE_INT_SIMD */
++
 +static void mp3d_synth(int32_t *xl, mp3d_sample_t *dstl, int nch, int32_t *lins) FL_NO_EXCEPT
 +{
 +    int i;
@@ -1569,6 +1988,9 @@ index 9fbd4d2..c43c40a 100644
 +    };
 +    int32_t *zlin = lins + 15*64;
 +    const int32_t *w = g_win;
++#if MP3D_HAVE_INT_SIMD
++    const int use_simd = MP3D_SIMD_AVAILABLE();
++#endif
 +
 +    zlin[4*15]     = xl[18*16];
 +    zlin[4*15 + 1] = xr[18*16];
@@ -1602,7 +2024,17 @@ index 9fbd4d2..c43c40a 100644
 +        zlin[4*(i - 16) + 2] = xl[18*(1 + i)];
 +        zlin[4*(i - 16) + 3] = xr[18*(1 + i)];
 +
++#if MP3D_HAVE_INT_SIMD
++        if (use_simd)
++        {
++            mp3d_synth_taps(zlin, w, i, a, b);
++            w += 16; /* the scalar chain below advances w as a side effect */
++        }
++        else
++#endif
++        {
 +        S0(0) S2(1) S1(2) S2(3) S1(4) S2(5) S1(6) S2(7)
++        }
 +
 +        dstr[(15 - i)*nch] = mp3d_scale_pcm(a[1]);
 +        dstr[(17 + i)*nch] = mp3d_scale_pcm(b[1]);
@@ -1612,10 +2044,9 @@ index 9fbd4d2..c43c40a 100644
 +        dstr[(49 + i)*nch] = mp3d_scale_pcm(b[3]);
 +        dstl[(47 - i)*nch] = mp3d_scale_pcm(a[2]);
 +        dstl[(49 + i)*nch] = mp3d_scale_pcm(b[2]);
-     }
- }
- 
--static void mp3d_DCT_II(float *grbuf, int n)
++    }
++}
++
 +static void mp3d_synth_granule(int32_t *qmf_state, int32_t *grbuf, int nbands,
 +                               int nch, mp3d_sample_t *pcm) FL_NO_EXCEPT
 +{
@@ -1649,7 +2080,7 @@ index 9fbd4d2..c43c40a 100644
  {
      static const float g_sec[24] = {
          10.19000816f,0.50060302f,0.50241929f,3.40760851f,0.50547093f,0.52249861f,2.05778098f,0.51544732f,0.56694406f,1.48416460f,0.53104258f,0.64682180f,1.16943991f,0.55310392f,0.78815460f,0.97256821f,0.58293498f,1.06067765f,0.83934963f,0.62250412f,1.72244716f,0.74453628f,0.67480832f,5.10114861f
-@@ -1427,7 +2450,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
+@@ -1427,7 +2867,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
  }
  
  #ifndef MINIMP3_FLOAT_OUTPUT
@@ -1658,7 +2089,7 @@ index 9fbd4d2..c43c40a 100644
  {
  #if HAVE_ARMV6
      int32_t s32 = (int32_t)(sample + .5f);
-@@ -1448,7 +2471,7 @@ static float mp3d_scale_pcm(float sample)
+@@ -1448,7 +2888,7 @@ static float mp3d_scale_pcm(float sample)
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
  
@@ -1667,7 +2098,7 @@ index 9fbd4d2..c43c40a 100644
  {
      float a;
      a  = (z[14*64] - z[    0]) * 29;
-@@ -1473,7 +2496,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
+@@ -1473,7 +2913,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
      pcm[16*nch] = mp3d_scale_pcm(a);
  }
  
@@ -1676,7 +2107,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i;
      float *xr = xl + 576*(nch - 1);
-@@ -1626,16 +2649,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
+@@ -1626,16 +3066,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
  #endif /* MINIMP3_ONLY_SIMD */
  }
  
@@ -1697,7 +2128,7 @@ index 9fbd4d2..c43c40a 100644
      for (i = 0; i < nbands; i += 2)
      {
          mp3d_synth(grbuf + i, pcm + 32*nch*i, nch, lins + i*64);
-@@ -1650,11 +2674,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
+@@ -1650,11 +3091,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
      } else
  #endif /* MINIMP3_NONSTANDARD_BUT_LOGICAL */
      {
@@ -1713,7 +2144,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, nmatch;
      for (i = 0, nmatch = 0; nmatch < MAX_FRAME_SYNC_MATCHES; nmatch++)
-@@ -1668,7 +2694,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
+@@ -1668,7 +3111,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
      return 1;
  }
  
@@ -1722,7 +2153,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i, k;
      for (i = 0; i < mp3_bytes - HDR_SIZE; i++, mp3++)
-@@ -1705,17 +2731,31 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
+@@ -1705,17 +3148,36 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
      return mp3_bytes;
  }
  
@@ -1735,6 +2166,11 @@ index 9fbd4d2..c43c40a 100644
 +int mp3dec_dsp_is_integer(void) FL_NO_EXCEPT
 +{
 +    return MINIMP3_DSP_INTEGER;
++}
++
++int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT
++{
++    return MP3D_SIMD_KERNELS_LIVE;
 +}
 +
 +void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT
@@ -1757,7 +2193,7 @@ index 9fbd4d2..c43c40a 100644
  
      if (mp3_bytes > 4 && dec->header[0] == 0xff && hdr_compare(dec->header, mp3))
      {
-@@ -1758,23 +2798,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1758,23 +3220,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  
      if (info->layer == 3)
      {
@@ -1787,7 +2223,7 @@ index 9fbd4d2..c43c40a 100644
      } else
      {
  #ifdef MINIMP3_ONLY_MP3
-@@ -1783,15 +2823,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1783,15 +3245,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
          L12_scale_info sci[1];
          L12_read_scale_info(hdr, bs_frame, sci);
  
@@ -1812,7 +2248,7 @@ index 9fbd4d2..c43c40a 100644
                  pcm += 384*info->channels;
              }
              if (bs_frame->pos > bs_frame->limit)
-@@ -1806,7 +2850,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1806,7 +3272,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  }
  
  #ifdef MINIMP3_FLOAT_OUTPUT
@@ -1821,7 +2257,7 @@ index 9fbd4d2..c43c40a 100644
  {
      int i = 0;
  #if HAVE_SIMD
-@@ -1862,4 +2906,99 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
+@@ -1862,4 +3328,114 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
      }
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
@@ -1852,10 +2288,25 @@ index 9fbd4d2..c43c40a 100644
 +#undef MP3D_PCM_LOWER
 +/* Only release MINIMP3_NO_SIMD if this header is what set it; a caller that
 +   asked for the scalar build must keep getting it on a re-include. */
-+#ifdef MP3D_OWNS_NO_SIMD
-+#undef MINIMP3_NO_SIMD
-+#undef MP3D_OWNS_NO_SIMD
-+#endif
++#undef MP3D_FLOAT_SIMD_OFF
++#undef MP3D_V_ZERO64
++#undef MP3D_V_LOAD4
++#undef MP3D_V_SPLAT
++#undef MP3D_V_MUL_LO
++#undef MP3D_V_MUL_HI
++#undef MP3D_V_ADD64
++#undef MP3D_V_SUB64
++#undef MP3D_V_GET64
++#undef MP3D_V_PREP
++#undef MP3D_V_SIGN
++#undef MP3D_V_ADDSAT
++#undef MP3D_V_SUBSAT
++#undef MP3D_V_MULSHIFT
++#undef MP3D_V_STORE4
++#undef MP3D_HAVE_INT_SIMD
++#undef MP3D_INT_SIMD_SSE
++#undef MP3D_INT_SIMD_NEON
++#undef MP3D_SIMD_KERNELS_LIVE
 +#undef BITS_DEQUANTIZER_OUT
 +#undef BSPOS
 +#undef CHECK_BITS

--- a/src/third_party/minimp3/FASTLED.patch
+++ b/src/third_party/minimp3/FASTLED.patch
@@ -1,8 +1,8 @@
 diff --git a/minimp3.h b/minimp3.h
-index 9fbd4d2..588d897 100644
+index 9fbd4d2..eb0397a 100644
 --- a/minimp3.h
 +++ b/minimp3.h
-@@ -1,50 +1,178 @@
+@@ -1,50 +1,198 @@
  #ifndef MINIMP3_H
  #define MINIMP3_H
 +// SPDX-License-Identifier: CC0-1.0
@@ -19,6 +19,26 @@ index 9fbd4d2..588d897 100644
  
  #define MINIMP3_MAX_SAMPLES_PER_FRAME (1152*2)
  
++
++/* FastLED: intrinsics headers are included here, at global scope, rather than
++   next to the code that uses them.
++
++   The implementation section runs inside `namespace fl { namespace
++   MINIMP3_NAMESPACE {`, so an #include there declares int32x4_t and friends
++   *inside* that namespace. With one instantiation that is merely untidy; with
++   several -- which the fixed-vs-float and SIMD-vs-scalar gates require -- the
++   header guard means only the first variant gets the types and every later one
++   fails to compile with "did you mean minimp3_float_probe::int32x4_t". Found by
++   the macOS ARM64 CI job, which is the only place NEON is actually built. */
++#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
++    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
++#include <immintrin.h>
++#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
++#include <cpuid.h>
++#endif
++#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
++#include <arm_neon.h>
++#endif
 +
 +/* FastLED: fixed-point mode. MINIMP3_HAVE_FIXED_POINT reports whether this
 +   instantiation actually built the integer DSP path. The macro is recomputed on
@@ -193,7 +213,7 @@ index 9fbd4d2..588d897 100644
  
  #define MAX_FREE_FORMAT_FRAME_SIZE  2304    /* more than ISO spec's */
  #ifndef MAX_FRAME_SYNC_MATCHES
-@@ -84,7 +212,191 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -84,7 +232,181 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  #define MINIMP3_MIN(a, b)           ((a) > (b) ? (b) : (a))
  #define MINIMP3_MAX(a, b)           ((a) < (b) ? (b) : (a))
  
@@ -310,22 +330,12 @@ index 9fbd4d2..588d897 100644
 +   though it does not overflow a 32-bit add. */
 +static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 +{
-+    const int32_t sum = (int32_t)((uint32_t)a + (uint32_t)b);
-+    if (((a ^ sum) & (b ^ sum)) < 0)
-+    {
-+        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
-+    }
-+    return sum < MP3D_SAT_MIN ? MP3D_SAT_MIN : sum;
++    return mp3d_sat64((int64_t)a + (int64_t)b);
 +}
 +
 +static int32_t mp3d_sub_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 +{
-+    const int32_t diff = (int32_t)((uint32_t)a - (uint32_t)b);
-+    if (((a ^ b) & (a ^ diff)) < 0)
-+    {
-+        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
-+    }
-+    return diff < MP3D_SAT_MIN ? MP3D_SAT_MIN : diff;
++    return mp3d_sat64((int64_t)a - (int64_t)b);
 +}
 +
 +/* One Q26 unit of 1.0, and the clamp applied to dequantised samples.
@@ -386,7 +396,7 @@ index 9fbd4d2..588d897 100644
  
  #if !defined(MINIMP3_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__) || defined(_M_ARM64))
  /* x64 always have SSE2, arm64 always have neon, no need for generic code */
-@@ -136,7 +448,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
+@@ -136,7 +458,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
  #endif /* defined(__PIC__)*/
  }
  #endif /* defined(_MSC_VER) || defined(MINIMP3_ONLY_SIMD) */
@@ -395,7 +405,7 @@ index 9fbd4d2..588d897 100644
  {
  #ifdef MINIMP3_ONLY_SIMD
      return 1;
-@@ -187,9 +499,42 @@ static int have_simd()
+@@ -187,9 +509,37 @@ static int have_simd()
  #error MINIMP3_ONLY_SIMD used, but SSE/NEON not enabled
  #endif /* MINIMP3_ONLY_SIMD */
  #endif /* SIMD checks... */
@@ -413,15 +423,10 @@ index 9fbd4d2..588d897 100644
 +#if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
 +#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
 +    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
-+#include <immintrin.h>
-+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
-+#include <cpuid.h>
-+#endif
 +#define MP3D_HAVE_INT_SIMD 1
 +#define MP3D_INT_SIMD_SSE  1
 +typedef __m128i mp3d_i32x4;
 +#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
-+#include <arm_neon.h>
 +#define MP3D_HAVE_INT_SIMD 1
 +#define MP3D_INT_SIMD_NEON 1
 +typedef int32x4_t mp3d_i32x4;
@@ -440,7 +445,7 @@ index 9fbd4d2..588d897 100644
  
  #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
  #define HAVE_ARMV6 1
-@@ -211,7 +556,21 @@ typedef struct
+@@ -211,7 +561,21 @@ typedef struct
  
  typedef struct
  {
@@ -462,7 +467,7 @@ index 9fbd4d2..588d897 100644
      uint8_t total_bands, stereo_bands, bitalloc[64], scfcod[64];
  } L12_scale_info;
  
-@@ -234,18 +593,34 @@ typedef struct
+@@ -234,18 +598,34 @@ typedef struct
      bs_t bs;
      uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
      L3_gr_info_t gr_info[4];
@@ -501,7 +506,7 @@ index 9fbd4d2..588d897 100644
  {
      uint32_t next, cache = 0, s = bs->pos & 7;
      int shl = n + s;
-@@ -261,7 +636,7 @@ static uint32_t get_bits(bs_t *bs, int n)
+@@ -261,7 +641,7 @@ static uint32_t get_bits(bs_t *bs, int n)
      return cache | (next >> -shl);
  }
  
@@ -510,7 +515,7 @@ index 9fbd4d2..588d897 100644
  {
      return h[0] == 0xff &&
          ((h[1] & 0xF0) == 0xf0 || (h[1] & 0xFE) == 0xe2) &&
-@@ -270,7 +645,7 @@ static int hdr_valid(const uint8_t *h)
+@@ -270,7 +650,7 @@ static int hdr_valid(const uint8_t *h)
          (HDR_GET_SAMPLE_RATE(h) != 3);
  }
  
@@ -519,7 +524,7 @@ index 9fbd4d2..588d897 100644
  {
      return hdr_valid(h2) &&
          ((h1[1] ^ h2[1]) & 0xFE) == 0 &&
-@@ -278,7 +653,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
+@@ -278,7 +658,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
          !(HDR_IS_FREE_FORMAT(h1) ^ HDR_IS_FREE_FORMAT(h2));
  }
  
@@ -528,7 +533,7 @@ index 9fbd4d2..588d897 100644
  {
      static const uint8_t halfrate[2][3][15] = {
          { { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,16,24,28,32,40,48,56,64,72,80,88,96,112,128 } },
-@@ -287,18 +662,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
+@@ -287,18 +667,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
      return 2*halfrate[!!HDR_TEST_MPEG1(h)][HDR_GET_LAYER(h) - 1][HDR_GET_BITRATE(h)];
  }
  
@@ -550,7 +555,7 @@ index 9fbd4d2..588d897 100644
  {
      int frame_bytes = hdr_frame_samples(h)*hdr_bitrate_kbps(h)*125/hdr_sample_rate_hz(h);
      if (HDR_IS_LAYER_1(h))
-@@ -308,13 +683,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
+@@ -308,13 +688,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
      return frame_bytes ? frame_bytes : free_format_size;
  }
  
@@ -566,7 +571,7 @@ index 9fbd4d2..588d897 100644
  {
      const L12_subband_alloc_t *alloc;
      int mode = HDR_GET_STEREO_MODE(hdr);
-@@ -359,7 +734,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
+@@ -359,7 +739,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
      return alloc;
  }
  
@@ -625,7 +630,7 @@ index 9fbd4d2..588d897 100644
  {
      static const float g_deq_L12[18*3] = {
  #define DQ(x) 9.53674316e-07f/x, 7.56931807e-07f/x, 6.00777173e-07f/x
-@@ -382,8 +807,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
+@@ -382,8 +812,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
          }
      }
  }
@@ -636,7 +641,7 @@ index 9fbd4d2..588d897 100644
  {
      static const uint8_t g_bitalloc_code_tab[] = {
          0,17, 3, 4, 5,6,7, 8,9,10,11,12,13,14,15,16,
-@@ -423,7 +849,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -423,7 +854,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
          sci->scfcod[i] = sci->bitalloc[i] ? HDR_IS_LAYER_1(hdr) ? 2 : get_bits(bs, 2) : 6;
      }
  
@@ -648,7 +653,7 @@ index 9fbd4d2..588d897 100644
  
      for (i = sci->stereo_bands; i < sci->total_bands; i++)
      {
-@@ -431,12 +861,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -431,12 +866,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
      }
  }
  
@@ -667,7 +672,7 @@ index 9fbd4d2..588d897 100644
          for (i = 0; i < 2*sci->total_bands; i++)
          {
              int ba = sci->bitalloc[i];
-@@ -447,7 +881,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -447,7 +886,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      int half = (1 << (ba - 1)) - 1;
                      for (k = 0; k < group_size; k++)
                      {
@@ -676,7 +681,7 @@ index 9fbd4d2..588d897 100644
                      }
                  } else
                  {
-@@ -455,7 +889,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -455,7 +894,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      unsigned code = get_bits(bs, mod + 2 - (mod >> 3));  /* 5, 7, 10 */
                      for (k = 0; k < group_size; k++, code /= mod)
                      {
@@ -685,7 +690,7 @@ index 9fbd4d2..588d897 100644
                      }
                  }
              }
-@@ -466,7 +900,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -466,7 +905,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
      return group_size*4;
  }
  
@@ -709,7 +714,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, k;
      memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
-@@ -479,9 +928,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
+@@ -479,9 +933,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
          }
      }
  }
@@ -721,7 +726,7 @@ index 9fbd4d2..588d897 100644
  {
      static const uint8_t g_scf_long[8][23] = {
          { 6,6,6,6,6,6,8,10,12,14,16,20,24,28,32,38,46,52,60,68,58,54,0 },
-@@ -606,7 +1056,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
+@@ -606,7 +1061,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
      return main_data_begin;
  }
  
@@ -730,7 +735,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, k;
      for (i = 0; i < 4 && scf_count[i]; i++, scfsi *= 2)
-@@ -639,7 +1089,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
+@@ -639,7 +1094,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
      scf[0] = scf[1] = scf[2] = 0;
  }
  
@@ -831,7 +836,7 @@ index 9fbd4d2..588d897 100644
  {
      static const float g_expfrac[4] = { 9.31322575e-10f,7.83145814e-10f,6.58544508e-10f,5.53767716e-10f };
      int e;
-@@ -650,8 +1192,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
+@@ -650,8 +1197,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
      } while ((exp_q2 -= e) > 0);
      return y;
  }
@@ -852,7 +857,7 @@ index 9fbd4d2..588d897 100644
  {
      static const uint8_t g_scf_partitions[3][28] = {
          { 6,5,5, 5,6,5,5,5,6,5, 7,3,11,10,0,0, 7, 7, 7,0, 6, 6,6,3, 8, 8,5,0 },
-@@ -661,7 +1213,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -661,7 +1218,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      const uint8_t *scf_partition = g_scf_partitions[!!gr->n_short_sfb + !gr->n_long_sfb];
      uint8_t scf_size[4], iscf[40];
      int i, scf_shift = gr->scalefac_scale + 1, gain_exp, scfsi = gr->scfsi;
@@ -862,7 +867,7 @@ index 9fbd4d2..588d897 100644
  
      if (HDR_TEST_MPEG1(hdr))
      {
-@@ -706,19 +1260,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -706,19 +1265,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      }
  
      gain_exp = gr->global_gain + BITS_DEQUANTIZER_OUT*4 - 210 - (HDR_IS_MS_STEREO(hdr) ? 2 : 0);
@@ -937,7 +942,7 @@ index 9fbd4d2..588d897 100644
  {
      float frac;
      int sign, mult = 256;
-@@ -738,8 +1346,9 @@ static float L3_pow_43(int x)
+@@ -738,8 +1351,9 @@ static float L3_pow_43(int x)
      frac = (float)((x & 63) - sign) / ((x & ~63) + sign);
      return g_pow43[16 + ((x + sign) >> 6)]*(1.f + frac*((4.f/3) + frac*(2.f/9)))*mult;
  }
@@ -948,7 +953,7 @@ index 9fbd4d2..588d897 100644
  {
      static const int16_t tabs[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          785,785,785,785,784,784,784,784,513,513,513,513,513,513,513,513,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,
-@@ -767,7 +1376,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -767,7 +1381,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
  #define CHECK_BITS    while (bs_sh >= 0) { bs_cache |= (uint32_t)*bs_next_ptr++ << bs_sh; bs_sh -= 8; }
  #define BSPOS         ((bs_next_ptr - bs->buf)*8 - 24 + bs_sh)
  
@@ -957,7 +962,7 @@ index 9fbd4d2..588d897 100644
      int ireg = 0, big_val_cnt = gr_info->big_values;
      const uint8_t *sfb = gr_info->sfbtab;
      const uint8_t *bs_next_ptr = bs->buf + bs->pos/8;
-@@ -787,7 +1396,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -787,7 +1401,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -966,7 +971,7 @@ index 9fbd4d2..588d897 100644
                  do
                  {
                      int j, w = 5;
-@@ -808,10 +1417,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -808,10 +1422,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                              lsb += PEEK_BITS(linbits);
                              FLUSH_BITS(linbits);
                              CHECK_BITS;
@@ -979,7 +984,7 @@ index 9fbd4d2..588d897 100644
                          }
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
-@@ -824,7 +1433,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -824,7 +1438,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -988,7 +993,7 @@ index 9fbd4d2..588d897 100644
                  do
                  {
                      int j, w = 5;
-@@ -840,7 +1449,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -840,7 +1454,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                      for (j = 0; j < 2; j++, dst++, leaf >>= 4)
                      {
                          int lsb = leaf & 0x0F;
@@ -997,7 +1002,7 @@ index 9fbd4d2..588d897 100644
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
                      CHECK_BITS;
-@@ -862,8 +1471,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -862,8 +1476,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
          {
              break;
          }
@@ -1008,7 +1013,7 @@ index 9fbd4d2..588d897 100644
          RELOAD_SCALEFACTOR;
          DEQ_COUNT1(0);
          DEQ_COUNT1(1);
-@@ -876,10 +1485,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -876,10 +1490,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
      bs->pos = layer3gr_limit;
  }
  
@@ -1021,7 +1026,7 @@ index 9fbd4d2..588d897 100644
  #if HAVE_SIMD
      if (have_simd())
      {
-@@ -901,24 +1510,47 @@ static void L3_midside_stereo(float *left, int n)
+@@ -901,24 +1515,47 @@ static void L3_midside_stereo(float *left, int n)
  #endif /* HAVE_SIMD */
      for (; i < n; i++)
      {
@@ -1071,7 +1076,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, k;
  
-@@ -938,9 +1570,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
+@@ -938,9 +1575,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
      }
  }
  
@@ -1097,7 +1102,7 @@ index 9fbd4d2..588d897 100644
      unsigned i, max_pos = HDR_TEST_MPEG1(hdr) ? 7 : 64;
  
      for (i = 0; sfb[i]; i++)
-@@ -948,6 +1595,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -948,6 +1600,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
          unsigned ipos = ist_pos[i];
          if ((int)i > max_band[i % 3] && ipos < max_pos)
          {
@@ -1125,7 +1130,7 @@ index 9fbd4d2..588d897 100644
              float kl, kr, s = HDR_TEST_MS_STEREO(hdr) ? 1.41421356f : 1;
              if (HDR_TEST_MPEG1(hdr))
              {
-@@ -964,6 +1632,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -964,6 +1637,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
                  }
              }
              L3_intensity_stereo_band(left, sfb[i], kl*s, kr*s);
@@ -1133,7 +1138,7 @@ index 9fbd4d2..588d897 100644
          } else if (HDR_TEST_MS_STEREO(hdr))
          {
              L3_midside_stereo(left, sfb[i]);
-@@ -972,7 +1641,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -972,7 +1646,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
      }
  }
  
@@ -1142,7 +1147,7 @@ index 9fbd4d2..588d897 100644
  {
      int max_band[3], n_sfb = gr->n_long_sfb + gr->n_short_sfb;
      int i, max_blocks = gr->n_short_sfb ? 3 : 1;
-@@ -992,10 +1661,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
+@@ -992,10 +1666,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
      L3_stereo_process(left, ist_pos, gr->sfbtab, hdr, max_band, gr[1].scalefac_compress & 1);
  }
  
@@ -1155,7 +1160,7 @@ index 9fbd4d2..588d897 100644
  
      for (;0 != (len = *sfb); sfb += 3, src += 2*len)
      {
-@@ -1006,15 +1675,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
+@@ -1006,15 +1680,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
              *dst++ = src[2*len];
          }
      }
@@ -1175,7 +1180,7 @@ index 9fbd4d2..588d897 100644
  
      for (; nbands > 0; nbands--, grbuf += 18)
      {
-@@ -1035,16 +1706,193 @@ static void L3_antialias(float *grbuf, int nbands)
+@@ -1035,16 +1711,193 @@ static void L3_antialias(float *grbuf, int nbands)
  #ifndef MINIMP3_ONLY_SIMD
          for(; i < 8; i++)
          {
@@ -1370,7 +1375,7 @@ index 9fbd4d2..588d897 100644
  {
      float s0, s1, s2, s3, s4, s5, s6, s7, s8, t0, t2, t4;
  
-@@ -1084,7 +1932,7 @@ static void L3_dct3_9(float *y)
+@@ -1084,7 +1937,7 @@ static void L3_dct3_9(float *y)
      y[8] = s4 + s7;
  }
  
@@ -1379,7 +1384,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, j;
      static const float g_twid9[18] = {
-@@ -1141,7 +1989,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
+@@ -1141,7 +1994,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
      }
  }
  
@@ -1388,7 +1393,7 @@ index 9fbd4d2..588d897 100644
  {
      float m1 = x1*0.86602540f;
      float a1 = x0 - x2*0.5f;
-@@ -1150,7 +1998,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
+@@ -1150,7 +2003,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
      dst[2] = a1 - m1;
  }
  
@@ -1397,7 +1402,7 @@ index 9fbd4d2..588d897 100644
  {
      static const float g_twid3[6] = { 0.79335334f,0.92387953f,0.99144486f, 0.60876143f,0.38268343f,0.13052619f };
      float co[3], si[3];
-@@ -1170,7 +2018,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
+@@ -1170,7 +2023,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
      }
  }
  
@@ -1406,7 +1411,7 @@ index 9fbd4d2..588d897 100644
  {
      for (;nbands > 0; nbands--, overlap += 9, grbuf += 18)
      {
-@@ -1183,7 +2031,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
+@@ -1183,7 +2036,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
      }
  }
  
@@ -1415,7 +1420,7 @@ index 9fbd4d2..588d897 100644
  {
      int b, i;
      for (b = 0, grbuf += 18; b < 32; b += 2, grbuf += 36)
-@@ -1191,7 +2039,7 @@ static void L3_change_sign(float *grbuf)
+@@ -1191,7 +2044,7 @@ static void L3_change_sign(float *grbuf)
              grbuf[i] = -grbuf[i];
  }
  
@@ -1424,7 +1429,7 @@ index 9fbd4d2..588d897 100644
  {
      static const float g_mdct_window[2][18] = {
          { 0.99904822f,0.99144486f,0.97629601f,0.95371695f,0.92387953f,0.88701083f,0.84339145f,0.79335334f,0.73727734f,0.04361938f,0.13052619f,0.21643961f,0.30070580f,0.38268343f,0.46174861f,0.53729961f,0.60876143f,0.67559021f },
-@@ -1208,8 +2056,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
+@@ -1208,8 +2061,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
      else
          L3_imdct36(grbuf, overlap, g_mdct_window[block_type == STOP_BLOCK_TYPE], 32 - n_long_bands);
  }
@@ -1436,7 +1441,7 @@ index 9fbd4d2..588d897 100644
  {
      int pos = (s->bs.pos + 7)/8u;
      int remains = s->bs.limit/8u - pos;
-@@ -1225,7 +2075,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
+@@ -1225,7 +2080,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
      h->reserv = remains;
  }
  
@@ -1445,7 +1450,7 @@ index 9fbd4d2..588d897 100644
  {
      int frame_bytes = (bs->limit - bs->pos)/8;
      int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-@@ -1235,15 +2085,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
+@@ -1235,15 +2090,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
      return h->reserv >= main_data_begin;
  }
  
@@ -1474,7 +1479,7 @@ index 9fbd4d2..588d897 100644
      }
  
      if (HDR_TEST_I_STEREO(h->header))
-@@ -1253,6 +2113,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1253,6 +2118,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
      {
          L3_midside_stereo(s->grbuf[0], 576);
      }
@@ -1482,7 +1487,7 @@ index 9fbd4d2..588d897 100644
  
      for (ch = 0; ch < nch; ch++, gr_info++)
      {
-@@ -1262,16 +2123,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1262,16 +2128,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
          if (gr_info->n_short_sfb)
          {
              aa_bands = n_long_bands - 1;
@@ -2080,7 +2085,7 @@ index 9fbd4d2..588d897 100644
  {
      static const float g_sec[24] = {
          10.19000816f,0.50060302f,0.50241929f,3.40760851f,0.50547093f,0.52249861f,2.05778098f,0.51544732f,0.56694406f,1.48416460f,0.53104258f,0.64682180f,1.16943991f,0.55310392f,0.78815460f,0.97256821f,0.58293498f,1.06067765f,0.83934963f,0.62250412f,1.72244716f,0.74453628f,0.67480832f,5.10114861f
-@@ -1427,7 +2867,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
+@@ -1427,7 +2872,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
  }
  
  #ifndef MINIMP3_FLOAT_OUTPUT
@@ -2089,7 +2094,7 @@ index 9fbd4d2..588d897 100644
  {
  #if HAVE_ARMV6
      int32_t s32 = (int32_t)(sample + .5f);
-@@ -1448,7 +2888,7 @@ static float mp3d_scale_pcm(float sample)
+@@ -1448,7 +2893,7 @@ static float mp3d_scale_pcm(float sample)
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
  
@@ -2098,7 +2103,7 @@ index 9fbd4d2..588d897 100644
  {
      float a;
      a  = (z[14*64] - z[    0]) * 29;
-@@ -1473,7 +2913,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
+@@ -1473,7 +2918,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
      pcm[16*nch] = mp3d_scale_pcm(a);
  }
  
@@ -2107,7 +2112,7 @@ index 9fbd4d2..588d897 100644
  {
      int i;
      float *xr = xl + 576*(nch - 1);
-@@ -1626,16 +3066,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
+@@ -1626,16 +3071,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
  #endif /* MINIMP3_ONLY_SIMD */
  }
  
@@ -2128,7 +2133,7 @@ index 9fbd4d2..588d897 100644
      for (i = 0; i < nbands; i += 2)
      {
          mp3d_synth(grbuf + i, pcm + 32*nch*i, nch, lins + i*64);
-@@ -1650,11 +3091,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
+@@ -1650,11 +3096,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
      } else
  #endif /* MINIMP3_NONSTANDARD_BUT_LOGICAL */
      {
@@ -2144,7 +2149,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, nmatch;
      for (i = 0, nmatch = 0; nmatch < MAX_FRAME_SYNC_MATCHES; nmatch++)
-@@ -1668,7 +3111,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
+@@ -1668,7 +3116,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
      return 1;
  }
  
@@ -2153,7 +2158,7 @@ index 9fbd4d2..588d897 100644
  {
      int i, k;
      for (i = 0; i < mp3_bytes - HDR_SIZE; i++, mp3++)
-@@ -1705,17 +3148,36 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
+@@ -1705,17 +3153,36 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
      return mp3_bytes;
  }
  
@@ -2193,7 +2198,7 @@ index 9fbd4d2..588d897 100644
  
      if (mp3_bytes > 4 && dec->header[0] == 0xff && hdr_compare(dec->header, mp3))
      {
-@@ -1758,23 +3220,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1758,23 +3225,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  
      if (info->layer == 3)
      {
@@ -2223,7 +2228,7 @@ index 9fbd4d2..588d897 100644
      } else
      {
  #ifdef MINIMP3_ONLY_MP3
-@@ -1783,15 +3245,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1783,15 +3250,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
          L12_scale_info sci[1];
          L12_read_scale_info(hdr, bs_frame, sci);
  
@@ -2248,7 +2253,7 @@ index 9fbd4d2..588d897 100644
                  pcm += 384*info->channels;
              }
              if (bs_frame->pos > bs_frame->limit)
-@@ -1806,7 +3272,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1806,7 +3277,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  }
  
  #ifdef MINIMP3_FLOAT_OUTPUT
@@ -2257,7 +2262,7 @@ index 9fbd4d2..588d897 100644
  {
      int i = 0;
  #if HAVE_SIMD
-@@ -1862,4 +3328,114 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
+@@ -1862,4 +3333,114 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
      }
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */

--- a/src/third_party/minimp3/PROVENANCE.md
+++ b/src/third_party/minimp3/PROVENANCE.md
@@ -32,6 +32,57 @@ here is why the conversion is small: minimp3 normalises its pipeline
 internally, so a single Q26 int32 format covers every stage and block floating
 point is needed only for scalefactor gains and `x**(4/3)`.
 
+## Integer SIMD, and where it stops
+
+The fixed-point path carries SSE4.1 and NEON kernels for the polyphase filter
+and the DCT-32, selected at run time on x86 and unconditionally on ARM64, and
+suppressed entirely by `MINIMP3_NO_SIMD`. They are held to exact equality with
+the scalar path rather than to a tolerance: both operate on the same integer
+representation, so any difference is a defect in one of them.
+
+Three findings from Phase 4 (FastLED/FastLED#4055) worth not rediscovering:
+
+- **SSE2 is slower than scalar here.** SSE2 has no signed 32x32 -> 64 multiply.
+  Emulating it (unsigned multiply plus a sign correction) measured 0.66x of
+  scalar in a standalone harness and 0.95x end to end. SSE2-only hardware
+  therefore stays scalar; `_mm_mul_epi32` from SSE4.1 measures 1.71x on the
+  kernel and about 1.16x end to end once the DCT-32 is included.
+- **SSE has no saturating 32-bit integer add** (only 8- and 16-bit), which is
+  the dominant operation in the DCT-32. Emulating it is still worth it, which
+  was not the expected answer and is why it was benchmarked before being
+  written off.
+- **`_mm_blendv_epi8` selects per byte**, on that byte's high bit. Handing it a
+  raw value rather than a lane mask produces output that is right in the high
+  bits and wrong in the low ones -- a one-LSB error that a PSNR gate would not
+  have caught.
+
+`L3_imdct36` is **not** vectorised, and the reason is structural rather than a
+measurement: its inner transform is a 9-point DCT-III whose butterfly does not
+map onto four lanes, and vectorising across bands would need stride-18 gathers
+because the IMDCT works within a band rather than across them (unlike the
+DCT-32, where four consecutive bands are four consecutive int32). Only the
+closing twiddle-and-window loop vectorises -- which is exactly what upstream's
+float kernel does -- and at ~13% of decode with roughly half the kernel
+addressable, the ceiling is around 2%. It is left scalar until something wants
+that 2% more than it wants the smaller diff.
+
+## Cortex-M4/M7 DSP evaluation
+
+`SMLAD` and its relatives are dual 16x16 -> 32 multiply-accumulates. The
+pipeline's contract is Q26 samples against Q27..Q31 coefficients, i.e. 32-bit
+mantissas throughout, and halving either operand to 16 bits costs roughly 16 dB
+of the margin the fixed-vs-float gates are currently passing with. `SMMUL` and
+`SMMLA` (32x32 -> upper 32) preserve the width but discard the low half, which
+is where this decoder's rounding lives -- the whole path rounds half toward
++infinity on the full 64-bit product, and #4055's SIMD kernels are required to
+be bit-identical to it. Using them would fork the arithmetic between M4/M7 and
+everything else, which is the one property the phase exists to prevent.
+
+The conclusion is that Cortex-M4/M7 stay on the scalar kernels, which the
+codegen ledger already covers: `codec_cpu_trend.json` records the cortex-m4
+inner-loop counts for both DCT-32 and polyphase, and those are the numbers a
+future DSP attempt would have to beat while still proving bit-exactness.
+
 FastLED's source-level integration changes are recorded in `FASTLED.patch`.
 They add the `fl::third_party` namespace, `FL_NO_EXCEPT` API annotations, SPDX
 markers, and the caller-owned `mp3dec_decode_frame_r` scratch API. FastLED does

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -488,7 +488,10 @@ static int have_simd()
 #if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
     ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
-#include <emmintrin.h>
+#include <immintrin.h>
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+#include <cpuid.h>
+#endif
 #define MP3D_HAVE_INT_SIMD 1
 #define MP3D_INT_SIMD_SSE  1
 typedef __m128i mp3d_i32x4;
@@ -508,7 +511,7 @@ typedef int32x4_t mp3d_i32x4;
    MP3D_HAVE_INT_SIMD -- having the intrinsics available is not the same as
    using them, and the gate is on the second. */
 #undef MP3D_SIMD_KERNELS_LIVE
-#define MP3D_SIMD_KERNELS_LIVE 0
+#define MP3D_SIMD_KERNELS_LIVE MP3D_HAVE_INT_SIMD
 
 #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
 #define HAVE_ARMV6 1
@@ -2233,6 +2236,156 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const int32_t *z) FL_NO
    up to int16, and it is the one place a 64-bit accumulator is genuinely
    required: the window coefficients reach 75038, so a single product already
    needs 48 bits before sixteen of them are summed. */
+#if MP3D_HAVE_INT_SIMD
+/* FastLED: integer vector helpers for the polyphase back-end.
+
+   The polyphase filter is the one kernel where vectorising is bit-exact for
+   free: it is a pure int32 x int32 -> int64 multiply-accumulate with no
+   intermediate rounding or saturation, and int64 addition is exact and
+   associative, so any lane arrangement reproduces the scalar result exactly.
+   Every other kernel rounds and saturates per operation, which is why they are
+   not vectorised -- see the disposition note on mp3d_synth below.
+
+   Both multiply helpers take two int32 lanes and return two int64 products:
+   `LO` for lanes 0 and 1, `HI` for lanes 2 and 3. */
+#if MP3D_INT_SIMD_NEON
+typedef int64x2_t mp3d_i64x2;
+#define MP3D_V_ZERO64()        vdupq_n_s64(0)
+#define MP3D_V_LOAD4(p)        vld1q_s32((const int32_t *)(p))
+#define MP3D_V_SPLAT(x)        vdupq_n_s32(x)
+#define MP3D_V_PREP(v)         (v)
+#define MP3D_V_MUL_LO(v, s)    vmull_s32(vget_low_s32(v), vget_low_s32(s))
+#define MP3D_V_MUL_HI(v, s)    vmull_s32(vget_high_s32(v), vget_high_s32(s))
+#define MP3D_V_ADD64(x, y)     vaddq_s64((x), (y))
+#define MP3D_V_SUB64(x, y)     vsubq_s64((x), (y))
+#define MP3D_V_GET64(x, lane)  ((lane) ? vgetq_lane_s64((x), 1) : vgetq_lane_s64((x), 0))
+/* NEON multiplies signed 32x32 -> 64 natively and is in the ARM64 baseline, so
+   there is nothing to detect. */
+#define MP3D_SIMD_AVAILABLE()  1
+#define MP3D_SIMD_TARGET
+#else /* MP3D_INT_SIMD_SSE */
+typedef __m128i mp3d_i64x2;
+#define MP3D_V_ZERO64()        _mm_setzero_si128()
+#define MP3D_V_LOAD4(p)        _mm_loadu_si128((const __m128i *)(const void *)(p))
+#define MP3D_V_SPLAT(x)        _mm_set1_epi32(x)
+/* _mm_mul_epi32 multiplies the even int32 lanes; shuffling to (0,1),(2,3) once
+   per vector lets both architectures share the accumulator bookkeeping. */
+#define MP3D_V_PREP(v)         _mm_shuffle_epi32((v), _MM_SHUFFLE(3, 1, 2, 0))
+#define MP3D_V_MUL_LO(v, s)    _mm_mul_epi32((v), (s))
+#define MP3D_V_MUL_HI(v, s)    _mm_mul_epi32(_mm_srli_si128((v), 4), (s))
+#define MP3D_V_ADD64(x, y)     _mm_add_epi64((x), (y))
+#define MP3D_V_SUB64(x, y)     _mm_sub_epi64((x), (y))
+
+static int64_t mp3d_get_i64(__m128i v, int lane) FL_NO_EXCEPT
+{
+    int64_t out[2];
+    _mm_storeu_si128((__m128i *)(void *)out, v);
+    return out[lane];
+}
+#define MP3D_V_GET64(x, lane)  mp3d_get_i64((x), (lane))
+
+/* Signed 32x32 -> 64 needs SSE4.1. SSE2 can emulate it with an unsigned
+   multiply plus a sign correction, and that was measured rather than assumed:
+   0.66x of scalar in a standalone harness, 0.95x inside the decoder. Slower is
+   not worth shipping, so SSE2-only hardware stays on the scalar kernel and the
+   vector path is chosen at run time -- the same shape as upstream's
+   have_simd() dispatch for the float kernels. The same harness measures 1.71x
+   once _mm_mul_epi32 is available. */
+#if defined(__GNUC__) || defined(__clang__)
+#define MP3D_SIMD_TARGET __attribute__((target("sse4.1")))
+#else
+#define MP3D_SIMD_TARGET
+#endif
+
+/* Self-contained: upstream's minimp3_cpuid lives inside the float SIMD block,
+   which the fixed build switches off, so this path cannot borrow it. */
+static int mp3d_have_sse41(void) FL_NO_EXCEPT
+{
+#if defined(__SSE4_1__)
+    return 1;
+#elif defined(_MSC_VER)
+    static int cached;
+    int info[4];
+    if (!cached)
+    {
+        __cpuid(info, 1);
+        cached = ((info[2] & (1 << 19)) != 0) + 1; /* ECX.SSE4_1 */
+    }
+    return cached - 1;
+#elif defined(__GNUC__) || defined(__clang__)
+    static int cached;
+    unsigned eax, ebx, ecx, edx;
+    if (!cached)
+    {
+        cached = (__get_cpuid(1, &eax, &ebx, &ecx, &edx) &&
+                  (ecx & (1u << 19))) + 1;
+    }
+    return cached - 1;
+#else
+    return 0;
+#endif
+}
+#define MP3D_SIMD_AVAILABLE()  mp3d_have_sse41()
+#endif
+
+#endif /* MP3D_HAVE_INT_SIMD */
+
+#if MP3D_HAVE_INT_SIMD
+/* One iteration's eight window taps.
+
+   Factored into its own function so the x86 build can put the SSE4.1 target
+   attribute on exactly this code and reach it through a run-time check,
+   without forcing the whole file to be compiled for a baseline the project
+   does not require. The tap order and the arithmetic are identical to the
+   scalar S0/S1/S2 chain: taps 1,3,5,7 accumulate `a` with the operands
+   swapped, which is what S2 does, and the rest follow S0/S1. Starting the
+   accumulators at zero makes S0's assignment and S1's accumulation the same
+   operation. */
+MP3D_SIMD_TARGET static void mp3d_synth_taps(const int32_t *zlin,
+                                             const int32_t *w, int i,
+                                             int64_t *a, int64_t *b) FL_NO_EXCEPT
+{
+    mp3d_i64x2 alo = MP3D_V_ZERO64(), ahi = MP3D_V_ZERO64();
+    mp3d_i64x2 blo = MP3D_V_ZERO64(), bhi = MP3D_V_ZERO64();
+    int k;
+
+    for (k = 0; k < 8; k++)
+    {
+        const int32_t w0 = *w++;
+        const int32_t w1 = *w++;
+        const mp3d_i32x4 vz = MP3D_V_PREP(MP3D_V_LOAD4(&zlin[4*i - k*64]));
+        const mp3d_i32x4 vy =
+            MP3D_V_PREP(MP3D_V_LOAD4(&zlin[4*i - (15 - k)*64]));
+        const mp3d_i32x4 s0 = MP3D_V_SPLAT(w0);
+        const mp3d_i32x4 s1 = MP3D_V_SPLAT(w1);
+
+        blo = MP3D_V_ADD64(blo, MP3D_V_ADD64(MP3D_V_MUL_LO(vz, s1),
+                                             MP3D_V_MUL_LO(vy, s0)));
+        bhi = MP3D_V_ADD64(bhi, MP3D_V_ADD64(MP3D_V_MUL_HI(vz, s1),
+                                             MP3D_V_MUL_HI(vy, s0)));
+        if (k & 1)
+        {
+            alo = MP3D_V_ADD64(alo, MP3D_V_SUB64(MP3D_V_MUL_LO(vy, s1),
+                                                 MP3D_V_MUL_LO(vz, s0)));
+            ahi = MP3D_V_ADD64(ahi, MP3D_V_SUB64(MP3D_V_MUL_HI(vy, s1),
+                                                 MP3D_V_MUL_HI(vz, s0)));
+        }
+        else
+        {
+            alo = MP3D_V_ADD64(alo, MP3D_V_SUB64(MP3D_V_MUL_LO(vz, s0),
+                                                 MP3D_V_MUL_LO(vy, s1)));
+            ahi = MP3D_V_ADD64(ahi, MP3D_V_SUB64(MP3D_V_MUL_HI(vz, s0),
+                                                 MP3D_V_MUL_HI(vy, s1)));
+        }
+    }
+
+    a[0] = MP3D_V_GET64(alo, 0); a[1] = MP3D_V_GET64(alo, 1);
+    a[2] = MP3D_V_GET64(ahi, 0); a[3] = MP3D_V_GET64(ahi, 1);
+    b[0] = MP3D_V_GET64(blo, 0); b[1] = MP3D_V_GET64(blo, 1);
+    b[2] = MP3D_V_GET64(bhi, 0); b[3] = MP3D_V_GET64(bhi, 1);
+}
+#endif /* MP3D_HAVE_INT_SIMD */
+
 static void mp3d_synth(int32_t *xl, mp3d_sample_t *dstl, int nch, int32_t *lins) FL_NO_EXCEPT
 {
     int i;
@@ -2258,6 +2411,9 @@ static void mp3d_synth(int32_t *xl, mp3d_sample_t *dstl, int nch, int32_t *lins)
     };
     int32_t *zlin = lins + 15*64;
     const int32_t *w = g_win;
+#if MP3D_HAVE_INT_SIMD
+    const int use_simd = MP3D_SIMD_AVAILABLE();
+#endif
 
     zlin[4*15]     = xl[18*16];
     zlin[4*15 + 1] = xr[18*16];
@@ -2291,7 +2447,17 @@ static void mp3d_synth(int32_t *xl, mp3d_sample_t *dstl, int nch, int32_t *lins)
         zlin[4*(i - 16) + 2] = xl[18*(1 + i)];
         zlin[4*(i - 16) + 3] = xr[18*(1 + i)];
 
+#if MP3D_HAVE_INT_SIMD
+        if (use_simd)
+        {
+            mp3d_synth_taps(zlin, w, i, a, b);
+            w += 16; /* the scalar chain below advances w as a side effect */
+        }
+        else
+#endif
+        {
         S0(0) S2(1) S1(2) S2(3) S1(4) S2(5) S1(6) S2(7)
+        }
 
         dstr[(15 - i)*nch] = mp3d_scale_pcm(a[1]);
         dstr[(17 + i)*nch] = mp3d_scale_pcm(b[1]);
@@ -2978,6 +3144,16 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXC
 /* Only release MINIMP3_NO_SIMD if this header is what set it; a caller that
    asked for the scalar build must keep getting it on a re-include. */
 #undef MP3D_FLOAT_SIMD_OFF
+#undef MP3D_V_ZERO64
+#undef MP3D_V_LOAD4
+#undef MP3D_V_SPLAT
+#undef MP3D_V_MUL_LO
+#undef MP3D_V_MUL_HI
+#undef MP3D_V_ADD64
+#undef MP3D_V_SUB64
+#undef MP3D_V_GET64
+#undef MP3D_V_PREP
+#undef MP3D_V_SIGN
 #undef MP3D_HAVE_INT_SIMD
 #undef MP3D_INT_SIMD_SSE
 #undef MP3D_INT_SIMD_NEON

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -14,6 +14,26 @@
 #define MINIMP3_MAX_SAMPLES_PER_FRAME (1152*2)
 
 
+/* FastLED: intrinsics headers are included here, at global scope, rather than
+   next to the code that uses them.
+
+   The implementation section runs inside `namespace fl { namespace
+   MINIMP3_NAMESPACE {`, so an #include there declares int32x4_t and friends
+   *inside* that namespace. With one instantiation that is merely untidy; with
+   several -- which the fixed-vs-float and SIMD-vs-scalar gates require -- the
+   header guard means only the first variant gets the types and every later one
+   fails to compile with "did you mean minimp3_float_probe::int32x4_t". Found by
+   the macOS ARM64 CI job, which is the only place NEON is actually built. */
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
+    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
+#include <immintrin.h>
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+#include <cpuid.h>
+#endif
+#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+
 /* FastLED: fixed-point mode. MINIMP3_HAVE_FIXED_POINT reports whether this
    instantiation actually built the integer DSP path. The macro is recomputed on
    every (re-)inclusion so that a float variant and a fixed variant can coexist
@@ -324,22 +344,12 @@ static int32_t mp3d_narrow_q30(int64_t acc) FL_NO_EXCEPT
    though it does not overflow a 32-bit add. */
 static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 {
-    const int32_t sum = (int32_t)((uint32_t)a + (uint32_t)b);
-    if (((a ^ sum) & (b ^ sum)) < 0)
-    {
-        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
-    }
-    return sum < MP3D_SAT_MIN ? MP3D_SAT_MIN : sum;
+    return mp3d_sat64((int64_t)a + (int64_t)b);
 }
 
 static int32_t mp3d_sub_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 {
-    const int32_t diff = (int32_t)((uint32_t)a - (uint32_t)b);
-    if (((a ^ b) & (a ^ diff)) < 0)
-    {
-        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
-    }
-    return diff < MP3D_SAT_MIN ? MP3D_SAT_MIN : diff;
+    return mp3d_sat64((int64_t)a - (int64_t)b);
 }
 
 /* One Q26 unit of 1.0, and the clamp applied to dequantised samples.
@@ -511,15 +521,10 @@ static int have_simd()
 #if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
     ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
-#include <immintrin.h>
-#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
-#include <cpuid.h>
-#endif
 #define MP3D_HAVE_INT_SIMD 1
 #define MP3D_INT_SIMD_SSE  1
 typedef __m128i mp3d_i32x4;
 #elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
-#include <arm_neon.h>
 #define MP3D_HAVE_INT_SIMD 1
 #define MP3D_INT_SIMD_NEON 1
 typedef int32x4_t mp3d_i32x4;

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -27,7 +27,9 @@
 #if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
     ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
 #include <immintrin.h>
-#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+#if defined(_MSC_VER)
+#include <intrin.h> /* __cpuid, for the SSE4.1 run-time check */
+#elif defined(__GNUC__) || defined(__clang__)
 #include <cpuid.h>
 #endif
 #elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
@@ -329,19 +331,18 @@ static int32_t mp3d_narrow_q30(int64_t acc) FL_NO_EXCEPT
     return mp3d_sat64((acc + ((int64_t)1 << 29)) >> 30);
 }
 
-/* Saturating add/subtract, computed entirely in 32 bits.
+/* Saturating add/subtract, via a 64-bit intermediate.
 
-   These run tens of times per butterfly in the DCT-32 and IMDCT, which is the
-   hot path on exactly the 32-bit MCUs this path exists for, and there a 64-bit
-   add costs a register pair and a carry chain. The overflow test is the
-   standard one: a signed add overflows exactly when both operands share a sign
-   that the result does not, which is what `(a ^ sum) & (b ^ sum) < 0` says. The
-   wrapping sum is computed on unsigned operands, where wraparound is defined
-   rather than UB.
+   These run tens of times per butterfly in the DCT-32 and IMDCT, so a 32-bit
+   branchless form is tempting -- a 64-bit add is a register pair and a carry
+   chain on the MCUs this path targets. It was tried and reverted: on the one
+   target that could actually be measured it cost 6,265 bytes of text (+24%)
+   and 48 bytes of decode stack for ~3% of decode time, and the MCU argument for
+   it was never verified on an MCU. Revisit only with cross-compiled codegen
+   numbers; codec_cpu_trend.json has the rig.
 
-   The trailing check preserves the previous behaviour exactly: the saturation
-   range is symmetric (see MP3D_SAT_MIN), so INT32_MIN is out of range even
-   though it does not overflow a 32-bit add. */
+   Note the saturation range is symmetric (see MP3D_SAT_MIN), which the vector
+   forms of these must reproduce exactly. */
 static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 {
     return mp3d_sat64((int64_t)a + (int64_t)b);
@@ -3165,7 +3166,17 @@ int mp3dec_dsp_is_integer(void) FL_NO_EXCEPT
 
 int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT
 {
-    return MP3D_SIMD_KERNELS_LIVE;
+#if MP3D_SIMD_KERNELS_LIVE
+    /* Compile-time availability is not the question -- on x86 the kernels are
+       compiled for any SSE2 build but only reached when the run-time SSE4.1
+       check passes. Reporting the compile-time answer would make the
+       bit-exactness gate compare a scalar decode against another scalar decode
+       and call it a pass, and would make the perf gate assert a ratio on two
+       identical runs, i.e. on timer noise. */
+    return MP3D_SIMD_AVAILABLE();
+#else
+    return 0;
+#endif
 }
 
 void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT
@@ -3370,7 +3381,6 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXC
 #undef MP3D_V_SUB64
 #undef MP3D_V_GET64
 #undef MP3D_V_PREP
-#undef MP3D_V_SIGN
 #undef MP3D_V_ADDSAT
 #undef MP3D_V_SUBSAT
 #undef MP3D_V_MULSHIFT
@@ -3379,6 +3389,8 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXC
 #undef MP3D_INT_SIMD_SSE
 #undef MP3D_INT_SIMD_NEON
 #undef MP3D_SIMD_KERNELS_LIVE
+#undef MP3D_SIMD_AVAILABLE
+#undef MP3D_SIMD_TARGET
 #undef BITS_DEQUANTIZER_OUT
 #undef BSPOS
 #undef CHECK_BITS

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -309,14 +309,37 @@ static int32_t mp3d_narrow_q30(int64_t acc) FL_NO_EXCEPT
     return mp3d_sat64((acc + ((int64_t)1 << 29)) >> 30);
 }
 
+/* Saturating add/subtract, computed entirely in 32 bits.
+
+   These run tens of times per butterfly in the DCT-32 and IMDCT, which is the
+   hot path on exactly the 32-bit MCUs this path exists for, and there a 64-bit
+   add costs a register pair and a carry chain. The overflow test is the
+   standard one: a signed add overflows exactly when both operands share a sign
+   that the result does not, which is what `(a ^ sum) & (b ^ sum) < 0` says. The
+   wrapping sum is computed on unsigned operands, where wraparound is defined
+   rather than UB.
+
+   The trailing check preserves the previous behaviour exactly: the saturation
+   range is symmetric (see MP3D_SAT_MIN), so INT32_MIN is out of range even
+   though it does not overflow a 32-bit add. */
 static int32_t mp3d_add_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 {
-    return mp3d_sat64((int64_t)a + (int64_t)b);
+    const int32_t sum = (int32_t)((uint32_t)a + (uint32_t)b);
+    if (((a ^ sum) & (b ^ sum)) < 0)
+    {
+        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
+    }
+    return sum < MP3D_SAT_MIN ? MP3D_SAT_MIN : sum;
 }
 
 static int32_t mp3d_sub_sat(int32_t a, int32_t b) FL_NO_EXCEPT
 {
-    return mp3d_sat64((int64_t)a - (int64_t)b);
+    const int32_t diff = (int32_t)((uint32_t)a - (uint32_t)b);
+    if (((a ^ b) & (a ^ diff)) < 0)
+    {
+        return a < 0 ? MP3D_SAT_MIN : MP3D_SAT_MAX;
+    }
+    return diff < MP3D_SAT_MIN ? MP3D_SAT_MIN : diff;
 }
 
 /* One Q26 unit of 1.0, and the clamp applied to dequantised samples.

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -144,6 +144,11 @@ void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT;
 int mp3dec_is_fixed_point(void) FL_NO_EXCEPT;
 /* 1 when this instantiation actually decodes with integer arithmetic. */
 int mp3dec_dsp_is_integer(void) FL_NO_EXCEPT;
+/* 1 when this instantiation compiled integer SIMD kernels. Reported
+   separately from the two above for the same reason they are separate from
+   each other: "the build accepted the flag" and "the build actually vectorised"
+   are different claims, and only the second is worth gating on. */
+int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT;
 #ifndef MINIMP3_FLOAT_OUTPUT
 typedef int16_t mp3d_sample_t;
 #else /* MINIMP3_FLOAT_OUTPUT */
@@ -356,15 +361,19 @@ static int32_t mp3d_scale_to_q(int32_t mant, int exp) FL_NO_EXCEPT
 #define MP3D_STAGE(stage, ch, buf, n) ((void)0)
 #endif
 
-/* FastLED: the SIMD kernels below are float-only. Integer SSE2/NEON kernels
-   are Phase 4 (FastLED/FastLED#4055); until then the fixed-point build is
-   scalar, and says so rather than silently compiling float vector code. */
-#if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
-#define MINIMP3_NO_SIMD
-#define MP3D_OWNS_NO_SIMD
+/* FastLED: the vector kernels come in two families that must not be confused.
+   The `HAVE_SIMD` block below is the float one, and it stays exactly as
+   upstream wrote it -- the fixed-point build must never compile float vector
+   code. The integer kernels live in their own MP3D_HAVE_INT_SIMD block and are
+   selected only for the fixed build. */
+#if MINIMP3_HAVE_FIXED_POINT
+/* Keep upstream's float SIMD out of the fixed build without disturbing the
+   caller's own MINIMP3_NO_SIMD, which still has to mean "scalar everywhere"
+   and is what the Phase 4 opt-out proof relies on. */
+#define MP3D_FLOAT_SIMD_OFF
 #endif
 
-#if !defined(MINIMP3_NO_SIMD)
+#if !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF)
 
 #if !defined(MINIMP3_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__) || defined(_M_ARM64))
 /* x64 always have SSE2, arm64 always have neon, no need for generic code */
@@ -467,9 +476,39 @@ static int have_simd()
 #error MINIMP3_ONLY_SIMD used, but SSE/NEON not enabled
 #endif /* MINIMP3_ONLY_SIMD */
 #endif /* SIMD checks... */
-#else /* !defined(MINIMP3_NO_SIMD) */
+#else /* !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF) */
 #define HAVE_SIMD 0
-#endif /* !defined(MINIMP3_NO_SIMD) */
+#endif /* !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF) */
+
+/* FastLED: integer SIMD for the fixed-point path (FastLED/FastLED#4055).
+   Deliberately a separate detection block from upstream's float one above --
+   the two select different instruction sets and must never both be live.
+   MINIMP3_NO_SIMD suppresses this as well, which is what makes the scalar
+   opt-out proof meaningful. */
+#if MINIMP3_HAVE_FIXED_POINT && !defined(MINIMP3_NO_SIMD)
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || \
+    ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
+#include <emmintrin.h>
+#define MP3D_HAVE_INT_SIMD 1
+#define MP3D_INT_SIMD_SSE  1
+typedef __m128i mp3d_i32x4;
+#elif defined(__ARM_NEON) || defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#define MP3D_HAVE_INT_SIMD 1
+#define MP3D_INT_SIMD_NEON 1
+typedef int32x4_t mp3d_i32x4;
+#endif
+#endif /* MINIMP3_HAVE_FIXED_POINT && !MINIMP3_NO_SIMD */
+
+#ifndef MP3D_HAVE_INT_SIMD
+#define MP3D_HAVE_INT_SIMD 0
+#endif
+
+/* 1 once integer kernels actually replace scalar ones. Separate from
+   MP3D_HAVE_INT_SIMD -- having the intrinsics available is not the same as
+   using them, and the gate is on the second. */
+#undef MP3D_SIMD_KERNELS_LIVE
+#define MP3D_SIMD_KERNELS_LIVE 0
 
 #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
 #define HAVE_ARMV6 1
@@ -2741,6 +2780,11 @@ int mp3dec_dsp_is_integer(void) FL_NO_EXCEPT
     return MINIMP3_DSP_INTEGER;
 }
 
+int mp3dec_dsp_uses_simd(void) FL_NO_EXCEPT
+{
+    return MP3D_SIMD_KERNELS_LIVE;
+}
+
 void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT
 {
     dec->header[0] = 0;
@@ -2933,10 +2977,11 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXC
 #undef MP3D_PCM_LOWER
 /* Only release MINIMP3_NO_SIMD if this header is what set it; a caller that
    asked for the scalar build must keep getting it on a re-include. */
-#ifdef MP3D_OWNS_NO_SIMD
-#undef MINIMP3_NO_SIMD
-#undef MP3D_OWNS_NO_SIMD
-#endif
+#undef MP3D_FLOAT_SIMD_OFF
+#undef MP3D_HAVE_INT_SIMD
+#undef MP3D_INT_SIMD_SSE
+#undef MP3D_INT_SIMD_NEON
+#undef MP3D_SIMD_KERNELS_LIVE
 #undef BITS_DEQUANTIZER_OUT
 #undef BSPOS
 #undef CHECK_BITS

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -2146,9 +2146,292 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_internal_t *s, L3_gr_info_t *g
    can drive dequantised samples to the +/-1 clamp, and this butterfly stacks
    three levels of adds on top of a 10.19x multiply. Saturating there turns a
    signed-overflow UB report into a bounded, audible-at-worst result. */
+#if MP3D_HAVE_INT_SIMD
+/* FastLED: integer vector helpers for the polyphase back-end.
+
+   The polyphase filter is the one kernel where vectorising is bit-exact for
+   free: it is a pure int32 x int32 -> int64 multiply-accumulate with no
+   intermediate rounding or saturation, and int64 addition is exact and
+   associative, so any lane arrangement reproduces the scalar result exactly.
+   Every other kernel rounds and saturates per operation, which is why they are
+   not vectorised -- see the disposition note on mp3d_synth below.
+
+   The MUL_LO/MUL_HI pair takes two int32 lanes and returns two int64 products
+   -- `LO` for lanes 0 and 1, `HI` for lanes 2 and 3. ADDSAT/SUBSAT/MULSHIFT are
+   the four-lane forms of the scalar helpers of the same name and must match
+   them exactly, including the symmetric saturation range. */
+#if MP3D_INT_SIMD_NEON
+typedef int64x2_t mp3d_i64x2;
+#define MP3D_V_ZERO64()        vdupq_n_s64(0)
+#define MP3D_V_LOAD4(p)        vld1q_s32((const int32_t *)(p))
+#define MP3D_V_SPLAT(x)        vdupq_n_s32(x)
+#define MP3D_V_PREP(v)         (v)
+#define MP3D_V_STORE4(p, v)    vst1q_s32((int32_t *)(p), (v))
+#define MP3D_V_MUL_LO(v, s)    vmull_s32(vget_low_s32(v), vget_low_s32(s))
+#define MP3D_V_MUL_HI(v, s)    vmull_s32(vget_high_s32(v), vget_high_s32(s))
+#define MP3D_V_ADD64(x, y)     vaddq_s64((x), (y))
+#define MP3D_V_SUB64(x, y)     vsubq_s64((x), (y))
+#define MP3D_V_GET64(x, lane)  ((lane) ? vgetq_lane_s64((x), 1) : vgetq_lane_s64((x), 0))
+/* NEON multiplies signed 32x32 -> 64 natively and is in the ARM64 baseline, so
+   there is nothing to detect. */
+#define MP3D_SIMD_AVAILABLE()  1
+#define MP3D_SIMD_TARGET
+
+/* Saturating add/subtract. vqaddq_s32 saturates to INT32_MIN/MAX; the decoder's
+   range is symmetric, so the extra vmaxq_s32 pulls INT32_MIN up to
+   MP3D_SAT_MIN exactly as the scalar helper does. */
+#define MP3D_V_ADDSAT(a, b)                                                    \
+    vmaxq_s32(vqaddq_s32((a), (b)), vdupq_n_s32(MP3D_SAT_MIN))
+#define MP3D_V_SUBSAT(a, b)                                                    \
+    vmaxq_s32(vqsubq_s32((a), (b)), vdupq_n_s32(MP3D_SAT_MIN))
+
+/* value * Q`bits` coefficient, rounded and saturated -- the vector form of
+   mp3d_mulshift, and it must round the same way: add half, then shift right
+   with sign extension (round half toward +infinity). */
+static int32x4_t mp3d_v_mulshift(int32x4_t v, int32_t coef,
+                                 int64x2_t round, int shift) FL_NO_EXCEPT
+{
+    const int32x2_t c = vdup_n_s32(coef);
+    int64x2_t lo = vaddq_s64(vmull_s32(vget_low_s32(v), c), round);
+    int64x2_t hi = vaddq_s64(vmull_s32(vget_high_s32(v), c), round);
+    lo = vshlq_s64(lo, vdupq_n_s64(-shift));
+    hi = vshlq_s64(hi, vdupq_n_s64(-shift));
+    return vmaxq_s32(vcombine_s32(vqmovn_s64(lo), vqmovn_s64(hi)),
+                     vdupq_n_s32(MP3D_SAT_MIN));
+}
+#define MP3D_V_MULSHIFT(v, coef, bits)                                         \
+    mp3d_v_mulshift((v), (coef), vdupq_n_s64((int64_t)1 << ((bits) - 1)),      \
+                    (bits))
+#else /* MP3D_INT_SIMD_SSE */
+typedef __m128i mp3d_i64x2;
+#define MP3D_V_ZERO64()        _mm_setzero_si128()
+#define MP3D_V_LOAD4(p)        _mm_loadu_si128((const __m128i *)(const void *)(p))
+#define MP3D_V_SPLAT(x)        _mm_set1_epi32(x)
+/* _mm_mul_epi32 multiplies the even int32 lanes; shuffling to (0,1),(2,3) once
+   per vector lets both architectures share the accumulator bookkeeping. */
+#define MP3D_V_PREP(v)         _mm_shuffle_epi32((v), _MM_SHUFFLE(3, 1, 2, 0))
+#define MP3D_V_STORE4(p, v)    _mm_storeu_si128((__m128i *)(void *)(p), (v))
+#define MP3D_V_MUL_LO(v, s)    _mm_mul_epi32((v), (s))
+#define MP3D_V_MUL_HI(v, s)    _mm_mul_epi32(_mm_srli_si128((v), 4), (s))
+#define MP3D_V_ADD64(x, y)     _mm_add_epi64((x), (y))
+#define MP3D_V_SUB64(x, y)     _mm_sub_epi64((x), (y))
+
+static int64_t mp3d_get_i64(__m128i v, int lane) FL_NO_EXCEPT
+{
+    int64_t out[2];
+    _mm_storeu_si128((__m128i *)(void *)out, v);
+    return out[lane];
+}
+#define MP3D_V_GET64(x, lane)  mp3d_get_i64((x), (lane))
+
+/* Signed 32x32 -> 64 needs SSE4.1. SSE2 can emulate it with an unsigned
+   multiply plus a sign correction, and that was measured rather than assumed:
+   0.66x of scalar in a standalone harness, 0.95x inside the decoder. Slower is
+   not worth shipping, so SSE2-only hardware stays on the scalar kernel and the
+   vector path is chosen at run time -- the same shape as upstream's
+   have_simd() dispatch for the float kernels. The same harness measures 1.71x
+   once _mm_mul_epi32 is available. */
+#if defined(__GNUC__) || defined(__clang__)
+#define MP3D_SIMD_TARGET __attribute__((target("sse4.1")))
+#else
+#define MP3D_SIMD_TARGET
+#endif
+
+/* Self-contained: upstream's minimp3_cpuid lives inside the float SIMD block,
+   which the fixed build switches off, so this path cannot borrow it. */
+static int mp3d_have_sse41(void) FL_NO_EXCEPT
+{
+#if defined(__SSE4_1__)
+    return 1;
+#elif defined(_MSC_VER)
+    static int cached;
+    int info[4];
+    if (!cached)
+    {
+        __cpuid(info, 1);
+        cached = ((info[2] & (1 << 19)) != 0) + 1; /* ECX.SSE4_1 */
+    }
+    return cached - 1;
+#elif defined(__GNUC__) || defined(__clang__)
+    static int cached;
+    unsigned eax, ebx, ecx, edx;
+    if (!cached)
+    {
+        cached = (__get_cpuid(1, &eax, &ebx, &ecx, &edx) &&
+                  (ecx & (1u << 19))) + 1;
+    }
+    return cached - 1;
+#else
+    return 0;
+#endif
+}
+#define MP3D_SIMD_AVAILABLE()  mp3d_have_sse41()
+
+/* Saturating add/subtract on four int32 lanes. SSE has saturating add only for
+   8- and 16-bit lanes, so the 32-bit form is the classic branchless test: a
+   signed add overflows exactly when both operands share a sign the result does
+   not. The trailing _mm_max_epi32 enforces the decoder's symmetric range, the
+   same trailing clamp the scalar helper carries. */
+MP3D_SIMD_TARGET static __m128i mp3d_v_addsat(__m128i a, __m128i b) FL_NO_EXCEPT
+{
+    const __m128i sum = _mm_add_epi32(a, b);
+    /* _mm_blendv_epi8 selects per byte on that byte's high bit, so every mask
+       here is broadcast to a full lane with _mm_srai_epi32(.., 31) first --
+       handing it a raw value blends bytes independently and silently produces
+       a wrong answer in the low bits. */
+    const __m128i overflow = _mm_srai_epi32(
+        _mm_and_si128(_mm_xor_si128(a, sum), _mm_xor_si128(b, sum)), 31);
+    const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
+                                         _mm_set1_epi32(MP3D_SAT_MIN),
+                                         _mm_srai_epi32(a, 31));
+    return _mm_max_epi32(_mm_blendv_epi8(sum, rail, overflow),
+                         _mm_set1_epi32(MP3D_SAT_MIN));
+}
+
+MP3D_SIMD_TARGET static __m128i mp3d_v_subsat(__m128i a, __m128i b) FL_NO_EXCEPT
+{
+    const __m128i diff = _mm_sub_epi32(a, b);
+    const __m128i overflow = _mm_srai_epi32(
+        _mm_and_si128(_mm_xor_si128(a, b), _mm_xor_si128(a, diff)), 31);
+    const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
+                                         _mm_set1_epi32(MP3D_SAT_MIN),
+                                         _mm_srai_epi32(a, 31));
+    return _mm_max_epi32(_mm_blendv_epi8(diff, rail, overflow),
+                         _mm_set1_epi32(MP3D_SAT_MIN));
+}
+
+/* value * Q`bits` coefficient, rounded and saturated. SSE has no arithmetic
+   64-bit shift before AVX-512, so the sign bits are folded back in by hand;
+   and no 64-bit compare before SSE4.2, so the narrow detects out-of-range by
+   checking that the high word is the sign extension of the low one. */
+MP3D_SIMD_TARGET static __m128i mp3d_v_mulshift(__m128i v, int32_t coef,
+                                                int bits) FL_NO_EXCEPT
+{
+    const __m128i c = _mm_set1_epi32(coef);
+    const __m128i round = _mm_set1_epi64x((int64_t)1 << (bits - 1));
+    const __m128i s = _mm_shuffle_epi32(v, _MM_SHUFFLE(3, 1, 2, 0));
+    __m128i p01 = _mm_add_epi64(_mm_mul_epi32(s, c), round);
+    __m128i p23 = _mm_add_epi64(_mm_mul_epi32(_mm_srli_si128(s, 4), c), round);
+    const __m128i sign01 =
+        _mm_srai_epi32(_mm_shuffle_epi32(p01, _MM_SHUFFLE(3, 3, 1, 1)), 31);
+    const __m128i sign23 =
+        _mm_srai_epi32(_mm_shuffle_epi32(p23, _MM_SHUFFLE(3, 3, 1, 1)), 31);
+    p01 = _mm_or_si128(_mm_srli_epi64(p01, bits),
+                       _mm_slli_epi64(sign01, 64 - bits));
+    p23 = _mm_or_si128(_mm_srli_epi64(p23, bits),
+                       _mm_slli_epi64(sign23, 64 - bits));
+    {
+        const __m128i lo = _mm_castps_si128(
+            _mm_shuffle_ps(_mm_castsi128_ps(p01), _mm_castsi128_ps(p23),
+                           _MM_SHUFFLE(2, 0, 2, 0)));
+        const __m128i hi = _mm_castps_si128(
+            _mm_shuffle_ps(_mm_castsi128_ps(p01), _mm_castsi128_ps(p23),
+                           _MM_SHUFFLE(3, 1, 3, 1)));
+        const __m128i in_range = _mm_cmpeq_epi32(hi, _mm_srai_epi32(lo, 31));
+        const __m128i rail = _mm_blendv_epi8(_mm_set1_epi32(MP3D_SAT_MAX),
+                                             _mm_set1_epi32(MP3D_SAT_MIN),
+                                             _mm_srai_epi32(hi, 31));
+        return _mm_max_epi32(_mm_blendv_epi8(rail, lo, in_range),
+                             _mm_set1_epi32(MP3D_SAT_MIN));
+    }
+}
+#define MP3D_V_ADDSAT(a, b)            mp3d_v_addsat((a), (b))
+#define MP3D_V_SUBSAT(a, b)            mp3d_v_subsat((a), (b))
+#define MP3D_V_MULSHIFT(v, coef, bits) mp3d_v_mulshift((v), (coef), (bits))
+#endif
+
+#endif /* MP3D_HAVE_INT_SIMD */
+
+#if MP3D_HAVE_INT_SIMD
+/* Four bands of the DCT-32 at once.
+
+   grbuf is laid out band-major, so `y[i*18]` for four consecutive k values is
+   four consecutive int32 -- the same property upstream's float kernel relies
+   on, and the reason this vectorises without gathers.
+
+   Transcribed operation for operation from the scalar version below rather
+   than re-associated. That matters here in a way it did not for the polyphase:
+   every add saturates and every multiply rounds, so reordering them is
+   observable, and #4055's gate is exact equality with the scalar path. */
+MP3D_SIMD_TARGET static void mp3d_dct2_bands4(int32_t *grbuf, int k) FL_NO_EXCEPT
+{
+    mp3d_i32x4 t[4][8], *x;
+    int32_t *y = grbuf + k;
+    int i;
+
+    for (x = t[0], i = 0; i < 8; i++, x++)
+    {
+        const mp3d_i32x4 x0 = MP3D_V_LOAD4(&y[i*18]);
+        const mp3d_i32x4 x1 = MP3D_V_LOAD4(&y[(15 - i)*18]);
+        const mp3d_i32x4 x2 = MP3D_V_LOAD4(&y[(16 + i)*18]);
+        const mp3d_i32x4 x3 = MP3D_V_LOAD4(&y[(31 - i)*18]);
+        const mp3d_i32x4 t0 = MP3D_V_ADDSAT(x0, x3);
+        const mp3d_i32x4 t1 = MP3D_V_ADDSAT(x1, x2);
+        const mp3d_i32x4 t2 =
+            MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x1, x2), g_sec_q27[3*i + 0], 27);
+        const mp3d_i32x4 t3 =
+            MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x3), g_sec_q27[3*i + 1], 27);
+        x[0]  = MP3D_V_ADDSAT(t0, t1);
+        x[8]  = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(t0, t1), g_sec_q27[3*i + 2], 27);
+        x[16] = MP3D_V_ADDSAT(t3, t2);
+        x[24] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(t3, t2), g_sec_q27[3*i + 2], 27);
+    }
+    for (x = t[0], i = 0; i < 4; i++, x += 8)
+    {
+        mp3d_i32x4 x0 = x[0], x1 = x[1], x2 = x[2], x3 = x[3];
+        mp3d_i32x4 x4 = x[4], x5 = x[5], x6 = x[6], x7 = x[7], xt;
+        xt = MP3D_V_SUBSAT(x0, x7); x0 = MP3D_V_ADDSAT(x0, x7);
+        x7 = MP3D_V_SUBSAT(x1, x6); x1 = MP3D_V_ADDSAT(x1, x6);
+        x6 = MP3D_V_SUBSAT(x2, x5); x2 = MP3D_V_ADDSAT(x2, x5);
+        x5 = MP3D_V_SUBSAT(x3, x4); x3 = MP3D_V_ADDSAT(x3, x4);
+        x4 = MP3D_V_SUBSAT(x0, x3); x0 = MP3D_V_ADDSAT(x0, x3);
+        x3 = MP3D_V_SUBSAT(x1, x2); x1 = MP3D_V_ADDSAT(x1, x2);
+        x[0] = MP3D_V_ADDSAT(x0, x1);
+        x[4] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x1), MP3D_Q31_COS_PI_4, 31);
+        x5 = MP3D_V_ADDSAT(x5, x6);
+        x6 = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x6, x7), MP3D_Q31_COS_PI_4, 31);
+        x7 = MP3D_V_ADDSAT(x7, xt);
+        x3 = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x3, x4), MP3D_Q31_COS_PI_4, 31);
+        x5 = MP3D_V_SUBSAT(x5, MP3D_V_MULSHIFT(x7, MP3D_Q31_TAN_PI_16, 31));
+        x7 = MP3D_V_ADDSAT(x7, MP3D_V_MULSHIFT(x5, MP3D_Q31_SIN_PI_8, 31));
+        x5 = MP3D_V_SUBSAT(x5, MP3D_V_MULSHIFT(x7, MP3D_Q31_TAN_PI_16, 31));
+        x0 = MP3D_V_SUBSAT(xt, x6); xt = MP3D_V_ADDSAT(xt, x6);
+        x[1] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(xt, x7), MP3D_Q29_SEC_PI_16, 29);
+        x[2] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x4, x3), MP3D_Q29_SEC_PI_8, 29);
+        x[3] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x0, x5), MP3D_Q29_SEC_3PI_16, 29);
+        x[5] = MP3D_V_MULSHIFT(MP3D_V_ADDSAT(x0, x5), MP3D_Q29_SEC_5PI_16, 29);
+        x[6] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(x4, x3), MP3D_Q29_SEC_3PI_8, 29);
+        x[7] = MP3D_V_MULSHIFT(MP3D_V_SUBSAT(xt, x7), MP3D_Q29_SEC_7PI_16, 29);
+    }
+    for (i = 0; i < 7; i++, y += 4*18)
+    {
+        MP3D_V_STORE4(&y[0*18], t[0][i]);
+        MP3D_V_STORE4(&y[1*18], MP3D_V_ADDSAT(MP3D_V_ADDSAT(t[2][i], t[3][i]),
+                                              t[3][i + 1]));
+        MP3D_V_STORE4(&y[2*18], MP3D_V_ADDSAT(t[1][i], t[1][i + 1]));
+        MP3D_V_STORE4(&y[3*18],
+                      MP3D_V_ADDSAT(MP3D_V_ADDSAT(t[2][i + 1], t[3][i]),
+                                    t[3][i + 1]));
+    }
+    MP3D_V_STORE4(&y[0*18], t[0][7]);
+    MP3D_V_STORE4(&y[1*18], MP3D_V_ADDSAT(t[2][7], t[3][7]));
+    MP3D_V_STORE4(&y[2*18], t[1][7]);
+    MP3D_V_STORE4(&y[3*18], t[3][7]);
+}
+#endif /* MP3D_HAVE_INT_SIMD */
+
 static void mp3d_DCT_II(int32_t *grbuf, int n) FL_NO_EXCEPT
 {
     int i, k = 0;
+#if MP3D_HAVE_INT_SIMD
+    if (MP3D_SIMD_AVAILABLE())
+    {
+        for (; k + 4 <= n; k += 4)
+        {
+            mp3d_dct2_bands4(grbuf, k);
+        }
+    }
+#endif
     for (; k < n; k++)
     {
         int32_t t[4][8], *x, *y = grbuf + k;
@@ -2259,100 +2542,6 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const int32_t *z) FL_NO
    up to int16, and it is the one place a 64-bit accumulator is genuinely
    required: the window coefficients reach 75038, so a single product already
    needs 48 bits before sixteen of them are summed. */
-#if MP3D_HAVE_INT_SIMD
-/* FastLED: integer vector helpers for the polyphase back-end.
-
-   The polyphase filter is the one kernel where vectorising is bit-exact for
-   free: it is a pure int32 x int32 -> int64 multiply-accumulate with no
-   intermediate rounding or saturation, and int64 addition is exact and
-   associative, so any lane arrangement reproduces the scalar result exactly.
-   Every other kernel rounds and saturates per operation, which is why they are
-   not vectorised -- see the disposition note on mp3d_synth below.
-
-   Both multiply helpers take two int32 lanes and return two int64 products:
-   `LO` for lanes 0 and 1, `HI` for lanes 2 and 3. */
-#if MP3D_INT_SIMD_NEON
-typedef int64x2_t mp3d_i64x2;
-#define MP3D_V_ZERO64()        vdupq_n_s64(0)
-#define MP3D_V_LOAD4(p)        vld1q_s32((const int32_t *)(p))
-#define MP3D_V_SPLAT(x)        vdupq_n_s32(x)
-#define MP3D_V_PREP(v)         (v)
-#define MP3D_V_MUL_LO(v, s)    vmull_s32(vget_low_s32(v), vget_low_s32(s))
-#define MP3D_V_MUL_HI(v, s)    vmull_s32(vget_high_s32(v), vget_high_s32(s))
-#define MP3D_V_ADD64(x, y)     vaddq_s64((x), (y))
-#define MP3D_V_SUB64(x, y)     vsubq_s64((x), (y))
-#define MP3D_V_GET64(x, lane)  ((lane) ? vgetq_lane_s64((x), 1) : vgetq_lane_s64((x), 0))
-/* NEON multiplies signed 32x32 -> 64 natively and is in the ARM64 baseline, so
-   there is nothing to detect. */
-#define MP3D_SIMD_AVAILABLE()  1
-#define MP3D_SIMD_TARGET
-#else /* MP3D_INT_SIMD_SSE */
-typedef __m128i mp3d_i64x2;
-#define MP3D_V_ZERO64()        _mm_setzero_si128()
-#define MP3D_V_LOAD4(p)        _mm_loadu_si128((const __m128i *)(const void *)(p))
-#define MP3D_V_SPLAT(x)        _mm_set1_epi32(x)
-/* _mm_mul_epi32 multiplies the even int32 lanes; shuffling to (0,1),(2,3) once
-   per vector lets both architectures share the accumulator bookkeeping. */
-#define MP3D_V_PREP(v)         _mm_shuffle_epi32((v), _MM_SHUFFLE(3, 1, 2, 0))
-#define MP3D_V_MUL_LO(v, s)    _mm_mul_epi32((v), (s))
-#define MP3D_V_MUL_HI(v, s)    _mm_mul_epi32(_mm_srli_si128((v), 4), (s))
-#define MP3D_V_ADD64(x, y)     _mm_add_epi64((x), (y))
-#define MP3D_V_SUB64(x, y)     _mm_sub_epi64((x), (y))
-
-static int64_t mp3d_get_i64(__m128i v, int lane) FL_NO_EXCEPT
-{
-    int64_t out[2];
-    _mm_storeu_si128((__m128i *)(void *)out, v);
-    return out[lane];
-}
-#define MP3D_V_GET64(x, lane)  mp3d_get_i64((x), (lane))
-
-/* Signed 32x32 -> 64 needs SSE4.1. SSE2 can emulate it with an unsigned
-   multiply plus a sign correction, and that was measured rather than assumed:
-   0.66x of scalar in a standalone harness, 0.95x inside the decoder. Slower is
-   not worth shipping, so SSE2-only hardware stays on the scalar kernel and the
-   vector path is chosen at run time -- the same shape as upstream's
-   have_simd() dispatch for the float kernels. The same harness measures 1.71x
-   once _mm_mul_epi32 is available. */
-#if defined(__GNUC__) || defined(__clang__)
-#define MP3D_SIMD_TARGET __attribute__((target("sse4.1")))
-#else
-#define MP3D_SIMD_TARGET
-#endif
-
-/* Self-contained: upstream's minimp3_cpuid lives inside the float SIMD block,
-   which the fixed build switches off, so this path cannot borrow it. */
-static int mp3d_have_sse41(void) FL_NO_EXCEPT
-{
-#if defined(__SSE4_1__)
-    return 1;
-#elif defined(_MSC_VER)
-    static int cached;
-    int info[4];
-    if (!cached)
-    {
-        __cpuid(info, 1);
-        cached = ((info[2] & (1 << 19)) != 0) + 1; /* ECX.SSE4_1 */
-    }
-    return cached - 1;
-#elif defined(__GNUC__) || defined(__clang__)
-    static int cached;
-    unsigned eax, ebx, ecx, edx;
-    if (!cached)
-    {
-        cached = (__get_cpuid(1, &eax, &ebx, &ecx, &edx) &&
-                  (ecx & (1u << 19))) + 1;
-    }
-    return cached - 1;
-#else
-    return 0;
-#endif
-}
-#define MP3D_SIMD_AVAILABLE()  mp3d_have_sse41()
-#endif
-
-#endif /* MP3D_HAVE_INT_SIMD */
-
 #if MP3D_HAVE_INT_SIMD
 /* One iteration's eight window taps.
 
@@ -3177,6 +3366,10 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXC
 #undef MP3D_V_GET64
 #undef MP3D_V_PREP
 #undef MP3D_V_SIGN
+#undef MP3D_V_ADDSAT
+#undef MP3D_V_SUBSAT
+#undef MP3D_V_MULSHIFT
+#undef MP3D_V_STORE4
 #undef MP3D_HAVE_INT_SIMD
 #undef MP3D_INT_SIMD_SSE
 #undef MP3D_INT_SIMD_NEON

--- a/tests/fl/codec/minimp3_variants.hpp
+++ b/tests/fl/codec/minimp3_variants.hpp
@@ -94,6 +94,21 @@ inline void mp3StageDump(int stage, int channel, const fl::i32* buf,
 #undef MINIMP3_FIXED_POINT
 #undef MINIMP3_NAMESPACE
 
+// ---- fixed-point, scalar only (SIMD opt-out) -------------------------------
+// Phase 4 (#4055) has to prove MINIMP3_NO_SIMD still yields a working scalar
+// decoder, and it is the reference the SIMD kernels must match bit for bit.
+#undef MINIMP3_H
+#undef _MINIMP3_IMPLEMENTATION_GUARD
+#define MINIMP3_NAMESPACE minimp3_fixed_scalar_probe
+#define MINIMP3_FIXED_POINT 1
+#define MINIMP3_NO_SIMD
+#define MINIMP3_IMPLEMENTATION
+#include "third_party/minimp3/minimp3.h" // ok cpp include
+#undef MINIMP3_IMPLEMENTATION
+#undef MINIMP3_NO_SIMD
+#undef MINIMP3_FIXED_POINT
+#undef MINIMP3_NAMESPACE
+
 // ---- restore the default instantiation -------------------------------------
 // The two blocks above leave MINIMP3_H defined for whichever variant went
 // last, which would make a later `#include "third_party/minimp3/minimp3.h"`
@@ -125,6 +140,9 @@ namespace fl {
         static bool dspIsInteger() FL_NO_EXCEPT {                              \
             return NS::mp3dec_dsp_is_integer() != 0;                           \
         }                                                                      \
+        static bool dspUsesSimd() FL_NO_EXCEPT {                               \
+            return NS::mp3dec_dsp_uses_simd() != 0;                            \
+        }                                                                      \
         static int decodeFrame(decoder_type* dec, scratch_type* scratch,       \
                                const fl::u8* mp3, int bytes,                   \
                                sample_type* pcm, info_type* info)              \
@@ -136,5 +154,6 @@ namespace fl {
 
 FL_MP3_VARIANT_ADAPTER(Minimp3FloatVariant, fl::minimp3_float_probe);
 FL_MP3_VARIANT_ADAPTER(Minimp3FixedVariant, fl::minimp3_fixed_probe);
+FL_MP3_VARIANT_ADAPTER(Minimp3FixedScalarVariant, fl::minimp3_fixed_scalar_probe);
 
 } // namespace fl

--- a/tests/fl/codec/mp3_fixed_point.hpp
+++ b/tests/fl/codec/mp3_fixed_point.hpp
@@ -286,6 +286,44 @@ FL_TEST_CASE("minimp3 fixed-point scalefactor gains match 2**(q/4) exactly") {
 // that merely accepted -DMINIMP3_FIXED_POINT and kept decoding in float would
 // otherwise sail through every fixed-vs-float comparison with a perfect score.
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Phase 4 (#4055): the SIMD kernels must be bit-identical to the scalar
+// fixed-point path, not merely close. Equality is the gate because both
+// operate on the same integer representation -- any difference is a defect in
+// one of them, not a rounding trade-off.
+// ---------------------------------------------------------------------------
+FL_TEST_CASE("minimp3 fixed-point SIMD kernels are bit-identical to scalar") {
+    fl::setTestFileSystemRoot("tests/data");
+
+    // The opt-out has to keep working: it is what makes "scalar" a real
+    // reference rather than whatever the default build happened to select.
+    FL_CHECK(fl::Minimp3FixedScalarVariant::dspIsInteger());
+    FL_CHECK_FALSE(fl::Minimp3FixedScalarVariant::dspUsesSimd());
+
+    // RED until the integer kernels land (#4055).
+    FL_CHECK(fl::Minimp3FixedVariant::dspUsesSimd());
+
+    for (const char* path : kFixedPointCorpus) {
+        const fl::vector<fl::u8> bytes = readCorpusBytes(path);
+        const VariantDecodeResult scalar =
+            decodeWithVariant<fl::Minimp3FixedScalarVariant>(bytes);
+        const VariantDecodeResult simd =
+            decodeWithVariant<fl::Minimp3FixedVariant>(bytes);
+
+        FL_CHECK_GT(scalar.mFrames, 0);
+        FL_REQUIRE_EQ(simd.mFrames, scalar.mFrames);
+        FL_REQUIRE_EQ(simd.mPcm.size(), scalar.mPcm.size());
+        for (fl::size i = 0; i < scalar.mPcm.size(); ++i) {
+            if (simd.mPcm[i] != scalar.mPcm[i]) {
+                printf("[simd-exact] %s diverges at sample %zu: %d != %d\n",
+                       path, i, static_cast<int>(simd.mPcm[i]),
+                       static_cast<int>(scalar.mPcm[i]));
+                FL_REQUIRE_EQ(simd.mPcm[i], scalar.mPcm[i]);
+            }
+        }
+    }
+}
+
 FL_TEST_CASE("minimp3 fixed-point variant decodes with integer arithmetic") {
     FL_CHECK(fl::Minimp3FixedVariant::isFixedPoint());
     FL_CHECK_FALSE(fl::Minimp3FloatVariant::isFixedPoint());

--- a/tests/fl/codec/mp3_fixed_point.hpp
+++ b/tests/fl/codec/mp3_fixed_point.hpp
@@ -300,8 +300,16 @@ FL_TEST_CASE("minimp3 fixed-point SIMD kernels are bit-identical to scalar") {
     FL_CHECK(fl::Minimp3FixedScalarVariant::dspIsInteger());
     FL_CHECK_FALSE(fl::Minimp3FixedScalarVariant::dspUsesSimd());
 
-    // RED until the integer kernels land (#4055).
-    FL_CHECK(fl::Minimp3FixedVariant::dspUsesSimd());
+    // Integer SIMD is not available on every target this file compiles for --
+    // SSE2-only x86 deliberately stays scalar because the emulated signed
+    // multiply measured slower than scalar, and a target with neither SSE nor
+    // NEON has no vector path at all. Where there is no SIMD there is nothing
+    // to compare, so say so rather than failing.
+    if (!fl::Minimp3FixedVariant::dspUsesSimd()) {
+        printf("[simd-exact] no integer SIMD on this target; equality gate is "
+               "vacuous here\n");
+        return;
+    }
 
     for (const char* path : kFixedPointCorpus) {
         const fl::vector<fl::u8> bytes = readCorpusBytes(path);
@@ -322,6 +330,57 @@ FL_TEST_CASE("minimp3 fixed-point SIMD kernels are bit-identical to scalar") {
             }
         }
     }
+}
+
+FL_TEST_CASE("minimp3 fixed-point SIMD is not slower than scalar") {
+    fl::setTestFileSystemRoot("tests/data");
+    const fl::vector<fl::u8> bytes =
+        readCorpusBytes("codec/minimp3/l3-lame-vbrtag.bit");
+
+    // Informational on its own -- host timing in a unit test is noisy -- but
+    // the direction is the enforced part of #4055's perf bar: whatever the
+    // machine, the vector path must not be *slower* than the scalar one it
+    // replaces. Both variants decode the same bytes in the same process, so
+    // the comparison is same-host by construction and needs no baseline.
+    const int kReps = 8;
+    fl::u32 scalar_us = 0;
+    fl::u32 simd_us = 0;
+    for (int rep = 0; rep < kReps; ++rep) {
+        const fl::u32 t0 = fl::micros();
+        decodeWithVariant<fl::Minimp3FixedScalarVariant>(bytes);
+        const fl::u32 t1 = fl::micros();
+        decodeWithVariant<fl::Minimp3FixedVariant>(bytes);
+        const fl::u32 t2 = fl::micros();
+        scalar_us += t1 - t0;
+        simd_us += t2 - t1;
+    }
+    const double ratio = simd_us ? static_cast<double>(scalar_us) /
+                                       static_cast<double>(simd_us)
+                                 : 0.0;
+    printf("[simd-perf] scalar=%u us  simd=%u us  speedup=%.3fx over %d reps\n",
+           scalar_us, simd_us, ratio, kReps);
+    FL_CHECK_GT(scalar_us, 0u);
+    FL_CHECK_GT(simd_us, 0u);
+
+    if (!fl::Minimp3FixedVariant::dspUsesSimd()) {
+        return; // nothing was vectorised; the ratio measures noise
+    }
+#if defined(__OPTIMIZE__)
+    // The enforced half of #4055's perf bar: whatever the machine, the vector
+    // path must not be *slower* than the scalar one it replaces. The 5%
+    // tolerance is for timer noise on a shared runner, not for a real
+    // regression -- x86 measures ~1.10x, and the SSE2 emulation this replaced
+    // came in at 0.95x, well outside it.
+    FL_CHECK_GE(ratio, 0.95);
+#else
+    // Deliberately not asserted in an unoptimised build. Intrinsics are hit
+    // far harder than scalar integer code by -O0 (every vector temporary
+    // round-trips through the stack), so the ratio there measures the compiler
+    // rather than the kernel: this same code measures 0.93x at -O0 and 1.10x
+    // at -O3. The gate that counts runs in ci/codec_cpu/audit.py, which builds
+    // optimised.
+    printf("[simd-perf] unoptimised build; ratio not enforced here\n");
+#endif
 }
 
 FL_TEST_CASE("minimp3 fixed-point variant decodes with integer arithmetic") {


### PR DESCRIPTION
## Summary

Integer SIMD for the fixed-point decoder (#4055): the polyphase filter and the DCT-32, on SSE4.1 and NEON.

Whole-decode speedup on x86, measured in release: **1.10×**, bit-identical to the scalar path sample for sample, sanitizers clean.

| kernel | share of decode | status |
| --- | ---: | --- |
| polyphase (`mp3d_synth`) | ~54% | vectorised, SSE4.1 + NEON |
| DCT-32 (`mp3d_DCT_II`) | ~12% | vectorised, SSE4.1 + NEON |
| IMDCT (`L3_imdct36`) | ~13% | scalar, with reasons below |

## Bit-exactness is the gate, not a tolerance

Both paths operate on the same integer representation, so any difference between them is a defect in one of them rather than a rounding trade-off — the opposite of the fixed-vs-float comparison in #4054, where a bounded difference is the expected result. The new test requires identical PCM sample for sample across the corpus, and a fourth decoder instantiation (fixed-point with `MINIMP3_NO_SIMD`) is both the reference it compares against and the opt-out proof #4055 owes.

That gate earned its keep immediately: it caught a one-LSB divergence from `_mm_blendv_epi8` being handed a raw value instead of a lane mask. It selects per *byte*, on that byte's high bit, so the four bytes of each lane blended independently — output right in the high bits, wrong in the low ones. A PSNR tolerance would have waved it through.

## Two results that changed the design

**The obvious x86 implementation was a regression.** SSE2 has no signed 32×32→64 multiply. Emulating it (unsigned multiply plus a sign correction) measured **0.66×** of scalar standalone and **0.95×** end-to-end — slower, consistently. Since #4055's enforced bar is "no target slower than scalar", shipping it would have been a regression wearing an optimization's clothes. SSE2-only hardware now stays scalar and the vector path dispatches at run time on SSE4.1, whose `_mm_mul_epi32` deletes the correction: **1.71×** on the kernel. The dispatch mirrors upstream's own `have_simd()` cpuid pattern already in this file. NEON needs none of it — `vmull_s32` is native and in the ARM64 baseline.

**Benchmarking saturation is why the DCT-32 kernel exists.** I assumed emulating a saturating int32 add — SSE has them only for 8- and 16-bit lanes — would cost more than vectorising saved, which would have made the DCT-32 a no-go. Measuring said otherwise, so the assumption was wrong and the kernel was worth writing.

That same measurement led me to rewrite the *scalar* saturating add branchlessly, reasoning that its int64 promotion is expensive on 32-bit MCUs. **I reverted that**, and it is worth saying plainly why: I never measured an MCU, and the target I can measure showed it costing 6,265 bytes of text (+24%) and 48 bytes of decode stack for ~3% of x86 decode time. Attribution was direct — reverting it alone restores every ledger row. Trading a quarter of the decoder's flash for a few percent of host speed is a bad deal on an embedded codec, and doing it on an unverified inference is worse. If the MCU claim is worth pursuing it should arrive with cross-compiled codegen numbers, which `codec_cpu_trend.json` already has the rig for.

## IMDCT is not vectorised, and why

Structural rather than a measurement: `L3_imdct36`'s inner transform is a 9-point DCT-III whose butterfly does not map onto four lanes, and vectorising across bands would need stride-18 gathers — the IMDCT works *within* a band, while the DCT-32 works across them, which is exactly why four consecutive bands are four consecutive int32 there and not here. Only the closing twiddle-and-window loop is addressable (which is all upstream's float kernel does), capping the gain near 2%. Left scalar until something wants that 2% more than it wants the smaller diff. Recorded in PROVENANCE alongside the rest.

## Cortex-M4/M7

The issue permits concluding "scalar stays" provided the reasoning is written down, and it is. `SMLAD` is a dual 16×16 MAC while this pipeline is 32-bit mantissas throughout, so halving an operand costs roughly 16 dB of the margin the fixed-vs-float gates currently pass with. `SMMUL`/`SMMLA` preserve the width but discard the low half of the product, which is where this decoder's rounding lives. Either would fork the arithmetic between M4/M7 and everything else — the one property the phase exists to prevent.

## Validation

- Bit-exact equality, SIMD vs scalar, across the corpus.
- `MINIMP3_NO_SIMD` opt-out proven by a dedicated decoder instantiation.
- 286/286 unit tests; sanitizers clean; lint clean.
- Memory ledger green, with the fixed-point TU audited **scalar**: the 2 KiB decode-stack budget is an MCU budget, and no FastLED MCU target compiles these kernels (Xtensa, RISC-V and Cortex-M have neither SSE nor NEON), so auditing the host's vectorised build measured a configuration that never ships where the budget applies.
- The perf gate now runs where it can fire: it asserts only in optimised builds (the same kernel measures 0.93× at ‑O0 and 1.10× at ‑O3, so ‑O0 would gate on the compiler), and the CPU audit job runs the codec tests in release explicitly — without that it would never have executed in CI.

## Disclosure

**ESP32-S3 PIE kernels are not in this PR.** The criterion asks for compile-time-guarded PIE paths for polyphase and DCT-32; what landed is the portable SSE4.1/NEON pair, which no Xtensa target compiles. So this PR delivers two of the three named kernels on two of the three named instruction sets, and the ESP32-S3 flagship path is outstanding. Called out here rather than left to be noticed.

Refs #4055, FastLED/license#14
