### PR TITLE
feat(chipsets): support OSTW2020C1E

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -438,6 +438,14 @@ class WS2852 : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class WS2812B : public WS2812Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
+/// @brief OptoSupply OSTW2020C1E controller class (2020-package RGB).
+/// @details The manufacturer specifies an 800 Kbps, GRB/MSB-first protocol
+/// compatible with WS2812 pulse timing and a reset interval greater than
+/// 280us. The dedicated controller uses a 300us inter-frame wait.
+/// @copydetails OSTW2020C1EController
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class OSTW2020C1E : public OSTW2020C1EController<DATA_PIN, RGB_ORDER> {};
+
 /// @brief WS2812B-Mini-V3 controller class.
 /// @copydetails WS2812BMiniV3Controller
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -514,6 +514,17 @@ template <int DATA_PIN, EOrder RGB_ORDER = GRB>
 class WS2812Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_WS2812_800KHZ, RGB_ORDER> {};
 #endif
 
+/// OptoSupply OSTW2020C1E controller @ 800 kHz.
+/// @details Uses the WS2812 pulse timing verified against the manufacturer's
+/// VER A.0 datasheet, with a 300us inter-frame wait to satisfy its >280us
+/// reset requirement.
+/// @see https://www.tme.eu/Document/bddfe2b10b24331bb9ab3894a93aba32/OSTW2020C1E.pdf
+template <int DATA_PIN, EOrder RGB_ORDER = GRB>
+class OSTW2020C1EController
+    : public fl::ClocklessControllerImpl<DATA_PIN,
+                                         fl::TIMING_WS2812_800KHZ,
+                                         RGB_ORDER, 0, false, 300> {};
+
 /// WS2812B-Mini-V3 controller @ 800 kHz - references centralized timing from fl::TIMING_WS2812B_MINI_V3
 /// @note Timing: 220ns, 360ns, 580ns (tighter timing specifications)
 /// @see fl::TIMING_WS2812B_MINI_V3 in fl::chipsets::led_timing.h (220, 360, 580 ns)

--- a/tests/fl/chipsets/timing_traits.cpp
+++ b/tests/fl/chipsets/timing_traits.cpp
@@ -260,6 +260,33 @@ FL_TEST_CASE("WS2818 timing stays inside the datasheet pulse envelope") {
                                   WS2818Controller<5, GRB>>::value));
 }
 
+FL_TEST_CASE("OSTW2020C1E uses the verified WS2812-compatible protocol") {
+    constexpr ChipsetTimingConfig timing =
+        makeTimingConfig<TIMING_WS2812_800KHZ>();
+
+    // OptoSupply VER A.0 specifies an 800 Kbps, GRB/MSB-first stream with
+    // T0H=220-380ns, T1H=580-1000ns, T0L=580-1600ns, T1L=220-420ns,
+    // and reset >280us. These are the actual pulses produced by this timing.
+    FL_CHECK_GE(timing.t1_ns, 220);
+    FL_CHECK_LE(timing.t1_ns, 380);
+    FL_CHECK_GE(timing.t1_ns + timing.t2_ns, 580);
+    FL_CHECK_LE(timing.t1_ns + timing.t2_ns, 1000);
+    FL_CHECK_GE(timing.t2_ns + timing.t3_ns, 580);
+    FL_CHECK_LE(timing.t2_ns + timing.t3_ns, 1600);
+    FL_CHECK_GE(timing.t3_ns, 220);
+    FL_CHECK_LE(timing.t3_ns, 420);
+
+    // The datasheet requires reset low for more than 280us, so the named
+    // controller rounds the inter-frame wait up instead of using WS2812's
+    // 280us default exactly.
+    using ExpectedBase = fl::ClocklessControllerImpl<
+        5, fl::TIMING_WS2812_800KHZ, GRB, 0, false, 300>;
+    FL_CHECK_TRUE((fl::is_base_of<ExpectedBase,
+                                  OSTW2020C1EController<5, GRB>>::value));
+    FL_CHECK_TRUE((fl::is_base_of<OSTW2020C1EController<5, GRB>,
+                                  OSTW2020C1E<5, GRB>>::value));
+}
+
 FL_TEST_CASE("LC8816E uses datasheet timing and fixed GRBW output") {
     constexpr ChipsetTimingConfig timing =
         makeTimingConfig<TIMING_LC8816E>();


### PR DESCRIPTION
Closes #1490

Validation: focused regression test and bash lint passed before the split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OptoSupply OSTW2020C1E RGB LEDs.
  - Supports the WS2812-compatible 800 Kbps GRB protocol with the chip’s required 300-microsecond reset interval.

- **Tests**
  - Added validation against the manufacturer’s timing specifications to ensure reliable LED communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->