### PR TITLE
fix(stm32): rename Esp32SpiBus enumerators off CMSIS macro names (#4113)

### DIFF
--- a/examples/MultipleEsp32SpiBuses/MultipleEsp32SpiBuses.ino
+++ b/examples/MultipleEsp32SpiBuses/MultipleEsp32SpiBuses.ino
@@ -21,9 +21,9 @@ CRGB spi3Leds[8];
 
 void setup() {
     FastLED.addLeds<APA102, 11, 12, RGB, DATA_RATE_MHZ(20)>(
-        spi2Leds, 8, fl::Esp32SpiBus::SPI2);
+        spi2Leds, 8, fl::Esp32SpiBus::HOST2);
     FastLED.addLeds<APA102, 13, 14, RGB, DATA_RATE_MHZ(20)>(
-        spi3Leds, 8, fl::Esp32SpiBus::SPI3);
+        spi3Leds, 8, fl::Esp32SpiBus::HOST3);
 }
 
 void loop() {

--- a/src/fl/spi_bus.h
+++ b/src/fl/spi_bus.h
@@ -6,10 +6,19 @@ namespace fl {
 
 /// ESP-IDF SPI host selection for an individual clocked LED controller.
 /// SPI1 is intentionally unavailable because ESP-IDF reserves it for flash/PSRAM.
+///
+/// HOST2 and HOST3 are ESP-IDF's SPI2_HOST and SPI3_HOST. They are deliberately
+/// *not* spelled SPI2 and SPI3: this header reaches every platform through
+/// fl/channels/cled_controller.h, and on STM32 the CMSIS device headers define
+/// those names as object-like macros --
+/// `#define SPI2 ((SPI_TypeDef *) SPI2_BASE)` -- so the preprocessor rewrote
+/// the enumerator to `((SPI_TypeDef *) SPI2_BASE) = 2` and every STM32 board
+/// failed to compile (FastLED#4113). Arduino-ESP32 3.1.0+ defines SPI2 as well.
+/// tests/fl/spi_bus_macro_collision.cpp pins this.
 enum class Esp32SpiBus : u8 {
     AUTO = 0,
-    SPI2 = 2,
-    SPI3 = 3,
+    HOST2 = 2,
+    HOST3 = 3,
 };
 
 } // namespace fl

--- a/src/platforms/esp/32/README.md
+++ b/src/platforms/esp/32/README.md
@@ -90,8 +90,8 @@ Additional I2S defines and guidance:
   - **`FASTLED_FORCE_SOFTWARE_SPI`**: Force software bit-banging SPI instead of hardware SPI. The SPI bus manager will still handle device registration and conflict detection, but all data transmission uses software bit-banging. Use only if hardware SPI causes issues.
   - **`FASTLED_ESP32_SPI_BUS`**: Select SPI bus: `VSPI`, `HSPI`, or `FSPI`. Defaults per target: S2/S3 use `FSPI`, others default to `VSPI` (see `fastspi_esp32.h`).
   - For independent per-controller selection with the ESP-IDF backend, pass
-    `fl::Esp32SpiBus::SPI2` or `fl::Esp32SpiBus::SPI3` as the final argument:
-    `FastLED.addLeds<APA102, DATA, CLOCK, RGB, DATA_RATE_MHZ(20)>(leds, count, fl::Esp32SpiBus::SPI3);`.
+    `fl::Esp32SpiBus::HOST2` or `fl::Esp32SpiBus::HOST3` as the final argument:
+    `FastLED.addLeds<APA102, DATA, CLOCK, RGB, DATA_RATE_MHZ(20)>(leds, count, fl::Esp32SpiBus::HOST3);`.
     An omitted override remains `AUTO` and preserves the existing automatic
     host allocation order.
   - **`FASTLED_ESP32_SPI_BULK_TRANSFER`**: When `1`, batches pixels into blocks to reduce transfer overhead and improve throughput at the cost of RAM. Default `0`.

--- a/src/platforms/esp/32/core/fastspi_esp32_idf.h
+++ b/src/platforms/esp/32/core/fastspi_esp32_idf.h
@@ -94,10 +94,10 @@ public:
 
     void setBus(Esp32SpiBus bus) FL_NO_EXCEPT {
         switch (bus) {
-            case Esp32SpiBus::SPI2:
+            case Esp32SpiBus::HOST2:
                 mHost = SPI2_HOST;
                 break;
-            case Esp32SpiBus::SPI3:
+            case Esp32SpiBus::HOST3:
 #if SOC_SPI_PERIPH_NUM > 2
                 mHost = SPI3_HOST;
 #else

--- a/tests/fl/channels/adapters/spi_channel_adapter.cpp
+++ b/tests/fl/channels/adapters/spi_channel_adapter.cpp
@@ -551,7 +551,7 @@ FL_TEST_CASE("SpiChannelEngineAdapter - explicit SPI host selects matching contr
     auto adapter = SpiChannelEngineAdapter::create(
         controllers, priorities, names, "SPI_UNIFIED");
 
-    adapter->enqueue(createSpiChannelData(5, 18, Esp32SpiBus::SPI3));
+    adapter->enqueue(createSpiChannelData(5, 18, Esp32SpiBus::HOST3));
     adapter->show();
 
     FL_CHECK_FALSE(spi2->wasTransmitCalled());

--- a/tests/fl/spi_bus_macro_collision.cpp
+++ b/tests/fl/spi_bus_macro_collision.cpp
@@ -1,0 +1,52 @@
+// ok cpp include
+//
+// Regression test for FastLED#4113.
+//
+// fl/spi_bus.h reaches every platform through fl/channels/cled_controller.h.
+// On STM32 the CMSIS device headers are included first and define the SPI
+// peripheral base pointers as *object-like macros*:
+//
+//     #define SPI2 ((SPI_TypeDef *) SPI2_BASE)
+//
+// so an enumerator named SPI2 was rewritten by the preprocessor into
+//
+//     ((SPI_TypeDef *) SPI2_BASE) = 2,
+//
+// and every STM32 board failed to compile with "expected identifier". Seven
+// board builds were red on master for it. Arduino-ESP32 3.1.0+ defines SPI2
+// too, so this is not STM32-specific.
+//
+// This file stands in for CMSIS: it defines the same shape of macro before
+// including the header, which reproduces the failure without needing an ARM
+// toolchain. If someone reintroduces a vendor-macro-shaped enumerator name,
+// this stops compiling -- which is the point, and is why the check lives here
+// rather than as a runtime assertion.
+
+struct SPI_TypeDef {
+    int dummy;
+};
+
+#define SPI2_BASE 0x40003800UL
+#define SPI3_BASE 0x40003C00UL
+#define SPI2 ((SPI_TypeDef *)SPI2_BASE)
+#define SPI3 ((SPI_TypeDef *)SPI3_BASE)
+// Arduino-ESP32 3.1.0+ and various vendor headers also claim these.
+#define HSPI 2
+#define VSPI 3
+
+#include "fl/spi_bus.h"
+
+#undef SPI2
+#undef SPI3
+#undef HSPI
+#undef VSPI
+
+#include "test.h"
+
+FL_TEST_CASE("fl::Esp32SpiBus survives vendor SPI peripheral macros") {
+    // Compiling at all is the assertion. These pin the wire values, which the
+    // ESP-IDF backend maps straight onto SPI2_HOST / SPI3_HOST.
+    FL_CHECK_EQ(static_cast<int>(fl::Esp32SpiBus::AUTO), 0);
+    FL_CHECK_EQ(static_cast<int>(fl::Esp32SpiBus::HOST2), 2);
+    FL_CHECK_EQ(static_cast<int>(fl::Esp32SpiBus::HOST3), 3);
+}

--- a/tests/platforms/shared/spi_manager.cpp
+++ b/tests/platforms/shared/spi_manager.cpp
@@ -77,16 +77,16 @@ FL_TEST_CASE("SPIBusManager - explicit ESP32 hosts are independent") {
 
     SPIBusHandle spi2 = manager.registerDevice(18, 23, 1000000,
                                                 (void*)0x1234,
-                                                Esp32SpiBus::SPI2);
+                                                Esp32SpiBus::HOST2);
     SPIBusHandle spi3 = manager.registerDevice(18, 19, 1000000,
                                                 (void*)0x5678,
-                                                Esp32SpiBus::SPI3);
+                                                Esp32SpiBus::HOST3);
 
     FL_REQUIRE_TRUE(spi2.is_valid);
     FL_REQUIRE_TRUE(spi3.is_valid);
     FL_CHECK_NE(spi2.bus_id, spi3.bus_id);
-    FL_CHECK_EQ(manager.getBusInfo(spi2.bus_id)->requested_bus, Esp32SpiBus::SPI2);
-    FL_CHECK_EQ(manager.getBusInfo(spi3.bus_id)->requested_bus, Esp32SpiBus::SPI3);
+    FL_CHECK_EQ(manager.getBusInfo(spi2.bus_id)->requested_bus, Esp32SpiBus::HOST2);
+    FL_CHECK_EQ(manager.getBusInfo(spi3.bus_id)->requested_bus, Esp32SpiBus::HOST3);
     manager.reset();
 }
 
@@ -114,9 +114,9 @@ FL_TEST_CASE("SPIBusManager - explicit host controls multi-lane allocation") {
 
     SPIBusManager& manager = getSPIBusManager();
     manager.reset();
-    manager.registerDevice(18, 23, 1000000, (void*)0x1234, Esp32SpiBus::SPI3);
+    manager.registerDevice(18, 23, 1000000, (void*)0x1234, Esp32SpiBus::HOST3);
     SPIBusHandle handle = manager.registerDevice(
-        18, 19, 1000000, (void*)0x5678, Esp32SpiBus::SPI3);
+        18, 19, 1000000, (void*)0x5678, Esp32SpiBus::HOST3);
 
     FL_REQUIRE_TRUE(manager.initialize());
     FL_CHECK_FALSE(spi2->isInitialized());


### PR DESCRIPTION
**Master is red on seven boards** and has been since #4088: `arduino_uno_q`, `nucleo_f429zi`, `nucleo_f439zi`, `stm32f103c8_bluepill`, `stm32f103cb_maplemini`, `stm32f103tb_tinystm`, `check_stm32f103c8_bluepill_size`.

## Cause

`fl/spi_bus.h` declared

```cpp
enum class Esp32SpiBus : u8 { AUTO = 0, SPI2 = 2, SPI3 = 3 };
```

and it reaches **every** platform via `fl/channels/cled_controller.h`. On STM32 the CMSIS device headers get there first and define those names as object-like macros:

```c
#define SPI2 ((SPI_TypeDef *) SPI2_BASE)
```

so the preprocessor rewrote the enumerator into `((SPI_TypeDef *) SPI2_BASE) = 2,` — which is exactly the reported diagnostics:

```
stm32f439xx.h:1278:29: error: expected identifier before '(' token
lib/FastLED/fl/spi_bus.h:15:1: error: expected declaration before '}' token
```

## Fix

Renamed to `HOST2` / `HOST3` — also closer to what they actually are, ESP-IDF's `SPI2_HOST` and `SPI3_HOST`. Wire values unchanged. API churn is negligible: #4088 landed hours ago and the only caller outside the library is its own example.

The alternatives were worse, and worth recording:

- **`#undef SPI2` in `fl/spi_bus.h`** — one line, keeps the names, but a core library header would be deleting a CMSIS peripheral macro out from under user sketches on STM32. Rude and a latent surprise.
- **Guard the enum on `#if defined(ESP32)`** — leaves `fl::Esp32SpiBus` undeclared everywhere else, and core code references it unconditionally.

## Regression test

`tests/fl/spi_bus_macro_collision.cpp` defines CMSIS-shaped macros before including the header, reproducing the failure **without an ARM toolchain**. I verified both directions: it fails to compile on the old names and passes on the new ones.

It also defines `HSPI`/`VSPI`, because Arduino-ESP32 3.1.0+ defines `SPI2` as well — this was never STM32-specific, which is why it gets a standing guard rather than a fix-and-forget.

288/288 unit tests, including the new one.

Closes #4113
Refs #4088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed ESP32 SPI bus selectors from `SPI2`/`SPI3` to `HOST2`/`HOST3` to prevent conflicts with platform-defined macros.
  * Update sketches and applications using the previous names.

* **Documentation**
  * Updated ESP32 SPI configuration guidance and examples with the new selector names.

* **Bug Fixes**
  * Improved compatibility with STM32 and newer Arduino-ESP32 environments.

* **Tests**
  * Added regression coverage for SPI selector macro collisions and explicit host selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->