### PR TITLE
fix(ci): point the toolchain wrappers at a CA bundle that exists

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,8 +1,11 @@
 """FastLED CI tools and utilities.
 
-Importing the ``ci`` package should make console output safe on Windows before
-any entrypoint prints Unicode status text. The helper remains lightweight and is
-best-effort only, so package import should never fail due to console setup.
+Importing the ``ci`` package arranges two things every entrypoint depends on
+and none of them should have to set up itself: console output is made safe on
+Windows before any Unicode status text is printed, and ``SSL_CERT_FILE`` is
+pointed at a CA bundle that exists before any HTTPS call (see
+``ci.util.tls_trust``). Both helpers are lightweight and best-effort only, so
+package import never fails because of them.
 """
 
 _ci_initialized = False
@@ -25,6 +28,19 @@ def _ensure_init() -> None:
         raise
     except Exception:
         # Never fail import due to console configuration
+        pass
+    try:
+        from ci.util.tls_trust import ensure_tls_trust_store
+
+        ensure_tls_trust_store()
+    except KeyboardInterrupt:
+        import _thread  # noqa: PLC0415
+
+        _thread.interrupt_main()
+        raise
+    except Exception:
+        # Never fail import due to trust-store setup; a genuine TLS problem is
+        # still reported by whoever makes the request.
         pass
 
 

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -21,6 +21,8 @@ from running_process import RunningProcess
 
 try:
     import certifi  # optional: only consulted when no system CA bundle exists
+except KeyboardInterrupt:
+    raise
 except ImportError:  # pragma: no cover - depends on the host environment
     certifi = None
 

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -18,14 +18,6 @@ from typing import NamedTuple, Optional, cast
 
 from running_process import RunningProcess
 
-
-try:
-    import certifi  # optional: only consulted when no system CA bundle exists
-except KeyboardInterrupt:
-    raise
-except ImportError:  # pragma: no cover - depends on the host environment
-    certifi = None
-
 from ci.meson.compiler import (
     get_compiler_version,
     get_meson_executable,
@@ -109,40 +101,6 @@ def _resolve_xcode_sdk_root() -> str:
     return path
 
 
-def _ensure_tls_trust_store() -> None:
-    """Give the clang-tool-chain wrappers a CA bundle they can actually find.
-
-    Every `clang-tool-chain-*` invocation version-checks its manifest over
-    HTTPS. On distributions whose Python is built expecting `/etc/ssl/cert.pem`
-    -- NixOS among them -- that file does not exist, and the `capath` fallback
-    (`/etc/ssl/certs`) carries no `c_rehash` symlinks, so *every* such request
-    dies with `CERTIFICATE_VERIFY_FAILED`.
-
-    The failure does not look like a network problem. The wrapper prints its
-    SSL traceback where the build generator expects a version string, so
-    configuration aborts with the thoroughly misleading::
-
-        ERROR: Unknown linker(s): [['.../clang-tool-chain-ar']]
-
-    Pointing `SSL_CERT_FILE` at a bundle that exists fixes it. Set only when
-    the caller has not already chosen one, and only to a path that is really
-    there, so this can neither override a deliberate configuration nor invent
-    a broken one.
-    """
-    if os.environ.get("SSL_CERT_FILE"):
-        return
-    candidates = [Path("/etc/ssl/certs/ca-certificates.crt")]
-    if certifi is not None:
-        candidates.append(Path(certifi.where()))
-    for candidate in candidates:
-        if candidate.is_file():
-            os.environ["SSL_CERT_FILE"] = str(candidate)
-            return
-    # No candidate is not an error. Windows and macOS have neither file and
-    # Python's default trust store works there; the wrapper will report any
-    # real TLS failure itself with the full traceback.
-
-
 def detect_compiler_and_cache(
     markers: MarkerPaths, verbose: bool, build_mode: str
 ) -> CompilerDetection:
@@ -166,11 +124,6 @@ def detect_compiler_and_cache(
             )
     else:
         _ts_print("[MESON] Skipping compiler cache in Docker (startup delay too long)")
-
-    # Before the first wrapper invocation: they phone home on every call,
-    # and a system without a resolvable CA bundle turns that failure into
-    # what looks like a broken linker.
-    _ensure_tls_trust_store()
 
     clang_wrapper = shutil.which("clang-tool-chain-c")
     clangxx_wrapper = shutil.which("clang-tool-chain-cpp")

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -18,6 +18,12 @@ from typing import NamedTuple, Optional, cast
 
 from running_process import RunningProcess
 
+
+try:
+    import certifi  # optional: only consulted when no system CA bundle exists
+except ImportError:  # pragma: no cover - depends on the host environment
+    certifi = None
+
 from ci.meson.compiler import (
     get_compiler_version,
     get_meson_executable,
@@ -124,12 +130,8 @@ def _ensure_tls_trust_store() -> None:
     if os.environ.get("SSL_CERT_FILE"):
         return
     candidates = [Path("/etc/ssl/certs/ca-certificates.crt")]
-    try:
-        import certifi  # noqa: PLC0415 - optional, and only needed on this path
-
+    if certifi is not None:
         candidates.append(Path(certifi.where()))
-    except ImportError:
-        pass
     for candidate in candidates:
         if candidate.is_file():
             os.environ["SSL_CERT_FILE"] = str(candidate)

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -101,6 +101,41 @@ def _resolve_xcode_sdk_root() -> str:
     return path
 
 
+def _ensure_tls_trust_store() -> None:
+    """Give the clang-tool-chain wrappers a CA bundle they can actually find.
+
+    Every `clang-tool-chain-*` invocation version-checks its manifest over
+    HTTPS. On distributions whose Python is built expecting `/etc/ssl/cert.pem`
+    -- NixOS among them -- that file does not exist, and the `capath` fallback
+    (`/etc/ssl/certs`) carries no `c_rehash` symlinks, so *every* such request
+    dies with `CERTIFICATE_VERIFY_FAILED`.
+
+    The failure does not look like a network problem. The wrapper prints its
+    SSL traceback where the build generator expects a version string, so
+    configuration aborts with the thoroughly misleading::
+
+        ERROR: Unknown linker(s): [['.../clang-tool-chain-ar']]
+
+    Pointing `SSL_CERT_FILE` at a bundle that exists fixes it. Set only when
+    the caller has not already chosen one, and only to a path that is really
+    there, so this can neither override a deliberate configuration nor invent
+    a broken one.
+    """
+    if os.environ.get("SSL_CERT_FILE"):
+        return
+    candidates = [Path("/etc/ssl/certs/ca-certificates.crt")]
+    try:
+        import certifi  # noqa: PLC0415 - optional, and only needed on this path
+
+        candidates.append(Path(certifi.where()))
+    except ImportError:
+        pass
+    for candidate in candidates:
+        if candidate.is_file():
+            os.environ["SSL_CERT_FILE"] = str(candidate)
+            return
+
+
 def detect_compiler_and_cache(
     markers: MarkerPaths, verbose: bool, build_mode: str
 ) -> CompilerDetection:
@@ -124,6 +159,11 @@ def detect_compiler_and_cache(
             )
     else:
         _ts_print("[MESON] Skipping compiler cache in Docker (startup delay too long)")
+
+    # Before the first wrapper invocation: they phone home on every call,
+    # and a system without a resolvable CA bundle turns that failure into
+    # what looks like a broken linker.
+    _ensure_tls_trust_store()
 
     clang_wrapper = shutil.which("clang-tool-chain-c")
     clangxx_wrapper = shutil.which("clang-tool-chain-cpp")

--- a/ci/meson/meson_setup_execute.py
+++ b/ci/meson/meson_setup_execute.py
@@ -134,6 +134,9 @@ def _ensure_tls_trust_store() -> None:
         if candidate.is_file():
             os.environ["SSL_CERT_FILE"] = str(candidate)
             return
+    # No candidate is not an error. Windows and macOS have neither file and
+    # Python's default trust store works there; the wrapper will report any
+    # real TLS failure itself with the full traceback.
 
 
 def detect_compiler_and_cache(

--- a/ci/util/tls_trust.py
+++ b/ci/util/tls_trust.py
@@ -1,0 +1,66 @@
+"""Point `SSL_CERT_FILE` at a CA bundle that exists on this machine.
+
+Every `clang-tool-chain-*` invocation version-checks its manifest over HTTPS.
+On distributions whose Python is built expecting `/etc/ssl/cert.pem` -- NixOS
+among them -- that file does not exist, and the `capath` fallback
+(`/etc/ssl/certs`) carries no `c_rehash` symlinks, so *every* such request dies
+with `CERTIFICATE_VERIFY_FAILED`.
+
+The failure does not look like a network problem. The wrapper prints its SSL
+traceback where the build generator expects a version string, so configuration
+aborts with the thoroughly misleading::
+
+    ERROR: Unknown linker(s): [['.../clang-tool-chain-ar']]
+
+which sends you looking at the linker, or at PATH, or at the toolchain
+install -- none of which are wrong.
+
+This lives in `ci.util` rather than in the build-setup module because the
+wrappers are invoked from at least nine entry points under `ci/` (WASM builds,
+IWYU, the AST checker, the compiler probe, the DLL path helper). Fixing it in
+one of them fixes exactly one. `ci/__init__.py` calls this on package import
+and all nine import `ci`, so the environment is right before any of them makes
+its first HTTPS call.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def ensure_tls_trust_store() -> None:
+    """Set `SSL_CERT_FILE` if it is unset and a real bundle can be found.
+
+    Set only when the caller has not already chosen one, and only to a path
+    that is really there, so this can neither override a deliberate
+    configuration nor invent a broken one.
+
+    Finding no candidate is not an error: Windows and macOS have neither file
+    and Python's default trust store works there. Any genuine TLS failure is
+    still reported by the caller, with its full traceback.
+    """
+    if os.environ.get("SSL_CERT_FILE"):
+        return
+
+    candidates = [Path("/etc/ssl/certs/ca-certificates.crt")]
+    try:
+        import certifi  # noqa: PLC0415 - optional, and only needed on this path
+
+        candidates.append(Path(certifi.where()))
+    except KeyboardInterrupt:
+        import _thread  # noqa: PLC0415
+
+        _thread.interrupt_main()
+        raise
+    except Exception:
+        # certifi is optional; the system bundle above is the common case.
+        pass
+
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                os.environ["SSL_CERT_FILE"] = str(candidate)
+                return
+        except OSError:
+            continue

--- a/ci/util/tls_trust.py
+++ b/ci/util/tls_trust.py
@@ -36,6 +36,14 @@ def ensure_tls_trust_store() -> None:
     that is really there, so this can neither override a deliberate
     configuration nor invent a broken one.
 
+    An *empty* `SSL_CERT_FILE` counts as not chosen, deliberately. OpenSSL
+    cannot load `""` as a trust store, so honouring it would leave the caller
+    with the exact failure this function exists to prevent and no benefit to
+    anyone; and an empty value is nearly always an accidental expansion of an
+    unset variable rather than a considered setting. Unsetting the variable,
+    not emptying it, is how you ask for OpenSSL's own defaults -- and that
+    path is untouched here.
+
     Finding no candidate is not an error: Windows and macOS have neither file
     and Python's default trust store works there. Any genuine TLS failure is
     still reported by the caller, with its full traceback.


### PR DESCRIPTION
## Summary

Every `clang-tool-chain-*` wrapper version-checks its manifest over HTTPS. On distributions whose Python is built expecting `/etc/ssl/cert.pem` (NixOS among them) that file does not exist and the `capath` fallback (`/etc/ssl/certs`) carries no `c_rehash` symlinks, so every request dies with `CERTIFICATE_VERIFY_FAILED`.

The failure does not look like a network problem. The wrapper prints its SSL traceback where the build generator expects a version string, so configuration aborts with:

```
ERROR: Unknown linker(s): [['.../clang-tool-chain-ar']]
```

This sets `SSL_CERT_FILE` before the first wrapper invocation, only when the caller has not set it, and only to a bundle that actually exists (system bundle first, then certifi's). It cannot override a deliberate configuration or invent a broken path.

## Test plan
- [x] `bash lint` green
- [x] `bash test --cpp` configures on a NixOS host where it previously failed with the linker error
- [ ] CI green (no behaviour change on hosts that already resolve a CA bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTPS certificate verification by automatically configuring a trusted CA certificate bundle when one is available.
  - Package initialization remains resilient when trust-store detection encounters non-critical errors.
  - Keyboard interrupts continue to behave correctly during initialization.
  - Empty or unavailable certificate settings are handled safely without preventing the package from loading.
  - Environments with nonstandard certificate locations can now use an available system or optional certificate bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->