### PR TITLE
fix(ci): name and retry zccache exit-113 daemon failures

### DIFF
--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -203,6 +203,21 @@ def _precompile_passes_can_be_skipped(build_dir: Path) -> bool:
     return abs(current - saved) < 1e-6
 
 
+@dataclass(slots=True)
+class _RetryOutcome:
+    """Result of ``_retry_ninja``.
+
+    ``output`` accumulates every attempt so downstream diagnostics keep the
+    full context; ``latest`` is the output of the last attempt alone so a
+    subsequent classifier is not confused by failures that an earlier
+    attempt already recovered from.
+    """
+
+    returncode: int
+    output: str
+    latest: str
+
+
 def _retry_ninja(
     cmd: list[str],
     output: str,
@@ -215,7 +230,7 @@ def _retry_ninja(
     timeout: int,
     env: dict[str, str] | None,
     output_formatter: TimestampFormatter | None,
-) -> tuple[int, str]:
+) -> _RetryOutcome:
     """Re-invoke the same ninja command while a transient failure persists.
 
     Shared by the ld.lld permission-denied retry (#2268) and the zccache
@@ -224,8 +239,7 @@ def _retry_ninja(
     stops the loop instead of being replayed. ``describe`` receives that
     latest output and the 1-based attempt number.
 
-    Returns the final ``(returncode, output)``; ``output`` accumulates every
-    attempt so downstream diagnostics keep the full context.
+    See ``_RetryOutcome`` for what is returned.
     """
     returncode = -1
     latest = output
@@ -269,7 +283,7 @@ def _retry_ninja(
         # and fall through to normal error handling.
         if not still_transient(latest):
             break
-    return returncode, output
+    return _RetryOutcome(returncode, output, latest)
 
 
 def compile_meson(
@@ -737,7 +751,8 @@ def compile_meson(
         # invocation a few times with a short backoff. This is a no-op on
         # non-Windows platforms because ``is_link_permission_denied_error``
         # returns False off-Windows.
-        if returncode != 0 and is_link_permission_denied_error(output):
+        latest_output = output
+        if returncode != 0 and is_link_permission_denied_error(latest_output):
 
             def _describe_lld(_latest: str, attempt: int) -> str:
                 return (
@@ -754,7 +769,7 @@ def compile_meson(
                         file=sys.stderr,
                     )
 
-            returncode, output = _retry_ninja(
+            _outcome = _retry_ninja(
                 cmd,
                 output,
                 max_retries=_LLD_PERM_DENIED_MAX_RETRIES,
@@ -767,13 +782,16 @@ def compile_meson(
                 env=None,
                 output_formatter=TimestampFormatter(),
             )
+            returncode = _outcome.returncode
+            output = _outcome.output
+            latest_output = _outcome.latest
 
         # zccache exit-113 retry (#4132).
         # zccache under load sometimes returns 113 without running the
         # compiler. That is a daemon problem, not a defect in the code being
         # built, so name it as such and re-invoke ninja: only the failed
         # objects rebuild, and the daemon has had a moment to drain.
-        if returncode != 0 and is_zccache_transient_failure(output):
+        if returncode != 0 and is_zccache_transient_failure(latest_output):
 
             def _describe_zccache(latest: str, attempt: int) -> str:
                 return (
@@ -784,7 +802,7 @@ def compile_meson(
                     f"(attempt {attempt}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})"
                 )
 
-            returncode, output = _retry_ninja(
+            _outcome = _retry_ninja(
                 cmd,
                 output,
                 max_retries=_ZCCACHE_TRANSIENT_MAX_RETRIES,
@@ -797,6 +815,9 @@ def compile_meson(
                 env=None,
                 output_formatter=TimestampFormatter(),
             )
+            returncode = _outcome.returncode
+            output = _outcome.output
+            latest_output = _outcome.latest
 
         if returncode != 0:
             # In quiet mode, don't print failure messages (fallback retries handle this)

--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -203,6 +203,71 @@ def _precompile_passes_can_be_skipped(build_dir: Path) -> bool:
     return abs(current - saved) < 1e-6
 
 
+def _retry_ninja(
+    cmd: list[str],
+    output: str,
+    max_retries: int,
+    backoff_seconds: float,
+    still_transient: Callable[[str], bool],
+    describe: Callable[[str, int], str],
+    before_retry: Callable[[], None] | None,
+    label: str,
+) -> tuple[int, str]:
+    """Re-invoke the same ninja command while a transient failure persists.
+
+    Shared by the ld.lld permission-denied retry (#2268) and the zccache
+    exit-113 retry (#4132). ``still_transient`` is evaluated on the output
+    of the *latest* attempt only, so a real defect that surfaces on a retry
+    stops the loop instead of being replayed. ``describe`` receives that
+    latest output and the 1-based attempt number.
+
+    Returns the final ``(returncode, output)``; ``output`` accumulates every
+    attempt so downstream diagnostics keep the full context.
+    """
+    returncode = -1
+    latest = output
+    for _attempt in range(max_retries):
+        _ts_print(f"[MESON] ⚠️  {describe(latest, _attempt + 1)}", file=sys.stderr)
+        if before_retry is not None:
+            before_retry()
+        # Linear backoff: gives the daemon / OS / AV time to settle.
+        time.sleep(backoff_seconds * (_attempt + 1))
+        try:
+            retry_proc = RunningProcess(
+                cmd,
+                timeout=600,
+                auto_run=True,
+                check=False,
+                output_formatter=TimestampFormatter(),
+            )
+            retry_proc.wait(echo=False)
+            returncode = cast(int, retry_proc.returncode)
+            latest = str(retry_proc.stdout)
+            output = output + "\n" + latest
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception as retry_error:
+            _ts_print(
+                f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
+                file=sys.stderr,
+            )
+            break
+
+        if returncode == 0:
+            _ts_print(
+                f"[MESON] ✅ {label} retry succeeded on attempt {_attempt + 1}",
+                file=sys.stderr,
+            )
+            break
+
+        # A different failure means a real defect surfaced — stop retrying
+        # and fall through to normal error handling.
+        if not still_transient(latest):
+            break
+    return returncode, output
+
+
 def compile_meson(
     build_dir: Path,
     target: Optional[str] = None,
@@ -669,62 +734,32 @@ def compile_meson(
         # non-Windows platforms because ``is_link_permission_denied_error``
         # returns False off-Windows.
         if returncode != 0 and is_link_permission_denied_error(output):
-            for _attempt in range(_LLD_PERM_DENIED_MAX_RETRIES):
-                _ts_print(
-                    f"[MESON] ⚠️  ld.lld permission denied on runner binary "
-                    f"(attempt {_attempt + 1}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
-                    f"killing stale runner processes and retrying",
-                    file=sys.stderr,
+
+            def _describe_lld(_latest: str, attempt: int) -> str:
+                return (
+                    f"ld.lld permission denied on runner binary "
+                    f"(attempt {attempt}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
+                    f"killing stale runner processes and retrying"
                 )
+
+            def _before_lld_retry() -> None:
                 _killed_retry = kill_stale_runner_processes(build_dir)
                 if _killed_retry:
                     _ts_print(
                         f"[MESON] 🧹 Killed {_killed_retry} stale runner process(es)",
                         file=sys.stderr,
                     )
-                # Backoff 0.5s, 1.0s, 1.5s — gives Windows/AV time to release
-                # any remaining handles on the .exe.
-                time.sleep(0.5 * (_attempt + 1))
 
-                # Re-invoke ninja for the same compile command. We reuse the
-                # original ``cmd`` (meson compile -C build_dir [target]) so
-                # ninja does an incremental relink of just the failed target.
-                try:
-                    retry_proc = RunningProcess(
-                        cmd,
-                        timeout=600,
-                        auto_run=True,
-                        check=False,
-                        output_formatter=TimestampFormatter(),
-                    )
-                    retry_proc.wait(echo=False)
-                    returncode = cast(int, retry_proc.returncode)
-                    retry_output = str(retry_proc.stdout)
-                    # Merge retry output into the captured output so downstream
-                    # diagnostics include the retry context.
-                    output = output + "\n" + retry_output
-                except KeyboardInterrupt as ki:
-                    handle_keyboard_interrupt(ki)
-                    raise
-                except Exception as retry_error:
-                    _ts_print(
-                        f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
-                        file=sys.stderr,
-                    )
-                    break
-
-                if returncode == 0:
-                    _ts_print(
-                        f"[MESON] ✅ Link retry succeeded on attempt {_attempt + 1}",
-                        file=sys.stderr,
-                    )
-                    break
-
-                # Only keep retrying while the failure is still the same
-                # permission-denied pattern. A different failure means the
-                # retry loop is done (fall through to normal error handling).
-                if not is_link_permission_denied_error(retry_output):
-                    break
+            returncode, output = _retry_ninja(
+                cmd,
+                output,
+                max_retries=_LLD_PERM_DENIED_MAX_RETRIES,
+                backoff_seconds=0.5,
+                still_transient=is_link_permission_denied_error,
+                describe=_describe_lld,
+                before_retry=_before_lld_retry,
+                label="Link",
+            )
 
         # zccache exit-113 retry (#4132).
         # zccache under load sometimes returns 113 without running the
@@ -732,53 +767,26 @@ def compile_meson(
         # built, so name it as such and re-invoke ninja: only the failed
         # objects rebuild, and the daemon has had a moment to drain.
         if returncode != 0 and is_zccache_transient_failure(output):
-            for _attempt in range(_ZCCACHE_TRANSIENT_MAX_RETRIES):
-                _ts_print(
-                    "[MESON] ⚠️  "
-                    + format_zccache_transient_message(
-                        find_zccache_transient_failures(output)
-                    ),
-                    file=sys.stderr,
-                )
-                _ts_print(
-                    f"[MESON] 🔁 Retrying the build "
-                    f"(attempt {_attempt + 1}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})",
-                    file=sys.stderr,
-                )
-                time.sleep(2.0 * (_attempt + 1))
-                try:
-                    retry_proc = RunningProcess(
-                        cmd,
-                        timeout=600,
-                        auto_run=True,
-                        check=False,
-                        output_formatter=TimestampFormatter(),
-                    )
-                    retry_proc.wait(echo=False)
-                    returncode = cast(int, retry_proc.returncode)
-                    retry_output = str(retry_proc.stdout)
-                    output = output + "\n" + retry_output
-                except KeyboardInterrupt as ki:
-                    handle_keyboard_interrupt(ki)
-                    raise
-                except Exception as retry_error:
-                    _ts_print(
-                        f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
-                        file=sys.stderr,
-                    )
-                    break
 
-                if returncode == 0:
-                    _ts_print(
-                        f"[MESON] ✅ zccache retry succeeded on attempt {_attempt + 1}",
-                        file=sys.stderr,
+            def _describe_zccache(latest: str, attempt: int) -> str:
+                return (
+                    format_zccache_transient_message(
+                        find_zccache_transient_failures(latest)
                     )
-                    break
+                    + f"\n  Retrying the build "
+                    f"(attempt {attempt}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})"
+                )
 
-                # A different failure means a real defect surfaced — stop
-                # retrying and fall through to normal error handling.
-                if not is_zccache_transient_failure(retry_output):
-                    break
+            returncode, output = _retry_ninja(
+                cmd,
+                output,
+                max_retries=_ZCCACHE_TRANSIENT_MAX_RETRIES,
+                backoff_seconds=2.0,
+                still_transient=is_zccache_transient_failure,
+                describe=_describe_zccache,
+                before_retry=None,
+                label="zccache",
+            )
 
         if returncode != 0:
             # In quiet mode, don't print failure messages (fallback retries handle this)

--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -22,6 +22,11 @@ from ci.meson.link_retry import (
     kill_stale_runner_processes,
 )
 from ci.meson.output import print_banner
+from ci.meson.zccache_retry import (
+    find_zccache_transient_failures,
+    format_zccache_transient_message,
+    is_zccache_transient_failure,
+)
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.output_formatter import TimestampFormatter
 from ci.util.tee import StreamTee
@@ -33,6 +38,11 @@ from ci.util.timestamp_print import ts_print as _ts_print
 # Each retry waits ``0.5 * (attempt + 1)`` seconds and is preceded by a
 # best-effort kill of any stale runner process under the build directory.
 _LLD_PERM_DENIED_MAX_RETRIES = 3
+
+# Maximum number of retries when zccache returns exit 113 (daemon overloaded
+# or unhealthy) with no compiler diagnostic. Each retry waits
+# ``2.0 * (attempt + 1)`` seconds to let the daemon drain its queue. See #4132.
+_ZCCACHE_TRANSIENT_MAX_RETRIES = 2
 
 
 @dataclass
@@ -714,6 +724,60 @@ def compile_meson(
                 # permission-denied pattern. A different failure means the
                 # retry loop is done (fall through to normal error handling).
                 if not is_link_permission_denied_error(retry_output):
+                    break
+
+        # zccache exit-113 retry (#4132).
+        # zccache under load sometimes returns 113 without running the
+        # compiler. That is a daemon problem, not a defect in the code being
+        # built, so name it as such and re-invoke ninja: only the failed
+        # objects rebuild, and the daemon has had a moment to drain.
+        if returncode != 0 and is_zccache_transient_failure(output):
+            for _attempt in range(_ZCCACHE_TRANSIENT_MAX_RETRIES):
+                _ts_print(
+                    "[MESON] ⚠️  "
+                    + format_zccache_transient_message(
+                        find_zccache_transient_failures(output)
+                    ),
+                    file=sys.stderr,
+                )
+                _ts_print(
+                    f"[MESON] 🔁 Retrying the build "
+                    f"(attempt {_attempt + 1}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})",
+                    file=sys.stderr,
+                )
+                time.sleep(2.0 * (_attempt + 1))
+                try:
+                    retry_proc = RunningProcess(
+                        cmd,
+                        timeout=600,
+                        auto_run=True,
+                        check=False,
+                        output_formatter=TimestampFormatter(),
+                    )
+                    retry_proc.wait(echo=False)
+                    returncode = cast(int, retry_proc.returncode)
+                    retry_output = str(retry_proc.stdout)
+                    output = output + "\n" + retry_output
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                    raise
+                except Exception as retry_error:
+                    _ts_print(
+                        f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
+                        file=sys.stderr,
+                    )
+                    break
+
+                if returncode == 0:
+                    _ts_print(
+                        f"[MESON] ✅ zccache retry succeeded on attempt {_attempt + 1}",
+                        file=sys.stderr,
+                    )
+                    break
+
+                # A different failure means a real defect surfaced — stop
+                # retrying and fall through to normal error handling.
+                if not is_zccache_transient_failure(retry_output):
                     break
 
         if returncode != 0:

--- a/ci/meson/compile.py
+++ b/ci/meson/compile.py
@@ -212,6 +212,9 @@ def _retry_ninja(
     describe: Callable[[str, int], str],
     before_retry: Callable[[], None] | None,
     label: str,
+    timeout: int,
+    env: dict[str, str] | None,
+    output_formatter: TimestampFormatter | None,
 ) -> tuple[int, str]:
     """Re-invoke the same ninja command while a transient failure persists.
 
@@ -235,10 +238,11 @@ def _retry_ninja(
         try:
             retry_proc = RunningProcess(
                 cmd,
-                timeout=600,
+                timeout=timeout,
                 auto_run=True,
                 check=False,
-                output_formatter=TimestampFormatter(),
+                env=env,
+                output_formatter=output_formatter,
             )
             retry_proc.wait(echo=False)
             returncode = cast(int, retry_proc.returncode)
@@ -759,6 +763,9 @@ def compile_meson(
                 describe=_describe_lld,
                 before_retry=_before_lld_retry,
                 label="Link",
+                timeout=600,
+                env=None,
+                output_formatter=TimestampFormatter(),
             )
 
         # zccache exit-113 retry (#4132).
@@ -786,6 +793,9 @@ def compile_meson(
                 describe=_describe_zccache,
                 before_retry=None,
                 label="zccache",
+                timeout=600,
+                env=None,
+                output_formatter=TimestampFormatter(),
             )
 
         if returncode != 0:

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -67,6 +67,49 @@ class StreamingResult:
     num_failed_examples: int = 0
 
 
+# Ninja line announcing a test/example executable link, e.g.
+# ``[35/1084] Linking CXX executable tests/fl/test_foo``.
+_LINK_PATTERN = re.compile(r"^\[\d+/\d+\]\s+Linking (?:CXX executable|target)\s+(.+)$")
+
+
+def link_line_test_path(line: str, build_dir: Path) -> Optional[Path]:
+    """Return the runnable test/example path a Ninja link line announces.
+
+    ``None`` when the line is not a link line, or links something the test
+    runner must not execute (the runner binaries themselves, profile
+    harnesses, anything outside ``tests/`` and ``examples/``). Shared by the
+    streamed parser and the retry path (#4132) so a test that only links
+    during a successful retry is still collected and run.
+    """
+    match = _LINK_PATTERN.match(line.strip())
+    if not match:
+        return None
+    rel_path = match.group(1)
+    if not (
+        "tests/" in rel_path
+        or "tests\\" in rel_path
+        or "examples/" in rel_path
+        or "examples\\" in rel_path
+    ):
+        return None
+    test_path = build_dir / rel_path
+    if test_path.stem in ("runner", "test_runner", "example_runner"):
+        return None
+    if "tests/profile/" in rel_path or "tests\\profile\\" in rel_path:
+        return None
+    return test_path
+
+
+def collect_test_paths(output: str, build_dir: Path) -> list[Path]:
+    """Collect every test/example path linked in a block of Ninja output."""
+    paths: list[Path] = []
+    for line in output.splitlines():
+        test_path = link_line_test_path(line, build_dir)
+        if test_path is not None:
+            paths.append(test_path)
+    return paths
+
+
 def is_example_artifact(test_path: Path) -> bool:
     """True when a built artifact is an example rather than a unit test.
 
@@ -178,9 +221,7 @@ def stream_compile_only(
         _ts_print(f"[MESON] 🧹 Killed {_killed} stale runner process(es) before link")
 
     # Pattern to detect test executable linking
-    link_pattern = re.compile(
-        r"^\[\d+/\d+\]\s+Linking (?:CXX executable|target)\s+(.+)$"
-    )
+    link_pattern = _LINK_PATTERN
 
     # Pattern to detect static library archiving
     archive_pattern = re.compile(r"^\[\d+/\d+\]\s+Linking static target\s+(.+)$")
@@ -396,34 +437,13 @@ def stream_compile_only(
                         _ts_print(f"[BUILD] Compiling... [{last_step}/{total_steps}]")
                         last_progress_time = time.time()
 
-                    # Collect compiled test paths
-                    match = (
-                        link_match if link_match else link_pattern.match(line.strip())
-                    )
-                    if match:
-                        rel_path = match.group(1)
-                        test_path = build_dir / rel_path
-
-                        # Only collect if it's a test executable
-                        if (
-                            "tests/" in rel_path
-                            or "tests\\" in rel_path
-                            or "examples/" in rel_path
-                            or "examples\\" in rel_path
-                        ):
-                            test_name = test_path.stem
-                            if test_name in ("runner", "test_runner", "example_runner"):
-                                continue
-                            if (
-                                "tests/profile/" in rel_path
-                                or "tests\\profile\\" in rel_path
-                            ):
-                                continue
-                            # DLLs/.so/.dylib are handled by runner in test_callback
-
-                            if verbose:
-                                _ts_print(f"[MESON] Test built: {test_path.name}")
-                            compiled_tests.append(test_path)
+                    # Collect compiled test paths. DLLs/.so/.dylib are
+                    # handled by runner in test_callback.
+                    test_path = link_line_test_path(line, build_dir)
+                    if test_path is not None:
+                        if verbose:
+                            _ts_print(f"[MESON] Test built: {test_path.name}")
+                        compiled_tests.append(test_path)
 
             # Check compilation result
             returncode = cast(int, proc.wait())
@@ -446,6 +466,12 @@ def stream_compile_only(
                     f.write("\n".join(last_error_lines))
 
             compilation_output = str(proc.stdout)
+            # Output of the most recent ninja attempt alone. Retry
+            # classification must look at this, not the accumulated log:
+            # an ld.lld failure that a retry already recovered from must
+            # not mask a zccache exit 113 on that retry (#4132).
+            latest_output = compilation_output
+            retried = False
 
             # Windows ld.lld 'permission denied' retry (#2268).
             # If the link failed because runner.exe / example_runner.exe was
@@ -453,7 +479,7 @@ def stream_compile_only(
             # ninja invocation a few times with a short backoff. No-op on
             # non-Windows platforms because ``is_link_permission_denied_error``
             # returns False off-Windows.
-            if returncode != 0 and is_link_permission_denied_error(compilation_output):
+            if returncode != 0 and is_link_permission_denied_error(latest_output):
 
                 def _describe_lld(_latest: str, attempt: int) -> str:
                     return (
@@ -470,7 +496,7 @@ def stream_compile_only(
                             file=sys.stderr,
                         )
 
-                returncode, compilation_output = _retry_ninja(
+                _outcome = _retry_ninja(
                     cmd,
                     compilation_output,
                     max_retries=_LLD_PERM_DENIED_MAX_RETRIES,
@@ -483,10 +509,14 @@ def stream_compile_only(
                     env=os.environ.copy(),
                     output_formatter=None,
                 )
+                returncode = _outcome.returncode
+                compilation_output = _outcome.output
+                latest_output = _outcome.latest
+                retried = True
 
             # zccache exit-113 retry (#4132). This is the path CI takes; see
             # compile.py for the same block on the non-streaming path.
-            if returncode != 0 and is_zccache_transient_failure(compilation_output):
+            if returncode != 0 and is_zccache_transient_failure(latest_output):
 
                 def _describe_zccache(latest: str, attempt: int) -> str:
                     return (
@@ -497,7 +527,7 @@ def stream_compile_only(
                         f"(attempt {attempt}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})"
                     )
 
-                returncode, compilation_output = _retry_ninja(
+                _outcome = _retry_ninja(
                     cmd,
                     compilation_output,
                     max_retries=_ZCCACHE_TRANSIENT_MAX_RETRIES,
@@ -510,6 +540,19 @@ def stream_compile_only(
                     env=os.environ.copy(),
                     output_formatter=None,
                 )
+                returncode = _outcome.returncode
+                compilation_output = _outcome.output
+                latest_output = _outcome.latest
+                retried = True
+
+            # A retry that succeeded ran without the streaming parser above,
+            # so any test it linked has not been collected yet.
+            if retried and returncode == 0:
+                for test_path in collect_test_paths(latest_output, build_dir):
+                    if test_path not in compiled_tests:
+                        if verbose:
+                            _ts_print(f"[MESON] Test built: {test_path.name}")
+                        compiled_tests.append(test_path)
 
             if returncode != 0:
                 phase_tracker.set_phase("LINK", target=target, path="streaming")

--- a/ci/meson/streaming.py
+++ b/ci/meson/streaming.py
@@ -14,8 +14,11 @@ from running_process import RunningProcess
 
 from ci.meson.build_optimizer import BuildOptimizer
 from ci.meson.compile import (
+    _LLD_PERM_DENIED_MAX_RETRIES,
+    _ZCCACHE_TRANSIENT_MAX_RETRIES,
     _create_error_context_filter,
     _is_compilation_error,
+    _retry_ninja,
 )
 from ci.meson.compiler import get_meson_executable
 from ci.meson.link_retry import (
@@ -25,6 +28,11 @@ from ci.meson.link_retry import (
 from ci.meson.mtime_stabilizer import stabilize_dll_mtimes
 from ci.meson.output import print_error, print_success
 from ci.meson.phase_tracker import PhaseTracker
+from ci.meson.zccache_retry import (
+    find_zccache_transient_failures,
+    format_zccache_transient_message,
+    is_zccache_transient_failure,
+)
 from ci.util.cpu_count import cpu_count
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.tee import StreamTee
@@ -446,57 +454,62 @@ def stream_compile_only(
             # non-Windows platforms because ``is_link_permission_denied_error``
             # returns False off-Windows.
             if returncode != 0 and is_link_permission_denied_error(compilation_output):
-                for _attempt in range(_LLD_PERM_DENIED_MAX_RETRIES):
-                    _ts_print(
-                        f"[MESON] ⚠️  ld.lld permission denied on runner binary "
-                        f"(attempt {_attempt + 1}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
-                        f"killing stale runner processes and retrying",
-                        file=sys.stderr,
+
+                def _describe_lld(_latest: str, attempt: int) -> str:
+                    return (
+                        f"ld.lld permission denied on runner binary "
+                        f"(attempt {attempt}/{_LLD_PERM_DENIED_MAX_RETRIES}) - "
+                        f"killing stale runner processes and retrying"
                     )
+
+                def _before_lld_retry() -> None:
                     _killed_retry = kill_stale_runner_processes(build_dir)
                     if _killed_retry:
                         _ts_print(
                             f"[MESON] 🧹 Killed {_killed_retry} stale runner process(es)",
                             file=sys.stderr,
                         )
-                    # Backoff 0.5s, 1.0s, 1.5s — gives Windows / antivirus
-                    # time to release any remaining handles on the .exe.
-                    time.sleep(0.5 * (_attempt + 1))
 
-                    try:
-                        retry_proc = RunningProcess(
-                            cmd,
-                            timeout=compile_timeout,
-                            auto_run=True,
-                            check=False,
-                            env=os.environ.copy(),
-                        )
-                        retry_proc.wait(echo=False)
-                        returncode = cast(int, retry_proc.returncode)
-                        retry_output = str(retry_proc.stdout)
-                        compilation_output = compilation_output + "\n" + retry_output
-                    except KeyboardInterrupt as ki:
-                        handle_keyboard_interrupt(ki)
-                        raise
-                    except Exception as retry_error:
-                        _ts_print(
-                            f"[MESON] ⚠️  Retry invocation failed: {retry_error}",
-                            file=sys.stderr,
-                        )
-                        break
+                returncode, compilation_output = _retry_ninja(
+                    cmd,
+                    compilation_output,
+                    max_retries=_LLD_PERM_DENIED_MAX_RETRIES,
+                    backoff_seconds=0.5,
+                    still_transient=is_link_permission_denied_error,
+                    describe=_describe_lld,
+                    before_retry=_before_lld_retry,
+                    label="Link",
+                    timeout=compile_timeout,
+                    env=os.environ.copy(),
+                    output_formatter=None,
+                )
 
-                    if returncode == 0:
-                        _ts_print(
-                            f"[MESON] ✅ Link retry succeeded on attempt {_attempt + 1}",
-                            file=sys.stderr,
-                        )
-                        break
+            # zccache exit-113 retry (#4132). This is the path CI takes; see
+            # compile.py for the same block on the non-streaming path.
+            if returncode != 0 and is_zccache_transient_failure(compilation_output):
 
-                    # Only keep retrying while the failure is still the same
-                    # permission-denied pattern. Non-retryable failures fall
-                    # through to the normal error path below.
-                    if not is_link_permission_denied_error(retry_output):
-                        break
+                def _describe_zccache(latest: str, attempt: int) -> str:
+                    return (
+                        format_zccache_transient_message(
+                            find_zccache_transient_failures(latest)
+                        )
+                        + f"\n  Retrying the build "
+                        f"(attempt {attempt}/{_ZCCACHE_TRANSIENT_MAX_RETRIES})"
+                    )
+
+                returncode, compilation_output = _retry_ninja(
+                    cmd,
+                    compilation_output,
+                    max_retries=_ZCCACHE_TRANSIENT_MAX_RETRIES,
+                    backoff_seconds=2.0,
+                    still_transient=is_zccache_transient_failure,
+                    describe=_describe_zccache,
+                    before_retry=None,
+                    label="zccache",
+                    timeout=compile_timeout,
+                    env=os.environ.copy(),
+                    output_formatter=None,
+                )
 
             if returncode != 0:
                 phase_tracker.set_phase("LINK", target=target, path="streaming")

--- a/ci/meson/zccache_retry.py
+++ b/ci/meson/zccache_retry.py
@@ -1,0 +1,74 @@
+"""Detect transient zccache daemon failures (exit 113) so the build can retry.
+
+zccache wraps every compiler invocation in the meson build. When its daemon
+is under load or unhealthy it sometimes returns exit code 113 without ever
+running the compiler, and ninja reports it as::
+
+    FAILED: [code=113] ci/meson/native/fastled.so.p/..._third_party+.cpp.o
+    "/.../.venv/bin/zccache" /.../ctc-clang++ -I... -c ../../src/fl/build/third_party+.cpp
+    zccache[info][Q]: daemon under load: queued, position 1 of 3 queued, 3 in flight
+
+113 is zccache's exit code, not clang's. A real compile error prints a
+diagnostic (``file:line:col: error: ...``) and is deterministic; these print
+nothing and move between objects on reruns of the same commit.
+
+This module provides:
+  * ``ZCCACHE_TRANSIENT_EXIT_CODE`` — the exit code zccache uses.
+  * ``find_zccache_transient_failures`` — the objects that failed with 113.
+  * ``is_zccache_transient_failure`` — True when the build failed *only*
+    because of 113s, i.e. no compiler diagnostic accompanies any failure.
+  * ``format_zccache_transient_message`` — a self-identifying explanation.
+
+Related: FastLED issue #4132.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+ZCCACHE_TRANSIENT_EXIT_CODE = 113
+
+# Example line (ninja's failure banner, possibly ANSI-coloured):
+#   FAILED: [code=113] ci/meson/native/fastled.so.p/.._.._.._src_fl_build_third_party+.cpp.o
+_FAILED_113_PATTERN = re.compile(
+    r"FAILED:\s*\[code=113\]\s*(?P<obj>\S+)",
+)
+
+# Any real compiler/linker diagnostic. Matches clang-style
+# ``path:line:col: error:`` and driver-style ``clang: error:`` / ``ld.lld:
+# error:`` lines. zccache's own log lines are tagged ``zccache[...]`` and are
+# excluded so its chatter can never be mistaken for a compile error.
+_COMPILER_ERROR_PATTERN = re.compile(
+    r"(?m)^(?!zccache\[)[^\n]*\b(?:fatal )?error:",
+)
+
+
+def find_zccache_transient_failures(output: str) -> list[str]:
+    """Return the object paths that ninja reported as ``FAILED: [code=113]``."""
+    if not output:
+        return []
+    return [m.group("obj") for m in _FAILED_113_PATTERN.finditer(output)]
+
+
+def is_zccache_transient_failure(output: str) -> bool:
+    """Return True if the build failed only with zccache exit 113 and no diagnostic.
+
+    A 113 that sits next to a genuine ``error:`` line anywhere in the output
+    is NOT treated as transient: the retry would just replay a real defect.
+    """
+    if not find_zccache_transient_failures(output):
+        return False
+    return _COMPILER_ERROR_PATTERN.search(output) is None
+
+
+def format_zccache_transient_message(objects: list[str]) -> str:
+    """Explain a 113 failure in one read, the way fbuild's daemon errors do."""
+    listed = "\n".join(f"    {obj}" for obj in objects)
+    return (
+        f"zccache returned exit code {ZCCACHE_TRANSIENT_EXIT_CODE} with no "
+        f"compiler diagnostic for {len(objects)} object(s):\n{listed}\n"
+        f"  This is a zccache daemon problem (overloaded or unhealthy), not a "
+        f"defect in the code being built — no compilation was attempted. "
+        f"See FastLED #4132."
+    )

--- a/ci/meson/zccache_retry.py
+++ b/ci/meson/zccache_retry.py
@@ -43,12 +43,22 @@ _COMPILER_ERROR_PATTERN = re.compile(
     r"(?m)^(?!zccache\[)[^\n]*\b(?:fatal )?error:",
 )
 
+# The meson build passes -fdiagnostics-color=always, so clang emits
+# ``\x1b[0;1;31merror: \x1b[0m`` — no word boundary before ``error``. Strip
+# SGR sequences before matching so coloured diagnostics are still seen.
+_ANSI_SGR_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_SGR_PATTERN.sub("", text)
+
 
 def find_zccache_transient_failures(output: str) -> list[str]:
     """Return the object paths that ninja reported as ``FAILED: [code=113]``."""
     if not output:
         return []
-    return [m.group("obj") for m in _FAILED_113_PATTERN.finditer(output)]
+    plain = _strip_ansi(output)
+    return [m.group("obj") for m in _FAILED_113_PATTERN.finditer(plain)]
 
 
 def is_zccache_transient_failure(output: str) -> bool:
@@ -59,7 +69,7 @@ def is_zccache_transient_failure(output: str) -> bool:
     """
     if not find_zccache_transient_failures(output):
         return False
-    return _COMPILER_ERROR_PATTERN.search(output) is None
+    return _COMPILER_ERROR_PATTERN.search(_strip_ansi(output)) is None
 
 
 def format_zccache_transient_message(objects: list[str]) -> str:

--- a/ci/meson/zccache_retry.py
+++ b/ci/meson/zccache_retry.py
@@ -16,7 +16,8 @@ This module provides:
   * ``ZCCACHE_TRANSIENT_EXIT_CODE`` — the exit code zccache uses.
   * ``find_zccache_transient_failures`` — the objects that failed with 113.
   * ``is_zccache_transient_failure`` — True when the build failed *only*
-    because of 113s, i.e. no compiler diagnostic accompanies any failure.
+    because of 113s, i.e. no compiler diagnostic and no other exit code
+    accompanies any failure.
   * ``format_zccache_transient_message`` — a self-identifying explanation.
 
 Related: FastLED issue #4132.
@@ -25,6 +26,16 @@ Related: FastLED issue #4132.
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typeguard import typechecked
+else:
+    # No-op decorator: skip typeguard's ~277ms import cost on the build path.
+    # Static type checkers (mypy/pyright) still see the real decorator.
+    def typechecked(f):  # type: ignore[no-redef]
+        return f
 
 
 ZCCACHE_TRANSIENT_EXIT_CODE = 113
@@ -34,6 +45,10 @@ ZCCACHE_TRANSIENT_EXIT_CODE = 113
 _FAILED_113_PATTERN = re.compile(
     r"FAILED:\s*\[code=113\]\s*(?P<obj>\S+)",
 )
+
+# Any ninja failure banner, whatever the exit code. Used to refuse a retry
+# when a non-113 failure sits in the same run: that one is not zccache.
+_FAILED_ANY_PATTERN = re.compile(r"FAILED:\s*\[code=(?P<code>\d+)\]")
 
 # Any real compiler/linker diagnostic. Matches clang-style
 # ``path:line:col: error:`` and driver-style ``clang: error:`` / ``ld.lld:
@@ -53,25 +68,36 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_SGR_PATTERN.sub("", text)
 
 
+@typechecked
 def find_zccache_transient_failures(output: str) -> list[str]:
     """Return the object paths that ninja reported as ``FAILED: [code=113]``."""
     if not output:
         return []
     plain = _strip_ansi(output)
-    return [m.group("obj") for m in _FAILED_113_PATTERN.finditer(plain)]
+    objects: list[str] = []
+    for match in _FAILED_113_PATTERN.finditer(plain):
+        objects.append(match.group("obj"))
+    return objects
 
 
+@typechecked
 def is_zccache_transient_failure(output: str) -> bool:
     """Return True if the build failed only with zccache exit 113 and no diagnostic.
 
-    A 113 that sits next to a genuine ``error:`` line anywhere in the output
-    is NOT treated as transient: the retry would just replay a real defect.
+    A 113 that sits next to a genuine ``error:`` line, or next to a failure
+    banner with any other exit code, is NOT treated as transient: the retry
+    would just replay a real defect.
     """
     if not find_zccache_transient_failures(output):
         return False
-    return _COMPILER_ERROR_PATTERN.search(_strip_ansi(output)) is None
+    plain = _strip_ansi(output)
+    for match in _FAILED_ANY_PATTERN.finditer(plain):
+        if int(match.group("code")) != ZCCACHE_TRANSIENT_EXIT_CODE:
+            return False
+    return _COMPILER_ERROR_PATTERN.search(plain) is None
 
 
+@typechecked
 def format_zccache_transient_message(objects: list[str]) -> str:
     """Explain a 113 failure in one read, the way fbuild's daemon errors do."""
     listed = "\n".join(f"    {obj}" for obj in objects)

--- a/ci/tests/test_zccache_retry.py
+++ b/ci/tests/test_zccache_retry.py
@@ -1,0 +1,72 @@
+"""Unit tests for ci.meson.zccache_retry helpers (#4132)."""
+
+from __future__ import annotations
+
+from ci.meson.zccache_retry import (
+    find_zccache_transient_failures,
+    format_zccache_transient_message,
+    is_zccache_transient_failure,
+)
+
+
+_OBJ_A = "ci/meson/native/fastled.so.p/.._.._.._src_fl_build_third_party+.cpp.o"
+_OBJ_B = "ci/meson/native/fastled.so.p/.._.._.._src_fl_build_platforms+.cpp.o"
+
+# Verbatim shape of the CI log cited in #4132 (job 100469403724).
+_TRANSIENT_OUTPUT = (
+    f"[16/618] Compiling C++ object {_OBJ_A}\n"
+    f"\x1b[91mFAILED: [code=113] {_OBJ_A} \x1b[0m\n"
+    '"/home/runner/work/FastLED/FastLED/.venv/bin/zccache" /home/runner/ctc-clang++ -I/x -c a.cpp\n'
+    "zccache[info][Q]: daemon under load: queued, position 1 of 3 queued, 3 in flight\n"
+    "zccache[info][Q]: daemon under load: compiling, position 0 of 3 queued, 3 in flight\n"
+    "[clang-tool-chain] Added -shared-libasan for AddressSanitizer\n"
+    f"[17/618] Compiling C++ object {_OBJ_B}\n"
+    f"FAILED: [code=113] {_OBJ_B} \n"
+    "src/fl/stl/not_null.cpp.hpp:24:41: warning: unused parameter 'message' [-Wunused-parameter]\n"
+    "ninja: build stopped: subcommand failed.\n"
+)
+
+
+def test_finds_every_113_object_in_order() -> None:
+    assert find_zccache_transient_failures(_TRANSIENT_OUTPUT) == [_OBJ_A, _OBJ_B]
+
+
+def test_transient_when_no_diagnostic() -> None:
+    """Warnings and zccache chatter do not count as a compiler diagnostic."""
+    assert is_zccache_transient_failure(_TRANSIENT_OUTPUT)
+
+
+def test_not_transient_with_real_compile_error() -> None:
+    output = (
+        _TRANSIENT_OUTPUT
+        + "FAILED: [code=1] ci/meson/native/x.o\n"
+        + "../../src/fl/foo.cpp:12:5: error: use of undeclared identifier 'bar'\n"
+    )
+    assert not is_zccache_transient_failure(output)
+
+
+def test_not_transient_with_driver_error() -> None:
+    output = (
+        _TRANSIENT_OUTPUT + "clang: error: linker command failed with exit code 1\n"
+    )
+    assert not is_zccache_transient_failure(output)
+
+
+def test_not_transient_with_fatal_error() -> None:
+    output = _TRANSIENT_OUTPUT + "a.cpp:1:10: fatal error: 'nope.h' file not found\n"
+    assert not is_zccache_transient_failure(output)
+
+
+def test_not_transient_without_113() -> None:
+    output = "FAILED: [code=1] ci/meson/native/x.o\nninja: build stopped: subcommand failed.\n"
+    assert not is_zccache_transient_failure(output)
+    assert find_zccache_transient_failures(output) == []
+    assert not is_zccache_transient_failure("")
+
+
+def test_message_is_self_identifying() -> None:
+    msg = format_zccache_transient_message([_OBJ_A])
+    assert "113" in msg
+    assert _OBJ_A in msg
+    assert "no compilation was attempted" in msg
+    assert "#4132" in msg

--- a/ci/tests/test_zccache_retry.py
+++ b/ci/tests/test_zccache_retry.py
@@ -73,6 +73,12 @@ def test_not_transient_with_fatal_error() -> None:
     assert not is_zccache_transient_failure(output)
 
 
+def test_not_transient_with_mixed_exit_codes() -> None:
+    """A non-113 failure in the same run is not zccache, even with no diagnostic."""
+    output = _TRANSIENT_OUTPUT + "FAILED: [code=1] ci/meson/native/x.o\n"
+    assert not is_zccache_transient_failure(output)
+
+
 def test_not_transient_without_113() -> None:
     output = "FAILED: [code=1] ci/meson/native/x.o\nninja: build stopped: subcommand failed.\n"
     assert not is_zccache_transient_failure(output)

--- a/ci/tests/test_zccache_retry.py
+++ b/ci/tests/test_zccache_retry.py
@@ -52,6 +52,22 @@ def test_not_transient_with_driver_error() -> None:
     assert not is_zccache_transient_failure(output)
 
 
+def test_not_transient_with_ansi_coloured_error() -> None:
+    """clang under -fdiagnostics-color=always: no word boundary before 'error'."""
+    coloured = (
+        "\x1b[1m../../src/fl/foo.cpp:12:5: \x1b[0m\x1b[0;1;31merror: \x1b[0m"
+        "\x1b[1muse of undeclared identifier 'bar'\x1b[0m\n"
+    )
+    assert not is_zccache_transient_failure(_TRANSIENT_OUTPUT + coloured)
+
+
+def test_not_transient_with_ansi_coloured_driver_error() -> None:
+    coloured = (
+        "clang++: \x1b[0;1;31merror: \x1b[0mlinker command failed with exit code 1\n"
+    )
+    assert not is_zccache_transient_failure(_TRANSIENT_OUTPUT + coloured)
+
+
 def test_not_transient_with_fatal_error() -> None:
     output = _TRANSIENT_OUTPUT + "a.cpp:1:10: fatal error: 'nope.h' file not found\n"
     assert not is_zccache_transient_failure(output)

--- a/ci/tests/test_zccache_retry.py
+++ b/ci/tests/test_zccache_retry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from ci.meson.streaming import collect_test_paths, link_line_test_path
 from ci.meson.zccache_retry import (
     find_zccache_transient_failures,
     format_zccache_transient_message,
@@ -92,3 +95,35 @@ def test_message_is_self_identifying() -> None:
     assert _OBJ_A in msg
     assert "no compilation was attempted" in msg
     assert "#4132" in msg
+
+
+# --- retry output feeds test collection (#4132 review) ---------------------
+
+
+def test_link_line_yields_test_path() -> None:
+    build = Path("/b")
+    line = "[35/1084] Linking CXX executable tests/fl/test_foo"
+    assert link_line_test_path(line, build) == build / "tests/fl/test_foo"
+
+
+def test_link_line_skips_runner_and_profile_and_library() -> None:
+    build = Path("/b")
+    assert link_line_test_path("[1/2] Linking target tests/runner", build) is None
+    assert link_line_test_path("[1/2] Linking target tests/profile/p_x", build) is None
+    assert link_line_test_path("[1/2] Linking target src/libfastled.a", build) is None
+    assert link_line_test_path("[1/2] Compiling C++ object x.o", build) is None
+
+
+def test_collect_test_paths_from_retry_output() -> None:
+    build = Path("/b")
+    output = "\n".join(
+        [
+            "[1/3] Compiling C++ object tests/fl/test_foo.p/foo.cpp.o",
+            "[2/3] Linking CXX executable tests/fl/test_foo",
+            "[3/3] Linking CXX executable examples/Blink/Blink",
+        ]
+    )
+    assert collect_test_paths(output, build) == [
+        build / "tests/fl/test_foo",
+        build / "examples/Blink/Blink",
+    ]


### PR DESCRIPTION
## Summary
- zccache under load returns exit 113 without running the compiler; ninja shows `FAILED: [code=113] <obj>` with no diagnostic (#4132, nine occurrences across six PRs).
- `ci/meson/zccache_retry.py` recognises that shape: `[code=113]` failures with no compiler `error:` line anywhere in the output.
- `ci/meson/compile.py` prints a self-identifying message (daemon problem, no compilation attempted) and re-invokes ninja up to twice with a short backoff. It stops retrying the moment a real diagnostic appears, so genuine defects are never masked.

## Verification
- `uv run pytest ci/tests/test_zccache_retry.py` (7 passed, log shape taken verbatim from job 100469403724)
- `bash lint` on the three files
- `bash test ease` builds through the patched driver; 17/17 pass

Closes #4132

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Builds now automatically retry transient zccache daemon failures, reducing failures caused by temporary overload or unhealthy daemon states.
  * Retries stop immediately when the build succeeds or encounters a non-transient compiler error.
  * Build output now identifies transient zccache failures and reports retry progress.
  * Detection works with colorized compiler output and avoids retrying when other failure types occur in the same build.
  * Windows linker permission errors continue to receive automatic retry handling.
  * Tests linked successfully during a recovered retry are now included in compiled test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->