### PR TITLE
fix(core): silence -Wunused-parameter on small platforms

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -24,6 +24,7 @@
 #include "fl/math/xymap.h"
 #include "fl/stl/singleton.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
 
@@ -70,6 +71,7 @@ class ReorderingPixelIteratorAny {
         Rgbww rgbww,
         const fl::string& channelName)
         : mPixelIterator(pixels, rgbOrder, rgbw, rgbww) {
+        FL_UNUSED(channelName);  // only consumed by FL_ERROR_F, a no-op on small platforms
 
         // Apply addressing transformation if configured
         if (addressing) {
@@ -129,6 +131,8 @@ FL_NO_INLINE
 static void emitDisabledDriverError(const fl::string& channelName,
                                     const fl::string& driverName,
                                     const fl::string& exclusive) FL_NO_EXCEPT {
+    FL_UNUSED(channelName);  // only consumed by FL_ERROR_F, a no-op on small platforms
+    FL_UNUSED(driverName);
     if (!exclusive.empty()) {
         FL_ERROR_F("Channel '%s': bound driver '%s' is currently DISABLED by exclusive-driver selection '%s'. Frame will be silently dropped. Resolve with: FastLED.enableDrivers<fl::Bus::%s>() or FastLED.enableAllDrivers().", channelName, driverName, exclusive, driverName);
     } else {

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -74,6 +74,7 @@ protected:
     }
 
     bool rejectFixedWhiteChannelChange(const char* operation) const FL_NO_EXCEPT {
+        FL_UNUSED(operation);  // only consumed by FL_WARN_F, a no-op on small platforms
         const char* chipset = fixedWhiteChannelChipset();
         if (chipset == nullptr) {
             return false;

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -239,6 +239,7 @@ class PixelIterator {
     /// @note Protocol: [Start:32b 0x00][LED:[0xE0|bri5][B][G][R]] x N, then [End: (N/32)+1 x 32b 0xFF]
     template <typename CONTAINER_UIN8_T>
     void writeAPA102(CONTAINER_UIN8_T* out, bool hd_gamma = false) FL_NO_EXCEPT {
+        FL_UNUSED(hd_gamma);  // only read under FASTLED_HD_COLOR_MIXING
         auto back_ins = fl::back_inserter(*out);
 
         #if FASTLED_HD_COLOR_MIXING
@@ -271,6 +272,7 @@ class PixelIterator {
     /// @note Protocol: Same as APA102, including the all-ones end clock frame.
     template <typename CONTAINER_UIN8_T>
     void writeSK9822(CONTAINER_UIN8_T* out, bool hd_gamma = false) FL_NO_EXCEPT {
+        FL_UNUSED(hd_gamma);  // only read under FASTLED_HD_COLOR_MIXING
         auto back_ins = fl::back_inserter(*out);
 
         #if FASTLED_HD_COLOR_MIXING

--- a/src/fl/control/wled.cpp.hpp
+++ b/src/fl/control/wled.cpp.hpp
@@ -2,6 +2,7 @@
 #include "fl/fx/wled.h"
 #include "fl/log/log.h"
 #include "fl/log/log.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 namespace fl {
 
 // WLED Constructor and Stub Implementations
@@ -18,6 +19,7 @@ fl::optional<fl::json> WLED::stubRequestSource() {
 }
 
 void WLED::stubResponseSink(const fl::json& response) {
+    FL_UNUSED(response);  // only consumed by FL_ERROR_F, a no-op on small platforms
     FL_ERROR_F("WLED::stubResponseSink: Not implemented - provide a real ResponseSink callback");
 }
 

--- a/src/fl/log/async_logger.cpp.hpp
+++ b/src/fl/log/async_logger.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/task/task.h"  // For fl::task
 #include "fl/task/scheduler.h"  // For fl::task::Scheduler
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
 
@@ -17,6 +18,8 @@ namespace detail {
     /// Called from checkLoggerEnabled template function
     /// IMPORTANT: This must NOT be inline - needs external linkage for cross-TU calls
     void printLoggerDisabledError(const char* category_name, const char* define_name) {
+        FL_UNUSED(category_name);  // only consumed by FL_ERROR_F, a no-op on small platforms
+        FL_UNUSED(define_name);
         FL_ERROR_F("%s ASYNC LOGGING NOT ENABLED. Add '#define %s' before including FastLED.h", category_name, define_name);
     }
 } // namespace detail

--- a/src/fl/net/http/fetch.cpp.hpp
+++ b/src/fl/net/http/fetch.cpp.hpp
@@ -17,6 +17,7 @@
 // Include WASM-specific implementation
 // IWYU pragma: begin_keep
 #include "platforms/wasm/js_fetch.h"  // ok platform headers
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 // IWYU pragma: end_keep
 
 // Native networking includes
@@ -30,7 +31,6 @@
     #include "platforms/posix/socket_posix.h"  // ok platform headers  // IWYU pragma: keep
     #include <fcntl.h>  // ok platform headers (for O_NONBLOCK flag)  // IWYU pragma: keep
 #include "fl/stl/noexcept.h"
-#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 #endif
 #endif
 

--- a/src/fl/net/http/fetch.cpp.hpp
+++ b/src/fl/net/http/fetch.cpp.hpp
@@ -30,6 +30,7 @@
     #include "platforms/posix/socket_posix.h"  // ok platform headers  // IWYU pragma: keep
     #include <fcntl.h>  // ok platform headers (for O_NONBLOCK flag)  // IWYU pragma: keep
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 #endif
 #endif
 
@@ -408,7 +409,8 @@ void fetch(const fl::string& url, const FetchCallback& callback) {
 }
 
 fl::task::Promise<Response> execute_fetch_request(const fl::string& url, const FetchOptions& request) {
-    (void)request;
+    FL_UNUSED(request);
+    FL_UNUSED(url);  // only consumed by FL_WARN_F, a no-op on small platforms
     FL_WARN_F("HTTP fetch is not supported on this platform. URL: %s", url);
     Response error_response(501, "Not Implemented");
     error_response.set_body("HTTP fetch is not available on this platform.");

--- a/src/fl/net/http/stream_transport.cpp.hpp
+++ b/src/fl/net/http/stream_transport.cpp.hpp
@@ -6,6 +6,7 @@
 #include "fl/stl/cstring.h"
 #include "fl/stl/stdio.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
 namespace net {
@@ -53,6 +54,9 @@ HttpStreamTransport::HttpStreamTransport(const fl::string& host, u16 port, u32 h
     , mHeartbeatInterval(heartbeatIntervalMs)
     , mTimeoutMs(60000)  // Default 60s timeout
     , mWasConnected(false) {
+    // The concrete transport owns the endpoint; connect() is pure virtual here.
+    FL_UNUSED(host);
+    FL_UNUSED(port);
 }
 
 HttpStreamTransport::~HttpStreamTransport() FL_NO_EXCEPT {

--- a/src/fl/stl/istream.h
+++ b/src/fl/stl/istream.h
@@ -12,6 +12,7 @@
 // cstdio.h symbol — `fl::available()` — so forward-declare it here
 // and let consumers that need the full cstdio API include it themselves.
 #include "fl/stl/noexcept.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
     int available() FL_NO_EXCEPT;
@@ -257,6 +258,8 @@ public:
     istream& putback(char c) {
 #if SKETCH_HAS_LARGE_MEMORY
         mRealStream.putback(c);
+#else
+        FL_UNUSED(c);
 #endif
         return *this;
     }

--- a/src/fl/task/scheduler.cpp.hpp
+++ b/src/fl/task/scheduler.cpp.hpp
@@ -2,6 +2,7 @@
 #include "fl/stl/singleton.h"
 #include "fl/stl/chrono.h"
 #include "fl/log/log.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
 namespace task {
@@ -187,6 +188,7 @@ void Scheduler::update_frame_listener_registration() FL_NO_EXCEPT {
 }
 
 void Scheduler::warn_no_then(int task_id, const fl::string& trace_label) {
+    FL_UNUSED(task_id);  // only consumed by FL_WARN_F, a no-op on small platforms
     if (!trace_label.empty()) {
         FL_WARN_F("%s%s launched at %s", fl::string("[fl::task] Warning: no then() callback set for Task#"), task_id, trace_label);
     } else {
@@ -195,7 +197,9 @@ void Scheduler::warn_no_then(int task_id, const fl::string& trace_label) {
 }
 
 void Scheduler::warn_no_catch(int task_id, const fl::string& trace_label, const Error& error) {
-        if (!trace_label.empty()) {
+    FL_UNUSED(task_id);  // only consumed by FL_WARN_F, a no-op on small platforms
+    FL_UNUSED(error);
+    if (!trace_label.empty()) {
         FL_WARN_F("%s%s launched at %s. Error: %s", fl::string("[fl::task] Warning: no catch_() callback set for Task#"), task_id, trace_label, error.message);
     } else {
         FL_WARN_F("%s%s. Error: %s", fl::string("[fl/task] Warning: no catch_() callback set for Task#"), task_id, error.message);

--- a/src/fl/wdt/_build.cpp.hpp
+++ b/src/fl/wdt/_build.cpp.hpp
@@ -9,6 +9,7 @@
 #include "fl/system/delay.h"
 
 #include "fl/wdt/watchdog.cpp.hpp"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep - FL_UNUSED
 
 namespace fl {
 namespace platforms {
@@ -17,6 +18,7 @@ namespace platforms {
 // here (in the unity TU) rather than in watchdog.cpp.hpp so that public
 // headers don't pull in fl/log/log.h.
 void scopedWatchdogPrintLine(fl::string_view sv) FL_NO_EXCEPT {
+    FL_UNUSED(sv);  // only consumed by FL_WARN_F, a no-op on small platforms
     FL_WARN_F("%s", sv);
 }
 


### PR DESCRIPTION
## Summary
- On AVR, `FL_WARN_F` / `FL_ERROR_F` compile to nothing, so their message arguments become unused parameters. An Arduino IDE build with warnings set to "All" (`-Wall -Wextra`) prints 26 `-Wunused-parameter` warnings from FastLED headers (#4137).
- The no-op log macros must keep dropping arguments (log.h documents call sites that declare them only under `FASTLED_LOG_*_ENABLED`), so each affected parameter is marked `FL_UNUSED` at its site.
- Three non-log sites are covered too: `hd_gamma` (read only under `FASTLED_HD_COLOR_MIXING`), `istream::putback` on small memory, and the `HttpStreamTransport` base constructor whose endpoint belongs to the concrete transport.

## Verification
- Replayed the uno build with the Arduino toolchain (`avr-g++` 7.3) and `-Wall -Wextra` across all 30 translation units: unused-parameter warnings 26 -> 0, all units compile.
- `bash test fl_task_task` passes (4/4).
- `bash lint` clean on all 10 files.

Closes #4137

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build compatibility across platforms by handling parameters that may be unused in reduced-feature configurations.
  * Reduced compiler warnings in networking, logging, streaming, scheduling, watchdog, channel, and pixel-processing components.
  * Standardized compiler-control handling across supported builds.

* **Bug Fixes**
  * No user-facing behavior changes. Existing error reporting, warnings, and unsupported-platform responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->