### PR TITLE
fix(ci): permanently disable issue auto-close in stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,12 @@ jobs:
           stale-pr-label: "status: stale"
           days-before-issue-stale: 60
           days-before-pr-stale: 30
-          days-before-issue-close: 30
+          # Issue auto-close is permanently disabled: the 60/30 close schedule
+          # auto-closed 53 real issues as not_planned over three runs
+          # (2026-09-01 -> 09-03), accelerating each day. -1 is the
+          # actions/stale documented value for "never close". Do not change
+          # this back to a number without repo owner sign-off.
+          days-before-issue-close: -1
           days-before-pr-close: 30
           exempt-issue-labels: >-
             status: in-progress,
@@ -53,9 +58,9 @@ jobs:
           operations-per-run: 100
           stale-issue-message: >-
             This issue has had no activity for 60 days and is now marked stale.
-            It will close in 30 days unless there is new activity or a maintainer
-            applies an exempt label. Comment with current, actionable information
-            to keep it open; the stale label will be removed automatically.
+            This label is a triage signal only; the issue will not be closed
+            automatically. Comment with current, actionable information at any
+            time and the stale label will be removed automatically.
           close-issue-message: >-
             This issue was closed after 30 additional days without activity.
             If it is still relevant, please comment with current reproduction


### PR DESCRIPTION
## What happened

The stale workflow added in #4101 (7d618b04f0) auto-closes issues 30 days
after they are marked stale. It has run three times so far
(2026-09-01, 09-02, 09-03 at 08:33 UTC) and has already auto-closed
**53 real issues** as `not_planned` — 14, then 18, then 21, accelerating
each run.

## What this PR changes

- `days-before-issue-close: 30` -> `-1`. In `actions/stale`, `-1` is the
  documented value meaning "never close." A YAML comment above the key
  explains why, so it doesn't get "fixed" back to a number later.
- `days-before-issue-stale: 60` is unchanged — issues are still labeled
  stale after 60 days of inactivity. That label is a non-destructive
  triage signal; only the auto-close behavior is disabled.
- `stale-issue-message` is rewritten because it previously said "It will
  close in 30 days unless...", which is no longer true. It now says the
  stale label is a triage signal only and the issue will not be closed
  automatically.
- `close-issue-message` is left in place even though it is now
  unreachable for issues (kept for low churn / easy revert if the policy
  ever changes back).

## What this PR deliberately does NOT change

All PR-related stale/close settings are untouched: `days-before-pr-stale`,
`days-before-pr-close`, `stale-pr-message`, `close-pr-message`,
`exempt-pr-labels`, `exempt-draft-pr`. The owner's instruction was
specifically about issues, not PRs — PRs still stale at 30 days and close
30 days after that.

## Follow-up

The 53 issues that were incorrectly auto-closed are being reopened
separately by the repo owner; this PR only stops it from happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Stale issues will no longer be automatically closed.
  - The stale label now serves only as a triage signal.
  - Pull requests continue to be automatically closed after 30 days of inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->