### PR TITLE
chore(mp3): re-baseline the fixed-point codegen bounds after the DCT-32 rework

### DIFF
--- a/agents/docs/mp3-decoder-performance.md
+++ b/agents/docs/mp3-decoder-performance.md
@@ -146,7 +146,7 @@ Helix target codegen, also recovered (instructions / inner-loop):
 | riscv32-esp | 15 / 0 | 776 / 0 |
 | xtensa-esp32 | 551 / 117 | 2075 / 1251 |
 
-Do not read these against minimp3's current polyphase figures (75-195
+Do not read these against minimp3's current polyphase figures (90-263
 instructions) as if they were the same measurement. Helix's polyphase is one
 large unrolled routine; minimp3's `mp3d_synth_pair` is small and called many
 times. Static size does not order the two -- dynamic instruction count does,

--- a/codec_cpu_trend.json
+++ b/codec_cpu_trend.json
@@ -45,37 +45,37 @@
       },
       "host": {
         "callgrind": {
-          "branch_misses": 975543,
-          "branches": 25170807,
+          "branch_misses": 818393,
+          "branches": 15264668,
           "functions": {
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_antialias(int*, int)": 67670454,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_dct3_9(int*)": 100403200,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_decode(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_internal_t*, fl::minimp3_fixed::L3_gr_info_t*, int)": 292808466,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_huffman(int*, fl::minimp3_fixed::bs_t*, fl::minimp3_fixed::L3_gr_info_t const*, int const*, short const*, int)": 30896343,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct36(int*, int*, int const*, int)": 175754360,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct_gr(int*, int*, unsigned int, unsigned int)": 176830326,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_midside_stereo(int*, int)": 12751864,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_DCT_II(int*, int)": 202859854,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_add_sat(int, int)": 94137648,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_imdct36_twiddle(int*, int*, int const*, int const*, int const*)": 54068480,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_mulshift(int, int, int)": 107095393,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_narrow_q30(long)": 24629760,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_sat64(long)": 172018903,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_scale_pcm(long)": 27068344,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_antialias(int*, int)": 20417774,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_change_sign(int*)": 1479496,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_dct3_9(int*)": 41789440,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_decode(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_internal_t*, fl::minimp3_fixed::L3_gr_info_t*, int)": 139009823,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_decode_scalefactors(unsigned char const*, unsigned char*, fl::minimp3_fixed::bs_t*, fl::minimp3_fixed::L3_gr_info_t const*, int*, short*, int)": 2769174,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_huffman(int*, fl::minimp3_fixed::bs_t*, fl::minimp3_fixed::L3_gr_info_t const*, int const*, short const*, int)": 26998670,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct36(int*, int*, int const*, int)": 77522040,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_imdct_gr(int*, int*, unsigned int, unsigned int)": 78114166,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::L3_midside_stereo(int*, int)": 6563320,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_add_sat(int, int)": 10159776,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_huff_escape(int, int, int, int)": 2585343,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_imdct36_twiddle(int*, int*, int const*, int const*, int const*)": 5495040,
             "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_shr_round(int, int)": 4129372,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_sub_sat(int, int)": 79788016,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth(int*, short*, int, int*)": 145270996,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth_granule(int*, int*, int, int, short*)": 349803817,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_synth_pair(short*, int, int const*)": 5412102,
-            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3dec_decode_frame_r(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_t*, unsigned char const*, int, short*, fl::minimp3_fixed::mp3dec_frame_info_t*)": 650418217
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3d_sub_sat(int, int)": 12062400,
+            "src/third_party/minimp3/minimp3.h:fl::minimp3_fixed::mp3dec_decode_frame_r(fl::minimp3_fixed::mp3dec_t*, fl::minimp3_fixed::mp3dec_scratch_t*, unsigned char const*, int, short*, fl::minimp3_fixed::mp3dec_frame_info_t*)": 321991900,
+            "src/third_party/minimp3/minimp3_synth_fixed.h:fl::minimp3_fixed::mp3d_DCT_II(int*, int)": 80786468,
+            "src/third_party/minimp3/minimp3_synth_fixed.h:fl::minimp3_fixed::mp3d_imdct36_twiddle(int*, int*, int const*, int const*, int const*)": 23676160,
+            "src/third_party/minimp3/minimp3_synth_fixed.h:fl::minimp3_fixed::mp3d_synth(int*, short*, int, int*)": 99031624,
+            "src/third_party/minimp3/minimp3_synth_fixed.h:fl::minimp3_fixed::mp3d_synth_granule(int*, int*, int, int, short*)": 181491059,
+            "src/third_party/minimp3/minimp3_synth_fixed.h:fl::minimp3_fixed::mp3d_synth_pair(short*, int, int const*)": 3770744
           },
-          "instructions": 659084514
+          "instructions": 330658197
         },
         "counter_median": {
-          "branch_misses": 975543,
-          "cycles": 187720962.0,
-          "instructions": 659084514,
-          "ipc": 3.51098
+          "branch_misses": 818393,
+          "cycles": 63826750.0,
+          "instructions": 330658197,
+          "ipc": 5.180558
         },
         "counter_source": {
           "branch_misses": "Valgrind Callgrind simulated Bcm plus Bim",
@@ -119,14 +119,14 @@
           }
         },
         "stage_ns_median": {
-          "antialias": 7213.8,
+          "antialias": 1367.381,
           "dequant": 0.0,
-          "huffman": 11160.302,
-          "imdct": 19186.098,
-          "reorder": 13.944,
-          "scalefactors": 579.044,
-          "stereo": 1610.025,
-          "synthesis": 41586.536
+          "huffman": 5068.234,
+          "imdct": 7490.064,
+          "reorder": 5.701,
+          "scalefactors": 295.652,
+          "stereo": 851.385,
+          "synthesis": 17322.67
         }
       },
       "operations": {

--- a/codec_cpu_trend.json
+++ b/codec_cpu_trend.json
@@ -4,42 +4,42 @@
       "codegen": {
         "cortex-m0plus": {
           "dct32": {
-            "inner_loop_instructions": 312,
-            "instructions": 339
+            "inner_loop_instructions": 881,
+            "instructions": 959
           },
           "polyphase": {
-            "inner_loop_instructions": 0,
-            "instructions": 195
+            "inner_loop_instructions": 110,
+            "instructions": 263
           }
         },
         "cortex-m4": {
           "dct32": {
-            "inner_loop_instructions": 278,
-            "instructions": 294
+            "inner_loop_instructions": 512,
+            "instructions": 531
           },
           "polyphase": {
-            "inner_loop_instructions": 0,
-            "instructions": 75
+            "inner_loop_instructions": 55,
+            "instructions": 115
           }
         },
         "riscv32-esp": {
           "dct32": {
             "inner_loop_instructions": 0,
-            "instructions": 47
+            "instructions": 91
           },
           "polyphase": {
             "inner_loop_instructions": 0,
-            "instructions": 183
+            "instructions": 90
           }
         },
         "xtensa-esp32": {
           "dct32": {
-            "inner_loop_instructions": 303,
-            "instructions": 317
+            "inner_loop_instructions": 1013,
+            "instructions": 1028
           },
           "polyphase": {
             "inner_loop_instructions": 0,
-            "instructions": 187
+            "instructions": 243
           }
         }
       },


### PR DESCRIPTION
## Summary

The `MP3 CPU audit` workflow has been red on master since #4140 merged (see the last comment on #4138):

```
RuntimeError: minimp3-fixed/codegen/xtensa-esp32/dct32/instructions regressed: 1028 > 332.850000
```

#4140 re-baselined the exact operation ledger but not the cross-compiled codegen bounds. Every fixed-point kernel moved, and the growth is the speed-for-text trade that PR recorded on purpose (secants folded in as template immediates, force-inlined leaves, DCT-32/IMDCT at -O3). This commits the new bounds.

- Numbers come from CI's own `codec-cpu-current` artifact (run 33706008004) and are identical across the last three master runs on two different runner CPUs.
- `check_trend` against that artifact passes with the new baseline. Float backend and the operation ledger are untouched.
- The perf doc's stale polyphase figure range is updated to match.
- Second commit: the primary host profile for `minimp3-fixed` also carried pre-#4140 Callgrind numbers (659M instructions, now 330M). The share-of-total gate on `L3_huffman` tripped on the first runner that gated the fixed backend (its absolute count actually fell 30.9M -> 27.0M) and several symbols changed signature. Refreshed from the same artifact; identical between the EPYC 9V45 and 7763 runs.

Refs #4138.

## Test plan

- [x] `PYTEST_ADDOPTS="-k codec_cpu_audit" bash test --py` — 27 passed
- [x] `bash lint`
- [ ] `MP3 CPU audit` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the historical performance documentation with revised instruction-count ranges for the minimp3 decoder.

- **Chores**
  - Refreshed codec performance benchmarks across supported processor architectures, including updated measurements for key decoding routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->