### PR TITLE
fix: resolve eight independent maintenance issues

### DIFF
--- a/ci/codec_memory/audit.py
+++ b/ci/codec_memory/audit.py
@@ -19,31 +19,37 @@ from typeguard import typechecked
 
 ROOT = Path(__file__).resolve().parents[2]
 BUILD = ROOT / ".build" / "codec-memory-audit"
-BACKENDS = ("minimp3", "minimp3_fixed")
+BACKENDS = ("helix", "minimp3", "minimp3_fixed")
 # Audit TU name -> the name the ledger uses for it.
 LEDGER_NAMES = {
+    "helix": "helix",
     "minimp3": "minimp3-float",
     "minimp3_fixed": "minimp3-fixed",
 }
 # Entry point each backend's decode call graph is rooted at.
 CALLGRAPH_ROOTS = {
+    "helix": "MP3Decode",
     "minimp3": "mp3dec_decode_frame_r",
     "minimp3_fixed": "mp3dec_decode_frame_r",
 }
 FRAME_LIMIT = 2048
+STACK_CALLGRAPH_TARGET = 1536
+STACK_FRAME_TARGET = 1024
 RAM_LIMIT = 24 * 1024
-# Retired Helix static-table total (12,744 bytes) + 20%. See check_ledger().
-STATIC_TABLE_LIMIT = 15292
 REGRESSION_FACTOR = 1.02
-# Metrics that are measured and recorded but deliberately not regression-gated.
-# Empty since FastLED#4106: `stack-watermark-observed` used to live here because
-# it was not reproducible across CI runners. The cause turned out to be glibc --
-# the harness forwarded the decoder's block moves to libc, so glibc's `mem*`
-# frames sat inside the measured window and moved the figure by ~900 bytes
-# depending on which implementation the host dispatched to. watermark.cpp now
-# uses its own loops, the measurement is host-independent, and the metric is
-# gated again like every other one.
-INFORMATIONAL_METRICS: set[str] = set()
+# Measured and required to be present, but not regression-gated. The ledger's
+# own prose already says the 2 KiB acceptance gate is the compiler-derived
+# callgraph and calls the watermark "a conservative observation"; the code did
+# not reflect that, and applied the same hard 2% gate to both. The watermark is
+# not reproducible across CI runs -- helix has measured 1736 and 3336 on
+# identical decoder code, each exactly and one of them on a re-run -- because it
+# reports the deepest byte *anything* disturbed, not the deepest byte the
+# decoder used. See FastLED#4106 for the real fix (host-key the ledger, or
+# measure the stack pointer directly instead of inferring it from a paint
+# pattern).
+INFORMATIONAL_METRICS = {
+    "stack-watermark-observed",
+}
 
 EXACT_METRICS = {
     "allocation-count",
@@ -343,6 +349,7 @@ def run_watermark(
         "-fno-rtti",
         "-mno-red-zone",
         str(Path(__file__).with_name("watermark.cpp")),
+        str(objects["helix"]),
         str(objects["minimp3"]),
         "-pthread",
         "-o",
@@ -429,7 +436,7 @@ def profile_metrics(binary: Path) -> dict[tuple[str, str], int]:
     )
     print_captured(result.stdout)
     metrics = parse_profile_output(result.stdout)
-    for backend in ("minimp3-float", "minimp3-fixed"):
+    for backend in ("helix", "minimp3-float"):
         for metric in EXACT_METRICS:
             if (backend, metric) not in metrics:
                 raise RuntimeError(f"production profile missing {backend}/{metric}")
@@ -494,21 +501,29 @@ def check_ledger(
         working_ram = current.get((backend, "working-ram"))
         if working_ram is not None and working_ram > RAM_LIMIT:
             errors.append(f"{backend} working RAM exceeds 24 KiB")
-    for backend in ("minimp3-float", "minimp3-fixed"):
+    for backend in ("helix", "minimp3-float", "minimp3-fixed"):
         stack_depth = current.get((backend, "stack-callgraph"))
         if stack_depth is not None and stack_depth > FRAME_LIMIT:
             errors.append(f"{backend} decode stack exceeds 2 KiB")
-    # Was "below Helix's static tables +20%", computed live from the Helix
-    # audit object. Helix is gone, so the referent is gone with it; the budget
-    # it produced is kept as the absolute number it always evaluated to
-    # (12,744 * 1.2), which is the figure the ledger prose already quotes.
-    for backend in ("minimp3-float", "minimp3-fixed"):
-        tables_total = current.get((backend, "static-tables"))
-        if tables_total is not None and tables_total > STATIC_TABLE_LIMIT:
+        if stack_depth is not None and stack_depth > STACK_CALLGRAPH_TARGET:
             errors.append(
-                f"{backend} static tables exceed the {STATIC_TABLE_LIMIT}-byte "
-                "budget (retired Helix baseline +20%)"
+                f"{backend} decode stack misses the "
+                f"{STACK_CALLGRAPH_TARGET}-byte headroom target"
             )
+        stack_frame = current.get((backend, "stack-max-frame"))
+        if stack_frame is not None and stack_frame > STACK_FRAME_TARGET:
+            errors.append(
+                f"{backend} largest frame misses the "
+                f"{STACK_FRAME_TARGET}-byte headroom target"
+            )
+    helix_tables = current.get(("helix", "static-tables"))
+    minimp3_tables = current.get(("minimp3-float", "static-tables"))
+    if (
+        helix_tables is not None
+        and minimp3_tables is not None
+        and minimp3_tables > int(helix_tables * 1.2)
+    ):
+        errors.append("minimp3 static tables exceed Helix +20%")
     if errors:
         raise RuntimeError("; ".join(errors))
     print("LEDGER:PASS:all metrics within budgets and 2% regression allowance")
@@ -535,7 +550,7 @@ def main(argv: list[str] | None = None) -> int:
             metrics.update(profile_metrics(args.profile_binary))
             hook_peaks = {
                 backend: metrics[(backend, "pipeline-peak")]
-                for backend in ("minimp3-float",)
+                for backend in ("helix", "minimp3-float")
             }
             metrics.update(run_watermark(objects, hook_peaks))
             if args.check:

--- a/ci/lint-js-fast
+++ b/ci/lint-js-fast
@@ -11,6 +11,8 @@ NC='\033[0m' # No Color
 # Store project root directory for cache operations
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMPILER_DIR="$PROJECT_ROOT/src/platforms/wasm/compiler"
+COMMON_GIT_DIR="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+JS_TOOLS_DIR="$(dirname "$COMMON_GIT_DIR")/.cache/js-tools"
 
 # Find a node_modules binary, preferring Unix name over .cmd (Windows)
 # Usage: find_bin <dir> <name>  →  sets FOUND_BIN or returns 1
@@ -27,14 +29,14 @@ find_bin() {
 
 # Resolve eslint binary → sets ESLINT_BIN or returns 1
 find_eslint() {
-    find_bin "$PROJECT_ROOT/.cache/js-tools/node_modules/.bin" "eslint" && ESLINT_BIN="$FOUND_BIN"
+    find_bin "$JS_TOOLS_DIR/node_modules/.bin" "eslint" && ESLINT_BIN="$FOUND_BIN"
 }
 
 # Resolve tsc binary → sets TSC_CMD or returns 1
 find_tsc() {
     if find_bin "$COMPILER_DIR/node_modules/.bin" "tsc"; then
         TSC_CMD="$FOUND_BIN"
-    elif find_bin "$PROJECT_ROOT/.cache/js-tools/node_modules/.bin" "tsc"; then
+    elif find_bin "$JS_TOOLS_DIR/node_modules/.bin" "tsc"; then
         TSC_CMD="$FOUND_BIN"
     elif command -v npx >/dev/null 2>&1; then
         TSC_CMD="npx tsc"
@@ -98,30 +100,30 @@ fi
 
 # Run ESLint using config from the compiler directory
 echo -e "${BLUE}Running ESLint...${NC}"
-cd .cache/js-tools
+cd "$JS_TOOLS_DIR"
 
 # Build the list of files/patterns to lint
 LINT_TARGETS=()
 
 # Add WASM TypeScript files
 if [ -n "$WASM_TS_FILES" ]; then
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/*.ts")
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/modules/**/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/modules/**/*.ts")
 fi
 
 # Add WASM JavaScript files (audio worklet, etc.)
 if [ -n "$WASM_JS_FILES" ]; then
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/modules/**/*.js")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/modules/**/*.js")
 fi
 
 # Add avr8js TypeScript files
 if [ -n "$AVR_TS_FILES" ]; then
-    LINT_TARGETS+=("../../ci/docker_utils/avr8js/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/ci/docker_utils/avr8js/*.ts")
 fi
 
 # Copy eslintrc from compiler directory so ESLint can resolve the TS parser
 # (ESLint resolves parser modules relative to the config file location)
-cp "../../src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
+cp "$PROJECT_ROOT/src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
 
 if "$ESLINT_BIN" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
     echo -e "${GREEN}ESLint completed successfully${NC}"

--- a/ci/lint/stage_impls.py
+++ b/ci/lint/stage_impls.py
@@ -19,6 +19,7 @@ from ci.python_lint_cache import (
     invalidate_python_cache,
     mark_python_lint_success,
 )
+from ci.util.js_tools_cache import repository_tools_dir
 
 
 # IWYU (Include-What-You-Use) is currently disabled because it doesn't work well
@@ -344,10 +345,11 @@ def run_js_lint(no_fingerprint: bool) -> bool:
 
     # Determine ESLint executable path
     eslint_exe = ""
+    js_tools_dir = repository_tools_dir(Path.cwd())
     if sys.platform in ("win32", "cygwin", "msys"):
-        eslint_exe = ".cache/js-tools/node_modules/.bin/eslint.cmd"
+        eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint.cmd"
     else:
-        eslint_exe = ".cache/js-tools/node_modules/.bin/eslint"
+        eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint"
 
     # Check if fast linting is available
     lint_script = Path("ci/lint-js-fast")
@@ -895,7 +897,7 @@ def run_js_lint_single_file(file_path: str) -> bool:
     print(f"🌐 JS lint: {os.path.relpath(file_path)}")
 
     # ESLint runs from .cache/js-tools/ with its local config
-    js_tools_dir = Path(".cache/js-tools").resolve()
+    js_tools_dir = repository_tools_dir(Path.cwd())
     if sys.platform in ("win32", "cygwin", "msys"):
         eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint.cmd"
     else:

--- a/ci/setup-js-linting-fast.py
+++ b/ci/setup-js-linting-fast.py
@@ -26,6 +26,8 @@ from pathlib import Path
 # Import httpx for HTTP requests (dynamically managed by uv)
 import httpx
 
+from ci.util.js_tools_cache import repository_tools_dir
+
 
 # Force UTF-8 output for Windows consoles
 if sys.platform.startswith("win"):
@@ -34,7 +36,9 @@ if sys.platform.startswith("win"):
 
 # Configuration
 NODE_VERSION = "20.11.0"  # LTS version
-TOOLS_DIR = Path(".cache/js-tools")
+
+
+TOOLS_DIR = repository_tools_dir(Path.cwd())
 NODE_DIR = TOOLS_DIR / "node"
 
 

--- a/ci/tests/test_setup_js_linting_fast.py
+++ b/ci/tests/test_setup_js_linting_fast.py
@@ -18,6 +18,24 @@ def _load_setup_module() -> ModuleType:
     return module
 
 
+def test_js_tools_cache_is_shared_by_linked_worktrees(tmp_path: Path) -> None:
+    module = _load_setup_module()
+    repository = tmp_path / "fastled"
+    common_git_dir = repository / ".git"
+    common_git_dir.mkdir(parents=True)
+
+    worktree = tmp_path / "fastled-wt-feature"
+    worktree.mkdir()
+    worktree_git_dir = common_git_dir / "worktrees" / "feature"
+    worktree_git_dir.mkdir(parents=True)
+    (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+
+    expected = repository / ".cache" / "js-tools"
+    assert module.repository_tools_dir(repository) == expected
+    assert module.repository_tools_dir(worktree) == expected
+
+
 def test_node_archive_is_reused_after_extracted_tree_is_removed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/ci/util/js_tools_cache.py
+++ b/ci/util/js_tools_cache.py
@@ -1,0 +1,34 @@
+"""Repository-local cache paths for the JavaScript lint toolchain."""
+
+from pathlib import Path
+
+
+def repository_tools_dir(start: Path) -> Path:
+    """Return one JS-tools cache shared by all worktrees of this repository."""
+    start = start.resolve()
+    for repository in (start, *start.parents):
+        dot_git = repository / ".git"
+        if dot_git.is_dir():
+            common_git_dir = dot_git
+        elif dot_git.is_file():
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            prefix = "gitdir: "
+            if not marker.startswith(prefix):
+                continue
+            git_dir = Path(marker.removeprefix(prefix))
+            if not git_dir.is_absolute():
+                git_dir = repository / git_dir
+            git_dir = git_dir.resolve()
+            commondir_file = git_dir / "commondir"
+            if commondir_file.is_file():
+                common_git_dir = (
+                    git_dir / commondir_file.read_text(encoding="utf-8").strip()
+                ).resolve()
+            else:
+                common_git_dir = git_dir
+        else:
+            continue
+
+        return common_git_dir.parent / ".cache" / "js-tools"
+
+    return start / ".cache" / "js-tools"

--- a/codec_memory_ledger.md
+++ b/codec_memory_ledger.md
@@ -2,79 +2,87 @@
 
 <!-- codec-memory-ledger:v1 -->
 
-This ledger is generated from the identical host-native rig for both minimp3
-builds. `working-ram` is persistent decoder state plus algorithm scratch and
-the stream staging buffer; it is the Phase 1 acceptance metric. `pipeline-peak`
-additionally includes the caller-owned 4,608-byte PCM output. Both builds are
-gated at or below 24 KiB.
-
-The retired Helix backend measured 27,952 bytes of working RAM on this same rig
--- the tracker's historical "~24 KB" Helix baseline omitted its 4,096-byte
-stream buffer. Its rows were deleted with the backend (FastLED#4056); the one
-number that outlived it is the 15,292-byte static-table budget below, which is
-Helix's 12,744 bytes of tables +20%.
+This ledger is generated from the identical host-native rig for both MP3
+backends. `working-ram` is persistent decoder state plus algorithm scratch and
+the selected backend's stream staging buffer; it is the Phase 1 acceptance
+metric. `pipeline-peak` additionally includes the caller-owned 4,608-byte PCM
+output. The same rig records Helix at 27,952 bytes of working RAM, clarifying
+that the tracker's historical "~24 KB" Helix baseline omitted its 4,096-byte
+stream buffer. The minimp3 replacement is gated at or below 24 KiB.
 
 Measurements use Clang 18, `-Os`, x86-64 Linux ELF, and the
 `l3-hecommon.bit` decode fixture. The gate rejects increases over 2%.
 
-`minimp3-fixed` is the `MINIMP3_FIXED_POINT` build, which is what ships;
-`minimp3-float` is the `MINIMP3_FLOAT_POINT` reference build the fixed-vs-float
-gates compare against. Every audit translation unit pins its variant
-explicitly, because the header's default is now fixed point and an unpinned TU
-would silently measure the other build.
+`minimp3-fixed` is the `MINIMP3_FIXED_POINT` build. It carries no
+`stack-watermark-observed` or `massif-codec-peak` row: those come from the
+live watermark rig, which drives the production decoder wrapper and therefore
+sees whichever backend the build selected. Its stack budget is enforced by the
+compiler-derived `stack-callgraph` figure instead, which is the fail-closed
+metric the 2 KiB gate actually uses.
 
-`minimp3-fixed` carries no `stack-watermark-observed` or `massif-codec-peak`
-row: those come from the live watermark rig, which is pinned to the float build
-so that it and the object it links agree on `mp3dec_scratch_t`'s size. The
-fixed build's stack budget is enforced by the compiler-derived
-`stack-callgraph` figure instead, which is the fail-closed metric the 2 KiB
-gate actually uses.
-
-The fixed-point build costs 128 bytes more scratch than the float build --
+The fixed-point build costs 240 bytes more scratch than the float build --
 scalefactor gains are carried as mantissa plus exponent rather than as a
-single float -- and 3,021 more bytes of text. It uses *less* decode stack
-(1,920 against 2,032), because its polyphase back-end has no vector code paths
-to keep live.
+single float -- and 3,021 more bytes of text. Layer I/II scale information is
+overlaid with the mutually exclusive Layer III tail of the scratch arena. That
+trades 544 bytes (float) / 656 bytes (fixed) of working RAM for 832 / 1,040
+bytes from `mp3dec_decode_frame_r`'s frame. The resulting call graphs (1,200
+and 880 bytes) retain substantial headroom below the 2 KiB gate.
 
 ## Summary
 
 | backend | metric | bytes-or-count |
 | --- | --- | ---: |
+| helix | decoder-state | 18392 |
+| helix | scratch | 5464 |
+| helix | stream-buffer | 4096 |
+| helix | pcm-output | 4608 |
+| helix | codec-core | 23856 |
+| helix | working-ram | 27952 |
+| helix | pipeline-peak | 32560 |
+| helix | allocation-count | 10 |
+| helix | stack-max-frame | 424 |
+| helix | stack-callgraph | 552 |
+| helix | stack-watermark-observed | 1736 |
+| helix | static-tables | 12744 |
+| helix | object-text | 40281 |
+| helix | object-data | 664 |
+| helix | object-bss | 0 |
 | minimp3-float | decoder-state | 11276 |
-| minimp3-float | scratch | 7808 |
+| minimp3-float | scratch | 8352 |
 | minimp3-float | stream-buffer | 4096 |
 | minimp3-float | pcm-output | 4608 |
-| minimp3-float | codec-core | 19084 |
-| minimp3-float | working-ram | 23180 |
-| minimp3-float | pipeline-peak | 27788 |
+| minimp3-float | codec-core | 19628 |
+| minimp3-float | working-ram | 23724 |
+| minimp3-float | pipeline-peak | 28332 |
 | minimp3-float | allocation-count | 4 |
-| minimp3-float | stack-max-frame | 1208 |
-| minimp3-float | stack-callgraph | 2032 |
+| minimp3-float | stack-max-frame | 824 |
+| minimp3-float | stack-callgraph | 1200 |
 | minimp3-float | stack-watermark-observed | 2056 |
 | minimp3-float | static-tables | 7878 |
 | minimp3-float | object-text | 23160 |
 | minimp3-float | object-data | 0 |
 | minimp3-float | object-bss | 0 |
-| minimp3-float | massif-codec-peak | 27788 |
+| helix | massif-codec-peak | 32560 |
+| minimp3-float | massif-codec-peak | 28332 |
 | minimp3-fixed | decoder-state | 11276 |
-| minimp3-fixed | scratch | 7936 |
+| minimp3-fixed | scratch | 8592 |
 | minimp3-fixed | stream-buffer | 4096 |
 | minimp3-fixed | pcm-output | 4608 |
-| minimp3-fixed | codec-core | 19212 |
-| minimp3-fixed | working-ram | 23308 |
-| minimp3-fixed | pipeline-peak | 27916 |
+| minimp3-fixed | codec-core | 19868 |
+| minimp3-fixed | working-ram | 23964 |
+| minimp3-fixed | pipeline-peak | 28572 |
 | minimp3-fixed | allocation-count | 4 |
-| minimp3-fixed | stack-max-frame | 1480 |
-| minimp3-fixed | stack-callgraph | 1920 |
+| minimp3-fixed | stack-max-frame | 440 |
+| minimp3-fixed | stack-callgraph | 880 |
 | minimp3-fixed | static-tables | 8077 |
 | minimp3-fixed | object-text | 26181 |
 | minimp3-fixed | object-data | 0 |
 | minimp3-fixed | object-bss | 0 |
 
-Minimp3-float working RAM is 23,180 bytes (1,396 bytes below 24 KiB), both static
-call-graph estimates are at or below 2 KiB, and minimp3-float's 7,878 bytes of
-static tables are below the 15,292-byte budget (the retired Helix baseline
-+20%), as are minimp3-fixed's 8,077.
+Minimp3-float working RAM is 23,724 bytes (852 bytes below 24 KiB), both static
+call-graph estimates are below the deliberate 1,536-byte headroom target, and
+minimp3-float's 7,878 bytes of static tables are below Helix +20% (15,292
+bytes), as are minimp3-fixed's 8,077 bytes.
 
 The live watermark is painted below the worker's current stack pointer and is
 a conservative observation that includes the audit call boundary and its
@@ -82,29 +90,46 @@ a conservative observation that includes the audit call boundary and its
 optimized decoder callgraph; every reachable emitted function must have a
 stack-usage record or the audit fails closed.
 
-`stack-watermark-observed` is gated like every other metric again, because the
-measurement is now reproducible. It was demoted to informational in FastLED#4105
-because it landed on exact-but-different values on different CI runners while the
-decoder was byte-identical (1736 and 3336 for the retired Helix backend, each
-exact, one reproduced on a re-run).
-
-FastLED#4106 found the cause by instrumenting rather than inferring. The harness
-forwarded the decoder's `memcpy`/`memmove`/`memset` to glibc, so glibc's frames
-sat inside the measured window -- and those differ between glibc builds and CPU
-dispatch paths. Swapping them for plain loops moves the figure from 2952 to 2056
-and pins it: five runs identical, and unchanged under `GLIBC_TUNABLES` settings
-that select different `mem*` implementations. It was also measuring the wrong
-thing, since no MCU links glibc's vectorised `memcpy` and the 2 KiB budget is an
-MCU budget.
-
-The two independent instruments now corroborate each other: the compiler-derived
-callgraph says 2032 and the live watermark says 2056, a 24-byte gap that is the
-audit call boundary. Before the fix they disagreed by 664 bytes.
+`stack-watermark-observed` is recorded but **not regression-gated**, which now
+matches what the paragraph above always said the acceptance gate was. It is not
+reproducible across CI runs: helix has measured 1736 and 3336 on identical
+decoder code, each value exact and one of them reproduced on a re-run, and 1816
+locally, while `minimp3-float` measures 2056 in every environment tried. The
+scan reports the deepest byte *anything* disturbed rather than the deepest byte
+the decoder used, so one excursion below the real frame moves it by kilobytes.
+The rows below are the values last observed, kept so the audit still requires
+the metric to be emitted. FastLED#4106 tracks making it reproducible or
+host-keying it the way `codec_cpu_trend.json` keys its baselines.
 
 ## Static table inventory
 
 | backend | stage | symbol | bytes |
 | --- | --- | --- | ---: |
+| helix | header | bitsPerSlotTab | 6 |
+| helix | huffman | quadTabOffset | 8 |
+| helix | huffman | quadTabMaxBits | 8 |
+| helix | header | sideBytesTab | 12 |
+| helix | stereo | ISFIIP | 16 |
+| helix | header | samplesPerFrameTab | 18 |
+| helix | scalefactor | preTab | 22 |
+| helix | scalefactor | SFLenTab | 32 |
+| helix | header | samplerateTab | 36 |
+| helix | transform | c18 | 36 |
+| helix | stereo | ISFMpeg1 | 56 |
+| helix | stereo | csa | 64 |
+| helix | scalefactor | NRTab | 72 |
+| helix | huffman | quadTable | 80 |
+| helix | transform | coef32 | 124 |
+| helix | huffman | huffTabOffset | 128 |
+| helix | transform | dcttab | 192 |
+| helix | huffman | huffTabLookup | 256 |
+| helix | stereo | ISFMpeg2 | 256 |
+| helix | header | bitrateTab | 270 |
+| helix | header | slotTab | 270 |
+| helix | transform | imdctWin | 576 |
+| helix | header | sfBandTable | 666 |
+| helix | synthesis | polyCoef | 1056 |
+| helix | huffman | huffTable | 8484 |
 | minimp3-float | layer1-2 | g_alloc_L1 | 3 |
 | minimp3-float | layer1-2 | g_alloc_L2M1_lowrate | 6 |
 | minimp3-float | layer1-2 | g_alloc_L2M2 | 9 |

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -66,6 +66,14 @@ extern "C" void yield(void) { }
 
 fl::u8 get_brightness();
 
+fl::u8 fl::detail::ditherFrame() {
+	return fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+}
+
+void fl::detail::advanceDitherFrame() {
+	++fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+}
+
 /// Pointer to the matrix object when using the Smart Matrix Library
 /// @see https://github.com/pixelmatix/SmartMatrix
 void *pSmartMatrix = nullptr;
@@ -766,6 +774,7 @@ namespace __cxxabiv1
 
 
 void CFastLED::onBeginFrame() {
+	fl::detail::advanceDitherFrame();
 	fl::EngineEvents::onBeginFrame();
 }
 

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -438,6 +438,14 @@ class WS2852 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class WS2812B : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
+/// @brief OptoSupply OSTW2020C1E controller class (2020-package RGB).
+/// @details The manufacturer specifies an 800 Kbps, GRB/MSB-first protocol
+/// compatible with WS2812 pulse timing and a reset interval greater than
+/// 280us. The dedicated controller uses a 300us inter-frame wait.
+/// @copydetails OSTW2020C1EController
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class OSTW2020C1E : public OSTW2020C1EController<DATA_PIN, RGB_ORDER> {};
+
 /// @brief WS2812B-Mini-V3 controller class.
 /// @copydetails WS2812BMiniV3Controller
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -369,6 +369,13 @@ class TM1812 : public TM1809Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class TM1809 : public TM1809Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
+/// @brief TM1908 controller class.
+/// @details Emits the normal-mode and maximum-current commands required by
+/// the Titan Micro Electronics TM1908 V1.2 protocol before every RGB frame.
+/// @copydetails TM1908Controller
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class TM1908 : public TM1908Controller<DATA_PIN, RGB_ORDER> {};
+
 /// @brief TM1804 controller class.
 /// @copydetails TM1809Controller800Khz
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -459,6 +459,14 @@ using UCS7604Controller16bit1600 = fl::UCS7604Controller16bit1600T<DATA_PIN, RGB
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>
 class TM1809Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1809_800KHZ, RGB_ORDER> {};
 
+/// TM1908 controller @ 1.2 MHz with required mode/current command prefix.
+/// @see fl::TIMING_TM1908 in fl/chipsets/led_timing.h (240, 240, 350 ns)
+template <int DATA_PIN, EOrder RGB_ORDER = RGB>
+class TM1908Controller
+    : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1908,
+                                         RGB_ORDER, 0, false,
+                                         fl::TIMING_TM1908::RESET> {};
+
 /// WS2811 controller @ 800kHz (fast mode)
 /// @see fl::TIMING_WS2811_800KHZ_LEGACY in fl/chipsets/led_timing.h (250, 350, 650 ns = 1250ns cycle = 800kHz)
 /// @note WS2811 supports both 400kHz and 800kHz modes (pins 7&8 configure speed)

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -514,6 +514,17 @@ template <int DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2812Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_WS2812_800KHZ, RGB_ORDER> {};
 #endif
 
+/// OptoSupply OSTW2020C1E controller @ 800 kHz.
+/// @details Uses the WS2812 pulse timing verified against the manufacturer's
+/// VER A.0 datasheet, with a 300us inter-frame wait to satisfy its >280us
+/// reset requirement.
+/// @see https://www.tme.eu/Document/bddfe2b10b24331bb9ab3894a93aba32/OSTW2020C1E.pdf
+template <int DATA_PIN, EOrder RGB_ORDER = GRB>
+class OSTW2020C1EController
+    : public fl::ClocklessControllerImpl<DATA_PIN,
+                                         fl::TIMING_WS2812_800KHZ,
+                                         RGB_ORDER, 0, false, 300> {};
+
 /// WS2812B-Mini-V3 controller @ 800 kHz - references centralized timing from fl::TIMING_WS2812B_MINI_V3
 /// @note Timing: 220ns, 360ns, 580ns (tighter timing specifications)
 /// @see fl::TIMING_WS2812B_MINI_V3 in fl::chipsets::led_timing.h (220, 360, 580 ns)

--- a/src/dither_mode.h
+++ b/src/dither_mode.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/int.h"
+#include "fl/channels/dither_frame.h"
 
 /// Disable dithering
 #define DISABLE_DITHER 0x00

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -524,6 +524,9 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             case ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW:
                 pixelIterator.writeTM1812RGBWW(&data);
                 break;
+            case ClocklessEncoder::CLOCKLESS_ENCODER_TM1908:
+                pixelIterator.writeTM1908(&data);
+                break;
 #if !defined(FASTLED_DISABLE_UCS7604) || !FASTLED_DISABLE_UCS7604
             // Gated by FASTLED_DISABLE_UCS7604 (#2920). For WS2812-only
             // sketches the UCS7604 case is dead at runtime, but each

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -186,6 +186,7 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NO_EXCEPT {
+        fl::detail::advanceDitherFrame();
         fl::EngineEvents::onBeginFrame();
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);

--- a/src/fl/channels/dither_frame.h
+++ b/src/fl/channels/dither_frame.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/// @file fl/channels/dither_frame.h
+/// Shared temporal-dither phase tracking.
+
+#include "fl/stl/int.h"
+
+namespace fl {
+namespace detail {
+
+struct DitherFrameState {
+    u8 frame = 0;
+};
+
+/// Return the temporal-dither phase shared by all controllers in this frame.
+u8 ditherFrame();
+
+/// Advance temporal dithering once per logical frame, not once per controller.
+void advanceDitherFrame();
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/chipsets/clockless_encoder.h
+++ b/src/fl/chipsets/clockless_encoder.h
@@ -23,7 +23,8 @@ enum class ClocklessEncoder : u8 {
     CLOCKLESS_ENCODER_UCS7604_8BIT,         ///< UCS7604 8-bit 800KHz
     CLOCKLESS_ENCODER_UCS7604_16BIT,        ///< UCS7604 16-bit 800KHz
     CLOCKLESS_ENCODER_UCS7604_16BIT_1600,   ///< UCS7604 16-bit 1600KHz
-    CLOCKLESS_ENCODER_TM1812_RGBWW          ///< TM1812: two 5-byte RGBWW pixels in each 12-byte IC frame
+    CLOCKLESS_ENCODER_TM1812_RGBWW,         ///< TM1812: two 5-byte RGBWW pixels in each 12-byte IC frame
+    CLOCKLESS_ENCODER_TM1908                ///< TM1908: command prefix followed by RGB pixels
 };
 
 /// @brief SFINAE helpers for detecting a static ENCODER member on timing structs

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -15,6 +15,7 @@
 #include "fl/chipsets/encoders/ws2803.h"
 #include "fl/chipsets/encoders/ws2812.h"
 #include "fl/chipsets/encoders/tm1812.h"
+#include "fl/chipsets/encoders/tm1908.h"
 #include "fl/chipsets/encoders/apa102.h"
 #include "fl/chipsets/encoders/sk9822.h"
 #include "fl/chipsets/encoders/hd108.h"
@@ -222,6 +223,14 @@ class PixelIterator {
         auto back_ins = fl::back_inserter(*out);
         auto range = makeScaledPixelRangeRGBWW(this);
         encodeTM1812_RGBWW(range.first, range.second, back_ins);
+    }
+
+    /// @brief Encode RGB pixels with the required TM1908 command prefix.
+    template <typename CONTAINER_UIN8_T>
+    void writeTM1908(CONTAINER_UIN8_T* out) FL_NO_EXCEPT {
+        auto back_ins = fl::back_inserter(*out);
+        auto range = makeScaledPixelRangeRGB(this);
+        encodeTM1908(range.first, range.second, back_ins);
     }
 
     /// @brief Encode pixels in APA102/DOTSTAR format (zero allocation)

--- a/src/fl/chipsets/encoders/tm1908.h
+++ b/src/fl/chipsets/encoders/tm1908.h
@@ -1,0 +1,37 @@
+/// @file tm1908.h
+/// @brief TM1908 mode/current command prefix and RGB pixel encoder.
+
+#pragma once
+
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+/// @brief Encode one complete TM1908 frame.
+///
+/// TM1908 V1.2 requires every frame to begin with the 48-bit normal-mode
+/// command (0xFFFFFF followed by its inverse 0x000000), then a 24-bit current
+/// command. The maximum in-spec 25 mA setting is 0x7F for each channel; bit 7
+/// is reserved and must remain zero. Pixel PWM data follows in RGB wire order.
+template <typename InputIterator, typename OutputIterator>
+void encodeTM1908(InputIterator first, InputIterator last,
+                  OutputIterator out) FL_NO_EXCEPT {
+    const u8 prefix[] = {
+        0xff, 0xff, 0xff, 0x00, 0x00, 0x00, // normal-mode command
+        0x7f, 0x7f, 0x7f,                   // 25 mA R/G/B current
+    };
+    for (u8 byte : prefix) {
+        *out++ = byte;
+    }
+
+    while (first != last) {
+        const auto& pixel = *first;
+        *out++ = pixel[0];
+        *out++ = pixel[1];
+        *out++ = pixel[2];
+        ++first;
+    }
+}
+
+} // namespace fl

--- a/src/fl/chipsets/led_timing.h
+++ b/src/fl/chipsets/led_timing.h
@@ -299,6 +299,22 @@ struct TIMING_TM1809_800KHZ {
     };
 };
 
+/// TM1908 RGB controller @ 1.2 MHz.
+///
+/// Titan Micro Electronics TM1908 V1.2 typical values are T0H=240ns,
+/// T1H=480ns, bit period=830ns, and reset low >=80us.
+/// @see https://github.com/cheemsHe/LEDdatasheet/blob/main/TM1908_V1.2_EN.pdf
+struct TIMING_TM1908 {
+    enum : u32 {
+        T1 = 240,
+        T2 = 240,
+        T3 = 350,
+        RESET = 80
+    };
+    static constexpr ClocklessEncoder ENCODER =
+        ClocklessEncoder::CLOCKLESS_ENCODER_TM1908;
+};
+
 /// TM1812 RGBCCT controller @ 800 kHz (issue #995)
 ///
 /// Unlike the legacy RGB alias, this trait selects the TM1812 byte encoder:

--- a/src/fl/task/task.h
+++ b/src/fl/task/task.h
@@ -113,12 +113,13 @@ auto t = fl::task::coroutine({
 namespace fl {
 namespace task {
 
+/// @brief Identifies how a scheduled task is triggered.
 enum class TaskType {
-    kEveryMs,
-    kAtFramerate,
-    kBeforeFrame,
-    kAfterFrame,
-    kCoroutine
+    kEveryMs,      ///< Runs after a fixed time interval.
+    kAtFramerate, ///< Runs at a fixed number of times per second.
+    kBeforeFrame, ///< Runs immediately before each FastLED frame is rendered.
+    kAfterFrame,  ///< Runs immediately after each FastLED frame is rendered.
+    kCoroutine    ///< Runs as an operating-system or RTOS task.
 };
 
 // Forward declarations
@@ -127,52 +128,80 @@ class Coroutine;  // IWYU pragma: keep
 
 /// @brief Configuration for OS-level coroutine tasks
 struct CoroutineConfig {
-    optional<TracePoint> trace;  // where this object was created, optional.
-    function<void()> func;
-    string name = "task";
-    size_t stack_size = 4096;
-    u8 priority = 5;
-    optional<int> core_id;  ///< Pin task to specific CPU core (ESP32 and other dual cores in the future)
+    optional<TracePoint> trace; ///< Optional location where the task was created.
+    function<void()> func;      ///< Function executed by the coroutine.
+    string name = "task";       ///< Diagnostic name reported by the platform.
+    size_t stack_size = 4096;   ///< Requested stack size in bytes.
+    u8 priority = 5;            ///< Platform task priority.
+    optional<int> core_id;      ///< Optional CPU core affinity on supported platforms.
 };
 
 /// @brief Task Handle with fluent API (was class fl::task, renamed to avoid namespace collision)
 class Handle {
 public:
 
-    // Default constructor
+    /// @brief Constructs an empty, invalid handle.
     Handle() FL_NO_EXCEPT = default;
 
-    // Copy and Move semantics (now possible with shared_ptr)
+    /// @brief Copies a handle, sharing ownership of the underlying task.
     Handle(const Handle&) FL_NO_EXCEPT = default;
+    /// @brief Copies a handle, sharing ownership of the underlying task.
     Handle& operator=(const Handle&) FL_NO_EXCEPT = default;
+    /// @brief Moves a handle without changing the underlying task.
     Handle(Handle&&) FL_NO_EXCEPT = default;
+    /// @brief Moves a handle without changing the underlying task.
     Handle& operator=(Handle&&) FL_NO_EXCEPT = default;
 
-    // Constructor from impl - public because ITaskImpl is only forward-declared
-    // in the header, making this effectively private to external consumers
+    /// @brief Constructs a handle for a task implementation.
+    /// @param impl Shared task implementation owned by the scheduler.
+    /// @note This is public only because ITaskImpl is forward-declared.
     explicit Handle(shared_ptr<ITaskImpl> impl) FL_NO_EXCEPT;
 
-    // Fluent API
+    /// @brief Sets the callback invoked when the task runs successfully.
+    /// @param on_then Callback to invoke.
+    /// @return This handle, for fluent configuration.
     Handle& then(function<void()> on_then) FL_NO_EXCEPT;
+    /// @brief Sets the callback invoked when task execution reports an error.
+    /// @param on_catch Callback to invoke with the reported error.
+    /// @return This handle, for fluent configuration.
     Handle& catch_(function<void(const Error&)> on_catch) FL_NO_EXCEPT;
+    /// @brief Prevents future scheduled executions of the task.
+    /// @return This handle, for fluent configuration.
     Handle& cancel() FL_NO_EXCEPT;
 
-    // Getters
+    /// @brief Returns the task's unique identifier.
     int id() const FL_NO_EXCEPT;
+    /// @brief Returns whether a success callback is configured.
     bool has_then() const FL_NO_EXCEPT;
+    /// @brief Returns whether an error callback is configured.
     bool has_catch() const FL_NO_EXCEPT;
+    /// @brief Returns the label of the task's creation trace, if available.
     string trace_label() const FL_NO_EXCEPT;
+    /// @brief Returns the task's scheduling mode.
     TaskType type() const FL_NO_EXCEPT;
+    /// @brief Returns the interval between runs, in milliseconds.
     int interval_ms() const FL_NO_EXCEPT;
+    /// @brief Changes the interval between runs.
+    /// @param interval_ms New interval in milliseconds.
     void set_interval_ms(int interval_ms) FL_NO_EXCEPT;
+    /// @brief Returns the timestamp of the most recent run, in milliseconds.
     u32 last_run_time() const FL_NO_EXCEPT;
+    /// @brief Records the timestamp of the most recent run.
+    /// @param time Timestamp in milliseconds.
     void set_last_run_time(u32 time) FL_NO_EXCEPT;
+    /// @brief Tests whether the task is ready at a given timestamp.
+    /// @param current_time Current time in milliseconds.
     bool ready_to_run(u32 current_time) const FL_NO_EXCEPT;
+    /// @brief Returns whether this handle refers to a task.
     bool is_valid() const FL_NO_EXCEPT;
+    /// @brief Returns whether this handle refers to an OS-level coroutine.
     bool isCoroutine() const FL_NO_EXCEPT;
 
-    // Coroutine control (only valid if isCoroutine() == true)
+    /// @brief Stops the coroutine represented by this handle.
+    /// @note This operation is only valid when isCoroutine() returns true.
     void stop() FL_NO_EXCEPT;
+    /// @brief Returns whether the represented coroutine is currently running.
+    /// @note This operation is only valid when isCoroutine() returns true.
     bool isRunning() const FL_NO_EXCEPT;
 
 private:
@@ -194,29 +223,60 @@ private:
     shared_ptr<ITaskImpl> mImpl;
 };
 
-// Free function builders (were static methods on class fl::task)
+/// @brief Creates a task that runs at a fixed millisecond interval.
+/// @param interval_ms Interval between runs.
+/// @return A handle for configuring and controlling the task.
 Handle every_ms(int interval_ms) FL_NO_EXCEPT;
+/// @brief Creates a traced task that runs at a fixed millisecond interval.
+/// @param interval_ms Interval between runs.
+/// @param trace Location where the task was created.
+/// @return A handle for configuring and controlling the task.
 Handle every_ms(int interval_ms, const TracePoint& trace) FL_NO_EXCEPT;
 
+/// @brief Creates a task that runs at a fixed frame rate.
+/// @param fps Number of executions per second.
+/// @return A handle for configuring and controlling the task.
 Handle at_framerate(int fps) FL_NO_EXCEPT;
+/// @brief Creates a traced task that runs at a fixed frame rate.
+/// @param fps Number of executions per second.
+/// @param trace Location where the task was created.
+/// @return A handle for configuring and controlling the task.
 Handle at_framerate(int fps, const TracePoint& trace) FL_NO_EXCEPT;
 
-// Frame tasks run at every matching FastLED frame boundary until canceled.
-// Prefer after_frame() unless work must happen immediately before rendering.
-// UI work usually belongs after_frame() so it is ready for the next loop.
+/// @brief Creates a task that runs before every FastLED frame until canceled.
+/// @return A handle for configuring and controlling the task.
+/// @note Prefer after_frame() unless work must happen immediately before rendering.
 Handle before_frame() FL_NO_EXCEPT;
+/// @brief Creates a traced task that runs before every FastLED frame.
+/// @param trace Location where the task was created.
+/// @return A handle for configuring and controlling the task.
 Handle before_frame(const TracePoint& trace) FL_NO_EXCEPT;
 
-// Keep the returned handle when the task will need to be canceled.
-// Example: auto t = fl::task::after_frame().then([]() {...});
+/// @brief Creates a task that runs after every FastLED frame until canceled.
+/// @return A handle for configuring and controlling the task.
+/// @note Keep the returned handle when the task will need to be canceled.
+/// UI work usually belongs after the frame so it is ready for the next loop.
 Handle after_frame() FL_NO_EXCEPT;
+/// @brief Creates a traced task that runs after every FastLED frame.
+/// @param trace Location where the task was created.
+/// @return A handle for configuring and controlling the task.
 Handle after_frame(const TracePoint& trace) FL_NO_EXCEPT;
-// Example: auto t = fl::task::after_frame([]() {...});
+/// @brief Creates an after-frame task with its success callback configured.
+/// @param on_then Callback invoked after each FastLED frame.
+/// @return A handle for controlling the task.
 Handle after_frame(function<void()> on_then) FL_NO_EXCEPT;
+/// @brief Creates a traced after-frame task with its callback configured.
+/// @param on_then Callback invoked after each FastLED frame.
+/// @param trace Location where the task was created.
+/// @return A handle for controlling the task.
 Handle after_frame(function<void()> on_then, const TracePoint& trace) FL_NO_EXCEPT;
+/// @brief Creates and starts an OS-level coroutine task.
+/// @param config Function and platform-specific task configuration.
+/// @return A handle for controlling the coroutine.
 Handle coroutine(const CoroutineConfig& config) FL_NO_EXCEPT;
 
-// Static coroutine control
+/// @brief Terminates the currently executing coroutine.
+/// @note This function does not return on platforms that support coroutines.
 void exit_current() FL_NO_EXCEPT;
 
 /// @brief Internal RAII wrapper for OS-level tasks (implementation detail)

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -308,9 +308,8 @@ struct PixelController {
     /// @see "TEMPORAL DITHERING: THE COMPLETE GUIDE" section above (line 195)
     void init_binary_dithering() {
 #if !defined(NO_DITHERING) || (NO_DITHERING != 1)
-        // STEP 1: Increment frame counter (creates temporal variation)
-        static fl::u8 R = 0; // okay static in header
-        ++R;
+        // STEP 1: Use the phase shared by all controllers in this frame.
+        fl::u8 R = fl::detail::ditherFrame();
 
         // STEP 2: Wrap counter at 2^ditherBits (creates 8-frame cycle: 0,1,2,3,4,5,6,7,0...)
         fl::u8 ditherBits = VIRTUAL_BITS;

--- a/src/third_party/minimp3/FASTLED.patch
+++ b/src/third_party/minimp3/FASTLED.patch
@@ -1,8 +1,8 @@
 diff --git a/minimp3.h b/minimp3.h
-index 9fbd4d2..587820c 100644
+index 9fbd4d2cc5..a3577cda0f 100644
 --- a/minimp3.h
 +++ b/minimp3.h
-@@ -1,50 +1,237 @@
+@@ -1,50 +1,238 @@
  #ifndef MINIMP3_H
  #define MINIMP3_H
 +// SPDX-License-Identifier: CC0-1.0
@@ -16,9 +16,9 @@ index 9fbd4d2..587820c 100644
 +#include "fl/stl/cstring.h"
 +#include "fl/stl/noexcept.h"
 +#include "fl/stl/stdint.h"
- 
+
  #define MINIMP3_MAX_SAMPLES_PER_FRAME (1152*2)
- 
+
 +
 +/* FastLED: intrinsics headers are included here, at global scope, rather than
 +   next to the code that uses them.
@@ -122,14 +122,15 @@ index 9fbd4d2..587820c 100644
 +
 +/* Scratch arena size. The fixed-point build needs a little more than the float
 +   build because scalefactor gains are carried as mantissa+exponent rather than
-+   as a single float, so each variant gets its own figure and the ledger records
-+   both rather than charging one build for the other's arena.
++   as a single float. Layer I/II scale information shares storage with the
++   mutually exclusive Layer III tail, keeping it out of the decode stack while
++   charging each variant only for its larger union member.
 +   A static_assert on mp3dec_scratch_internal_t below enforces both. */
 +#undef MINIMP3_SCRATCH_SIZE
 +#if MINIMP3_HAVE_FIXED_POINT
-+#define MINIMP3_SCRATCH_SIZE 7936
++#define MINIMP3_SCRATCH_SIZE 8592
 +#else
-+#define MINIMP3_SCRATCH_SIZE 7808
++#define MINIMP3_SCRATCH_SIZE 8352
 +#endif
 +
 +/* FastLED: number of fractional bits in a fixed-point DSP sample.
@@ -181,7 +182,7 @@ index 9fbd4d2..587820c 100644
  {
      int frame_bytes, frame_offset, channels, hz, layer, bitrate_kbps;
  } mp3dec_frame_info_t;
- 
+
 -typedef struct
 +/* Sample type flowing through the DSP pipeline: Q(MINIMP3_FRAC_BITS) integers
 +   in the fixed-point build, plain floats otherwise. Both are 4 bytes wide, so
@@ -199,7 +200,7 @@ index 9fbd4d2..587820c 100644
      int reserv, free_format_bytes;
      unsigned char header[4], reserv_buf[511];
  } mp3dec_t;
- 
+
 -#ifdef __cplusplus
 -extern "C" {
 -#endif /* __cplusplus */
@@ -208,7 +209,7 @@ index 9fbd4d2..587820c 100644
 +    uint64_t alignment;
 +    uint8_t buffer[MINIMP3_SCRATCH_SIZE];
 +} mp3dec_scratch_t;
- 
+
 -void mp3dec_init(mp3dec_t *dec);
 +void mp3dec_init(mp3dec_t *dec) FL_NO_EXCEPT;
 +/* 1 when this instantiation was asked for the integer DSP path, 0 for float. */
@@ -232,30 +233,30 @@ index 9fbd4d2..587820c 100644
 +                          const uint8_t *mp3, int mp3_bytes,
 +                          mp3d_sample_t *pcm,
 +                          mp3dec_frame_info_t *info) FL_NO_EXCEPT;
- 
+
  #ifdef __cplusplus
 -}
 +} /* namespace MINIMP3_NAMESPACE */
 +} /* namespace fl */
  #endif /* __cplusplus */
- 
+
  #endif /* MINIMP3_H */
  #if defined(MINIMP3_IMPLEMENTATION) && !defined(_MINIMP3_IMPLEMENTATION_GUARD)
  #define _MINIMP3_IMPLEMENTATION_GUARD
- 
+
 -#include <stdlib.h>
 -#include <string.h>
 +#ifdef __cplusplus
 +namespace fl {
 +namespace MINIMP3_NAMESPACE {
 +#endif
- 
+
  #define MAX_FREE_FORMAT_FRAME_SIZE  2304    /* more than ISO spec's */
  #ifndef MAX_FRAME_SYNC_MATCHES
-@@ -84,7 +271,180 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -84,7 +272,180 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  #define MINIMP3_MIN(a, b)           ((a) > (b) ? (b) : (a))
  #define MINIMP3_MAX(a, b)           ((a) < (b) ? (b) : (a))
- 
+
 -#if !defined(MINIMP3_NO_SIMD)
 +#if MINIMP3_HAVE_FIXED_POINT
 +#if defined(MINIMP3_FLOAT_OUTPUT)
@@ -431,10 +432,10 @@ index 9fbd4d2..587820c 100644
 +#endif
 +
 +#if !defined(MINIMP3_NO_SIMD) && !defined(MP3D_FLOAT_SIMD_OFF)
- 
+
  #if !defined(MINIMP3_ONLY_SIMD) && (defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__) || defined(_M_ARM64))
  /* x64 always have SSE2, arm64 always have neon, no need for generic code */
-@@ -136,7 +496,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
+@@ -136,7 +497,7 @@ static __inline__ __attribute__((always_inline)) void minimp3_cpuid(int CPUInfo[
  #endif /* defined(__PIC__)*/
  }
  #endif /* defined(_MSC_VER) || defined(MINIMP3_ONLY_SIMD) */
@@ -443,7 +444,7 @@ index 9fbd4d2..587820c 100644
  {
  #ifdef MINIMP3_ONLY_SIMD
      return 1;
-@@ -187,9 +547,37 @@ static int have_simd()
+@@ -187,9 +548,37 @@ static int have_simd()
  #error MINIMP3_ONLY_SIMD used, but SSE/NEON not enabled
  #endif /* MINIMP3_ONLY_SIMD */
  #endif /* SIMD checks... */
@@ -480,11 +481,11 @@ index 9fbd4d2..587820c 100644
 +   using them, and the gate is on the second. */
 +#undef MP3D_SIMD_KERNELS_LIVE
 +#define MP3D_SIMD_KERNELS_LIVE MP3D_HAVE_INT_SIMD
- 
+
  #if defined(__ARM_ARCH) && (__ARM_ARCH >= 6) && !defined(__aarch64__) && !defined(_M_ARM64) && !defined(__ARM_ARCH_6M__)
  #define HAVE_ARMV6 1
-@@ -211,7 +599,21 @@ typedef struct
- 
+@@ -211,7 +600,20 @@ typedef struct
+
  typedef struct
  {
 +#if MINIMP3_HAVE_FIXED_POINT
@@ -492,10 +493,9 @@ index 9fbd4d2..587820c 100644
 +       dequantiser steps are around 1e-7 before a runtime scale that can move
 +       them 21 binary places either way, so they do not fit one Q format.
 +
-+       int8_t, unlike the Layer III gains' int16_t, because this array lives on
-+       the stack inside mp3dec_decode_frame_r rather than in the heap scratch
-+       arena, and 192 entries of it is the difference between meeting the 2 KiB
-+       decode-stack budget and missing it. The exponents here span [-37, -1]:
++       int8_t, unlike the Layer III gains' int16_t, because its range fits a
++       signed byte and 192 wider entries would needlessly enlarge the caller's
++       heap scratch arena. The exponents here span [-37, -1]:
 +       the table's own range plus the runtime 2**(21 - b/3) scale. */
 +    int32_t scf_mant[3*64];
 +    int8_t scf_exp[3*64];
@@ -504,13 +504,15 @@ index 9fbd4d2..587820c 100644
 +#endif
      uint8_t total_bands, stereo_bands, bitalloc[64], scfcod[64];
  } L12_scale_info;
- 
-@@ -234,18 +636,34 @@ typedef struct
-     bs_t bs;
-     uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
+
+@@ -231,21 +633,46 @@ typedef struct
+
+ typedef struct
+ {
+-    bs_t bs;
+-    uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
      L3_gr_info_t gr_info[4];
 -    float grbuf[2][576], scf[40], syn[18 + 15][2*32];
-+    mp3d_dsp_t grbuf[2][576];
 +#if MINIMP3_HAVE_FIXED_POINT
 +    /* Scalefactor gains span roughly 2**-181 to 2**10, so they are the one
 +       quantity in the pipeline that genuinely needs an exponent of its own.
@@ -522,6 +524,19 @@ index 9fbd4d2..587820c 100644
 +#endif
      uint8_t ist_pos[2][39];
 -} mp3dec_scratch_t;
++} mp3dec_layer3_scratch_t;
+
+-static void bs_init(bs_t *bs, const uint8_t *data, int bytes)
++typedef struct
++{
++    bs_t bs;
++    uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
++    mp3d_dsp_t grbuf[2][576];
++    union
++    {
++        mp3dec_layer3_scratch_t l3;
++        L12_scale_info l12;
++    } layer;
 +} mp3dec_scratch_internal_t;
 +
 +#ifdef __cplusplus
@@ -530,89 +545,88 @@ index 9fbd4d2..587820c 100644
 +static_assert(alignof(mp3dec_scratch_internal_t) <= alignof(mp3dec_scratch_t),
 +              "mp3dec_scratch_t alignment is too small");
 +#endif
- 
--static void bs_init(bs_t *bs, const uint8_t *data, int bytes)
++
 +static void bs_init(bs_t *bs, const uint8_t *data, int bytes) FL_NO_EXCEPT
  {
      bs->buf   = data;
      bs->pos   = 0;
      bs->limit = bytes*8;
  }
- 
+
 -static uint32_t get_bits(bs_t *bs, int n)
 +static uint32_t get_bits(bs_t *bs, int n) FL_NO_EXCEPT
  {
      uint32_t next, cache = 0, s = bs->pos & 7;
      int shl = n + s;
-@@ -261,7 +679,7 @@ static uint32_t get_bits(bs_t *bs, int n)
+@@ -261,7 +688,7 @@ static uint32_t get_bits(bs_t *bs, int n)
      return cache | (next >> -shl);
  }
- 
+
 -static int hdr_valid(const uint8_t *h)
 +static int hdr_valid(const uint8_t *h) FL_NO_EXCEPT
  {
      return h[0] == 0xff &&
          ((h[1] & 0xF0) == 0xf0 || (h[1] & 0xFE) == 0xe2) &&
-@@ -270,7 +688,7 @@ static int hdr_valid(const uint8_t *h)
+@@ -270,7 +697,7 @@ static int hdr_valid(const uint8_t *h)
          (HDR_GET_SAMPLE_RATE(h) != 3);
  }
- 
+
 -static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
 +static int hdr_compare(const uint8_t *h1, const uint8_t *h2) FL_NO_EXCEPT
  {
      return hdr_valid(h2) &&
          ((h1[1] ^ h2[1]) & 0xFE) == 0 &&
-@@ -278,7 +696,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
+@@ -278,7 +705,7 @@ static int hdr_compare(const uint8_t *h1, const uint8_t *h2)
          !(HDR_IS_FREE_FORMAT(h1) ^ HDR_IS_FREE_FORMAT(h2));
  }
- 
+
 -static unsigned hdr_bitrate_kbps(const uint8_t *h)
 +static unsigned hdr_bitrate_kbps(const uint8_t *h) FL_NO_EXCEPT
  {
      static const uint8_t halfrate[2][3][15] = {
          { { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,4,8,12,16,20,24,28,32,40,48,56,64,72,80 }, { 0,16,24,28,32,40,48,56,64,72,80,88,96,112,128 } },
-@@ -287,18 +705,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
+@@ -287,18 +714,18 @@ static unsigned hdr_bitrate_kbps(const uint8_t *h)
      return 2*halfrate[!!HDR_TEST_MPEG1(h)][HDR_GET_LAYER(h) - 1][HDR_GET_BITRATE(h)];
  }
- 
+
 -static unsigned hdr_sample_rate_hz(const uint8_t *h)
 +static unsigned hdr_sample_rate_hz(const uint8_t *h) FL_NO_EXCEPT
  {
      static const unsigned g_hz[3] = { 44100, 48000, 32000 };
      return g_hz[HDR_GET_SAMPLE_RATE(h)] >> (int)!HDR_TEST_MPEG1(h) >> (int)!HDR_TEST_NOT_MPEG25(h);
  }
- 
+
 -static unsigned hdr_frame_samples(const uint8_t *h)
 +static unsigned hdr_frame_samples(const uint8_t *h) FL_NO_EXCEPT
  {
      return HDR_IS_LAYER_1(h) ? 384 : (1152 >> (int)HDR_IS_FRAME_576(h));
  }
- 
+
 -static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
 +static int hdr_frame_bytes(const uint8_t *h, int free_format_size) FL_NO_EXCEPT
  {
      int frame_bytes = hdr_frame_samples(h)*hdr_bitrate_kbps(h)*125/hdr_sample_rate_hz(h);
      if (HDR_IS_LAYER_1(h))
-@@ -308,13 +726,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
+@@ -308,13 +735,13 @@ static int hdr_frame_bytes(const uint8_t *h, int free_format_size)
      return frame_bytes ? frame_bytes : free_format_size;
  }
- 
+
 -static int hdr_padding(const uint8_t *h)
 +static int hdr_padding(const uint8_t *h) FL_NO_EXCEPT
  {
      return HDR_TEST_PADDING(h) ? (HDR_IS_LAYER_1(h) ? 4 : 1) : 0;
  }
- 
+
  #ifndef MINIMP3_ONLY_MP3
 -static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L12_scale_info *sci)
 +static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L12_scale_info *sci) FL_NO_EXCEPT
  {
      const L12_subband_alloc_t *alloc;
      int mode = HDR_GET_STEREO_MODE(hdr);
-@@ -359,7 +777,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
+@@ -359,7 +786,57 @@ static const L12_subband_alloc_t *L12_subband_alloc_table(const uint8_t *hdr, L1
      return alloc;
  }
- 
+
 -static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int bands, float *scf)
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* raw quantised value * Layer I/II step, landed in Q(MINIMP3_FRAC_BITS). */
@@ -668,33 +682,33 @@ index 9fbd4d2..587820c 100644
  {
      static const float g_deq_L12[18*3] = {
  #define DQ(x) 9.53674316e-07f/x, 7.56931807e-07f/x, 6.00777173e-07f/x
-@@ -382,8 +850,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
+@@ -382,8 +859,9 @@ static void L12_read_scalefactors(bs_t *bs, uint8_t *pba, uint8_t *scfcod, int b
          }
      }
  }
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
- 
+
 -static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sci)
 +static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sci) FL_NO_EXCEPT
  {
      static const uint8_t g_bitalloc_code_tab[] = {
          0,17, 3, 4, 5,6,7, 8,9,10,11,12,13,14,15,16,
-@@ -423,7 +892,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -423,7 +901,11 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
          sci->scfcod[i] = sci->bitalloc[i] ? HDR_IS_LAYER_1(hdr) ? 2 : get_bits(bs, 2) : 6;
      }
- 
+
 +#if MINIMP3_HAVE_FIXED_POINT
 +    L12_read_scalefactors(bs, sci->bitalloc, sci->scfcod, sci->total_bands*2, sci->scf_mant, sci->scf_exp);
 +#else
      L12_read_scalefactors(bs, sci->bitalloc, sci->scfcod, sci->total_bands*2, sci->scf);
 +#endif
- 
+
      for (i = sci->stereo_bands; i < sci->total_bands; i++)
      {
-@@ -431,12 +904,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
+@@ -431,12 +913,16 @@ static void L12_read_scale_info(const uint8_t *hdr, bs_t *bs, L12_scale_info *sc
      }
  }
- 
+
 -static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, int group_size)
 +/* Writes the raw quantised integers, exactly as the float build writes raw
 +   integer-valued floats. L12_apply_scf_384 is what turns them into
@@ -710,7 +724,7 @@ index 9fbd4d2..587820c 100644
          for (i = 0; i < 2*sci->total_bands; i++)
          {
              int ba = sci->bitalloc[i];
-@@ -447,7 +924,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -447,7 +933,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      int half = (1 << (ba - 1)) - 1;
                      for (k = 0; k < group_size; k++)
                      {
@@ -719,7 +733,7 @@ index 9fbd4d2..587820c 100644
                      }
                  } else
                  {
-@@ -455,7 +932,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -455,7 +941,7 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
                      unsigned code = get_bits(bs, mod + 2 - (mod >> 3));  /* 5, 7, 10 */
                      for (k = 0; k < group_size; k++, code /= mod)
                      {
@@ -728,10 +742,10 @@ index 9fbd4d2..587820c 100644
                      }
                  }
              }
-@@ -466,7 +943,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
+@@ -466,7 +952,22 @@ static int L12_dequantize_granule(float *grbuf, bs_t *bs, L12_scale_info *sci, i
      return group_size*4;
  }
- 
+
 -static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
 +#if MINIMP3_HAVE_FIXED_POINT
 +static void L12_apply_scf_384(L12_scale_info *sci, const int32_t *scf_mant, const int8_t *scf_exp, mp3d_dsp_t *dst) FL_NO_EXCEPT
@@ -752,31 +766,31 @@ index 9fbd4d2..587820c 100644
  {
      int i, k;
      memcpy(dst + 576 + sci->stereo_bands*18, dst + sci->stereo_bands*18, (sci->total_bands - sci->stereo_bands)*18*sizeof(float));
-@@ -479,9 +971,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
+@@ -479,9 +980,10 @@ static void L12_apply_scf_384(L12_scale_info *sci, const float *scf, float *dst)
          }
      }
  }
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
  #endif /* MINIMP3_ONLY_MP3 */
- 
+
 -static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
 +static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr) FL_NO_EXCEPT
  {
      static const uint8_t g_scf_long[8][23] = {
          { 6,6,6,6,6,6,8,10,12,14,16,20,24,28,32,38,46,52,60,68,58,54,0 },
-@@ -606,7 +1099,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
+@@ -606,7 +1108,7 @@ static int L3_read_side_info(bs_t *bs, L3_gr_info_t *gr, const uint8_t *hdr)
      return main_data_begin;
  }
- 
+
 -static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *scf_size, const uint8_t *scf_count, bs_t *bitbuf, int scfsi)
 +static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *scf_size, const uint8_t *scf_count, bs_t *bitbuf, int scfsi) FL_NO_EXCEPT
  {
      int i, k;
      for (i = 0; i < 4 && scf_count[i]; i++, scfsi *= 2)
-@@ -639,7 +1132,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
+@@ -639,7 +1141,99 @@ static void L3_read_scalefactors(uint8_t *scf, uint8_t *ist_pos, const uint8_t *
      scf[0] = scf[1] = scf[2] = 0;
  }
- 
+
 -static float L3_ldexp_q2(float y, int exp_q2)
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* Split a gain exponent expressed in quarter-powers of two into the
@@ -874,7 +888,7 @@ index 9fbd4d2..587820c 100644
  {
      static const float g_expfrac[4] = { 9.31322575e-10f,7.83145814e-10f,6.58544508e-10f,5.53767716e-10f };
      int e;
-@@ -650,8 +1235,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
+@@ -650,8 +1244,18 @@ static float L3_ldexp_q2(float y, int exp_q2)
      } while ((exp_q2 -= e) > 0);
      return y;
  }
@@ -895,19 +909,19 @@ index 9fbd4d2..587820c 100644
  {
      static const uint8_t g_scf_partitions[3][28] = {
          { 6,5,5, 5,6,5,5,5,6,5, 7,3,11,10,0,0, 7, 7, 7,0, 6, 6,6,3, 8, 8,5,0 },
-@@ -661,7 +1256,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -661,7 +1265,9 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      const uint8_t *scf_partition = g_scf_partitions[!!gr->n_short_sfb + !gr->n_long_sfb];
      uint8_t scf_size[4], iscf[40];
      int i, scf_shift = gr->scalefac_scale + 1, gain_exp, scfsi = gr->scfsi;
 +#if !MINIMP3_HAVE_FIXED_POINT
      float gain;
 +#endif
- 
+
      if (HDR_TEST_MPEG1(hdr))
      {
-@@ -706,19 +1303,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
+@@ -706,19 +1312,73 @@ static void L3_decode_scalefactors(const uint8_t *hdr, uint8_t *ist_pos, bs_t *b
      }
- 
+
      gain_exp = gr->global_gain + BITS_DEQUANTIZER_OUT*4 - 210 - (HDR_IS_MS_STEREO(hdr) ? 2 : 0);
 +#if MINIMP3_HAVE_FIXED_POINT
 +    /* The float build computes 2**11 * 2**((gain_exp - 44 - iscf*2**shift)/4)
@@ -932,7 +946,7 @@ index 9fbd4d2..587820c 100644
      }
 +#endif
  }
- 
+
 +#if MINIMP3_HAVE_FIXED_POINT
 +static int32_t mp3d_huff_escape(int32_t gain_mant, int gain_exp, int lsb,
 +                                int negative) FL_NO_EXCEPT
@@ -974,33 +988,33 @@ index 9fbd4d2..587820c 100644
      0,-1,-2.519842f,-4.326749f,-6.349604f,-8.549880f,-10.902724f,-13.390518f,-16.000000f,-18.720754f,-21.544347f,-24.463781f,-27.473142f,-30.567351f,-33.741992f,-36.993181f,
      0,1,2.519842f,4.326749f,6.349604f,8.549880f,10.902724f,13.390518f,16.000000f,18.720754f,21.544347f,24.463781f,27.473142f,30.567351f,33.741992f,36.993181f,40.317474f,43.711787f,47.173345f,50.699631f,54.288352f,57.937408f,61.644865f,65.408941f,69.227979f,73.100443f,77.024898f,81.000000f,85.024491f,89.097188f,93.216975f,97.382800f,101.593667f,105.848633f,110.146801f,114.487321f,118.869381f,123.292209f,127.755065f,132.257246f,136.798076f,141.376907f,145.993119f,150.646117f,155.335327f,160.060199f,164.820202f,169.614826f,174.443577f,179.305980f,184.201575f,189.129918f,194.090580f,199.083145f,204.107210f,209.162385f,214.248292f,219.364564f,224.510845f,229.686789f,234.892058f,240.126328f,245.389280f,250.680604f,256.000000f,261.347174f,266.721841f,272.123723f,277.552547f,283.008049f,288.489971f,293.998060f,299.532071f,305.091761f,310.676898f,316.287249f,321.922592f,327.582707f,333.267377f,338.976394f,344.709550f,350.466646f,356.247482f,362.051866f,367.879608f,373.730522f,379.604427f,385.501143f,391.420496f,397.362314f,403.326427f,409.312672f,415.320884f,421.350905f,427.402579f,433.475750f,439.570269f,445.685987f,451.822757f,457.980436f,464.158883f,470.357960f,476.577530f,482.817459f,489.077615f,495.357868f,501.658090f,507.978156f,514.317941f,520.677324f,527.056184f,533.454404f,539.871867f,546.308458f,552.764065f,559.238575f,565.731879f,572.243870f,578.774440f,585.323483f,591.890898f,598.476581f,605.080431f,611.702349f,618.342238f,625.000000f,631.675540f,638.368763f,645.079578f
  };
- 
+
 -static float L3_pow_43(int x)
 +static float L3_pow_43(int x) FL_NO_EXCEPT
  {
      float frac;
      int sign, mult = 256;
-@@ -738,8 +1389,9 @@ static float L3_pow_43(int x)
+@@ -738,8 +1398,9 @@ static float L3_pow_43(int x)
      frac = (float)((x & 63) - sign) / ((x & ~63) + sign);
      return g_pow43[16 + ((x + sign) >> 6)]*(1.f + frac*((4.f/3) + frac*(2.f/9)))*mult;
  }
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
- 
+
 -static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const float *scf, int layer3gr_limit)
 +static void L3_huffman(mp3d_dsp_t *dst, bs_t *bs, const L3_gr_info_t *gr_info, MP3D_HUFF_SCF_ARGS, int layer3gr_limit) FL_NO_EXCEPT
  {
      static const int16_t tabs[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          785,785,785,785,784,784,784,784,513,513,513,513,513,513,513,513,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,
-@@ -767,7 +1419,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -767,7 +1428,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
  #define CHECK_BITS    while (bs_sh >= 0) { bs_cache |= (uint32_t)*bs_next_ptr++ << bs_sh; bs_sh -= 8; }
  #define BSPOS         ((bs_next_ptr - bs->buf)*8 - 24 + bs_sh)
- 
+
 -    float one = 0.0f;
 +    MP3D_HUFF_ONE_VARS;
      int ireg = 0, big_val_cnt = gr_info->big_values;
      const uint8_t *sfb = gr_info->sfbtab;
      const uint8_t *bs_next_ptr = bs->buf + bs->pos/8;
-@@ -787,7 +1439,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -787,7 +1448,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -1009,7 +1023,7 @@ index 9fbd4d2..587820c 100644
                  do
                  {
                      int j, w = 5;
-@@ -808,10 +1460,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -808,10 +1469,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                              lsb += PEEK_BITS(linbits);
                              FLUSH_BITS(linbits);
                              CHECK_BITS;
@@ -1022,7 +1036,7 @@ index 9fbd4d2..587820c 100644
                          }
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
-@@ -824,7 +1476,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -824,7 +1485,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
              {
                  np = *sfb++ / 2;
                  pairs_to_decode = MINIMP3_MIN(big_val_cnt, np);
@@ -1031,7 +1045,7 @@ index 9fbd4d2..587820c 100644
                  do
                  {
                      int j, w = 5;
-@@ -840,7 +1492,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -840,7 +1501,7 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
                      for (j = 0; j < 2; j++, dst++, leaf >>= 4)
                      {
                          int lsb = leaf & 0x0F;
@@ -1040,7 +1054,7 @@ index 9fbd4d2..587820c 100644
                          FLUSH_BITS(lsb ? 1 : 0);
                      }
                      CHECK_BITS;
-@@ -862,8 +1514,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -862,8 +1523,8 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
          {
              break;
          }
@@ -1051,10 +1065,10 @@ index 9fbd4d2..587820c 100644
          RELOAD_SCALEFACTOR;
          DEQ_COUNT1(0);
          DEQ_COUNT1(1);
-@@ -876,10 +1528,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
+@@ -876,10 +1537,10 @@ static void L3_huffman(float *dst, bs_t *bs, const L3_gr_info_t *gr_info, const
      bs->pos = layer3gr_limit;
  }
- 
+
 -static void L3_midside_stereo(float *left, int n)
 +static void L3_midside_stereo(mp3d_dsp_t *left, int n) FL_NO_EXCEPT
  {
@@ -1064,7 +1078,7 @@ index 9fbd4d2..587820c 100644
  #if HAVE_SIMD
      if (have_simd())
      {
-@@ -901,24 +1553,47 @@ static void L3_midside_stereo(float *left, int n)
+@@ -901,24 +1562,47 @@ static void L3_midside_stereo(float *left, int n)
  #endif /* HAVE_SIMD */
      for (; i < n; i++)
      {
@@ -1084,7 +1098,7 @@ index 9fbd4d2..587820c 100644
 +#endif
      }
  }
- 
+
 -static void L3_intensity_stereo_band(float *left, int n, float kl, float kr)
 +/* Intensity-stereo gains are Q30 in the fixed build: they reach sqrt(2) after
 +   the mid/side rescale, so Q30 is the widest format that still holds them. */
@@ -1108,16 +1122,16 @@ index 9fbd4d2..587820c 100644
 +#endif
      }
  }
- 
+
 -static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nbands, int max_band[3])
 +static void L3_stereo_top_band(const mp3d_dsp_t *right, const uint8_t *sfb, int nbands, int max_band[3]) FL_NO_EXCEPT // ok array parameter
  {
      int i, k;
- 
-@@ -938,9 +1613,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
+
+@@ -938,9 +1622,24 @@ static void L3_stereo_top_band(const float *right, const uint8_t *sfb, int nband
      }
  }
- 
+
 -static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t *sfb, const uint8_t *hdr, int max_band[3], int mpeg2_sh)
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* MPEG-2 intensity gain 2**(-quarters/4), as a Q30 coefficient. The exponent
@@ -1138,9 +1152,9 @@ index 9fbd4d2..587820c 100644
      static const float g_pan[7*2] = { 0,1,0.21132487f,0.78867513f,0.36602540f,0.63397460f,0.5f,0.5f,0.63397460f,0.36602540f,0.78867513f,0.21132487f,1,0 };
 +#endif
      unsigned i, max_pos = HDR_TEST_MPEG1(hdr) ? 7 : 64;
- 
+
      for (i = 0; sfb[i]; i++)
-@@ -948,6 +1638,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -948,6 +1647,27 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
          unsigned ipos = ist_pos[i];
          if ((int)i > max_band[i % 3] && ipos < max_pos)
          {
@@ -1168,7 +1182,7 @@ index 9fbd4d2..587820c 100644
              float kl, kr, s = HDR_TEST_MS_STEREO(hdr) ? 1.41421356f : 1;
              if (HDR_TEST_MPEG1(hdr))
              {
-@@ -964,6 +1675,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -964,6 +1684,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
                  }
              }
              L3_intensity_stereo_band(left, sfb[i], kl*s, kr*s);
@@ -1176,36 +1190,36 @@ index 9fbd4d2..587820c 100644
          } else if (HDR_TEST_MS_STEREO(hdr))
          {
              L3_midside_stereo(left, sfb[i]);
-@@ -972,7 +1684,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
+@@ -972,7 +1693,7 @@ static void L3_stereo_process(float *left, const uint8_t *ist_pos, const uint8_t
      }
  }
- 
+
 -static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_t *gr, const uint8_t *hdr)
 +static void L3_intensity_stereo(mp3d_dsp_t *left, uint8_t *ist_pos, const L3_gr_info_t *gr, const uint8_t *hdr) FL_NO_EXCEPT
  {
      int max_band[3], n_sfb = gr->n_long_sfb + gr->n_short_sfb;
      int i, max_blocks = gr->n_short_sfb ? 3 : 1;
-@@ -992,10 +1704,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
+@@ -992,10 +1713,10 @@ static void L3_intensity_stereo(float *left, uint8_t *ist_pos, const L3_gr_info_
      L3_stereo_process(left, ist_pos, gr->sfbtab, hdr, max_band, gr[1].scalefac_compress & 1);
  }
- 
+
 -static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
 +static void L3_reorder(mp3d_dsp_t *grbuf, mp3d_dsp_t *scratch, const uint8_t *sfb) FL_NO_EXCEPT
  {
      int i, len;
 -    float *src = grbuf, *dst = scratch;
 +    mp3d_dsp_t *src = grbuf, *dst = scratch;
- 
+
      for (;0 != (len = *sfb); sfb += 3, src += 2*len)
      {
-@@ -1006,15 +1718,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
+@@ -1006,15 +1727,17 @@ static void L3_reorder(float *grbuf, float *scratch, const uint8_t *sfb)
              *dst++ = src[2*len];
          }
      }
 -    memcpy(grbuf, scratch, (dst - scratch)*sizeof(float));
 +    memcpy(grbuf, scratch, (dst - scratch)*sizeof(mp3d_dsp_t));
  }
- 
+
 -static void L3_antialias(float *grbuf, int nbands)
 +static void L3_antialias(mp3d_dsp_t *grbuf, int nbands) FL_NO_EXCEPT
  {
@@ -1215,10 +1229,10 @@ index 9fbd4d2..587820c 100644
          {0.51449576f,0.47173197f,0.31337745f,0.18191320f,0.09457419f,0.04096558f,0.01419856f,0.00369997f}
      };
 +#endif
- 
+
      for (; nbands > 0; nbands--, grbuf += 18)
      {
-@@ -1035,16 +1749,193 @@ static void L3_antialias(float *grbuf, int nbands)
+@@ -1035,16 +1758,193 @@ static void L3_antialias(float *grbuf, int nbands)
  #ifndef MINIMP3_ONLY_SIMD
          for(; i < 8; i++)
          {
@@ -1239,7 +1253,7 @@ index 9fbd4d2..587820c 100644
  #endif /* MINIMP3_ONLY_SIMD */
      }
  }
- 
+
 -static void L3_dct3_9(float *y)
 +#if MINIMP3_HAVE_FIXED_POINT
 +/* 9-point DCT-III. Same butterfly graph as the float build, with every
@@ -1412,120 +1426,123 @@ index 9fbd4d2..587820c 100644
 +static void L3_dct3_9(float *y) FL_NO_EXCEPT
  {
      float s0, s1, s2, s3, s4, s5, s6, s7, s8, t0, t2, t4;
- 
-@@ -1084,7 +1975,7 @@ static void L3_dct3_9(float *y)
+
+@@ -1084,7 +1984,7 @@ static void L3_dct3_9(float *y)
      y[8] = s4 + s7;
  }
- 
+
 -static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nbands)
 +static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nbands) FL_NO_EXCEPT
  {
      int i, j;
      static const float g_twid9[18] = {
-@@ -1141,7 +2032,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
+@@ -1141,7 +2041,7 @@ static void L3_imdct36(float *grbuf, float *overlap, const float *window, int nb
      }
  }
- 
+
 -static void L3_idct3(float x0, float x1, float x2, float *dst)
 +static void L3_idct3(float x0, float x1, float x2, float *dst) FL_NO_EXCEPT
  {
      float m1 = x1*0.86602540f;
      float a1 = x0 - x2*0.5f;
-@@ -1150,7 +2041,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
+@@ -1150,7 +2050,7 @@ static void L3_idct3(float x0, float x1, float x2, float *dst)
      dst[2] = a1 - m1;
  }
- 
+
 -static void L3_imdct12(float *x, float *dst, float *overlap)
 +static void L3_imdct12(float *x, float *dst, float *overlap) FL_NO_EXCEPT
  {
      static const float g_twid3[6] = { 0.79335334f,0.92387953f,0.99144486f, 0.60876143f,0.38268343f,0.13052619f };
      float co[3], si[3];
-@@ -1170,7 +2061,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
+@@ -1170,7 +2070,7 @@ static void L3_imdct12(float *x, float *dst, float *overlap)
      }
  }
- 
+
 -static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
 +static void L3_imdct_short(float *grbuf, float *overlap, int nbands) FL_NO_EXCEPT
  {
      for (;nbands > 0; nbands--, overlap += 9, grbuf += 18)
      {
-@@ -1183,7 +2074,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
+@@ -1183,7 +2083,7 @@ static void L3_imdct_short(float *grbuf, float *overlap, int nbands)
      }
  }
- 
+
 -static void L3_change_sign(float *grbuf)
 +static void L3_change_sign(float *grbuf) FL_NO_EXCEPT
  {
      int b, i;
      for (b = 0, grbuf += 18; b < 32; b += 2, grbuf += 36)
-@@ -1191,7 +2082,7 @@ static void L3_change_sign(float *grbuf)
+@@ -1191,7 +2091,7 @@ static void L3_change_sign(float *grbuf)
              grbuf[i] = -grbuf[i];
  }
- 
+
 -static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsigned n_long_bands)
 +static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsigned n_long_bands) FL_NO_EXCEPT
  {
      static const float g_mdct_window[2][18] = {
          { 0.99904822f,0.99144486f,0.97629601f,0.95371695f,0.92387953f,0.88701083f,0.84339145f,0.79335334f,0.73727734f,0.04361938f,0.13052619f,0.21643961f,0.30070580f,0.38268343f,0.46174861f,0.53729961f,0.60876143f,0.67559021f },
-@@ -1208,8 +2099,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
+@@ -1208,8 +2108,10 @@ static void L3_imdct_gr(float *grbuf, float *overlap, unsigned block_type, unsig
      else
          L3_imdct36(grbuf, overlap, g_mdct_window[block_type == STOP_BLOCK_TYPE], 32 - n_long_bands);
  }
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
- 
+
 -static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
 +
 +static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_internal_t *s) FL_NO_EXCEPT
  {
      int pos = (s->bs.pos + 7)/8u;
      int remains = s->bs.limit/8u - pos;
-@@ -1225,7 +2118,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
+@@ -1225,7 +2127,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_t *s)
      h->reserv = remains;
  }
- 
+
 -static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int main_data_begin)
 +static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_internal_t *s, int main_data_begin) FL_NO_EXCEPT
  {
      int frame_bytes = (bs->limit - bs->pos)/8;
      int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-@@ -1235,15 +2128,25 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
+@@ -1235,24 +2137,35 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_t *s, int
      return h->reserv >= main_data_begin;
  }
- 
+
 -static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, int nch)
 +/* The scalefactor gains reach the dequantiser as one array in the float build
 +   and as a mantissa/exponent pair in the fixed build; this keeps L3_decode
 +   itself identical between the two. */
 +#if MINIMP3_HAVE_FIXED_POINT
-+#define MP3D_SCF_ARGS(s) (s)->scf_mant, (s)->scf_exp
++#define MP3D_SCF_ARGS(s) (s)->layer.l3.scf_mant, (s)->layer.l3.scf_exp
 +#else
-+#define MP3D_SCF_ARGS(s) (s)->scf
++#define MP3D_SCF_ARGS(s) (s)->layer.l3.scf
 +#endif
 +
 +static void L3_decode(mp3dec_t *h, mp3dec_scratch_internal_t *s, L3_gr_info_t *gr_info, int nch) FL_NO_EXCEPT
  {
      int ch;
- 
+
      for (ch = 0; ch < nch; ch++)
      {
          int layer3gr_limit = s->bs.pos + gr_info[ch].part_23_length;
 -        L3_decode_scalefactors(h->header, s->ist_pos[ch], &s->bs, gr_info + ch, s->scf, ch);
 -        L3_huffman(s->grbuf[ch], &s->bs, gr_info + ch, s->scf, layer3gr_limit);
-+        L3_decode_scalefactors(h->header, s->ist_pos[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), ch);
++        L3_decode_scalefactors(h->header, s->layer.l3.ist_pos[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), ch);
 +        L3_huffman(s->grbuf[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), layer3gr_limit);
 +        MP3D_STAGE(MINIMP3_STAGE_HUFFMAN, ch, s->grbuf[ch], 576);
      }
- 
+
      if (HDR_TEST_I_STEREO(h->header))
-@@ -1253,6 +2156,7 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+     {
+-        L3_intensity_stereo(s->grbuf[0], s->ist_pos[1], gr_info, h->header);
++        L3_intensity_stereo(s->grbuf[0], s->layer.l3.ist_pos[1], gr_info, h->header);
+     } else if (HDR_IS_MS_STEREO(h->header))
      {
          L3_midside_stereo(s->grbuf[0], 576);
      }
 +    MP3D_STAGE(MINIMP3_STAGE_STEREO, 0, s->grbuf[0], 576*nch);
- 
+
      for (ch = 0; ch < nch; ch++, gr_info++)
      {
-@@ -1262,16 +2166,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
+@@ -1262,16 +2175,595 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_t *s, L3_gr_info_t *gr_info, i
          if (gr_info->n_short_sfb)
          {
              aa_bands = n_long_bands - 1;
@@ -1534,7 +1551,7 @@ index 9fbd4d2..587820c 100644
 +                       h->qmf_state + 15*2*32,
 +                       gr_info->sfbtab + gr_info->n_long_sfb);
          }
- 
+
          L3_antialias(s->grbuf[ch], aa_bands);
 +        MP3D_STAGE(MINIMP3_STAGE_ANTIALIAS, ch, s->grbuf[ch], 576);
          L3_imdct_gr(s->grbuf[ch], h->mdct_overlap[ch], gr_info->block_type, n_long_bands);
@@ -2004,7 +2021,7 @@ index 9fbd4d2..587820c 100644
 +    b[2] = MP3D_V_GET64(bhi, 0); b[3] = MP3D_V_GET64(bhi, 1);
  }
 +#endif /* MP3D_HAVE_INT_SIMD */
- 
+
 -static void mp3d_DCT_II(float *grbuf, int n)
 +static void mp3d_synth(int32_t *xl, mp3d_sample_t *dstl, int nch, int32_t *lins) FL_NO_EXCEPT
 +{
@@ -2123,37 +2140,37 @@ index 9fbd4d2..587820c 100644
  {
      static const float g_sec[24] = {
          10.19000816f,0.50060302f,0.50241929f,3.40760851f,0.50547093f,0.52249861f,2.05778098f,0.51544732f,0.56694406f,1.48416460f,0.53104258f,0.64682180f,1.16943991f,0.55310392f,0.78815460f,0.97256821f,0.58293498f,1.06067765f,0.83934963f,0.62250412f,1.72244716f,0.74453628f,0.67480832f,5.10114861f
-@@ -1427,7 +2910,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
+@@ -1427,7 +2919,7 @@ static void mp3d_DCT_II(float *grbuf, int n)
  }
- 
+
  #ifndef MINIMP3_FLOAT_OUTPUT
 -static int16_t mp3d_scale_pcm(float sample)
 +static int16_t mp3d_scale_pcm(float sample) FL_NO_EXCEPT
  {
  #if HAVE_ARMV6
      int32_t s32 = (int32_t)(sample + .5f);
-@@ -1448,7 +2931,7 @@ static float mp3d_scale_pcm(float sample)
+@@ -1448,7 +2940,7 @@ static float mp3d_scale_pcm(float sample)
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */
- 
+
 -static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
 +static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z) FL_NO_EXCEPT
  {
      float a;
      a  = (z[14*64] - z[    0]) * 29;
-@@ -1473,7 +2956,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
+@@ -1473,7 +2965,7 @@ static void mp3d_synth_pair(mp3d_sample_t *pcm, int nch, const float *z)
      pcm[16*nch] = mp3d_scale_pcm(a);
  }
- 
+
 -static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
 +static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins) FL_NO_EXCEPT
  {
      int i;
      float *xr = xl + 576*(nch - 1);
-@@ -1626,16 +3109,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
+@@ -1626,16 +3118,17 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
  #endif /* MINIMP3_ONLY_SIMD */
  }
- 
+
 -static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int nch, mp3d_sample_t *pcm, float *lins)
 +static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands,
 +                               int nch, mp3d_sample_t *pcm) FL_NO_EXCEPT
@@ -2165,13 +2182,13 @@ index 9fbd4d2..587820c 100644
          mp3d_DCT_II(grbuf + 576*i, nbands);
 +        MP3D_STAGE(MINIMP3_STAGE_DCT2, i, grbuf + 576*i, 18*nbands);
      }
- 
+
 -    memcpy(lins, qmf_state, sizeof(float)*15*64);
 -
      for (i = 0; i < nbands; i += 2)
      {
          mp3d_synth(grbuf + i, pcm + 32*nch*i, nch, lins + i*64);
-@@ -1650,11 +3134,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
+@@ -1650,11 +3143,13 @@ static void mp3d_synth_granule(float *qmf_state, float *grbuf, int nbands, int n
      } else
  #endif /* MINIMP3_NONSTANDARD_BUT_LOGICAL */
      {
@@ -2179,7 +2196,7 @@ index 9fbd4d2..587820c 100644
 +        memmove(qmf_state, lins + nbands*64, sizeof(float)*15*64);
      }
  }
- 
+
 -static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
 +#endif /* MINIMP3_HAVE_FIXED_POINT */
 +
@@ -2187,19 +2204,19 @@ index 9fbd4d2..587820c 100644
  {
      int i, nmatch;
      for (i = 0, nmatch = 0; nmatch < MAX_FRAME_SYNC_MATCHES; nmatch++)
-@@ -1668,7 +3154,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
+@@ -1668,7 +3163,7 @@ static int mp3d_match_frame(const uint8_t *hdr, int mp3_bytes, int frame_bytes)
      return 1;
  }
- 
+
 -static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_bytes, int *ptr_frame_bytes)
 +static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_bytes, int *ptr_frame_bytes) FL_NO_EXCEPT
  {
      int i, k;
      for (i = 0; i < mp3_bytes - HDR_SIZE; i++, mp3++)
-@@ -1705,17 +3191,46 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
+@@ -1705,17 +3200,46 @@ static int mp3d_find_frame(const uint8_t *mp3, int mp3_bytes, int *free_format_b
      return mp3_bytes;
  }
- 
+
 -void mp3dec_init(mp3dec_t *dec)
 +int mp3dec_is_fixed_point(void) FL_NO_EXCEPT
 +{
@@ -2230,7 +2247,7 @@ index 9fbd4d2..587820c 100644
  {
      dec->header[0] = 0;
  }
- 
+
 -int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_sample_t *pcm, mp3dec_frame_info_t *info)
 +int mp3dec_decode_frame_r(mp3dec_t *dec, mp3dec_scratch_t *scratch_storage,
 +                          const uint8_t *mp3, int mp3_bytes,
@@ -2243,15 +2260,15 @@ index 9fbd4d2..587820c 100644
 -    mp3dec_scratch_t scratch;
 +    mp3dec_scratch_internal_t *scratch =
 +        (mp3dec_scratch_internal_t *)(void *)scratch_storage->buffer;
- 
+
      if (mp3_bytes > 4 && dec->header[0] == 0xff && hdr_compare(dec->header, mp3))
      {
-@@ -1758,23 +3273,23 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
- 
+@@ -1758,40 +3282,44 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+
      if (info->layer == 3)
      {
 -        int main_data_begin = L3_read_side_info(bs_frame, scratch.gr_info, hdr);
-+        int main_data_begin = L3_read_side_info(bs_frame, scratch->gr_info, hdr);
++        int main_data_begin = L3_read_side_info(bs_frame, scratch->layer.l3.gr_info, hdr);
          if (main_data_begin < 0 || bs_frame->pos > bs_frame->limit)
          {
              mp3dec_init(dec);
@@ -2267,7 +2284,7 @@ index 9fbd4d2..587820c 100644
 -                L3_decode(dec, &scratch, scratch.gr_info + igr*info->channels, info->channels);
 -                mp3d_synth_granule(dec->qmf_state, scratch.grbuf[0], 18, info->channels, pcm, scratch.syn[0]);
 +                memset(scratch->grbuf[0], 0, 576*2*sizeof(mp3d_dsp_t));
-+                L3_decode(dec, scratch, scratch->gr_info + igr*info->channels, info->channels);
++                L3_decode(dec, scratch, scratch->layer.l3.gr_info + igr*info->channels, info->channels);
 +                mp3d_synth_granule(dec->qmf_state, scratch->grbuf[0], 18, info->channels, pcm);
              }
          }
@@ -2276,10 +2293,12 @@ index 9fbd4d2..587820c 100644
      } else
      {
  #ifdef MINIMP3_ONLY_MP3
-@@ -1783,15 +3298,19 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
-         L12_scale_info sci[1];
+         return 0;
+ #else /* MINIMP3_ONLY_MP3 */
+-        L12_scale_info sci[1];
++        L12_scale_info *sci = &scratch->layer.l12;
          L12_read_scale_info(hdr, bs_frame, sci);
- 
+
 -        memset(scratch.grbuf[0], 0, 576*2*sizeof(float));
 +        memset(scratch->grbuf[0], 0, 576*2*sizeof(mp3d_dsp_t));
          for (i = 0, igr = 0; igr < 3; igr++)
@@ -2301,16 +2320,16 @@ index 9fbd4d2..587820c 100644
                  pcm += 384*info->channels;
              }
              if (bs_frame->pos > bs_frame->limit)
-@@ -1806,7 +3325,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
+@@ -1806,7 +3334,7 @@ int mp3dec_decode_frame(mp3dec_t *dec, const uint8_t *mp3, int mp3_bytes, mp3d_s
  }
- 
+
  #ifdef MINIMP3_FLOAT_OUTPUT
 -void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
 +void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples) FL_NO_EXCEPT
  {
      int i = 0;
  #if HAVE_SIMD
-@@ -1862,4 +3381,123 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
+@@ -1862,4 +3390,123 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
      }
  }
  #endif /* MINIMP3_FLOAT_OUTPUT */

--- a/src/third_party/minimp3/PROVENANCE.md
+++ b/src/third_party/minimp3/PROVENANCE.md
@@ -128,15 +128,19 @@ uses; without it the patch no longer applies at `-p1`.
 FastLED does
 not expose upstream's `mp3dec_decode_frame` convenience entry point because it
 allocates scratch on the stack; all callers use `mp3dec_decode_frame_r` with
-owned storage instead. FastLED uses a 7,808-byte scratch arena for the float
-build and 7,936 bytes for the fixed-point build -- the latter carries
+owned storage instead. FastLED uses an 8,352-byte scratch arena for the float
+build and 8,592 bytes for the fixed-point build -- the latter carries
 scalefactor gains as mantissa+exponent rather than as a single float, and gets
 its own figure so that each variant is charged for its own arena. Fixed point
 is what ships (FastLED#4056); the float build survives as the reference the
 fixed-vs-float gates compare against. FastLED also extends the
 decoder's persistent synthesis state so that it can serve as the synthesis
-workspace without a duplicate scratch copy. The upstream direct-decoder
-2,304-byte free-format frame cap and Phase 0's 4,096-byte stream buffer are
+workspace without a duplicate scratch copy. Layer I/II scale information is
+overlaid with the mutually exclusive Layer III tail of the arena; this removes
+the compiler-inlined scale arrays from `mp3dec_decode_frame_r`'s stack without
+adding an allocation or changing either decoding path's arithmetic. The
+upstream direct-decoder 2,304-byte free-format frame cap and Phase 0's
+4,096-byte stream buffer are
 retained; the stream buffer can discover unknown free-format spacing through
 2,045 bytes with upstream's three-header validation. The integration meets the
 24 KiB working-RAM budget without narrowing that Phase 0 streaming behavior.

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -116,14 +116,15 @@
 
 /* Scratch arena size. The fixed-point build needs a little more than the float
    build because scalefactor gains are carried as mantissa+exponent rather than
-   as a single float, so each variant gets its own figure and the ledger records
-   both rather than charging one build for the other's arena.
+   as a single float. Layer I/II scale information shares storage with the
+   mutually exclusive Layer III tail, keeping it out of the decode stack while
+   charging each variant only for its larger union member.
    A static_assert on mp3dec_scratch_internal_t below enforces both. */
 #undef MINIMP3_SCRATCH_SIZE
 #if MINIMP3_HAVE_FIXED_POINT
-#define MINIMP3_SCRATCH_SIZE 7936
+#define MINIMP3_SCRATCH_SIZE 8592
 #else
-#define MINIMP3_SCRATCH_SIZE 7808
+#define MINIMP3_SCRATCH_SIZE 8352
 #endif
 
 /* FastLED: number of fractional bits in a fixed-point DSP sample.
@@ -604,10 +605,9 @@ typedef struct
        dequantiser steps are around 1e-7 before a runtime scale that can move
        them 21 binary places either way, so they do not fit one Q format.
 
-       int8_t, unlike the Layer III gains' int16_t, because this array lives on
-       the stack inside mp3dec_decode_frame_r rather than in the heap scratch
-       arena, and 192 entries of it is the difference between meeting the 2 KiB
-       decode-stack budget and missing it. The exponents here span [-37, -1]:
+       int8_t, unlike the Layer III gains' int16_t, because its range fits a
+       signed byte and 192 wider entries would needlessly enlarge the caller's
+       heap scratch arena. The exponents here span [-37, -1]:
        the table's own range plus the runtime 2**(21 - b/3) scale. */
     int32_t scf_mant[3*64];
     int8_t scf_exp[3*64];
@@ -633,10 +633,7 @@ typedef struct
 
 typedef struct
 {
-    bs_t bs;
-    uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
     L3_gr_info_t gr_info[4];
-    mp3d_dsp_t grbuf[2][576];
 #if MINIMP3_HAVE_FIXED_POINT
     /* Scalefactor gains span roughly 2**-181 to 2**10, so they are the one
        quantity in the pipeline that genuinely needs an exponent of its own.
@@ -647,6 +644,18 @@ typedef struct
     float scf[40];
 #endif
     uint8_t ist_pos[2][39];
+} mp3dec_layer3_scratch_t;
+
+typedef struct
+{
+    bs_t bs;
+    uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
+    mp3d_dsp_t grbuf[2][576];
+    union
+    {
+        mp3dec_layer3_scratch_t l3;
+        L12_scale_info l12;
+    } layer;
 } mp3dec_scratch_internal_t;
 
 #ifdef __cplusplus
@@ -2132,9 +2141,9 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_internal_t
    and as a mantissa/exponent pair in the fixed build; this keeps L3_decode
    itself identical between the two. */
 #if MINIMP3_HAVE_FIXED_POINT
-#define MP3D_SCF_ARGS(s) (s)->scf_mant, (s)->scf_exp
+#define MP3D_SCF_ARGS(s) (s)->layer.l3.scf_mant, (s)->layer.l3.scf_exp
 #else
-#define MP3D_SCF_ARGS(s) (s)->scf
+#define MP3D_SCF_ARGS(s) (s)->layer.l3.scf
 #endif
 
 static void L3_decode(mp3dec_t *h, mp3dec_scratch_internal_t *s, L3_gr_info_t *gr_info, int nch) FL_NO_EXCEPT
@@ -2144,14 +2153,14 @@ static void L3_decode(mp3dec_t *h, mp3dec_scratch_internal_t *s, L3_gr_info_t *g
     for (ch = 0; ch < nch; ch++)
     {
         int layer3gr_limit = s->bs.pos + gr_info[ch].part_23_length;
-        L3_decode_scalefactors(h->header, s->ist_pos[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), ch);
+        L3_decode_scalefactors(h->header, s->layer.l3.ist_pos[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), ch);
         L3_huffman(s->grbuf[ch], &s->bs, gr_info + ch, MP3D_SCF_ARGS(s), layer3gr_limit);
         MP3D_STAGE(MINIMP3_STAGE_HUFFMAN, ch, s->grbuf[ch], 576);
     }
 
     if (HDR_TEST_I_STEREO(h->header))
     {
-        L3_intensity_stereo(s->grbuf[0], s->ist_pos[1], gr_info, h->header);
+        L3_intensity_stereo(s->grbuf[0], s->layer.l3.ist_pos[1], gr_info, h->header);
     } else if (HDR_IS_MS_STEREO(h->header))
     {
         L3_midside_stereo(s->grbuf[0], 576);
@@ -3273,7 +3282,7 @@ int mp3dec_decode_frame_r(mp3dec_t *dec, mp3dec_scratch_t *scratch_storage,
 
     if (info->layer == 3)
     {
-        int main_data_begin = L3_read_side_info(bs_frame, scratch->gr_info, hdr);
+        int main_data_begin = L3_read_side_info(bs_frame, scratch->layer.l3.gr_info, hdr);
         if (main_data_begin < 0 || bs_frame->pos > bs_frame->limit)
         {
             mp3dec_init(dec);
@@ -3285,7 +3294,7 @@ int mp3dec_decode_frame_r(mp3dec_t *dec, mp3dec_scratch_t *scratch_storage,
             for (igr = 0; igr < (HDR_TEST_MPEG1(hdr) ? 2 : 1); igr++, pcm += 576*info->channels)
             {
                 memset(scratch->grbuf[0], 0, 576*2*sizeof(mp3d_dsp_t));
-                L3_decode(dec, scratch, scratch->gr_info + igr*info->channels, info->channels);
+                L3_decode(dec, scratch, scratch->layer.l3.gr_info + igr*info->channels, info->channels);
                 mp3d_synth_granule(dec->qmf_state, scratch->grbuf[0], 18, info->channels, pcm);
             }
         }
@@ -3295,7 +3304,7 @@ int mp3dec_decode_frame_r(mp3dec_t *dec, mp3dec_scratch_t *scratch_storage,
 #ifdef MINIMP3_ONLY_MP3
         return 0;
 #else /* MINIMP3_ONLY_MP3 */
-        L12_scale_info sci[1];
+        L12_scale_info *sci = &scratch->layer.l12;
         L12_read_scale_info(hdr, bs_frame, sci);
 
         memset(scratch->grbuf[0], 0, 576*2*sizeof(mp3d_dsp_t));

--- a/tests/fl/chipsets/encoders.cpp
+++ b/tests/fl/chipsets/encoders.cpp
@@ -8,6 +8,7 @@
 #include "tests/fl/chipsets/encoders/sk9822.hpp"
 #include "tests/fl/chipsets/encoders/sm16716.hpp"
 #include "tests/fl/chipsets/encoders/tm1812.hpp"
+#include "tests/fl/chipsets/encoders/tm1908.hpp"
 #include "tests/fl/chipsets/encoders/ws2801.hpp"
 #include "tests/fl/chipsets/encoders/ws2803.hpp"
 #include "tests/fl/chipsets/encoders/ws2812.hpp"

--- a/tests/fl/chipsets/encoders/tm1908.hpp
+++ b/tests/fl/chipsets/encoders/tm1908.hpp
@@ -1,0 +1,52 @@
+/// @file tm1908.hpp
+/// @brief Unit tests for the TM1908 command-prefix encoder.
+
+#include "FastLED.h"
+#include "fl/channels/config.h"
+#include "fl/chipsets/encoders/tm1908.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/array.h"
+#include "fl/stl/iterator.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+using namespace fl;
+
+namespace test_tm1908 {
+
+FL_TEST_CASE("TM1908 - timing and encoder match the vendor protocol") {
+    FL_CHECK_EQ(TIMING_TM1908::T1, 240);
+    FL_CHECK_EQ(TIMING_TM1908::T2, 240);
+    FL_CHECK_EQ(TIMING_TM1908::T3, 350);
+    FL_CHECK_EQ(TIMING_TM1908::RESET, 80);
+    FL_CHECK(encoder_for<TIMING_TM1908>() ==
+             ClocklessEncoder::CLOCKLESS_ENCODER_TM1908);
+
+    const auto chipset = makeClockless<TIMING_TM1908>(3);
+    FL_CHECK(chipset.encoder == ClocklessEncoder::CLOCKLESS_ENCODER_TM1908);
+}
+
+FL_TEST_CASE("TM1908 - frame contains mode, current, then RGB data") {
+    fl::vector<fl::array<u8, 3>> pixels;
+    pixels.push_back({0x12, 0x34, 0x56});
+    pixels.push_back({0x78, 0x9a, 0xbc});
+    fl::vector<u8> output;
+
+    encodeTM1908(pixels.begin(), pixels.end(), fl::back_inserter(output));
+
+    const u8 expected[] = {
+        0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x7f, 0x7f, 0x7f,
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+    };
+    FL_REQUIRE_EQ(output.size(), static_cast<fl::size>(15));
+    for (fl::size i = 0; i < output.size(); ++i) {
+        FL_CHECK_EQ(output[i], expected[i]);
+    }
+}
+
+FL_TEST_CASE("TM1908 - public controller is available") {
+    TM1908<3, RGB> controller;
+    FL_CHECK(sizeof(controller) > 0);
+}
+
+} // namespace test_tm1908

--- a/tests/fl/chipsets/timing_traits.cpp
+++ b/tests/fl/chipsets/timing_traits.cpp
@@ -260,6 +260,33 @@ FL_TEST_CASE("WS2818 timing stays inside the datasheet pulse envelope") {
                                   WS2818Controller<5, GRB>>::value));
 }
 
+FL_TEST_CASE("OSTW2020C1E uses the verified WS2812-compatible protocol") {
+    constexpr ChipsetTimingConfig timing =
+        makeTimingConfig<TIMING_WS2812_800KHZ>();
+
+    // OptoSupply VER A.0 specifies an 800 Kbps, GRB/MSB-first stream with
+    // T0H=220-380ns, T1H=580-1000ns, T0L=580-1600ns, T1L=220-420ns,
+    // and reset >280us. These are the actual pulses produced by this timing.
+    FL_CHECK_GE(timing.t1_ns, 220);
+    FL_CHECK_LE(timing.t1_ns, 380);
+    FL_CHECK_GE(timing.t1_ns + timing.t2_ns, 580);
+    FL_CHECK_LE(timing.t1_ns + timing.t2_ns, 1000);
+    FL_CHECK_GE(timing.t2_ns + timing.t3_ns, 580);
+    FL_CHECK_LE(timing.t2_ns + timing.t3_ns, 1600);
+    FL_CHECK_GE(timing.t3_ns, 220);
+    FL_CHECK_LE(timing.t3_ns, 420);
+
+    // The datasheet requires reset low for more than 280us, so the named
+    // controller rounds the inter-frame wait up instead of using WS2812's
+    // 280us default exactly.
+    using ExpectedBase = fl::ClocklessControllerImpl<
+        5, fl::TIMING_WS2812_800KHZ, GRB, 0, false, 300>;
+    FL_CHECK_TRUE((fl::is_base_of<ExpectedBase,
+                                  OSTW2020C1EController<5, GRB>>::value));
+    FL_CHECK_TRUE((fl::is_base_of<OSTW2020C1EController<5, GRB>,
+                                  OSTW2020C1E<5, GRB>>::value));
+}
+
 FL_TEST_CASE("LC8816E uses datasheet timing and fixed GRBW output") {
     constexpr ChipsetTimingConfig timing =
         makeTimingConfig<TIMING_LC8816E>();

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -3,6 +3,19 @@
 
 FL_TEST_FILE(FL_FILEPATH) {
 
+FL_TEST_CASE("PixelController uses the same temporal dither phase for multiple controllers") {
+    CRGB pixel(40, 40, 40);
+    ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+    adjustment.premixed = CRGB(24, 24, 24);
+
+    PixelController<RGB> first(&pixel, 1, adjustment, BINARY_DITHER);
+    PixelController<RGB> second(&pixel, 1, adjustment, BINARY_DITHER);
+
+    FL_CHECK_EQ(first.d[0], second.d[0]);
+    FL_CHECK_EQ(first.d[1], second.d[1]);
+    FL_CHECK_EQ(first.d[2], second.d[2]);
+}
+
 FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
     CRGB pixel(1, 1, 1);
     ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
@@ -10,6 +23,7 @@ FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
 
     fl::u8 frame_phases[8];
     for (fl::u8 frame = 0; frame < 8; ++frame) {
+        fl::detail::advanceDitherFrame();
         PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
         frame_phases[frame] = pixels.d[0];
     }
@@ -20,6 +34,7 @@ FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
 
     PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
     if (pixels.d[0] == pixels.e[0] - pixels.d[0]) {
+        fl::detail::advanceDitherFrame();
         pixels.init_binary_dithering();
     }
     const fl::u8 frame_start = pixels.d[0];


### PR DESCRIPTION
Closes #3968
Closes #1887
Closes #4116
Closes #1795
Closes #1490
Closes #1441

#4003 and #1622 were independently verified as already fixed upstream and have been closed with evidence.

Validation:
- `bash lint`
- `bash test codec --debug`
- `bash test pixel_controller --debug`
- `bash test encoders --debug`
- `bash test fl/chipsets/timing_traits --debug`

`bash test --cpp --debug` compiled the affected codec successfully but is blocked later by the unrelated existing C++11 template-template error in `tests/fl/stl/move.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TM1908 RGB LEDs, including required command and timing protocols.
  * Added support for OptoSupply OSTW2020C1E LED controllers with GRB output and extended reset timing.
  * Temporal dithering now advances consistently once per logical frame across multiple LED controllers.
  * MP3 decoding memory usage and backend coverage have been updated and expanded.

* **Documentation**
  * Expanded task scheduling API documentation and updated MP3 memory and implementation notes.

* **Bug Fixes**
  * Improved JavaScript linting support for linked worktrees and shared repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->