### PR TITLE
docs(asset): stop documenting sha256/fallback as unenforced

### DIFF
--- a/ci/compiler/asset_scanner.py
+++ b/ci/compiler/asset_scanner.py
@@ -22,9 +22,11 @@ entry of a shared manifest.
 
 v1 scope:
     - Platforms: WASM + host/stub only. ESP32 LittleFS is future work.
-    - Metadata keys parsed but NOT enforced: ``sha256=<hex>``, ``fallback=<url>``.
-      The scanner records them so the shipping manifest is forward-compatible
-      with future integrity/retry features; the runtime ignores them in v1.
+    - Metadata keys ``sha256=<hex>`` and ``fallback=<url>`` are enforced by the
+      WASM loader (``src/platforms/wasm/compiler/index.ts``): it retries the
+      fallback when the primary URL fails and drops any asset whose bytes do
+      not match the declared digest (#4025). The C++ registry only resolves
+      URLs and does not check either field.
     - ``.lnk`` file naming: ``<asset>.<ext>.lnk`` (e.g. ``track.mp3.lnk``). The
       scanner reports the relative path WITHOUT the trailing ``.lnk``, so
       sketches can write ``fl::asset("data/track.mp3")`` and get a hit.

--- a/ci/wasm_build.py
+++ b/ci/wasm_build.py
@@ -1702,9 +1702,9 @@ def generate_asset_manifest(example_name: str, output_dir: Path) -> None:
     """Generate the v1 asset manifest for `<sketch>/data/*.lnk` files.
 
     Part of FastLED issue #2284. Scans the sketch's ``data/`` directory for
-    ``*.lnk`` asset-link files, parses each into ``{url, sha256, fallback}``
-    (sha256/fallback are reserved and not enforced in v1), and writes the
-    resulting manifest to ``<output_dir>/asset_manifest.json``.
+    ``*.lnk`` asset-link files, parses each into ``{url, sha256, fallback}``,
+    and writes the resulting manifest to ``<output_dir>/asset_manifest.json``.
+    The browser loader verifies ``sha256`` and retries ``fallback`` (#4025).
 
     The HTML bootstrap (``src/platforms/wasm/compiler/index.ts``) fetches
     this file and injects it as ``window.fastledAssetManifest``. The C++

--- a/src/fl/asset/asset.h
+++ b/src/fl/asset/asset.h
@@ -158,9 +158,9 @@ constexpr asset_ref asset(const char* path) FL_NO_EXCEPT {
 ///   - **Other platforms (e.g., ESP32):** v1 returns an empty url(). ESP32
 ///     LittleFS / SD-card resolution is tracked as future work.
 ///
-/// The runtime ignores any `sha256=` / `fallback=` metadata in `.lnk` files.
-/// These are parsed by `fl::parse_lnk_with_metadata()` for forward-compat and
-/// reserved for future integrity/retry features.
+/// The C++ registry ignores any `sha256=` / `fallback=` metadata in `.lnk`
+/// files; `fl::parse_lnk_with_metadata()` only carries them. On WASM the
+/// browser loader enforces both before the asset reaches the sketch (#4025).
 ///
 /// Declared here; defined in `fl/asset/asset.cpp.hpp`.
 fl::url resolve_asset(const asset_ref& a) FL_NO_EXCEPT;

--- a/src/fl/stl/url.h
+++ b/src/fl/stl/url.h
@@ -247,12 +247,12 @@ using Url = url;
 
 /// Metadata extracted from a `.lnk` asset link file.
 ///
-/// v1: parsed but not enforced; reserved for future integrity/fallback
-/// features. The runtime ignores everything except `primary`.
+/// The C++ side only resolves `primary`. The WASM browser loader verifies
+/// `sha256` and retries `fallback` (#4025); other platforms do not yet.
 struct LnkMetadata {
     fl::url primary;       ///< First non-comment URL in the file.
-    fl::string sha256;     ///< Hex-encoded sha256 of the expected asset (reserved).
-    fl::url fallback;      ///< Mirror URL used if `primary` fails (reserved).
+    fl::string sha256;     ///< Hex-encoded sha256 of the expected asset.
+    fl::url fallback;      ///< Mirror URL used if `primary` fails.
 
     bool isValid() const FL_NO_EXCEPT { return primary.isValid(); }
     explicit operator bool() const FL_NO_EXCEPT { return primary.isValid(); }
@@ -318,10 +318,9 @@ inline url parse_lnk(fl::string_view content) FL_NO_EXCEPT {
 ///   - `fallback=<url>` — stored in `LnkMetadata::fallback`
 /// Unknown keys are silently ignored (forward-compat).
 ///
-/// v1: the returned metadata is parsed but NOT enforced by the runtime.
-/// `sha256` is not verified and `fallback` is not retried. These fields
-/// are reserved for future integrity/retry features so existing `.lnk`
-/// files remain valid when richer behavior lands.
+/// This parser only extracts the fields. Enforcement lives in the WASM
+/// browser loader, which verifies `sha256` and retries `fallback` (#4025);
+/// C++ resolution on other platforms still uses only the primary URL.
 inline LnkMetadata parse_lnk_with_metadata(fl::string_view content) FL_NO_EXCEPT {
     LnkMetadata out;
     bool gotPrimary = false;

--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -68,8 +68,9 @@ console.log(`⭐ index.js loading, URL: ${window.location.href}`);
  *
  * The WASM build pipeline emits `asset_manifest.json` alongside `fastled.js`.
  * The manifest maps sketch-relative asset paths (e.g. "data/track.mp3") to
- * `{url, sha256, fallback}`. sha256 and fallback are parsed but NOT enforced
- * by v1 — they are reserved for future integrity/retry features.
+ * `{url, sha256, fallback}`. `resolveManifestAssets()` below fetches each
+ * asset, retries `fallback` when the primary URL fails, and verifies the bytes
+ * against `sha256` before the sketch can read them (issue #4025).
  *
  * We expose the manifest as `window.fastledAssetManifest` so C++-side
  * `fl::resolve_asset()` consumers (populated via register_asset calls in

--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -820,14 +820,21 @@ async function resolveManifestAssets(manifest) {
 
     if (spec.sha256) {
       const actual = await sha256Hex(bytes);
-      if (actual && actual !== String(spec.sha256).toLowerCase()) {
+      if (!actual) {
+        // Fail closed: a declared digest that cannot be checked (no
+        // SubtleCrypto, e.g. an insecure origin) must not admit the bytes.
+        console.error(
+          `Asset '${path}' declares a sha256 but SubtleCrypto is unavailable; cannot verify. Dropping it.`,
+        );
+        return null;
+      }
+      if (actual !== String(spec.sha256).toLowerCase()) {
         console.error(
           `Asset '${path}' failed integrity check: declared ${spec.sha256}, got ${actual}. Dropping it.`,
         );
         return null;
       }
-      if (actual) console.log(`Asset '${path}' sha256 verified`);
-      else console.warn(`Asset '${path}': no SubtleCrypto, sha256 not verified`);
+      console.log(`Asset '${path}' sha256 verified`);
     } else {
       console.warn(`Asset '${path}' declares no sha256; contents are unverified`);
     }


### PR DESCRIPTION
## Summary
- Since #4028 the WASM loader (`resolveManifestAssets` in `index.ts`) verifies each asset's declared `sha256`, retries `fallback` when the primary URL fails, and drops mismatched assets. Six comments in `url.h`, `asset.h`, `asset_scanner.py`, `wasm_build.py` and `index.ts` still said the fields were parsed but not enforced.
- Reword them to describe the actual behaviour, and note that the C++ registry on non-WASM platforms still resolves only the primary URL.
- One code change (from review): `resolveManifestAssets()` now drops an asset whose declared `sha256` cannot be verified because SubtleCrypto is unavailable, instead of warning and injecting it. This makes the loader match the corrected docs.

Closes #4025

## Verification
- `bash compile wasm --examples Blink` green with the loader change
- `bash lint` (Python + TypeScript) green
- `uv run pytest ci/tests/test_asset_scanner.py` 33 passed
- `bash test url` / `bash test asset` compile and link (runner spawn is blocked on this host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WASM asset loading now rejects assets with declared SHA-256 checksums when integrity verification is unavailable, preventing unverified assets from being loaded.
  * WASM loading retries the fallback URL when the primary asset download fails and verifies downloaded assets against their declared SHA-256 digest.

* **Documentation**
  * Clarified that non-WASM C++ asset resolution uses the primary URL without enforcing `sha256` or `fallback` metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
