### PR TITLE
perf(mp3): share Layer I/II scale info with the main-data window (#4116)

### DIFF
--- a/codec_memory_ledger.md
+++ b/codec_memory_ledger.md
@@ -32,9 +32,19 @@ gate actually uses.
 
 The fixed-point build costs 128 bytes more scratch than the float build --
 scalefactor gains are carried as mantissa plus exponent rather than as a
-single float -- and 3,021 more bytes of text. It uses *less* decode stack
-(1,920 against 2,032), because its polyphase back-end has no vector code paths
-to keep live.
+single float -- and 3,021 more bytes of text. It uses less decode stack than
+the float build (896 against 1,200), because its polyphase back-end has no
+vector code paths to keep live.
+
+Both figures dropped by about 1 KB in FastLED#4116, which moved
+`L12_scale_info` off the stack. Layer I/II scale info is ~1090 bytes in the
+fixed build and used to sit inside `mp3dec_decode_frame_r`, where it was almost
+the whole 1,480-byte frame; the fixed decoder was running at 94% of its 2 KiB
+budget, and the figure moved with the compiler's inlining decisions rather than
+with anything in the decoder. It now shares arena storage with Layer III's
+`maindata` through a union -- a frame is one layer or the other, never both --
+so `scratch` and `working-ram` do not move and the saving is free. The budget
+now sits at 44% for fixed and 59% for float.
 
 ## Summary
 
@@ -48,9 +58,9 @@ to keep live.
 | minimp3-float | working-ram | 23180 |
 | minimp3-float | pipeline-peak | 27788 |
 | minimp3-float | allocation-count | 4 |
-| minimp3-float | stack-max-frame | 1208 |
-| minimp3-float | stack-callgraph | 2032 |
-| minimp3-float | stack-watermark-observed | 2056 |
+| minimp3-float | stack-max-frame | 824 |
+| minimp3-float | stack-callgraph | 1200 |
+| minimp3-float | stack-watermark-observed | 1224 |
 | minimp3-float | static-tables | 7878 |
 | minimp3-float | object-text | 23160 |
 | minimp3-float | object-data | 0 |
@@ -64,8 +74,8 @@ to keep live.
 | minimp3-fixed | working-ram | 23308 |
 | minimp3-fixed | pipeline-peak | 27916 |
 | minimp3-fixed | allocation-count | 4 |
-| minimp3-fixed | stack-max-frame | 1480 |
-| minimp3-fixed | stack-callgraph | 1920 |
+| minimp3-fixed | stack-max-frame | 456 |
+| minimp3-fixed | stack-callgraph | 896 |
 | minimp3-fixed | static-tables | 8077 |
 | minimp3-fixed | object-text | 26181 |
 | minimp3-fixed | object-data | 0 |

--- a/src/third_party/minimp3/minimp3.h
+++ b/src/third_party/minimp3/minimp3.h
@@ -655,7 +655,26 @@ typedef struct
 typedef struct
 {
     bs_t bs;
-    uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
+    /* Layer III's main-data window and Layer I/II's scale info share storage:
+       a frame is one or the other, never both (FastLED#4116).
+
+       L12_scale_info is ~1090 bytes in the fixed-point build -- mantissa plus
+       exponent for 192 scalefactors -- and it used to sit on the stack inside
+       mp3dec_decode_frame_r, where it was almost the entire 1480-byte frame and
+       the difference between meeting the 2 KiB decode-stack budget and missing
+       it. Moving it to the heap arena would normally cost working RAM, of which
+       there were only 692 bytes spare against the 24 KiB budget. Overlapping it
+       with maindata costs nothing instead: maindata is at least 1951 bytes, so
+       the union sizes to maindata and MINIMP3_SCRATCH_SIZE does not move.
+
+       The exclusivity is structural, not incidental. maindata is written only
+       by L3_restore_reservoir and read only by the Layer III bitstream reader;
+       the Layer I/II path never touches it, and never runs in the same call. */
+    union
+    {
+        uint8_t maindata[MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES];
+        L12_scale_info l12;
+    } u;
     L3_gr_info_t gr_info[4];
     mp3d_dsp_t grbuf[2][576];
 #if MINIMP3_HAVE_FIXED_POINT
@@ -673,6 +692,12 @@ typedef struct
 #ifdef __cplusplus
 static_assert(sizeof(mp3dec_scratch_internal_t) <= MINIMP3_SCRATCH_SIZE,
               "MINIMP3_SCRATCH_SIZE is too small");
+/* The whole point of overlapping L12_scale_info with maindata is that it is
+   free. If L12_scale_info ever outgrows maindata the union starts costing
+   working RAM silently, which is exactly what this change exists to avoid. */
+static_assert(sizeof(L12_scale_info) <=
+                  MAX_BITRESERVOIR_BYTES + MAX_L3_FRAME_PAYLOAD_BYTES,
+              "L12_scale_info no longer fits inside maindata");
 static_assert(alignof(mp3dec_scratch_internal_t) <= alignof(mp3dec_scratch_t),
               "mp3dec_scratch_t alignment is too small");
 #endif
@@ -2130,7 +2155,7 @@ static void L3_save_reservoir(mp3dec_t *h, mp3dec_scratch_internal_t *s) FL_NO_E
     }
     if (remains > 0)
     {
-        memmove(h->reserv_buf, s->maindata + pos, remains);
+        memmove(h->reserv_buf, s->u.maindata + pos, remains);
     }
     h->reserv = remains;
 }
@@ -2139,9 +2164,9 @@ static int L3_restore_reservoir(mp3dec_t *h, bs_t *bs, mp3dec_scratch_internal_t
 {
     int frame_bytes = (bs->limit - bs->pos)/8;
     int bytes_have = MINIMP3_MIN(h->reserv, main_data_begin);
-    memcpy(s->maindata, h->reserv_buf + MINIMP3_MAX(0, h->reserv - main_data_begin), MINIMP3_MIN(h->reserv, main_data_begin));
-    memcpy(s->maindata + bytes_have, bs->buf + bs->pos/8, frame_bytes);
-    bs_init(&s->bs, s->maindata, bytes_have + frame_bytes);
+    memcpy(s->u.maindata, h->reserv_buf + MINIMP3_MAX(0, h->reserv - main_data_begin), MINIMP3_MIN(h->reserv, main_data_begin));
+    memcpy(s->u.maindata + bytes_have, bs->buf + bs->pos/8, frame_bytes);
+    bs_init(&s->bs, s->u.maindata, bytes_have + frame_bytes);
     return h->reserv >= main_data_begin;
 }
 
@@ -3458,7 +3483,8 @@ int mp3dec_decode_frame_r(mp3dec_t *dec, mp3dec_scratch_t *scratch_storage,
 #ifdef MINIMP3_ONLY_MP3
         return 0;
 #else /* MINIMP3_ONLY_MP3 */
-        L12_scale_info sci[1];
+        /* Aliases the arena rather than the stack; see the union above. */
+        L12_scale_info *sci = &scratch->u.l12;
         L12_read_scale_info(hdr, bs_frame, sci);
 
         memset(scratch->grbuf[0], 0, 576*2*sizeof(mp3d_dsp_t));

--- a/tests/fl/codec/mp3.hpp
+++ b/tests/fl/codec/mp3.hpp
@@ -348,6 +348,70 @@ FL_TEST_CASE("minimp3 Layer I synthesis matches its reference vector") {
     FL_CHECK_GT(reportPsnr(reference, decoded.mPcm), 60.0);
 }
 
+FL_TEST_CASE("minimp3 Layer I and Layer III do not collide in shared scratch") {
+    // FastLED#4116 overlaps Layer I/II's L12_scale_info with Layer III's
+    // maindata window in a union, on the grounds that a frame is one layer or
+    // the other and never both. The static_assert beside the union checks that
+    // L12_scale_info still fits. Nothing checked the other half of the claim --
+    // that the two are really never live at once -- and that is the half whose
+    // failure would be silent: the sizes would still be fine and only the audio
+    // would be wrong.
+    //
+    // Decoding both layers through one decoder, and so one scratch arena, is
+    // what exercises it. Each stream must come out bit-identical to decoding it
+    // on a decoder that has seen nothing else.
+    fl::setTestFileSystemRoot("tests/data");
+    const fl::vector<fl::u8> layer1 =
+        loadMp3CorpusFile("codec/minimp3/ILL2_layer1.bit");
+    const fl::vector<fl::u8> layer3 =
+        loadMp3CorpusFile("codec/minimp3/l3-hecommon.bit");
+
+    const Mp3DecodeResult alone1 = decodeMp3Corpus<Mp3Minimp3Decoder>(layer1);
+    const Mp3DecodeResult alone3 = decodeMp3Corpus<Mp3Minimp3Decoder>(layer3);
+    FL_REQUIRE_GT(alone1.mPcm.size(), 0u);
+    FL_REQUIRE_GT(alone3.mPcm.size(), 0u);
+    FL_REQUIRE_EQ(alone1.mMetadata[0].mLayer, 1);
+    FL_REQUIRE_EQ(alone3.mMetadata[0].mLayer, 3);
+
+    // Both orders: Layer III leaves the reservoir populated, so III-then-I is
+    // the direction where stale maindata could reach the scale info, and
+    // I-then-III the direction where scale info could survive into maindata.
+    for (int order = 0; order < 2; ++order) {
+        Mp3Minimp3Decoder decoder;
+        FL_REQUIRE(decoder.init());
+
+        const fl::vector<fl::u8>& first = order == 0 ? layer1 : layer3;
+        const fl::vector<fl::u8>& second = order == 0 ? layer3 : layer1;
+        const Mp3DecodeResult& expect_first = order == 0 ? alone1 : alone3;
+        const Mp3DecodeResult& expect_second = order == 0 ? alone3 : alone1;
+
+        fl::vector<fl::i16> got_first;
+        decoder.decode(first.data(), first.size(), [&](const Mp3Frame& frame) {
+            const int n = frame.samples * frame.channels;
+            for (int i = 0; i < n; ++i) {
+                got_first.push_back(frame.pcm[i]);
+            }
+        });
+        fl::vector<fl::i16> got_second;
+        decoder.decode(second.data(), second.size(),
+                       [&](const Mp3Frame& frame) {
+            const int n = frame.samples * frame.channels;
+            for (int i = 0; i < n; ++i) {
+                got_second.push_back(frame.pcm[i]);
+            }
+        });
+
+        FL_REQUIRE_EQ(got_first.size(), expect_first.mPcm.size());
+        FL_REQUIRE_EQ(got_second.size(), expect_second.mPcm.size());
+        for (fl::size i = 0; i < got_first.size(); ++i) {
+            FL_REQUIRE_EQ(got_first[i], expect_first.mPcm[i]);
+        }
+        for (fl::size i = 0; i < got_second.size(); ++i) {
+            FL_REQUIRE_EQ(got_second[i], expect_second.mPcm[i]);
+        }
+    }
+}
+
 FL_TEST_CASE("MP3 decoder resyncs past garbage and survives truncation") {
     fl::setTestFileSystemRoot("tests/data");
     const fl::vector<fl::u8> bitstream =


### PR DESCRIPTION
Closes #4116.

The fixed-point decoder was using **1,480 bytes of stack** in `mp3dec_decode_frame_r` against a 2 KiB budget — 94% — and almost all of it was one local. `L12_scale_info` carries mantissa plus exponent for 192 scalefactors in the fixed build, about 1090 bytes, and it sat on the stack. At 94% the figure moved with the compiler's inlining decisions rather than with anything in the decoder, which is not a margin worth defending.

Moving it to the heap arena would normally cost working RAM, and there were only 692 bytes spare against the 24 KiB budget. Overlapping it with Layer III's `maindata` costs nothing instead: a frame is one layer or the other, never both, and `maindata` is at least 1951 bytes, so the union sizes to `maindata` and `MINIMP3_SCRATCH_SIZE` does not move.

| metric | before | after | |
|---|---|---|---|
| fixed decode stack | 1,920 | **896** | 44% of budget, was 94% |
| float decode stack | 2,032 | **1,200** | 59% of budget |
| fixed max frame | 1,480 | 456 | |
| float max frame | 1,208 | 824 | |
| scratch / working-ram / pipeline-peak | — | unchanged | the saving is free |

## Guarding the claim

A `static_assert` checks `L12_scale_info` still fits inside `maindata`, so the union cannot start costing working RAM silently. That covers the sizes — and says nothing about the half whose failure would be quiet, which is whether the two members are really never live at once. There the sizes stay correct and only the audio goes wrong.

So the new test decodes Layer I and Layer III through one decoder, and so one arena, **in both orders**, and requires each stream to come out bit-identical to decoding it alone. Mutation-checked two ways:

- Calling `L3_save_reservoir` on the Layer I/II path — which would read `maindata` while it holds scale info — **segfaults**.
- Leaving a single stale byte in the reservoir window fails **exactly one assertion in the whole codec suite**, this test's. A standalone decode reads zero-initialised scratch there; an interleaved one reads leftover Layer I/II data.

That second one is the hazard the union introduces, and nothing else in the suite sees it.

## Verification

- 288/288 unit tests, 1116 Python tests
- Conformance 69 passed / 0 failed, with all 19 Layer I/II vectors at 104–122 dB
- `LEDGER:PASS` on the memory audit

## Note on the linter

`cpp_linting` is currently failing on `master` itself — 11 files, none of them mp3 (asset, spi adapter, ble, flexio, teensy4 mocks, string_search_b). I confirmed the identical set on a clean `master` checkout, so it is pre-existing and not from this branch. Flagging rather than folding an unrelated 11-file cleanup into a memory PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByD5ZKrnFJuchjRmPiQdd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced MP3 decoder stack usage, lowering memory pressure for both fixed-point and floating-point builds.
  * Moved temporary decoding data into shared scratch storage while preserving decoding behavior.

* **Bug Fixes**
  * Prevented Layer I and Layer III decoding data from interfering when streams are decoded sequentially using the same decoder.

* **Tests**
  * Added coverage confirming identical PCM output across decoding orders and isolated decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->