### PR TITLE
fix(ci): cap running-process below 4.10.10 to unbreak every CI job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,7 +321,12 @@ dependencies = [
     "ffmpeg-python>=0.2.0",
     "static-ffmpeg>=2.7",
     "fastled>=2.0.9",
-    "running-process>=4.0.0",
+    # Cap below 4.10.10: that release regressed its wheel tags from
+    # `cp310-abi3` (installable on 3.10+) to `cp311-cp311` (3.11 only), so
+    # every CI job on CPython 3.12 falls back to the sdist, and the sdist
+    # build fails because soldr refuses an unpinned Rust toolchain. Lift the
+    # cap once running-process publishes abi3 wheels again.
+    "running-process>=4.0.0,<4.10.10",
     "nodejs-wheel>=22.0.0",
     "daemoniker>=0.2.3",
     "colorama>=0.4.6",


### PR DESCRIPTION
All CI on all branches is currently red at the `uv sync` step. This pins around the cause.

## Root cause

`running-process` 4.10.10 regressed its wheel tags. Compare the published artifacts:

| version | wheel tags |
|---|---|
| 4.10.9 | `cp310-abi3-{macosx,manylinux_2_28,win}-*` — installable on CPython 3.10+ |
| 4.10.10 | `cp311-cp311-{macosx,manylinux_2_28,win}-*` — CPython 3.11 **only** |

CI runs CPython 3.12.3 (`Using CPython 3.12.3 interpreter at: /usr/bin/python3`), so no 4.10.10 wheel matches and uv falls back to building the sdist. That build cannot succeed on the runner:

```
× Failed to build `running-process==4.10.10`
├─▶ The build backend returned an error
╰─▶ Call to `soldr.build_wheel` failed (exit status: 1)
      RUSTUP_TOOLCHAIN=<channel>
      - or explicitly opt out: SOLDR_ALLOW_UNPINNED=1
    💥 maturin failed
```

soldr refuses an unpinned Rust toolchain in the CI image, so there is no source-build path.

## Blast radius

`uv sync` is a step in every workflow, so this is not confined to one job. Master's last green run was `2026-09-02T09:52`, before 4.10.10 was published; everything after fails. It is also what is currently blocking #4123.

## Fix

`"running-process>=4.0.0"` → `"running-process>=4.0.0,<4.10.10"`, with a comment recording why and when to lift it.

`<4.10.10` rather than `!=4.10.10` deliberately: the defect is in the upstream release pipeline's wheel tagging, not in one bad artifact, so a 4.10.11 cut from the same pipeline would silently re-break master. The cap fails closed.

## Verification

`uv lock` resolves cleanly with the cap and selects 4.10.9:

```
Resolved 172 packages in 508ms
name = "running-process"
version = "4.10.9"
```

`uv sync` then completes (`Checked 140 packages`). Nothing in the tree requires `>=4.10.10`, so the cap is satisfiable.

## Upstream

`running-process` is maintained in this org's own orbit (zackees/running-process) — the real fix is republishing abi3 wheels there, at which point this cap should be lifted. Filing that is left to a maintainer rather than done unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issues affecting CPython 3.12 environments by preventing installation of an incompatible dependency version.
  * Improved reliability of package installation and continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->