### PR TITLE
feat(mp3): audit the fixed-point decoder's CPU alongside the float one (#4110)

### DIFF
--- a/.github/workflows/mp3_cpu_audit.yml
+++ b/.github/workflows/mp3_cpu_audit.yml
@@ -86,15 +86,21 @@ jobs:
       - name: Verify the fixed-point SIMD is not slower than scalar
         run: bash test fl_codec --cpp --build-mode release
 
-      - name: Verify the focused CPU gate
-        env:
-          PYTEST_ADDOPTS: -k codec_cpu_audit
-        run: bash test --py --verbose
-
+      # Measure before gating, so a red gate still produces the numbers needed
+      # to diagnose it -- and so that adding a backend can bootstrap its
+      # baselines from a run that necessarily fails the check first. The upload
+      # below is `if: always()`, which was pointless while the step that writes
+      # the file sat behind a gate that could stop it running at all.
       - name: Enforce operation, host, and target-codegen trends
         run: >-
           uv run python ci/codec_cpu/audit.py --check
           --write codec_cpu_current.json
+
+      - name: Verify the focused CPU gate
+        if: always()
+        env:
+          PYTEST_ADDOPTS: -k codec_cpu_audit
+        run: bash test --py --verbose
 
       - name: Upload measured report
         if: always()

--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -922,10 +922,18 @@ def validate_trend(trend: dict[str, Any]) -> None:
         ):
             raise RuntimeError(f"host baseline key does not match environment: {key}")
         hosts = profile.get("hosts")
-        if not isinstance(hosts, dict) or set(hosts) != set(BACKENDS):
+        # A host baseline may cover a subset of BACKENDS: a backend added after
+        # a host was last measured has no numbers for it until a run lands there
+        # again. Unknown backends are still rejected, and an empty profile is
+        # meaningless.
+        if not isinstance(hosts, dict) or not hosts:
             raise RuntimeError(f"host baseline is missing backends: {key}")
-        for backend in BACKENDS:
-            host = hosts[backend]
+        unknown = set(hosts) - set(BACKENDS)
+        if unknown:
+            raise RuntimeError(
+                f"host baseline names unknown backends: {key}: {sorted(unknown)}"
+            )
+        for backend, host in hosts.items():
             if not isinstance(host, dict):
                 raise RuntimeError(f"invalid host baseline {key}/{backend}")
             validate_host(backend, host)
@@ -965,11 +973,28 @@ def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
         if current_operations != baseline_operations:
             raise RuntimeError(f"exact operation ledger changed for {backend}")
 
-        baseline_host = (
-            baseline_entry["host"]
-            if alternate_profile is None
-            else alternate_profile["hosts"][backend]
-        )
+        if alternate_profile is None:
+            baseline_host = baseline_entry["host"]
+        elif backend in alternate_profile["hosts"]:
+            baseline_host = alternate_profile["hosts"][backend]
+        else:
+            # A known host that has never measured this backend. The exact
+            # operation ledger above is host-independent and has already been
+            # enforced; the timing and callgrind figures are not comparable
+            # across hosts, and inventing a baseline from another machine's
+            # numbers would gate on the hardware rather than on the code.
+            #
+            # This is how a newly added backend accretes coverage: the runner
+            # pool rotates, and each host picks the backend up the first time a
+            # PR lands on it and someone commits the measured artifact. Loud on
+            # purpose -- a backend that stays uncovered here forever is a real
+            # gap, just not one worth blocking unrelated PRs over.
+            print(
+                f"UNGATED:{backend}/host={current_host_key}: no baseline for "
+                "this backend on this host; exact operation ledger still "
+                "enforced"
+            )
+            continue
         current_host = current_entry["host"]
         for metric in ("cycles", "instructions", "branch_misses"):
             _check_upper_bound(

--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -25,12 +25,11 @@ TREND_PATH = ROOT / "codec_cpu_trend.json"
 BUILD = Path(os.environ.get("CODEC_CPU_BUILD", ROOT / ".build" / "codec-cpu-audit"))
 REGRESSION_TOLERANCE = 0.05
 PROFILE_RUNS = 30
-# minimp3's float build. It stays the CPU-audited variant after Helix's
-# deletion: the host baselines in codec_cpu_trend.json are keyed by its symbols,
-# and re-baselining onto the fixed build is separate work (FastLED#4110). The
-# fixed path's speed is gated by the SIMD perf test in
-# tests/fl/codec/mp3_fixed_point.hpp.
-BACKENDS = ("minimp3-float",)
+# Both minimp3 builds. `minimp3-fixed` is what ships; `minimp3-float` is the
+# reference the fixed-vs-float gates compare against, and it keeps its history
+# rather than being replaced (FastLED#4110). They cannot share a translation
+# unit, so each has its own source below and its own namespace.
+BACKENDS = ("minimp3-float", "minimp3-fixed")
 STAGES = (
     "scalefactors",
     "huffman",
@@ -106,6 +105,7 @@ _STAGE_SYMBOLS: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 _FUSED_STAGES = {
     "minimp3-float": {"dequant": "huffman"},
+    "minimp3-fixed": {"dequant": "huffman"},
 }
 
 _LLVM_DEFINE_RE = re.compile(r'^\s*define\b.*@(?:"([^"]+)"|([^\s(]+))\(')
@@ -179,13 +179,60 @@ def _llvm_functions(lines: list[str]) -> list[tuple[int, int, str]]:
 
 
 def _operation_stage(backend: str, symbol: str) -> str | None:
-    if backend == "minimp3-float" and ("L3_huffman" in symbol or "L3_pow_43" in symbol):
+    if "L3_huffman" in symbol or "L3_pow_43" in symbol or "mp3d_pow43" in symbol:
         return "dequant"
     return classify_stage(symbol)
 
 
 def _uses_llvm_value(line: str, value: str) -> bool:
     return re.search(rf"{re.escape(value)}(?:\s|,|$)", line) is not None
+
+
+def _integer_product_lines(body: list[str]) -> tuple[set[int], set[str]]:
+    """Q-format multiplies in the fixed-point pipeline, and the values they
+    define.
+
+    The float build counts `fmul`, which is unambiguous. `mul` is not: at -O0
+    the decoder's integer arithmetic and the compiler's address and size
+    arithmetic are the same opcode. Measured on the fixed-point audit TU, the
+    discriminating shape is a 64-bit multiply with at least one operand sign
+    extended from i32 -- that is what `(int64_t)a * b` lowers to and what index
+    scaling never does -- whose product is not then consumed by a
+    `getelementptr` or passed to a call.
+
+    Those two exclusions are not decoration. Address scaling that does emit a
+    `mul` feeds a GEP, and `L12_apply_scf_384` computes a `memcpy` byte count as
+    `(total_bands - stereo_bands) * 18 * sizeof(...)`, which has the sign-extend
+    shape but is a size, not a sample. On the current tree this rule selects 69
+    multiplies and rejects exactly that one.
+    """
+    defs: dict[str, str] = {}
+    for line in body:
+        match = re.match(r"\s*(%[\w.]+) = (\w+)", line)
+        if match:
+            defs[match.group(1)] = match.group(2)
+
+    joined = "\n".join(body)
+    lines: set[int] = set()
+    values: set[str] = set()
+    for index, line in enumerate(body):
+        match = re.search(
+            r"(%[\w.]+) = mul (?:nsw |nuw )*i64 (%[\w.]+|-?\d+), (%[\w.]+|-?\d+)",
+            line,
+        )
+        if not match:
+            continue
+        result, left, right = match.group(1), match.group(2), match.group(3)
+        if defs.get(left) != "sext" and defs.get(right) != "sext":
+            continue
+        used = re.escape(result) + r"(?=[\s,)])"
+        if re.search(r"getelementptr[^\n]*" + used, joined):
+            continue
+        if re.search(r"\bcall\b[^\n]*" + used, joined):
+            continue
+        lines.add(index)
+        values.add(result)
+    return lines, values
 
 
 def _tainted_accumulate_lines(
@@ -271,6 +318,10 @@ def instrument_llvm_ir(
         float_accumulates = _tainted_accumulate_lines(
             body, fmul_values, r"\bf(?:add|sub)\b"
         )
+        integer_mul_lines, integer_mul_values = _integer_product_lines(body)
+        integer_accumulates = _tainted_accumulate_lines(
+            body, integer_mul_values, r"\b(?:add|sub)(?:\s+nsw|\s+nuw)*\s+i64\b"
+        )
         for relative, line in enumerate(body, start=start + 1):
             if (
                 operations
@@ -282,6 +333,26 @@ def instrument_llvm_ir(
                 inserts.setdefault(relative, []).append(
                     "  call void @fastled_mp3_cpu_operation("
                     f"i32 {operation_stage_index}, i32 {lanes}, i32 0)"
+                )
+                operation_sites += 1
+            elif (
+                operations
+                and backend == "minimp3-fixed"
+                and relative - (start + 1) in integer_mul_lines
+            ):
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 {operation_stage_index}, i32 1, i32 0)"
+                )
+                operation_sites += 1
+            elif (
+                operations
+                and backend == "minimp3-fixed"
+                and relative - (start + 1) in integer_accumulates
+            ):
+                inserts.setdefault(relative, []).append(
+                    "  call void @fastled_mp3_cpu_operation("
+                    f"i32 {operation_stage_index}, i32 0, i32 1)"
                 )
                 operation_sites += 1
             elif (
@@ -347,11 +418,12 @@ def build_instrumented_driver(*, operations: bool = True) -> InstrumentedDriver:
     compiler = compiler_path()
     sources = {
         "minimp3-float": ROOT / "ci" / "codec_memory" / "minimp3_audit.cpp",
+        "minimp3-fixed": ROOT / "ci" / "codec_cpu" / "minimp3_fixed_driver.cpp",
     }
     objects: list[Path] = []
     stage_coverage: dict[str, dict[str, dict[str, Any]]] = {}
     for backend, source in sources.items():
-        stem = backend.replace("-float", "")
+        stem = backend.replace("minimp3-", "minimp3_")
         mode = "operations" if operations else "timing"
         raw_ir = BUILD / f"{stem}.{mode}.ll"
         instrumented_ir = BUILD / f"{stem}.{mode}.instrumented.ll"
@@ -427,8 +499,11 @@ def build_plain_driver() -> Path:
     BUILD.mkdir(parents=True, exist_ok=True)
     compiler = compiler_path()
     objects: list[Path] = []
-    for backend in ("minimp3",):
-        source = ROOT / "ci" / "codec_memory" / f"{backend}_audit.cpp"
+    plain_sources = {
+        "minimp3": ROOT / "ci" / "codec_memory" / "minimp3_audit.cpp",
+        "minimp3_fixed": ROOT / "ci" / "codec_cpu" / "minimp3_fixed_driver.cpp",
+    }
+    for backend, source in plain_sources.items():
         obj = BUILD / f"{backend}.plain.o"
         RunningProcess.run(
             [
@@ -1104,9 +1179,14 @@ def run_codegen_audit() -> dict[str, dict[str, dict[str, dict[str, int]]]]:
     BUILD.mkdir(parents=True, exist_ok=True)
     sources = {
         "minimp3-float": Path(__file__).with_name("minimp3_codegen.cpp"),
+        "minimp3-fixed": Path(__file__).with_name("minimp3_fixed_codegen.cpp"),
     }
     kernel_needles = {
         "minimp3-float": {
+            "dct32": ("mp3d_DCT_II",),
+            "polyphase": ("mp3d_synth_pair",),
+        },
+        "minimp3-fixed": {
             "dct32": ("mp3d_DCT_II",),
             "polyphase": ("mp3d_synth_pair",),
         },
@@ -1117,7 +1197,7 @@ def run_codegen_audit() -> dict[str, dict[str, dict[str, dict[str, int]]]]:
     for target in TARGETS:
         tools = _target_tools(target)
         for backend, source in sources.items():
-            stem = backend.replace("-float", "")
+            stem = backend.replace("minimp3-", "minimp3_")
             obj = BUILD / f"{stem}.{target}.o"
             cross_flags = [
                 flag

--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -188,7 +188,18 @@ def _uses_llvm_value(line: str, value: str) -> bool:
     return re.search(rf"{re.escape(value)}(?:\s|,|$)", line) is not None
 
 
-def _integer_product_lines(body: list[str]) -> tuple[set[int], set[str]]:
+@typechecked
+@dataclass(frozen=True)
+class IntegerProducts:
+    """Where the fixed-point pipeline's Q-format multiplies are, and what they
+    define. `lines` indexes into the function body; `values` names the SSA
+    results, which the MAC taint analysis follows into the accumulates."""
+
+    lines: set[int]
+    values: set[str]
+
+
+def _integer_product_lines(body: list[str]) -> IntegerProducts:
     """Q-format multiplies in the fixed-point pipeline, and the values they
     define.
 
@@ -232,7 +243,7 @@ def _integer_product_lines(body: list[str]) -> tuple[set[int], set[str]]:
             continue
         lines.add(index)
         values.add(result)
-    return lines, values
+    return IntegerProducts(lines=lines, values=values)
 
 
 def _tainted_accumulate_lines(
@@ -318,9 +329,11 @@ def instrument_llvm_ir(
         float_accumulates = _tainted_accumulate_lines(
             body, fmul_values, r"\bf(?:add|sub)\b"
         )
-        integer_mul_lines, integer_mul_values = _integer_product_lines(body)
+        integer_products = _integer_product_lines(body)
         integer_accumulates = _tainted_accumulate_lines(
-            body, integer_mul_values, r"\b(?:add|sub)(?:\s+nsw|\s+nuw)*\s+i64\b"
+            body,
+            integer_products.values,
+            r"\b(?:add|sub)(?:\s+nsw|\s+nuw)*\s+i64\b",
         )
         for relative, line in enumerate(body, start=start + 1):
             if (
@@ -338,7 +351,7 @@ def instrument_llvm_ir(
             elif (
                 operations
                 and backend == "minimp3-fixed"
-                and relative - (start + 1) in integer_mul_lines
+                and relative - (start + 1) in integer_products.lines
             ):
                 inserts.setdefault(relative, []).append(
                     "  call void @fastled_mp3_cpu_operation("
@@ -955,6 +968,55 @@ def _check_lower_bound(path: str, baseline: float, current: float) -> None:
         raise RuntimeError(f"{path} regressed: {current} < {limit:.6f}")
 
 
+def _check_host_trend(
+    backend: str, baseline_host: dict[str, Any], current_host: dict[str, Any]
+) -> None:
+    """The host-dependent half of the trend gate: cycle counters, per-stage
+    timings and Callgrind attribution. Split out of check_trend so a host with
+    no baseline for this backend can skip exactly this and nothing else."""
+    for metric in ("cycles", "instructions", "branch_misses"):
+        _check_upper_bound(
+            f"{backend}/counter/{metric}",
+            baseline_host["counter_median"][metric],
+            current_host["counter_median"][metric],
+        )
+    _check_lower_bound(
+        f"{backend}/counter/ipc",
+        baseline_host["counter_median"]["ipc"],
+        current_host["counter_median"]["ipc"],
+    )
+    for stage in STAGES:
+        _check_upper_bound(
+            f"{backend}/stage/{stage}",
+            baseline_host["stage_ns_median"][stage],
+            current_host["stage_ns_median"][stage],
+        )
+    for metric in ("instructions", "branches", "branch_misses"):
+        _check_upper_bound(
+            f"{backend}/callgrind/{metric}",
+            baseline_host["callgrind"][metric],
+            current_host["callgrind"][metric],
+        )
+    baseline_functions = baseline_host["callgrind"]["functions"]
+    current_functions = current_host["callgrind"]["functions"]
+    for symbol, baseline_instructions in baseline_functions.items():
+        if symbol not in current_functions:
+            raise RuntimeError(
+                f"callgrind attribution disappeared for {backend}/{symbol}"
+            )
+        baseline_share = (
+            baseline_instructions / baseline_host["callgrind"]["instructions"]
+        )
+        current_share = (
+            current_functions[symbol] / current_host["callgrind"]["instructions"]
+        )
+        _check_upper_bound(
+            f"{backend}/callgrind-function/{symbol}",
+            baseline_share,
+            current_share,
+        )
+
+
 def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
     """Enforce exact portable counts and a 5% CPU/codegen regression budget."""
     validate_trend(baseline)
@@ -973,11 +1035,13 @@ def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
         if current_operations != baseline_operations:
             raise RuntimeError(f"exact operation ledger changed for {backend}")
 
+        baseline_host: dict[str, Any] | None
         if alternate_profile is None:
             baseline_host = baseline_entry["host"]
         elif backend in alternate_profile["hosts"]:
             baseline_host = alternate_profile["hosts"][backend]
         else:
+            baseline_host = None
             # A known host that has never measured this backend. The exact
             # operation ledger above is host-independent and has already been
             # enforced; the timing and callgrind figures are not comparable
@@ -990,54 +1054,19 @@ def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
             # purpose -- a backend that stays uncovered here forever is a real
             # gap, just not one worth blocking unrelated PRs over.
             print(
-                f"UNGATED:{backend}/host={current_host_key}: no baseline for "
-                "this backend on this host; exact operation ledger still "
-                "enforced"
-            )
-            continue
-        current_host = current_entry["host"]
-        for metric in ("cycles", "instructions", "branch_misses"):
-            _check_upper_bound(
-                f"{backend}/counter/{metric}",
-                baseline_host["counter_median"][metric],
-                current_host["counter_median"][metric],
-            )
-        _check_lower_bound(
-            f"{backend}/counter/ipc",
-            baseline_host["counter_median"]["ipc"],
-            current_host["counter_median"]["ipc"],
-        )
-        for stage in STAGES:
-            _check_upper_bound(
-                f"{backend}/stage/{stage}",
-                baseline_host["stage_ns_median"][stage],
-                current_host["stage_ns_median"][stage],
-            )
-        for metric in ("instructions", "branches", "branch_misses"):
-            _check_upper_bound(
-                f"{backend}/callgrind/{metric}",
-                baseline_host["callgrind"][metric],
-                current_host["callgrind"][metric],
-            )
-        baseline_functions = baseline_host["callgrind"]["functions"]
-        current_functions = current_host["callgrind"]["functions"]
-        for symbol, baseline_instructions in baseline_functions.items():
-            if symbol not in current_functions:
-                raise RuntimeError(
-                    f"callgrind attribution disappeared for {backend}/{symbol}"
-                )
-            baseline_share = (
-                baseline_instructions / baseline_host["callgrind"]["instructions"]
-            )
-            current_share = (
-                current_functions[symbol] / current_host["callgrind"]["instructions"]
-            )
-            _check_upper_bound(
-                f"{backend}/callgrind-function/{symbol}",
-                baseline_share,
-                current_share,
+                f"UNGATED:{backend}/host={current_host_key}: no host baseline "
+                "for this backend on this host; the exact operation ledger and "
+                "the target codegen bounds are still enforced"
             )
 
+        # Only the host-dependent half is skipped. The codegen bounds further
+        # down are cross-compiled instruction counts -- host-independent, and
+        # read from the backend entry rather than the host profile -- so a
+        # target codegen regression must still fail here. Skipping them along
+        # with the timings would let one through on any host that has not
+        # measured this backend yet.
+        if baseline_host is not None:
+            _check_host_trend(backend, baseline_host, current_entry["host"])
         for target in TARGETS:
             for kernel in KERNELS:
                 for metric in ("instructions", "inner_loop_instructions"):

--- a/ci/codec_cpu/driver.cpp
+++ b/ci/codec_cpu/driver.cpp
@@ -14,6 +14,19 @@
 #include "third_party/minimp3/minimp3.h"
 #undef MINIMP3_FLOAT_POINT
 
+// ...and the fixed-point build's declarations under its own namespace. The
+// implementation is ci/codec_cpu/minimp3_fixed_driver.cpp, linked alongside.
+// Two variants cannot share a translation unit -- different DSP path, different
+// mp3dec_scratch_t layout -- so the header is re-included with the guards
+// cleared, exactly as tests/fl/codec/minimp3_variants.hpp does.
+#undef MINIMP3_H
+#undef _MINIMP3_IMPLEMENTATION_GUARD
+#define MINIMP3_NAMESPACE minimp3_fixed
+#define MINIMP3_FIXED_POINT 1
+#include "third_party/minimp3/minimp3.h"
+#undef MINIMP3_FIXED_POINT
+#undef MINIMP3_NAMESPACE
+
 #if __has_include(<valgrind/callgrind.h>)
 #include <valgrind/callgrind.h>
 #define FL_CODEC_CPU_HAS_CALLGRIND
@@ -113,15 +126,41 @@ uint64_t checksumPcm(const int16_t* pcm, int samples, int channels) {
     return value;
 }
 
+/* One body, two instantiations. The two decoders have identical API shapes in
+   different namespaces, so the traits below are the only thing that differs --
+   keeping the measured work identical between the variants, which is the point
+   of comparing them. */
+struct FloatVariant {
+    typedef fl::third_party::mp3dec_t dec_t;
+    typedef fl::third_party::mp3dec_scratch_t scratch_t;
+    typedef fl::third_party::mp3dec_frame_info_t info_t;
+    static void init(dec_t* d) { fl::third_party::mp3dec_init(d); }
+    static int decode(dec_t* d, scratch_t* s, const unsigned char* in, int n,
+                      int16_t* pcm, info_t* i) {
+        return fl::third_party::mp3dec_decode_frame_r(d, s, in, n, pcm, i);
+    }
+};
+
+struct FixedVariant {
+    typedef fl::minimp3_fixed::mp3dec_t dec_t;
+    typedef fl::minimp3_fixed::mp3dec_scratch_t scratch_t;
+    typedef fl::minimp3_fixed::mp3dec_frame_info_t info_t;
+    static void init(dec_t* d) { fl::minimp3_fixed::mp3dec_init(d); }
+    static int decode(dec_t* d, scratch_t* s, const unsigned char* in, int n,
+                      int16_t* pcm, info_t* i) {
+        return fl::minimp3_fixed::mp3dec_decode_frame_r(d, s, in, n, pcm, i);
+    }
+};
+
+template <typename Variant>
 bool decodeMinimp3(const unsigned char* data, size_t size, uint64_t* checksum,
                    int* frames) {
     const int frames_before = *frames;
-    fl::third_party::mp3dec_t* decoder =
-        static_cast<fl::third_party::mp3dec_t*>(
-            ::malloc(sizeof(fl::third_party::mp3dec_t)));
-    fl::third_party::mp3dec_scratch_t* scratch =
-        static_cast<fl::third_party::mp3dec_scratch_t*>(
-            ::malloc(sizeof(fl::third_party::mp3dec_scratch_t)));
+    typename Variant::dec_t* decoder = static_cast<typename Variant::dec_t*>(
+        ::malloc(sizeof(typename Variant::dec_t)));
+    typename Variant::scratch_t* scratch =
+        static_cast<typename Variant::scratch_t*>(
+            ::malloc(sizeof(typename Variant::scratch_t)));
     if (!decoder || !scratch) {
         ::free(scratch);
         ::free(decoder);
@@ -133,11 +172,11 @@ bool decodeMinimp3(const unsigned char* data, size_t size, uint64_t* checksum,
         ::free(decoder);
         return false;
     }
-    fl::third_party::mp3dec_init(decoder);
+    Variant::init(decoder);
     size_t offset = 0;
     while (offset + 4 < size) {
-        fl::third_party::mp3dec_frame_info_t info = {};
-        const int samples = fl::third_party::mp3dec_decode_frame_r(
+        typename Variant::info_t info = {};
+        const int samples = Variant::decode(
             decoder, scratch, data + offset, static_cast<int>(size - offset),
             pcm, &info);
         if (info.frame_bytes <= 0) {
@@ -231,8 +270,10 @@ void Mp3MemoryFree(void* ptr, fl::size bytes, Mp3MemoryTag tag) FL_NO_EXCEPT {
 } // namespace fl
 
 int main(int argc, char** argv) {
-    if (argc != 2 || ::strcmp(argv[1], "minimp3-float") != 0) {
-        ::fprintf(stderr, "usage: codec_cpu_driver minimp3-float\n");
+    const bool want_fixed = argc == 2 && ::strcmp(argv[1], "minimp3-fixed") == 0;
+    const bool want_float = argc == 2 && ::strcmp(argv[1], "minimp3-float") == 0;
+    if (!want_fixed && !want_float) {
+        ::fprintf(stderr, "usage: codec_cpu_driver minimp3-float|minimp3-fixed\n");
         return 2;
     }
     uint64_t checksum = 0;
@@ -255,7 +296,11 @@ int main(int argc, char** argv) {
         }
         callgrindStart();
         const uint64_t cycle_start = cycleCounter();
-        const bool decoded = decodeMinimp3(data, size, &checksum, &frames);
+        const bool decoded =
+            want_fixed ? decodeMinimp3<FixedVariant>(data, size, &checksum,
+                                                     &frames)
+                       : decodeMinimp3<FloatVariant>(data, size, &checksum,
+                                                     &frames);
         cycles += cycleCounter() - cycle_start;
         callgrindStop();
         ::free(data);

--- a/ci/codec_cpu/minimp3_fixed_codegen.cpp
+++ b/ci/codec_cpu/minimp3_fixed_codegen.cpp
@@ -1,0 +1,41 @@
+// Standalone fixed-point minimp3 translation unit for target-ISA code
+// generation auditing -- the integer counterpart to minimp3_codegen.cpp.
+//
+// The wrappers take int32_t because the fixed-point kernels do; the float TU's
+// take float. That is why this is a separate file rather than a define flipped
+// in the other one.
+
+#include "fl/stl/compiler_control.h"
+
+#if defined(FL_CODEC_CPU_CODEGEN_ESP_TYPES)
+#define ESP32
+#include "fl/stl/stdint.h"
+#undef ESP32
+#else
+#include "fl/stl/stdint.h"
+#endif
+
+// fl/stl/stdint.h publishes uint32_t/int32_t at global scope but, for the
+// 64-bit pair, emits `u64`/`i64` rather than `uint64_t`/`int64_t`. minimp3's
+// scratch alignment member needs the first and the whole fixed-point pipeline
+// needs the second, and this TU's include path is `-I src` only -- no platform
+// header arrives to supply them. Declared here rather than in the shared header
+// because changing that one carries a conflicting-typedef risk its own comments
+// document at length. See FastLED#4110.
+typedef fl::u64 uint64_t;
+typedef fl::i64 int64_t;
+
+#define MINIMP3_FIXED_POINT 1
+#include "third_party/minimp3/_build.cpp.hpp"
+#undef MINIMP3_FIXED_POINT
+
+extern "C" FL_NO_INLINE void
+fl_codec_cpu_minimp3_fixed_dct32(int32_t* grbuf, int bands) FL_NO_EXCEPT {
+    fl::third_party::mp3d_DCT_II(grbuf, bands);
+}
+
+extern "C" FL_NO_INLINE void fl_codec_cpu_minimp3_fixed_polyphase(
+    fl::third_party::mp3d_sample_t* pcm, int channels,
+    const int32_t* coefficients) FL_NO_EXCEPT {
+    fl::third_party::mp3d_synth_pair(pcm, channels, coefficients);
+}

--- a/ci/codec_cpu/minimp3_fixed_driver.cpp
+++ b/ci/codec_cpu/minimp3_fixed_driver.cpp
@@ -1,0 +1,31 @@
+// Fixed-point minimp3 instantiation for the CPU audit driver.
+//
+// The CPU audit measures both variants in one binary, and they cannot share a
+// translation unit -- the header is included twice with different DSP paths and
+// different mp3dec_scratch_t layouts. This TU carries the fixed-point build
+// under its own namespace so the float build (ci/codec_memory/minimp3_audit.cpp,
+// pinned to MINIMP3_FLOAT_POINT and linked into the same driver) keeps the
+// unqualified fl::third_party names its ledger rows and host baselines are
+// keyed to.
+//
+// SIMD is left enabled: the whole point of a CPU row for this variant is to
+// track what actually ships on a host, and the vector kernels are what ships.
+// That is the opposite of ci/codec_memory/minimp3_fixed_audit.cpp, which pins
+// MINIMP3_NO_SIMD because the stack budget it enforces is an MCU budget.
+
+#include <stdint.h>
+#if defined(__SSE2__)
+#include <immintrin.h>
+#endif
+
+#include "platforms/new.h"
+
+#define MINIMP3_NAMESPACE minimp3_fixed
+#define MINIMP3_FIXED_POINT 1
+#define MINIMP3_IMPLEMENTATION
+#define MINIMP3_NO_STDIO
+#include "third_party/minimp3/minimp3.h" // ok cpp include
+#undef MINIMP3_NO_STDIO
+#undef MINIMP3_IMPLEMENTATION
+#undef MINIMP3_FIXED_POINT
+#undef MINIMP3_NAMESPACE

--- a/ci/codec_cpu/minimp3_fixed_driver.cpp
+++ b/ci/codec_cpu/minimp3_fixed_driver.cpp
@@ -8,10 +8,22 @@
 // unqualified fl::third_party names its ledger rows and host baselines are
 // keyed to.
 //
-// SIMD is left enabled: the whole point of a CPU row for this variant is to
-// track what actually ships on a host, and the vector kernels are what ships.
-// That is the opposite of ci/codec_memory/minimp3_fixed_audit.cpp, which pins
-// MINIMP3_NO_SIMD because the stack budget it enforces is an MCU budget.
+// This TU does not pin a SIMD setting because it does not get to: every CPU
+// audit build passes -DMINIMP3_NO_SIMD through _common_compile_flags(), for the
+// instrumented and plain drivers alike. So the whole CPU audit measures the
+// scalar path.
+//
+// That is the right choice for the operation ledger, which is meant to be a
+// portable, host-independent count of the arithmetic the algorithm performs --
+// pinning it to scalar is what keeps it stable when a kernel is vectorised, and
+// it is why the fixed and float builds report identical synthesis and antialias
+// multiply counts. It is also why FastLED#4109's IMDCT kernel does not perturb
+// these numbers.
+//
+// Whether the *host counter and Callgrind* halves should instead measure the
+// vectorised build -- which is what actually ships -- is a fair question, but it
+// applies equally to the float row that has been measured this way since #4053,
+// so changing it belongs in its own issue rather than here.
 
 #include <stdint.h>
 #if defined(__SSE2__)

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -85,10 +85,10 @@ def test_integer_product_selection_ignores_address_and_size_math() -> None:
         "  %r = call ptr @memcpy(ptr %d, ptr %s, i64 %bytes)",
         "  %wide = mul nsw i64 %x, %y",              # neither sign-extended
     ]
-    lines, values = AUDIT._integer_product_lines(body)
+    products = AUDIT._integer_product_lines(body)
 
-    assert values == {"%prod", "%scaled"}
-    assert lines == {2, 4}
+    assert products.values == {"%prod", "%scaled"}
+    assert products.lines == {2, 4}
 
 
 def test_integer_mac_counts_one_accumulate_for_two_products() -> None:

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -23,7 +23,7 @@ def test_checked_in_cpu_trend_is_complete() -> None:
 
 
 def test_five_percent_regression_gate() -> None:
-    baseline = {"minimp3-float": 2_000_000}
+    baseline = {"minimp3-float": 2_000_000, "minimp3-fixed": 2_500_000}
     AUDIT.check_regression(baseline, dict(baseline))
     changed = dict(baseline)
     changed["minimp3-float"] = 2_100_001
@@ -66,8 +66,71 @@ entry:
     assert result.stage_sites["huffman"] == 1
 
 
+def test_integer_product_selection_ignores_address_and_size_math() -> None:
+    """`mul` is ambiguous in a way `fmul` is not: at -O0 the fixed-point
+    decoder's arithmetic and the compiler's address/size arithmetic share the
+    opcode. Only the sign-extended 64-bit product that is *not* consumed by a
+    getelementptr or a call is a sample multiply."""
+    body = [
+        "  %a64 = sext i32 %a to i64",
+        "  %b64 = sext i32 %b to i64",
+        "  %prod = mul nsw i64 %a64, %b64",          # Q-format: counted
+        "  %coef = sext i32 %c to i64",
+        "  %scaled = mul nsw i64 %coef, 37489",      # literal tap: counted
+        "  %idx = sext i32 %i to i64",
+        "  %off = mul nsw i64 %idx, 4",              # address math: rejected
+        "  %p = getelementptr inbounds i32, ptr %base, i64 %off",
+        "  %n = sext i32 %count to i64",
+        "  %bytes = mul nsw i64 %n, 72",             # memcpy size: rejected
+        "  %r = call ptr @memcpy(ptr %d, ptr %s, i64 %bytes)",
+        "  %wide = mul nsw i64 %x, %y",              # neither sign-extended
+    ]
+    lines, values = AUDIT._integer_product_lines(body)
+
+    assert values == {"%prod", "%scaled"}
+    assert lines == {2, 4}
+
+
+def test_integer_mac_counts_one_accumulate_for_two_products() -> None:
+    """Mirrors the float MAC test. Two products feeding one add is two
+    multiplies and one multiply-accumulate, not three multiplies."""
+    llvm = """
+define void @L3_antialias() {
+entry:
+  %a64 = sext i32 %a to i64
+  %b64 = sext i32 %b to i64
+  %left = mul nsw i64 %a64, %b64
+  %c64 = sext i32 %c to i64
+  %right = mul nsw i64 %c64, %b64
+  %sum = add nsw i64 %left, %right
+  ret void
+}
+"""
+    result = AUDIT.instrument_llvm_ir(llvm, "minimp3-fixed")
+    assert result.text.count("i32 5, i32 1, i32 0") == 2
+    assert result.text.count("i32 5, i32 0, i32 1") == 1
+
+
+def test_float_instrumentation_does_not_fire_on_the_fixed_backend() -> None:
+    """The two backends must not cross-instrument: a float build has no
+    integer sample multiplies and a fixed build has no fmul."""
+    float_ir = """
+define void @L3_antialias() {
+entry:
+  %p = fmul float %a, %b
+  ret void
+}
+"""
+    # Counting the call form, not the `declare` line, which also names it.
+    assert AUDIT.instrument_llvm_ir(float_ir, "minimp3-float").text.count(
+        "call void @fastled_mp3_cpu_operation"
+    ) == 1
+    with pytest.raises(RuntimeError, match="no arithmetic sites"):
+        AUDIT.instrument_llvm_ir(float_ir, "minimp3-fixed")
+
+
 def test_host_counters_combine_cycle_median_and_callgrind() -> None:
-    cycles = {"minimp3-float": 200.0}
+    cycles = {"minimp3-float": 200.0, "minimp3-fixed": 250.0}
     callgrind = {
         backend: {"instructions": 250, "branch_misses": 4} for backend in AUDIT.BACKENDS
     }

--- a/codec_cpu_trend.json
+++ b/codec_cpu_trend.json
@@ -1,5 +1,188 @@
 {
   "backends": {
+    "minimp3-fixed": {
+      "codegen": {
+        "cortex-m0plus": {
+          "dct32": {
+            "inner_loop_instructions": 312,
+            "instructions": 339
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 195
+          }
+        },
+        "cortex-m4": {
+          "dct32": {
+            "inner_loop_instructions": 278,
+            "instructions": 294
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 75
+          }
+        },
+        "riscv32-esp": {
+          "dct32": {
+            "inner_loop_instructions": 0,
+            "instructions": 47
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 183
+          }
+        },
+        "xtensa-esp32": {
+          "dct32": {
+            "inner_loop_instructions": 303,
+            "instructions": 317
+          },
+          "polyphase": {
+            "inner_loop_instructions": 0,
+            "instructions": 187
+          }
+        }
+      },
+      "host": {
+        "callgrind": {
+          "branch_misses": 973345,
+          "branches": 25170807,
+          "functions": {
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_antialias(int*, int)": 67670454,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_dct3_9(int*)": 100403200,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_decode(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_internal_t*, fl::minimp3_fixed::L3_gr_info_t*, int)": 291383826,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_huffman(int*, fl::minimp3_fixed::bs_t*, fl::minimp3_fixed::L3_gr_info_t const*, int const*, short const*, int)": 30896343,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct36(int*, int*, int const*, int)": 174329720,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct_gr(int*, int*, unsigned int, unsigned int)": 175405686,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_midside_stereo(int*, int)": 12751864,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_DCT_II(int*, int)": 202859854,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_add_sat(int, int)": 94137648,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_dequant(int, int, int, int)": 4063716,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_mulshift(int, int, int)": 107095393,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_narrow_q30(long)": 24629760,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_sat64(long)": 172018903,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_scale_pcm(long)": 27068344,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_shr_round(int, int)": 4129372,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_sub_sat(int, int)": 79788016,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth(int*, short*, int, int*)": 145270996,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth_granule(int*, int*, int, int, short*)": 349803817,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth_pair(short*, int, int const*)": 5412102,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3dec_decode_frame_r(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_t*, unsigned char const*, int, short*, fl::minimp3_fixed::mp3dec_frame_info_t*)": 648993577
+          },
+          "instructions": 657659874
+        },
+        "counter_median": {
+          "branch_misses": 973345,
+          "cycles": 188201676.0,
+          "instructions": 657659874,
+          "ipc": 3.494442
+        },
+        "counter_source": {
+          "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
+          "cycles": "Clang readcyclecounter median over 30 pinned runs",
+          "instructions": "Valgrind Callgrind deterministic Ir",
+          "ipc": "Callgrind Ir divided by median cycle counter"
+        },
+        "stage_coverage": {
+          "antialias": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "dequant": {
+            "fused_with": "huffman",
+            "instrumentation_sites": 0,
+            "mode": "fused"
+          },
+          "huffman": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "imdct": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "reorder": {
+            "instrumentation_sites": 1,
+            "mode": "dedicated"
+          },
+          "scalefactors": {
+            "instrumentation_sites": 2,
+            "mode": "dedicated"
+          },
+          "stereo": {
+            "instrumentation_sites": 3,
+            "mode": "dedicated"
+          },
+          "synthesis": {
+            "instrumentation_sites": 2,
+            "mode": "dedicated"
+          }
+        },
+        "stage_ns_median": {
+          "antialias": 7209.909,
+          "dequant": 0.0,
+          "huffman": 11129.263,
+          "imdct": 19037.077,
+          "reorder": 14.012,
+          "scalefactors": 573.165,
+          "stereo": 1610.854,
+          "synthesis": 41576.832
+        }
+      },
+      "operations": {
+        "frames": 892,
+        "stages": {
+          "antialias": {
+            "macs_per_frame": 2357.668161,
+            "multiplies_per_frame": 2357.668161,
+            "total_macs": 2103040,
+            "total_multiplies": 2103040
+          },
+          "dequant": {
+            "macs_per_frame": 0.0,
+            "multiplies_per_frame": 10.86435,
+            "total_macs": 0,
+            "total_multiplies": 9691
+          },
+          "huffman": {
+            "macs_per_frame": 164.75,
+            "multiplies_per_frame": 164.75,
+            "total_macs": 146957,
+            "total_multiplies": 146957
+          },
+          "imdct": {
+            "macs_per_frame": 3981.919283,
+            "multiplies_per_frame": 6743.103139,
+            "total_macs": 3551872,
+            "total_multiplies": 6014848
+          },
+          "reorder": {
+            "macs_per_frame": 0.0,
+            "multiplies_per_frame": 0.0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "scalefactors": {
+            "macs_per_frame": 0.0,
+            "multiplies_per_frame": 0.0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "stereo": {
+            "macs_per_frame": 0.0,
+            "multiplies_per_frame": 0.0,
+            "total_macs": 0,
+            "total_multiplies": 0
+          },
+          "synthesis": {
+            "macs_per_frame": 16859.946188,
+            "multiplies_per_frame": 29634.941704,
+            "total_macs": 15039072,
+            "total_multiplies": 26434368
+          }
+        }
+      }
+    },
     "minimp3-float": {
       "codegen": {
         "cortex-m0plus": {


### PR DESCRIPTION
After #4056 the **shipping** decoder had no CPU trend row. The audit measured `minimp3-float` only, because `codec_cpu_trend.json`'s host baselines are keyed by that build's symbols and re-baselining onto fixed point would have invalidated every one of them at the same moment it changed what was measured.

Both are audited now. Float keeps its history rather than being replaced — it is still the reference the fixed-vs-float gates compare against, so the comparison between them stays available.

## Counting integer arithmetic is the interesting part

The float side counts `fmul`, which is unambiguous. `mul` is not: at `-O0` the decoder's Q-format arithmetic and the compiler's address and size arithmetic are the same opcode. I derived the discriminator from the IR instead of guessing:

| step | result |
| --- | --- |
| all `mul` in the fixed audit TU | 200 — mostly index scaling like `mul nsw i32 576, %n` |
| 64-bit with ≥1 operand `sext` from i32 — the shape `(int64_t)a * b` lowers to | 70 |
| minus products consumed by a `getelementptr` or passed to a call | **69** |

That last exclusion earns its place: `L12_apply_scf_384` computes a `memcpy` byte count as `(total_bands - stereo_bands) * 18 * sizeof(...)`, which has the sign-extend shape but is a size, not a sample. It is rejected; nothing else is.

**The tidier-looking rule would have been wrong.** "Both operands sign-extended" reads better and silently drops 16 real multiplies in the hottest kernel — `mp3d_synth_pair`'s polyphase taps are literal constants (29, 213, 459, 2037, 37489, …), so one operand is a constant by construction.

## The result corroborates itself

| stage | minimp3-float | minimp3-fixed |
| --- | ---: | ---: |
| synthesis multiplies | 26,434,368 | **26,434,368** |
| antialias multiplies | 2,103,040 | **2,103,040** |
| imdct multiplies | 6,289,664 | 6,014,848 |
| dequant / huffman | 296,116 / 0 | 9,691 / 146,957 |

Two independently written pipelines doing the same transform arrive at the *same* count. That is what should happen, and it is the check that the integer rule measures what `fmul` measures. Where they differ, they differ for stated reasons: the fixed build fuses dequant into huffman differently, and its IMDCT is not the same kernel.

Both decode 892 frames.

## Also here

- `ci/codec_cpu/minimp3_fixed_driver.cpp` and `minimp3_fixed_codegen.cpp` — the namespaced fixed-point instantiations. The driver's decode body is now a template over a traits struct, so both variants run byte-identical harness code and only the decoder differs.
- The codegen TU needs a local `typedef fl::i64 int64_t;`. `fl/stl/stdint.h` publishes `uint32_t`/`int32_t` globally but for the 64-bit pair emits `u64`/`i64` rather than `uint64_t`/`int64_t`, and this TU's include path is `-I src` only. That is the gap recorded on this issue; fixed here rather than in the shared header, which carries a conflicting-typedef risk its own comments document at length.

## Baselines are not in this commit — read before reviewing red

`codec_cpu_trend.json` needs `minimp3-fixed` entries **measured on the CI host**, which I cannot produce locally. `--write` runs before `--check` precisely so the audit job emits `codec_cpu_current.json` as an artifact even when the check then fails on the missing backend.

So on this first push, the audit job and five trend tests are red. That is the documented bootstrap, not a defect. I will land the measured numbers in a follow-up commit on this branch and the same checks go green.

Refs #4110, #4056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CPU auditing support for the fixed-point minimp3 backend alongside the floating-point backend.
  - CPU audit runs can select either backend and report results independently.
  - Added fixed-point code-generation coverage for key decoding and synthesis operations.

- **Bug Fixes**
  - Improved audit reliability by recording measurements before validation checks and ensuring results are uploaded when checks fail.
  - Improved trend validation for partial host baselines while preserving operation-level checks.

- **Tests**
  - Expanded coverage for fixed-point decoding and integer operation instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->