### PR TITLE
perf(ci): share JS lint tools across worktrees

### DIFF
--- a/ci/lint-js-fast
+++ b/ci/lint-js-fast
@@ -11,6 +11,8 @@ NC='\033[0m' # No Color
 # Store project root directory for cache operations
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMPILER_DIR="$PROJECT_ROOT/src/platforms/wasm/compiler"
+COMMON_GIT_DIR="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir)"
+JS_TOOLS_DIR="$(dirname "$COMMON_GIT_DIR")/.cache/js-tools"
 
 # Find a node_modules binary, preferring Unix name over .cmd (Windows)
 # Usage: find_bin <dir> <name>  →  sets FOUND_BIN or returns 1
@@ -27,14 +29,14 @@ find_bin() {
 
 # Resolve eslint binary → sets ESLINT_BIN or returns 1
 find_eslint() {
-    find_bin "$PROJECT_ROOT/.cache/js-tools/node_modules/.bin" "eslint" && ESLINT_BIN="$FOUND_BIN"
+    find_bin "$JS_TOOLS_DIR/node_modules/.bin" "eslint" && ESLINT_BIN="$FOUND_BIN"
 }
 
 # Resolve tsc binary → sets TSC_CMD or returns 1
 find_tsc() {
     if find_bin "$COMPILER_DIR/node_modules/.bin" "tsc"; then
         TSC_CMD="$FOUND_BIN"
-    elif find_bin "$PROJECT_ROOT/.cache/js-tools/node_modules/.bin" "tsc"; then
+    elif find_bin "$JS_TOOLS_DIR/node_modules/.bin" "tsc"; then
         TSC_CMD="$FOUND_BIN"
     elif command -v npx >/dev/null 2>&1; then
         TSC_CMD="npx tsc"
@@ -98,30 +100,30 @@ fi
 
 # Run ESLint using config from the compiler directory
 echo -e "${BLUE}Running ESLint...${NC}"
-cd .cache/js-tools
+cd "$JS_TOOLS_DIR"
 
 # Build the list of files/patterns to lint
 LINT_TARGETS=()
 
 # Add WASM TypeScript files
 if [ -n "$WASM_TS_FILES" ]; then
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/*.ts")
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/modules/**/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/modules/**/*.ts")
 fi
 
 # Add WASM JavaScript files (audio worklet, etc.)
 if [ -n "$WASM_JS_FILES" ]; then
-    LINT_TARGETS+=("../../src/platforms/wasm/compiler/modules/**/*.js")
+    LINT_TARGETS+=("$PROJECT_ROOT/src/platforms/wasm/compiler/modules/**/*.js")
 fi
 
 # Add avr8js TypeScript files
 if [ -n "$AVR_TS_FILES" ]; then
-    LINT_TARGETS+=("../../ci/docker_utils/avr8js/*.ts")
+    LINT_TARGETS+=("$PROJECT_ROOT/ci/docker_utils/avr8js/*.ts")
 fi
 
 # Copy eslintrc from compiler directory so ESLint can resolve the TS parser
 # (ESLint resolves parser modules relative to the config file location)
-cp "../../src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
+cp "$PROJECT_ROOT/src/platforms/wasm/compiler/.eslintrc.cjs" ".eslintrc.cjs" 2>/dev/null || true
 
 if "$ESLINT_BIN" --no-eslintrc --no-inline-config -c .eslintrc.cjs "${LINT_TARGETS[@]}"; then
     echo -e "${GREEN}ESLint completed successfully${NC}"

--- a/ci/lint/stage_impls.py
+++ b/ci/lint/stage_impls.py
@@ -19,6 +19,7 @@ from ci.python_lint_cache import (
     invalidate_python_cache,
     mark_python_lint_success,
 )
+from ci.util.js_tools_cache import repository_tools_dir
 
 
 # IWYU (Include-What-You-Use) is currently disabled because it doesn't work well
@@ -344,10 +345,11 @@ def run_js_lint(no_fingerprint: bool) -> bool:
 
     # Determine ESLint executable path
     eslint_exe = ""
+    js_tools_dir = repository_tools_dir(Path.cwd())
     if sys.platform in ("win32", "cygwin", "msys"):
-        eslint_exe = ".cache/js-tools/node_modules/.bin/eslint.cmd"
+        eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint.cmd"
     else:
-        eslint_exe = ".cache/js-tools/node_modules/.bin/eslint"
+        eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint"
 
     # Check if fast linting is available
     lint_script = Path("ci/lint-js-fast")
@@ -895,7 +897,7 @@ def run_js_lint_single_file(file_path: str) -> bool:
     print(f"🌐 JS lint: {os.path.relpath(file_path)}")
 
     # ESLint runs from .cache/js-tools/ with its local config
-    js_tools_dir = Path(".cache/js-tools").resolve()
+    js_tools_dir = repository_tools_dir(Path.cwd())
     if sys.platform in ("win32", "cygwin", "msys"):
         eslint_exe = js_tools_dir / "node_modules" / ".bin" / "eslint.cmd"
     else:

--- a/ci/setup-js-linting-fast.py
+++ b/ci/setup-js-linting-fast.py
@@ -26,6 +26,8 @@ from pathlib import Path
 # Import httpx for HTTP requests (dynamically managed by uv)
 import httpx
 
+from ci.util.js_tools_cache import repository_tools_dir
+
 
 # Force UTF-8 output for Windows consoles
 if sys.platform.startswith("win"):
@@ -34,7 +36,9 @@ if sys.platform.startswith("win"):
 
 # Configuration
 NODE_VERSION = "20.11.0"  # LTS version
-TOOLS_DIR = Path(".cache/js-tools")
+
+
+TOOLS_DIR = repository_tools_dir(Path.cwd())
 NODE_DIR = TOOLS_DIR / "node"
 
 

--- a/ci/tests/test_setup_js_linting_fast.py
+++ b/ci/tests/test_setup_js_linting_fast.py
@@ -18,6 +18,24 @@ def _load_setup_module() -> ModuleType:
     return module
 
 
+def test_js_tools_cache_is_shared_by_linked_worktrees(tmp_path: Path) -> None:
+    module = _load_setup_module()
+    repository = tmp_path / "fastled"
+    common_git_dir = repository / ".git"
+    common_git_dir.mkdir(parents=True)
+
+    worktree = tmp_path / "fastled-wt-feature"
+    worktree.mkdir()
+    worktree_git_dir = common_git_dir / "worktrees" / "feature"
+    worktree_git_dir.mkdir(parents=True)
+    (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+
+    expected = repository / ".cache" / "js-tools"
+    assert module.repository_tools_dir(repository) == expected
+    assert module.repository_tools_dir(worktree) == expected
+
+
 def test_node_archive_is_reused_after_extracted_tree_is_removed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/ci/util/js_tools_cache.py
+++ b/ci/util/js_tools_cache.py
@@ -1,0 +1,34 @@
+"""Repository-local cache paths for the JavaScript lint toolchain."""
+
+from pathlib import Path
+
+
+def repository_tools_dir(start: Path) -> Path:
+    """Return one JS-tools cache shared by all worktrees of this repository."""
+    start = start.resolve()
+    for repository in (start, *start.parents):
+        dot_git = repository / ".git"
+        if dot_git.is_dir():
+            common_git_dir = dot_git
+        elif dot_git.is_file():
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            prefix = "gitdir: "
+            if not marker.startswith(prefix):
+                continue
+            git_dir = Path(marker.removeprefix(prefix))
+            if not git_dir.is_absolute():
+                git_dir = repository / git_dir
+            git_dir = git_dir.resolve()
+            commondir_file = git_dir / "commondir"
+            if commondir_file.is_file():
+                common_git_dir = (
+                    git_dir / commondir_file.read_text(encoding="utf-8").strip()
+                ).resolve()
+            else:
+                common_git_dir = git_dir
+        else:
+            continue
+
+        return common_git_dir.parent / ".cache" / "js-tools"
+
+    return start / ".cache" / "js-tools"


### PR DESCRIPTION
Closes #3968

Validation: focused regression test and bash lint passed before the split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript linting setup and execution across repository worktrees.
  * Ensured linked worktrees share the same linting tools cache.
  * Improved path resolution for linting tools, configurations, and project files.

* **Tests**
  * Added regression coverage for shared linting caches in linked worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->