### PR TITLE
feat(chipsets): add TM1908 support

### DIFF
--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -369,6 +369,13 @@ class TM1812 : public TM1809Controller800Khz<DATA_PIN, RGB_ORDER> {};
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
 class TM1809 : public TM1809Controller800Khz<DATA_PIN, RGB_ORDER> {};
 
+/// @brief TM1908 controller class.
+/// @details Emits the normal-mode and maximum-current commands required by
+/// the Titan Micro Electronics TM1908 V1.2 protocol before every RGB frame.
+/// @copydetails TM1908Controller
+template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>
+class TM1908 : public TM1908Controller<DATA_PIN, RGB_ORDER> {};
+
 /// @brief TM1804 controller class.
 /// @copydetails TM1809Controller800Khz
 template<fl::u8 DATA_PIN, fl::EOrder RGB_ORDER>

--- a/src/chipsets.h
+++ b/src/chipsets.h
@@ -459,6 +459,14 @@ using UCS7604Controller16bit1600 = fl::UCS7604Controller16bit1600T<DATA_PIN, RGB
 template <int DATA_PIN, EOrder RGB_ORDER = RGB>
 class TM1809Controller800Khz : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1809_800KHZ, RGB_ORDER> {};
 
+/// TM1908 controller @ 1.2 MHz with required mode/current command prefix.
+/// @see fl::TIMING_TM1908 in fl/chipsets/led_timing.h (240, 240, 350 ns)
+template <int DATA_PIN, EOrder RGB_ORDER = RGB>
+class TM1908Controller
+    : public fl::ClocklessControllerImpl<DATA_PIN, fl::TIMING_TM1908,
+                                         RGB_ORDER, 0, false,
+                                         fl::TIMING_TM1908::RESET> {};
+
 /// WS2811 controller @ 800kHz (fast mode)
 /// @see fl::TIMING_WS2811_800KHZ_LEGACY in fl/chipsets/led_timing.h (250, 350, 650 ns = 1250ns cycle = 800kHz)
 /// @note WS2811 supports both 400kHz and 800kHz modes (pins 7&8 configure speed)

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -524,6 +524,9 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             case ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW:
                 pixelIterator.writeTM1812RGBWW(&data);
                 break;
+            case ClocklessEncoder::CLOCKLESS_ENCODER_TM1908:
+                pixelIterator.writeTM1908(&data);
+                break;
 #if !defined(FASTLED_DISABLE_UCS7604) || !FASTLED_DISABLE_UCS7604
             // Gated by FASTLED_DISABLE_UCS7604 (#2920). For WS2812-only
             // sketches the UCS7604 case is dead at runtime, but each

--- a/src/fl/chipsets/clockless_encoder.h
+++ b/src/fl/chipsets/clockless_encoder.h
@@ -23,7 +23,8 @@ enum class ClocklessEncoder : u8 {
     CLOCKLESS_ENCODER_UCS7604_8BIT,         ///< UCS7604 8-bit 800KHz
     CLOCKLESS_ENCODER_UCS7604_16BIT,        ///< UCS7604 16-bit 800KHz
     CLOCKLESS_ENCODER_UCS7604_16BIT_1600,   ///< UCS7604 16-bit 1600KHz
-    CLOCKLESS_ENCODER_TM1812_RGBWW          ///< TM1812: two 5-byte RGBWW pixels in each 12-byte IC frame
+    CLOCKLESS_ENCODER_TM1812_RGBWW,         ///< TM1812: two 5-byte RGBWW pixels in each 12-byte IC frame
+    CLOCKLESS_ENCODER_TM1908                ///< TM1908: command prefix followed by RGB pixels
 };
 
 /// @brief SFINAE helpers for detecting a static ENCODER member on timing structs

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -15,6 +15,7 @@
 #include "fl/chipsets/encoders/ws2803.h"
 #include "fl/chipsets/encoders/ws2812.h"
 #include "fl/chipsets/encoders/tm1812.h"
+#include "fl/chipsets/encoders/tm1908.h"
 #include "fl/chipsets/encoders/apa102.h"
 #include "fl/chipsets/encoders/sk9822.h"
 #include "fl/chipsets/encoders/hd108.h"
@@ -222,6 +223,14 @@ class PixelIterator {
         auto back_ins = fl::back_inserter(*out);
         auto range = makeScaledPixelRangeRGBWW(this);
         encodeTM1812_RGBWW(range.first, range.second, back_ins);
+    }
+
+    /// @brief Encode RGB pixels with the required TM1908 command prefix.
+    template <typename CONTAINER_UIN8_T>
+    void writeTM1908(CONTAINER_UIN8_T* out) FL_NO_EXCEPT {
+        auto back_ins = fl::back_inserter(*out);
+        auto range = makeScaledPixelRangeRGB(this);
+        encodeTM1908(range.first, range.second, back_ins);
     }
 
     /// @brief Encode pixels in APA102/DOTSTAR format (zero allocation)

--- a/src/fl/chipsets/encoders/tm1908.h
+++ b/src/fl/chipsets/encoders/tm1908.h
@@ -1,0 +1,37 @@
+/// @file tm1908.h
+/// @brief TM1908 mode/current command prefix and RGB pixel encoder.
+
+#pragma once
+
+#include "fl/stl/noexcept.h"
+#include "fl/stl/stdint.h"
+
+namespace fl {
+
+/// @brief Encode one complete TM1908 frame.
+///
+/// TM1908 V1.2 requires every frame to begin with the 48-bit normal-mode
+/// command (0xFFFFFF followed by its inverse 0x000000), then a 24-bit current
+/// command. The maximum in-spec 25 mA setting is 0x7F for each channel; bit 7
+/// is reserved and must remain zero. Pixel PWM data follows in RGB wire order.
+template <typename InputIterator, typename OutputIterator>
+void encodeTM1908(InputIterator first, InputIterator last,
+                  OutputIterator out) FL_NO_EXCEPT {
+    const u8 prefix[] = {
+        0xff, 0xff, 0xff, 0x00, 0x00, 0x00, // normal-mode command
+        0x7f, 0x7f, 0x7f,                   // 25 mA R/G/B current
+    };
+    for (u8 byte : prefix) {
+        *out++ = byte;
+    }
+
+    while (first != last) {
+        const auto& pixel = *first;
+        *out++ = pixel[0];
+        *out++ = pixel[1];
+        *out++ = pixel[2];
+        ++first;
+    }
+}
+
+} // namespace fl

--- a/src/fl/chipsets/led_timing.h
+++ b/src/fl/chipsets/led_timing.h
@@ -299,6 +299,22 @@ struct TIMING_TM1809_800KHZ {
     };
 };
 
+/// TM1908 RGB controller @ 1.2 MHz.
+///
+/// Titan Micro Electronics TM1908 V1.2 typical values are T0H=240ns,
+/// T1H=480ns, bit period=830ns, and reset low >=80us.
+/// @see https://github.com/cheemsHe/LEDdatasheet/blob/main/TM1908_V1.2_EN.pdf
+struct TIMING_TM1908 {
+    enum : u32 {
+        T1 = 240,
+        T2 = 240,
+        T3 = 350,
+        RESET = 80
+    };
+    static constexpr ClocklessEncoder ENCODER =
+        ClocklessEncoder::CLOCKLESS_ENCODER_TM1908;
+};
+
 /// TM1812 RGBCCT controller @ 800 kHz (issue #995)
 ///
 /// Unlike the legacy RGB alias, this trait selects the TM1812 byte encoder:

--- a/tests/fl/chipsets/encoders.cpp
+++ b/tests/fl/chipsets/encoders.cpp
@@ -8,6 +8,7 @@
 #include "tests/fl/chipsets/encoders/sk9822.hpp"
 #include "tests/fl/chipsets/encoders/sm16716.hpp"
 #include "tests/fl/chipsets/encoders/tm1812.hpp"
+#include "tests/fl/chipsets/encoders/tm1908.hpp"
 #include "tests/fl/chipsets/encoders/ws2801.hpp"
 #include "tests/fl/chipsets/encoders/ws2803.hpp"
 #include "tests/fl/chipsets/encoders/ws2812.hpp"

--- a/tests/fl/chipsets/encoders/tm1908.hpp
+++ b/tests/fl/chipsets/encoders/tm1908.hpp
@@ -1,0 +1,52 @@
+/// @file tm1908.hpp
+/// @brief Unit tests for the TM1908 command-prefix encoder.
+
+#include "FastLED.h"
+#include "fl/channels/config.h"
+#include "fl/chipsets/encoders/tm1908.h"
+#include "fl/chipsets/led_timing.h"
+#include "fl/stl/array.h"
+#include "fl/stl/iterator.h"
+#include "fl/stl/vector.h"
+#include "test.h"
+
+using namespace fl;
+
+namespace test_tm1908 {
+
+FL_TEST_CASE("TM1908 - timing and encoder match the vendor protocol") {
+    FL_CHECK_EQ(TIMING_TM1908::T1, 240);
+    FL_CHECK_EQ(TIMING_TM1908::T2, 240);
+    FL_CHECK_EQ(TIMING_TM1908::T3, 350);
+    FL_CHECK_EQ(TIMING_TM1908::RESET, 80);
+    FL_CHECK(encoder_for<TIMING_TM1908>() ==
+             ClocklessEncoder::CLOCKLESS_ENCODER_TM1908);
+
+    const auto chipset = makeClockless<TIMING_TM1908>(3);
+    FL_CHECK(chipset.encoder == ClocklessEncoder::CLOCKLESS_ENCODER_TM1908);
+}
+
+FL_TEST_CASE("TM1908 - frame contains mode, current, then RGB data") {
+    fl::vector<fl::array<u8, 3>> pixels;
+    pixels.push_back({0x12, 0x34, 0x56});
+    pixels.push_back({0x78, 0x9a, 0xbc});
+    fl::vector<u8> output;
+
+    encodeTM1908(pixels.begin(), pixels.end(), fl::back_inserter(output));
+
+    const u8 expected[] = {
+        0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x7f, 0x7f, 0x7f,
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+    };
+    FL_REQUIRE_EQ(output.size(), static_cast<fl::size>(15));
+    for (fl::size i = 0; i < output.size(); ++i) {
+        FL_CHECK_EQ(output[i], expected[i]);
+    }
+}
+
+FL_TEST_CASE("TM1908 - public controller is available") {
+    TM1908<3, RGB> controller;
+    FL_CHECK(sizeof(controller) > 0);
+}
+
+} // namespace test_tm1908


### PR DESCRIPTION
Closes #1441

Validation: focused regression test and bash lint passed before the split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TM1908 RGB LED controllers.
  * Added TM1908-specific timing and signal encoding, including required mode and current commands before each RGB frame.
  * Added a public `TM1908` controller for configuring compatible LED strips.

* **Tests**
  * Added coverage for TM1908 timing, command prefixes, pixel encoding, and controller initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->