### PR TITLE
test(mp3): gate the CPU trend on simulated metrics, not timed ones (#4130)

### DIFF
--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -968,18 +968,28 @@ def _check_lower_bound(path: str, baseline: float, current: float) -> None:
         raise RuntimeError(f"{path} regressed: {current} < {limit:.6f}")
 
 
-def _report_drift(path: str, baseline: float, current: float) -> None:
+def _report_drift(
+    path: str, baseline: float, current: float, *, higher_is_worse: bool = True
+) -> None:
     """Record a measurement without gating on it.
 
     Loud rather than silent: a real slowdown still has to be visible to someone
     reading the log, it just does not fail the build on a number the runner pool
     moves by more than the budget on its own.
+
+    `higher_is_worse` picks which direction earns the marker. Cycles and stage
+    timings regress upwards; IPC regresses *downwards*, so flagging only
+    positive drift there would stay quiet on exactly the case worth seeing --
+    a 30% cycle increase shows up as roughly -23% IPC.
     """
     if baseline == 0:
         print(f"UNGATED:{path} baseline=0 current={current:.6g}")
         return
     drift = (current - baseline) / baseline * 100.0
-    marker = "  <-- worth a look" if drift > 100.0 * REGRESSION_TOLERANCE else ""
+    regression = drift if higher_is_worse else -drift
+    marker = (
+        "  <-- worth a look" if regression > 100.0 * REGRESSION_TOLERANCE else ""
+    )
     print(
         f"UNGATED:{path} baseline={baseline:.6g} current={current:.6g} "
         f"drift={drift:+.2f}%{marker}"
@@ -1028,6 +1038,7 @@ def _check_host_trend(
         f"{backend}/counter/ipc",
         baseline_host["counter_median"]["ipc"],
         current_host["counter_median"]["ipc"],
+        higher_is_worse=False,
     )
     for stage in STAGES:
         _report_drift(

--- a/ci/codec_cpu/audit.py
+++ b/ci/codec_cpu/audit.py
@@ -968,25 +968,69 @@ def _check_lower_bound(path: str, baseline: float, current: float) -> None:
         raise RuntimeError(f"{path} regressed: {current} < {limit:.6f}")
 
 
+def _report_drift(path: str, baseline: float, current: float) -> None:
+    """Record a measurement without gating on it.
+
+    Loud rather than silent: a real slowdown still has to be visible to someone
+    reading the log, it just does not fail the build on a number the runner pool
+    moves by more than the budget on its own.
+    """
+    if baseline == 0:
+        print(f"UNGATED:{path} baseline=0 current={current:.6g}")
+        return
+    drift = (current - baseline) / baseline * 100.0
+    marker = "  <-- worth a look" if drift > 100.0 * REGRESSION_TOLERANCE else ""
+    print(
+        f"UNGATED:{path} baseline={baseline:.6g} current={current:.6g} "
+        f"drift={drift:+.2f}%{marker}"
+    )
+
+
 def _check_host_trend(
     backend: str, baseline_host: dict[str, Any], current_host: dict[str, Any]
 ) -> None:
-    """The host-dependent half of the trend gate: cycle counters, per-stage
-    timings and Callgrind attribution. Split out of check_trend so a host with
-    no baseline for this backend can skip exactly this and nothing else."""
-    for metric in ("cycles", "instructions", "branch_misses"):
+    """The host-dependent half of the trend gate.
+
+    Split by whether the measurement is a property of the *code* or of the
+    *machine that ran it* (FastLED#4130).
+
+    Gated: instruction count, branch misses, and everything else Callgrind
+    reports. `validate_trend` requires `counter_median` instructions and branch
+    misses to *equal* the Callgrind figures, so despite living under a "counter"
+    key those are simulated, exact and reproducible -- not hardware counters.
+
+    Ungated: cycles, the IPC derived from them, and the per-stage wall-clock
+    timings. Those are the only genuinely host-measured quantities here, and
+    they are properties of the machine. The `ubuntu-24.04` pool moves cycles by
+    more than the 5% budget between runners reporting the same CPU model,
+    because the host key identifies a CPU family and not a contention
+    environment.
+
+    The evidence for splitting here rather than widening the budget: on the PR
+    that prompted this, the float decoder's Callgrind instruction count matched
+    its baseline to 767 out of 261,532,799 -- 0.0003% -- while cycles came in
+    6.7% high, on a change that could not touch the float build at all. Same
+    work, different machine. Widening the budget would only move the threshold
+    the noise has to cross.
+    """
+    for metric in ("instructions", "branch_misses"):
         _check_upper_bound(
             f"{backend}/counter/{metric}",
             baseline_host["counter_median"][metric],
             current_host["counter_median"][metric],
         )
-    _check_lower_bound(
+    _report_drift(
+        f"{backend}/counter/cycles",
+        baseline_host["counter_median"]["cycles"],
+        current_host["counter_median"]["cycles"],
+    )
+    _report_drift(
         f"{backend}/counter/ipc",
         baseline_host["counter_median"]["ipc"],
         current_host["counter_median"]["ipc"],
     )
     for stage in STAGES:
-        _check_upper_bound(
+        _report_drift(
             f"{backend}/stage/{stage}",
             baseline_host["stage_ns_median"][stage],
             current_host["stage_ns_median"][stage],
@@ -1026,7 +1070,24 @@ def check_trend(baseline: dict[str, Any], current: dict[str, Any]) -> None:
     if baseline.get("host_key") != current_host_key:
         alternate_profile = baseline.get("host_baselines", {}).get(current_host_key)
         if alternate_profile is None:
-            raise RuntimeError(f"host baseline is unknown: {current_host_key}")
+            # An unknown host used to fail closed. That made sense while cycles
+            # were gated, because a cycle count from an unrecognised machine is
+            # not comparable to anything. It does not any more: after
+            # FastLED#4130 every *gated* figure is deterministic -- the exact
+            # operation ledger, the cross-compiled codegen bounds, and the
+            # Callgrind numbers that `counter_median` instructions and branch
+            # misses are required to equal. None of those depend on which
+            # machine ran them, so the primary baseline applies to any host.
+            #
+            # This matters operationally: the ubuntu-24.04 pool has presented at
+            # least five CPU models (EPYC 9V74, 9V45, 7763; Xeon 8573C,
+            # 6973P-C), and every new one blocked unrelated PRs until somebody
+            # harvested a baseline for it.
+            print(
+                f"UNKNOWN-HOST:{current_host_key}: no recorded profile; gating "
+                "on the primary baseline, which is safe because every gated "
+                "metric is simulated rather than timed"
+            )
     for backend in BACKENDS:
         baseline_entry = baseline["backends"][backend]
         current_entry = current["backends"][backend]

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -252,13 +252,48 @@ def test_callgrind_parser_prefers_complete_totals(tmp_path: Path) -> None:
 
 
 def test_trend_gate_rejects_more_than_five_percent() -> None:
+    """Retired instruction count is a property of the code, so it is gated."""
     baseline = AUDIT.load_trend()
     current = json.loads(json.dumps(baseline))
     counters = current["backends"]["minimp3-float"]["host"]["counter_median"]
-    counters["cycles"] *= 1.051
+    host = current["backends"]["minimp3-float"]["host"]
+    counters["instructions"] = int(counters["instructions"] * 1.051)
+    # perf and Callgrind instruction counts are cross-checked against each
+    # other, so both have to move or validation rejects the fixture first.
+    host["callgrind"]["instructions"] = int(host["callgrind"]["instructions"] * 1.051)
     counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
-    with pytest.raises(RuntimeError, match="minimp3-float/counter/cycles regressed"):
+    with pytest.raises(
+        RuntimeError, match="minimp3-float/counter/instructions regressed"
+    ):
         AUDIT.check_trend(baseline, current)
+
+
+def test_cycles_are_reported_but_do_not_fail_the_build(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cycles, the IPC derived from them, and per-stage wall-clock timings are
+    properties of the machine, not the code (FastLED#4130). Note that
+    `counter_median` instructions and branch misses are *not* in this set:
+    validate_trend requires them to equal the Callgrind figures, so they are
+    simulated and stay gated. Cycles are the only genuinely hardware-measured
+    quantity. The runner pool
+    moves them by more than the 5% budget between machines reporting the same
+    CPU model, which failed PRs that provably could not have caused it. They
+    are recorded loudly and no longer gated."""
+    baseline = AUDIT.load_trend()
+    current = json.loads(json.dumps(baseline))
+    counters = current["backends"]["minimp3-float"]["host"]["counter_median"]
+    counters["cycles"] = int(counters["cycles"] * 1.30)
+    counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
+    for stage in current["backends"]["minimp3-float"]["host"]["stage_ns_median"]:
+        current["backends"]["minimp3-float"]["host"]["stage_ns_median"][stage] *= 1.30
+
+    AUDIT.check_trend(baseline, current)  # a 30% swing must not raise
+
+    printed = capsys.readouterr().out
+    assert "UNGATED:minimp3-float/counter/cycles" in printed
+    assert "drift=+30.00%" in printed
+    assert "worth a look" in printed
 
 
 def test_trend_validation_rejects_inconsistent_derived_counters() -> None:
@@ -268,12 +303,37 @@ def test_trend_validation_rejects_inconsistent_derived_counters() -> None:
         AUDIT.validate_trend(trend)
 
 
-def test_trend_gate_fails_closed_on_unknown_host() -> None:
+def test_unknown_host_still_gates_the_deterministic_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown runner no longer fails closed (FastLED#4130).
+
+    It used to, and that was right while cycles were gated: a cycle count from
+    an unrecognised machine compares to nothing. After the demotion every gated
+    figure is simulated -- the operation ledger, the cross-compiled codegen
+    bounds, and the Callgrind numbers that counter_median is required to equal
+    -- so the primary baseline applies to any host. The ubuntu-24.04 pool has
+    presented at least five CPU models, and each new one used to block
+    unrelated PRs until someone harvested a baseline.
+
+    What must not happen is an unknown host silently gating nothing."""
     baseline = AUDIT.load_trend()
     current = json.loads(json.dumps(baseline))
-    current["environment"]["cpu_model"] = "different hosted runner"
+    current["environment"]["cpu_model"] = "some runner nobody has measured"
     current["host_key"] = AUDIT.environment_key(current["environment"])
-    with pytest.raises(RuntimeError, match="host baseline is unknown"):
+
+    AUDIT.check_trend(baseline, current)
+    assert "UNKNOWN-HOST:" in capsys.readouterr().out
+
+    # ...and the deterministic gate still fires on that same unknown host.
+    host = current["backends"]["minimp3-float"]["host"]
+    counters = host["counter_median"]
+    counters["instructions"] = int(counters["instructions"] * 1.051)
+    host["callgrind"]["instructions"] = int(host["callgrind"]["instructions"] * 1.051)
+    counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
+    with pytest.raises(
+        RuntimeError, match="minimp3-float/counter/instructions regressed"
+    ):
         AUDIT.check_trend(baseline, current)
 
 
@@ -302,9 +362,15 @@ def test_trend_gate_selects_known_host_baseline() -> None:
     }
     AUDIT.check_trend(baseline, current)
     counters = current["backends"]["minimp3-float"]["host"]["counter_median"]
-    counters["cycles"] *= 1.051
+    host = current["backends"]["minimp3-float"]["host"]
+    counters["instructions"] = int(counters["instructions"] * 1.051)
+    # perf and Callgrind instruction counts are cross-checked against each
+    # other, so both have to move or validation rejects the fixture first.
+    host["callgrind"]["instructions"] = int(host["callgrind"]["instructions"] * 1.051)
     counters["ipc"] = round(counters["instructions"] / counters["cycles"], 6)
-    with pytest.raises(RuntimeError, match="minimp3-float/counter/cycles regressed"):
+    with pytest.raises(
+        RuntimeError, match="minimp3-float/counter/instructions regressed"
+    ):
         AUDIT.check_trend(baseline, current)
 
 

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -295,6 +295,17 @@ def test_cycles_are_reported_but_do_not_fail_the_build(
     assert "drift=+30.00%" in printed
     assert "worth a look" in printed
 
+    # IPC regresses downwards, so the marker has to follow the metric's own
+    # direction. A 30% cycle increase is about -23% IPC, and flagging only
+    # positive drift would stay silent on exactly the case worth seeing.
+    ipc_line = next(
+        line
+        for line in printed.splitlines()
+        if line.startswith("UNGATED:minimp3-float/counter/ipc")
+    )
+    assert "drift=-23" in ipc_line
+    assert "worth a look" in ipc_line
+
 
 def test_trend_validation_rejects_inconsistent_derived_counters() -> None:
     trend = AUDIT.load_trend()


### PR DESCRIPTION
The audit gated `counter_median.cycles` at 5%, which is **tighter than the variance between machines in the `ubuntu-24.04` pool**. It failed #4128, whose only code change sits inside `#if MINIMP3_HAVE_FIXED_POINT` and so cannot touch the float build:

```
minimp3-float/counter/cycles regressed: 46509592.0 > 45758997.9
```

The same run's Callgrind figure matched its baseline to **767 instructions out of 261,532,799 — 0.0003%**.

| metric | baseline | that run | delta |
| --- | ---: | ---: | ---: |
| Callgrind instructions | 261,532,799 | 261,533,566 | **+0.0003%** |
| counter cycles | 43,580,950 | 46,509,592 | **+6.7%** |

Same work, different machine. Widening the budget only moves the threshold the noise has to cross.

## The split is by what the number measures

| | |
| --- | --- |
| **gated** | counter instructions, counter branch misses, every Callgrind figure, the exact operation ledger, the cross-compiled codegen bounds |
| **ungated** | cycles, the IPC derived from them, per-stage wall-clock timings |

`counter_median` instructions and branch misses stay gated *despite the name*: `validate_trend` requires them to **equal** the Callgrind figures, so they are simulated rather than sampled.

I had demoted branch misses too, assuming they were a hardware counter. The existing cross-check caught that and the demotion is narrowed to what is genuinely timed — cycles are the only hardware-measured quantity in there.

Ungated metrics print their drift and are flagged past the old budget, so a real slowdown stays visible to a human reading the log.

## Unknown hosts no longer fail closed

That behaviour was correct while cycles were gated — a cycle count from an unrecognised machine compares to nothing. It is wrong now that every gated figure is deterministic, so the primary baseline applies to any host.

Not hypothetical: the rerun of #4128's audit landed on `AMD EPYC 9V45`, a **sixth** CPU model, and failed closed for no reason connected to the change. The pool has presented EPYC 9V74, 9V45 and 7763, and Xeon 8573C and 6973P-C — each new machine blocked unrelated PRs until someone harvested a baseline.

An unknown host now prints `UNKNOWN-HOST:` and gates on the primary baseline. A test pins that it still *gates* — the failure mode to avoid is an unknown host silently checking nothing.

## Validation

1,115 Python tests. Two new tests pin both halves: a 30% cycles swing must not fail the build, and the deterministic gate must still fire on an unknown host.

This unblocks #4128, which is currently red on both host failure modes.

Closes #4130
Refs #4106, #4064, #4128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Performance trend checks now gate builds on deterministic instruction metrics.
  * Cycle counts and stage timing changes are reported without blocking builds.
  * IPC regressions are correctly identified when performance decreases.
  * Unknown hardware environments are reported clearly while deterministic metric checks continue to run.
  * Improved reporting distinguishes blocking regressions from non-blocking performance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->