### PR TITLE
fix(core): synchronize dithering across controllers

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -67,12 +67,17 @@ extern "C" void yield(void) { }
 fl::u8 get_brightness();
 
 #if !FL_PLATFORM_HAS_TINY_MEMORY
-fl::u8 fl::detail::ditherFrame() {
-    return fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+namespace {
+// FL_LINT_ALLOW_GLOBAL(shared dither phase is required once per logical frame)
+fl::detail::DitherFrameState ditherFrameState;
+} // namespace
+
+fl::u8 fl::detail::ditherFrame() FL_NO_EXCEPT {
+    return ditherFrameState.frame;
 }
 
-void fl::detail::advanceDitherFrame() {
-    ++fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+void fl::detail::advanceDitherFrame() FL_NO_EXCEPT {
+    ++ditherFrameState.frame;
 }
 #endif
 
@@ -776,9 +781,6 @@ namespace __cxxabiv1
 
 
 void CFastLED::onBeginFrame() {
-#if !FL_PLATFORM_HAS_TINY_MEMORY
-	fl::detail::advanceDitherFrame();
-#endif
 	fl::EngineEvents::onBeginFrame();
 }
 

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -66,13 +66,15 @@ extern "C" void yield(void) { }
 
 fl::u8 get_brightness();
 
+#if !FL_PLATFORM_HAS_TINY_MEMORY
 fl::u8 fl::detail::ditherFrame() {
-	return fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+    return fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
 }
 
 void fl::detail::advanceDitherFrame() {
-	++fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+    ++fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
 }
+#endif
 
 /// Pointer to the matrix object when using the Smart Matrix Library
 /// @see https://github.com/pixelmatix/SmartMatrix
@@ -774,7 +776,9 @@ namespace __cxxabiv1
 
 
 void CFastLED::onBeginFrame() {
+#if !FL_PLATFORM_HAS_TINY_MEMORY
 	fl::detail::advanceDitherFrame();
+#endif
 	fl::EngineEvents::onBeginFrame();
 }
 

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -67,17 +67,11 @@ extern "C" void yield(void) { }
 fl::u8 get_brightness();
 
 #if !FL_PLATFORM_HAS_TINY_MEMORY
-namespace {
 // FL_LINT_ALLOW_GLOBAL(shared dither phase is required once per logical frame)
-fl::detail::DitherFrameState ditherFrameState;
-} // namespace
+fl::u8 fl::detail::gDitherFrame;
 
 fl::u8 fl::detail::ditherFrame() FL_NO_EXCEPT {
-    return ditherFrameState.frame;
-}
-
-void fl::detail::advanceDitherFrame() FL_NO_EXCEPT {
-    ++ditherFrameState.frame;
+    return gDitherFrame;
 }
 #endif
 

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -66,6 +66,14 @@ extern "C" void yield(void) { }
 
 fl::u8 get_brightness();
 
+fl::u8 fl::detail::ditherFrame() {
+	return fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+}
+
+void fl::detail::advanceDitherFrame() {
+	++fl::Singleton<fl::detail::DitherFrameState>::instance().frame;
+}
+
 /// Pointer to the matrix object when using the Smart Matrix Library
 /// @see https://github.com/pixelmatix/SmartMatrix
 void *pSmartMatrix = nullptr;
@@ -766,6 +774,7 @@ namespace __cxxabiv1
 
 
 void CFastLED::onBeginFrame() {
+	fl::detail::advanceDitherFrame();
 	fl::EngineEvents::onBeginFrame();
 }
 

--- a/src/dither_mode.h
+++ b/src/dither_mode.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/int.h"
+#include "fl/channels/dither_frame.h"
 
 /// Disable dithering
 #define DISABLE_DITHER 0x00

--- a/src/dither_mode.h
+++ b/src/dither_mode.h
@@ -5,7 +5,10 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/int.h"
+#include "fl/system/sketch_macros.h"
+#if !FL_PLATFORM_HAS_TINY_MEMORY
 #include "fl/channels/dither_frame.h"
+#endif
 
 /// Disable dithering
 #define DISABLE_DITHER 0x00

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -186,6 +186,7 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NO_EXCEPT {
+        fl::detail::advanceDitherFrame();
         fl::EngineEvents::onBeginFrame();
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -186,9 +186,6 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NO_EXCEPT {
-#if !FL_PLATFORM_HAS_TINY_MEMORY
-        fl::detail::advanceDitherFrame();
-#endif
         fl::EngineEvents::onBeginFrame();
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -186,7 +186,9 @@ public:
 
     // Compatibility with the 3.8.x codebase.
     VIRTUAL_IF_NOT_AVR void showLeds(fl::u8 brightness) FL_NO_EXCEPT {
+#if !FL_PLATFORM_HAS_TINY_MEMORY
         fl::detail::advanceDitherFrame();
+#endif
         fl::EngineEvents::onBeginFrame();
         void* data = beginShowLeds(mLeds.size());
         showLedsInternal(brightness);

--- a/src/fl/channels/dither_frame.h
+++ b/src/fl/channels/dither_frame.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/// @file fl/channels/dither_frame.h
+/// Shared temporal-dither phase tracking.
+
+#include "fl/stl/int.h"
+
+namespace fl {
+namespace detail {
+
+struct DitherFrameState {
+    u8 frame = 0;
+};
+
+/// Return the temporal-dither phase shared by all controllers in this frame.
+u8 ditherFrame();
+
+/// Advance temporal dithering once per logical frame, not once per controller.
+void advanceDitherFrame();
+
+} // namespace detail
+} // namespace fl

--- a/src/fl/channels/dither_frame.h
+++ b/src/fl/channels/dither_frame.h
@@ -5,19 +5,20 @@
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"
 
 namespace fl {
 namespace detail {
 
-struct DitherFrameState {
-    u8 frame = 0;
-};
+extern u8 gDitherFrame;
 
 /// Return the temporal-dither phase shared by all controllers in this frame.
 u8 ditherFrame() FL_NO_EXCEPT;
 
 /// Advance temporal dithering once per logical frame, not once per controller.
-void advanceDitherFrame() FL_NO_EXCEPT;
+FL_ALWAYS_INLINE void advanceDitherFrame() FL_NO_EXCEPT {
+    ++gDitherFrame;
+}
 
 } // namespace detail
 } // namespace fl

--- a/src/fl/channels/dither_frame.h
+++ b/src/fl/channels/dither_frame.h
@@ -4,6 +4,7 @@
 /// Shared temporal-dither phase tracking.
 
 #include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
 
 namespace fl {
 namespace detail {
@@ -13,10 +14,10 @@ struct DitherFrameState {
 };
 
 /// Return the temporal-dither phase shared by all controllers in this frame.
-u8 ditherFrame();
+u8 ditherFrame() FL_NO_EXCEPT;
 
 /// Advance temporal dithering once per logical frame, not once per controller.
-void advanceDitherFrame();
+void advanceDitherFrame() FL_NO_EXCEPT;
 
 } // namespace detail
 } // namespace fl

--- a/src/fl/system/engine_events.cpp.hpp
+++ b/src/fl/system/engine_events.cpp.hpp
@@ -4,6 +4,9 @@
 // zackees/zccache#619 (Windows PCH path-spelling drift). The comment
 // above said "for printf debug" but no printf-debug call survived.
 #include "fl/stl/noexcept.h"
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+#include "fl/channels/dither_frame.h"
+#endif
 
 
 namespace fl {
@@ -40,6 +43,9 @@ void EngineEvents::setFrameTaskListener(Listener *listener) FL_NO_EXCEPT {
 }
 
 void EngineEvents::onBeginFrame() FL_NO_EXCEPT {
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    detail::advanceDitherFrame();
+#endif
 #if FASTLED_HAS_ENGINE_EVENTS
     EngineEvents::getInstance()->_onBeginFrame();
 #endif

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -308,8 +308,14 @@ struct PixelController {
     /// @see "TEMPORAL DITHERING: THE COMPLETE GUIDE" section above (line 195)
     void init_binary_dithering() {
 #if !defined(NO_DITHERING) || (NO_DITHERING != 1)
-        // STEP 1: Use the phase shared by all controllers in this frame.
+        // STEP 1: Tiny targets retain their one-byte local phase counter.
+        // Other targets share a phase once per logical frame.
+#if FL_PLATFORM_HAS_TINY_MEMORY
+        static fl::u8 R = 0; // okay static in header: preserves the tiny-target footprint
+        ++R;
+#else
         fl::u8 R = fl::detail::ditherFrame();
+#endif
 
         // STEP 2: Wrap counter at 2^ditherBits (creates 8-frame cycle: 0,1,2,3,4,5,6,7,0...)
         fl::u8 ditherBits = VIRTUAL_BITS;

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -308,9 +308,8 @@ struct PixelController {
     /// @see "TEMPORAL DITHERING: THE COMPLETE GUIDE" section above (line 195)
     void init_binary_dithering() {
 #if !defined(NO_DITHERING) || (NO_DITHERING != 1)
-        // STEP 1: Increment frame counter (creates temporal variation)
-        static fl::u8 R = 0; // okay static in header
-        ++R;
+        // STEP 1: Use the phase shared by all controllers in this frame.
+        fl::u8 R = fl::detail::ditherFrame();
 
         // STEP 2: Wrap counter at 2^ditherBits (creates 8-frame cycle: 0,1,2,3,4,5,6,7,0...)
         fl::u8 ditherBits = VIRTUAL_BITS;

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -3,6 +3,19 @@
 
 FL_TEST_FILE(FL_FILEPATH) {
 
+FL_TEST_CASE("PixelController uses the same temporal dither phase for multiple controllers") {
+    CRGB pixel(40, 40, 40);
+    ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+    adjustment.premixed = CRGB(24, 24, 24);
+
+    PixelController<RGB> first(&pixel, 1, adjustment, BINARY_DITHER);
+    PixelController<RGB> second(&pixel, 1, adjustment, BINARY_DITHER);
+
+    FL_CHECK_EQ(first.d[0], second.d[0]);
+    FL_CHECK_EQ(first.d[1], second.d[1]);
+    FL_CHECK_EQ(first.d[2], second.d[2]);
+}
+
 FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
     CRGB pixel(1, 1, 1);
     ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
@@ -10,6 +23,7 @@ FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
 
     fl::u8 frame_phases[8];
     for (fl::u8 frame = 0; frame < 8; ++frame) {
+        fl::detail::advanceDitherFrame();
         PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
         frame_phases[frame] = pixels.d[0];
     }
@@ -20,6 +34,7 @@ FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
 
     PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
     if (pixels.d[0] == pixels.e[0] - pixels.d[0]) {
+        fl::detail::advanceDitherFrame();
         pixels.init_binary_dithering();
     }
     const fl::u8 frame_start = pixels.d[0];


### PR DESCRIPTION
Closes #1887

Synchronize temporal dithering once per logical frame on normal-memory targets. Tiny-memory targets retain the prior per-template phase counter so no static-state or flash growth is introduced.

Validation:
- `bash test pixel_controller --debug`
- `bash compile attiny85 --examples Blink` — 3,454 B flash / 415 B RAM, exactly matching `master`
- `bash lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary dithering consistency across multiple pixel controllers by synchronizing their temporal dither phase.
  * Advanced dithering once per logical frame, producing more stable and predictable visual output.
  * Preserved lightweight dithering behavior on memory-constrained platforms.
* **Tests**
  * Added coverage verifying shared dither phases and frame-to-frame phase advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->