### PR TITLE
fix(lint): restore a green cpp_linting on master

### DIFF
--- a/src/fl/stl/thread_local.h
+++ b/src/fl/stl/thread_local.h
@@ -40,7 +40,8 @@ template <typename T> class ThreadLocalReal {
 
     // With default: each thread's object is copy-constructed from defaultVal
     template <typename U>
-    explicit ThreadLocalReal(const U &defaultVal) : mDefaultValue(defaultVal), mHasDefault(true) {
+    explicit ThreadLocalReal(const U &defaultVal) FL_NO_EXCEPT
+        : mDefaultValue(defaultVal), mHasDefault(true) {
         initializeKey();
     }
 
@@ -75,7 +76,7 @@ template <typename T> class ThreadLocalReal {
     }
 
     // Access the thread-local instance
-    T &access() {
+    T &access() FL_NO_EXCEPT {
         ThreadStorage* storage = getStorage();
         if (!storage) {
             storage = createStorage();
@@ -87,7 +88,7 @@ template <typename T> class ThreadLocalReal {
         return storage->value;
     }
 
-    const T &access() const {
+    const T &access() const FL_NO_EXCEPT {
         ThreadStorage* storage = getStorage();
         if (!storage) {
             storage = createStorage();
@@ -100,13 +101,13 @@ template <typename T> class ThreadLocalReal {
     }
 
     // Set the value for this thread
-    void set(const T& value) {
+    void set(const T& value) FL_NO_EXCEPT {
         copyValue(access(), value);
     }
 
     // Convenience operators
-    operator T &() { return access(); }
-    operator const T &() const { return access(); }
+    operator T &() FL_NO_EXCEPT { return access(); }
+    operator const T &() const FL_NO_EXCEPT { return access(); }
 
     ThreadLocalReal &operator=(const T &v) FL_NO_EXCEPT {
         set(v);
@@ -116,13 +117,13 @@ template <typename T> class ThreadLocalReal {
   private:
     // Helper function to copy values, specialized for arrays
     template<typename U>
-    static void copyValue(U& dest, const U& src) {
+    static void copyValue(U& dest, const U& src) FL_NO_EXCEPT {
         dest = src;  // Default behavior for non-array types
     }
 
     // Specialization for array types
     template<typename U, size_t N>
-    static void copyValue(U (&dest)[N], const U (&src)[N]) {
+    static void copyValue(U (&dest)[N], const U (&src)[N]) FL_NO_EXCEPT {
         for (size_t i = 0; i < N; ++i) {
             copyValue(dest[i], src[i]);  // Recursively handle nested arrays
         }
@@ -141,7 +142,7 @@ template <typename T> class ThreadLocalReal {
     bool mHasDefault = false;
 
     // Initialize the pthread key
-    void initializeKey() {
+    void initializeKey() FL_NO_EXCEPT {
         int result = pthread_key_create(&mKey, cleanupThreadStorage);
         if (result == 0) {
             mKeyInitialized = true;
@@ -152,7 +153,7 @@ template <typename T> class ThreadLocalReal {
     }
 
     // Get thread-specific storage
-    ThreadStorage* getStorage() const {
+    ThreadStorage* getStorage() const FL_NO_EXCEPT {
         if (!mKeyInitialized) {
             return nullptr;
         }
@@ -160,7 +161,7 @@ template <typename T> class ThreadLocalReal {
     }
 
     // Create thread-specific storage
-    ThreadStorage* createStorage() const {
+    ThreadStorage* createStorage() const FL_NO_EXCEPT {
         if (!mKeyInitialized) {
             return nullptr;
         }
@@ -175,7 +176,7 @@ template <typename T> class ThreadLocalReal {
     }
 
     // Cleanup function called when thread exits
-    static void cleanupThreadStorage(void* data) {
+    static void cleanupThreadStorage(void* data) FL_NO_EXCEPT {
         if (data) {
             delete static_cast<ThreadStorage*>(data);  // ok bare allocation
         }

--- a/src/platforms/shared/atomic.h
+++ b/src/platforms/shared/atomic.h
@@ -29,8 +29,8 @@ enum memory_order { // ok plain enum
 template <typename T>
 class AtomicReal {
 public:
-    AtomicReal() : mValue{} {}
-    explicit AtomicReal(T value) : mValue(value) {}
+    AtomicReal() FL_NO_EXCEPT : mValue{} {}
+    explicit AtomicReal(T value) FL_NO_EXCEPT : mValue(value) {}
 
     // Non-copyable and non-movable (matches std::atomic behavior)
     AtomicReal(const AtomicReal&) = delete;
@@ -57,24 +57,24 @@ public:
 
     // Pre-increment: ++atomic
     // Returns the NEW value after increment
-    T operator++() {
+    T operator++() FL_NO_EXCEPT {
         return __atomic_add_fetch(&mValue, 1, __ATOMIC_ACQ_REL);
     }
 
     // Pre-decrement: --atomic
     // Returns the NEW value after decrement
-    T operator--() {
+    T operator--() FL_NO_EXCEPT {
         return __atomic_sub_fetch(&mValue, 1, __ATOMIC_ACQ_REL);
     }
 
     // Assignment operator
-    T operator=(T value) {
+    T operator=(T value) FL_NO_EXCEPT {
         store(value);
         return value;
     }
 
     // Conversion operator - returns current value
-    operator T() const {
+    operator T() const FL_NO_EXCEPT {
         return load();
     }
 

--- a/src/platforms/stub/thread_stub_stl.h
+++ b/src/platforms/stub/thread_stub_stl.h
@@ -29,8 +29,12 @@
 // FASTLED_MULTITHREADED is defined by fl/stl/thread_config.h
 // This file provides the STL-based thread implementation for multithreaded platforms
 
-// Forward declare fl::yield() for this_thread::yield() (which calls it on main thread)
-namespace fl { void yield(); }
+// fl::yield() for this_thread::yield() (which calls it on the main thread).
+// Included rather than forward-declared: a local copy of the declaration has to
+// be kept in step with fl/system/yield.h by hand, and the day FL_NO_EXCEPT stops
+// being a no-op a stale copy becomes a mismatched exception specification --
+// a compile error at the point of use, far from the duplicate that caused it.
+#include "fl/system/yield.h"
 
 namespace fl {
 namespace platforms {


### PR DESCRIPTION
`bash lint` fails on a clean checkout of `master`, which quietly trains everyone to skip it or pass `--skip-lint`.

All **19 hard failures came from one checker**, `NoexceptAstChecker`, across three files.

## The 35 other findings are not the problem

```
[ContainerElementAddressChecker]   7 violation(s)  (warn-only — not failing CI)
[SingletonElisionChecker]         28 violation(s)  (warn-only — not failing CI)
❌ Total violations: 19
```

Worth stating explicitly, because the file list at the top of the output makes those 35 look like the failure — 11 files spanning asset, spi adapter, BLE, FlexIO, Teensy4 mocks. They fail nothing.

Acting on them would have meant rewriting **ISR-shared DMA state** in two Teensy FlexIO drivers into `fl::Singleton<T>` — a lazy-initialized indirection reachable from an interrupt handler. That code's own comments document an IMPRECISERR data bus fault from a freed channel pointer (#3410) and a posted-store race needing an explicit `dsb` (#3416). `flexio_dma_isr` reads `sDmaChannel` and writes `sDmaComplete`; a singleton there could be constructed *from interrupt context*.

The checker's message sanctions exactly that case via `FL_LINT_ALLOW_GLOBAL`. Nothing here needs it today, so **nothing is annotated** — that judgement belongs to whoever owns those drivers, not to a lint-cleanup PR.

## What actually changed

**`fl/stl/thread_local.h`** (12) and **`platforms/shared/atomic.h`** (6) already marked most members `FL_NO_EXCEPT` — `ThreadLocalReal`'s constructor, destructor and `operator=`; `AtomicReal`'s `load`, `store`, `exchange` — and simply missed the rest. `FL_NO_EXCEPT` is a **no-op on every platform by design** (`fl/stl/noexcept.h`), so these are annotations with no semantic effect and no terminate-on-throw risk on the allocating paths.

**`platforms/stub/thread_stub_stl.h`** carried its own `namespace fl { void yield(); }`, duplicating `fl/system/yield.h`. Annotating a second copy of a declaration is the wrong repair: the copies then have to be kept in step by hand, and the day `FL_NO_EXCEPT` stops being a no-op a stale one becomes a mismatched exception specification — a compile error at the point of use, far from the duplicate that caused it. The duplicate is gone; the canonical header is included instead.

## Verification

- `cpp_linting` exits **0**
- **288/288** unit tests — and again from a **clean rebuild**, since swapping a forward declaration for a real include can only fail on include order
- **esp32c6 Blink** builds (422 KB flash, 22.2 KB RAM); `atomic.h` is shared platform code, so a host-only pass would not have covered it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByD5ZKrnFJuchjRmPiQdd5