### PR TITLE
fix(hooks): resolve the merge guard's repo from the command's own cwd

### DIFF
--- a/ci/hooks/check_pr_merge_reviews.py
+++ b/ci/hooks/check_pr_merge_reviews.py
@@ -35,6 +35,38 @@ REPO_ARG_RE = re.compile(r"(?:--repo|-R)[= ]\s*([\w.-]+/[\w.-]+)")
 # `gh pr merge https://github.com/OWNER/NAME/pull/N` would be checked
 # against the current checkout instead of OWNER/NAME.
 PR_URL_RE = re.compile(r"github\.com/([\w.-]+/[\w.-]+)/pull/\d+")
+# `cd <dir> && gh pr merge N` — `gh` resolves the repo from *that* directory,
+# so the hook has to as well. Without this, merging another project's PR from
+# its worktree was checked against this checkout: merging zackees/clud#1150
+# from `cd ~/dev/clud-wt-gate` was judged against FastLED/FastLED#1150, an
+# unrelated PR that happened to share a number.
+CD_RE = re.compile(r"(?:^|&&|;|\|\|)\s*cd\s+(?:--\s+)?([^\s;&|]+)")
+REMOTE_URL_RE = re.compile(r"[:/]([\w.-]+/[\w.-]+?)(?:\.git)?$")
+
+
+def _repo_at(path: str) -> str | None:
+    """`owner/repo` for the git checkout at `path`, or None.
+
+    Reads `remote.origin.url` rather than calling `gh`: no network, and it
+    fails closed to None on anything unexpected (missing dir, not a repo, no
+    origin, a URL shape this does not recognise).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", path, "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except KeyboardInterrupt as ki:
+        handle_keyboard_interrupt(ki)
+        raise
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = REMOTE_URL_RE.search(result.stdout.strip())
+    return match.group(1) if match else None
 
 
 def _target(command: str) -> tuple[str | None, str | None]:
@@ -48,8 +80,14 @@ def _target(command: str) -> tuple[str | None, str | None]:
     if pr_match:
         pr = pr_match.group(1) or pr_match.group(2)
     repo_match = REPO_ARG_RE.search(command) or PR_URL_RE.search(command)
-    repo = repo_match.group(1) if repo_match else None
-    return pr, repo
+    if repo_match:
+        return pr, repo_match.group(1)
+    # No explicit repo. If the command cd's somewhere first, that is where
+    # `gh` will resolve the repo from, so resolve it from there too.
+    cd_match = CD_RE.search(command)
+    if cd_match:
+        return pr, _repo_at(cd_match.group(1))
+    return pr, None
 
 
 def main() -> int:
@@ -76,6 +114,15 @@ def main() -> int:
     # repository — and blocked with "no PR found for current branch" whenever
     # the current branch had no PR of its own.
     pr, repo = _target(command)
+    if repo is None and CD_RE.search(command):
+        # The command changes directory but we could not name the repository
+        # there. Checking `pr` against *this* checkout is what produced the
+        # original false positive, so decline to judge rather than judge wrong.
+        sys.stderr.write(
+            "[check_pr_merge_reviews] command changes directory and the "
+            "repository there could not be identified; allowing merge.\n"
+        )
+        return 0
     cmd = ["uv", "run", "python", "ci/tools/coderabbit_addressor.py", "--check"]
     if pr:
         cmd.append(pr)
@@ -98,10 +145,10 @@ def main() -> int:
     if result.returncode == 0:
         return 0
 
-    # Exit 2 from the addressor means "could not identify a PR", not
-    # "this PR has unresolved reviews". Blocking then is a false positive:
-    # there is no review state to protect. Only a real unresolved-comment
-    # verdict (exit 1) blocks.
+    # Exit 2 from the addressor means "could not identify a PR" or "the check
+    # itself failed" — not "this PR has unresolved reviews". Blocking then is
+    # a false positive: there is no review state to protect. Only a real
+    # unresolved-comment verdict (exit 1) blocks.
     if result.returncode != 1:
         sys.stderr.write(result.stderr or "")
         sys.stderr.write(

--- a/ci/hooks/check_pr_merge_reviews.py
+++ b/ci/hooks/check_pr_merge_reviews.py
@@ -52,10 +52,16 @@ def _repo_at(path: str) -> str | None:
     origin, a URL shape this does not recognise).
     """
     try:
-        result = subprocess.run(
+        # noqa: SRC001 - RunningProcess.run merges stderr into stdout, and this
+        # parses stdout as a URL: one git warning on stderr would be spliced
+        # into the value and yield a wrong owner/repo, which is the class of
+        # bug this function exists to fix.
+        result = subprocess.run(  # noqa: SRC001
             ["git", "-C", path, "config", "--get", "remote.origin.url"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
     except KeyboardInterrupt as ki:
@@ -130,7 +136,10 @@ def main() -> int:
         cmd.extend(["--repo", repo])
 
     try:
-        result = subprocess.run(
+        # noqa: SRC001 - the streams are used separately: stderr is forwarded to
+        # the user as the block reason, stdout is not. Merging them would put
+        # the checker's diagnostics into the wrong channel.
+        result = subprocess.run(  # noqa: SRC001
             cmd,
             capture_output=True,
             text=True,

--- a/ci/tests/test_check_pr_merge_reviews.py
+++ b/ci/tests/test_check_pr_merge_reviews.py
@@ -80,8 +80,8 @@ def _make_repo(tmp_path: Any, name: str, origin: str) -> str:
 
     path = tmp_path / name
     path.mkdir()
-    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
-    subprocess.run(["git", "remote", "add", "origin", origin], cwd=path, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)  # noqa: SRC001
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=path, check=True)  # noqa: SRC001
     return str(path)
 
 
@@ -155,7 +155,7 @@ def test_addressor_crash_exits_2_not_1(tmp_path: Any) -> None:
 
     addressor = REPO_ROOT / "ci" / "tools" / "coderabbit_addressor.py"
     # A PR number that cannot exist drives `gh api` to fail inside the check.
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: SRC001
         [
             _sys.executable,
             str(addressor),
@@ -166,6 +166,8 @@ def test_addressor_crash_exits_2_not_1(tmp_path: Any) -> None:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=120,
     )
 

--- a/ci/tests/test_check_pr_merge_reviews.py
+++ b/ci/tests/test_check_pr_merge_reviews.py
@@ -64,3 +64,112 @@ def test_non_merge_commands_are_ignored() -> None:
     assert not hook.MERGE_RE.search("gh pr view 1268 --repo FastLED/fbuild")
     assert not hook.MERGE_RE.search("gh pr create --title x")
     assert hook.MERGE_RE.search("gh pr merge 1268")
+
+
+# ---------------------------------------------------------------------------
+# `cd <dir> && gh pr merge N` — the repo comes from the directory, not the
+# checkout the hook happens to run in.
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Any, name: str, origin: str) -> str:
+    """A real git repo with an origin, so `_repo_at` is exercised rather than
+    mocked. The hook shells out to `git config`; a fake would not prove it
+    parses what git actually prints."""
+    import subprocess
+
+    path = tmp_path / name
+    path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "remote", "add", "origin", origin], cwd=path, check=True)
+    return str(path)
+
+
+def test_cd_prefix_resolves_the_repo_from_that_directory(tmp_path: Any) -> None:
+    """The false positive this fixes: merging another project's PR from its
+    worktree was judged against *this* checkout. clud#1150 and
+    FastLED/FastLED#1150 are unrelated PRs that happen to share a number, and
+    the hook blocked the clud merge citing the FastLED one."""
+    hook = _load_hook()
+    other = _make_repo(tmp_path, "clud-wt", "https://github.com/zackees/clud.git")
+
+    pr, repo = hook._target(f"cd {other} && gh pr merge 1150 --squash --delete-branch")
+
+    assert pr == "1150"
+    assert repo == "zackees/clud", "must not fall back to the current checkout"
+
+
+def test_ssh_remote_urls_resolve(tmp_path: Any) -> None:
+    hook = _load_hook()
+    other = _make_repo(tmp_path, "ssh-wt", "git@github.com:zackees/clud.git")
+
+    _, repo = hook._target(f"cd {other} && gh pr merge 7 --squash")
+
+    assert repo == "zackees/clud"
+
+
+def test_explicit_repo_still_wins_over_the_cd(tmp_path: Any) -> None:
+    """`--repo` is what the user actually asked for; a `cd` earlier in the
+    chain must not override it."""
+    hook = _load_hook()
+    other = _make_repo(tmp_path, "wt", "https://github.com/zackees/clud.git")
+
+    _, repo = hook._target(
+        f"cd {other} && gh pr merge 1268 --repo FastLED/fbuild --squash"
+    )
+
+    assert repo == "FastLED/fbuild"
+
+
+def test_no_cd_is_unchanged(tmp_path: Any) -> None:
+    """The ordinary same-repo merge keeps resolving to the current checkout,
+    so this fix cannot weaken the guard it exists to enforce."""
+    hook = _load_hook()
+
+    assert hook._target("gh pr merge 3866 --squash --delete-branch") == ("3866", None)
+
+
+def test_a_cd_to_a_non_repo_is_allowed_rather_than_misjudged(tmp_path: Any) -> None:
+    """If the directory is not a git checkout we cannot name the target repo.
+    Judging the number against *this* checkout is exactly the original bug, so
+    the hook declines instead."""
+    hook = _load_hook()
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+
+    _, repo = hook._target(f"cd {plain} && gh pr merge 1150 --squash")
+
+    assert repo is None
+
+
+def test_addressor_crash_exits_2_not_1(tmp_path: Any) -> None:
+    """A crash in the checker must not read as "unresolved reviews".
+
+    An unhandled traceback exits 1, which is precisely the code the hook
+    treats as a real verdict — so a `gh` failure, a network blip, or a PR
+    number that does not exist in the resolved repo all blocked the merge
+    while claiming there were review comments to address.
+    """
+    import subprocess
+    import sys as _sys
+
+    addressor = REPO_ROOT / "ci" / "tools" / "coderabbit_addressor.py"
+    # A PR number that cannot exist drives `gh api` to fail inside the check.
+    result = subprocess.run(
+        [
+            _sys.executable,
+            str(addressor),
+            "--check",
+            "999999999",
+            "--repo",
+            "FastLED/FastLED",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode != 1, (
+        "exit 1 is the hook's 'unresolved reviews' verdict; an internal "
+        f"failure must not use it. stderr:\n{result.stderr[-600:]}"
+    )

--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -313,4 +313,24 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        raise
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - the exit code is the point
+        # Exit 2, not the 1 an unhandled traceback would produce. The merge
+        # hook reads 1 as "this PR has unresolved review comments" and blocks
+        # on it; a crash in here is not that. Letting the traceback out made
+        # every internal failure — a `gh` error, a network blip, a PR number
+        # that does not exist in this repo — indistinguishable from a real
+        # verdict, and it blocked the merge either way.
+        import traceback
+
+        traceback.print_exc()
+        print(
+            "[address-reviews] internal error (above); not a review verdict",
+            file=sys.stderr,
+        )
+        sys.exit(2)

--- a/ci/tools/coderabbit_addressor.py
+++ b/ci/tools/coderabbit_addressor.py
@@ -315,8 +315,11 @@ def main() -> int:
 if __name__ == "__main__":
     try:
         sys.exit(main())
-    except KeyboardInterrupt:
-        raise
+    except KeyboardInterrupt as ki:
+        import _thread  # noqa: PLC0415
+
+        _thread.interrupt_main()
+        raise ki
     except SystemExit:
         raise
     except Exception as exc:  # noqa: BLE001 - the exit code is the point


### PR DESCRIPTION
Two false positives in the `gh pr merge` review guard. Both block a merge while giving a reason that is not true, and I hit each of them repeatedly today.

## 1. The repo came from the hook's directory, not the command's

`gh pr merge N` with no `--repo` resolves the repository from the working directory. The hook read the number but not the `cd`, and ran its check from whatever checkout it happened to be invoked in.

    cd ~/dev/clud-wt-gate && gh pr merge 1150 --squash

was judged against **FastLED/FastLED#1150** — an unrelated PR that happens to share a number with `zackees/clud#1150`. The merge was refused, citing review comments belonging to a different project.

This is the same defect the `--repo` handling already fixed once (see the comment at `PR_URL_RE`); the `cd` form was simply not covered. The hook now reads `remote.origin.url` from the directory the command cd's into. An explicit `--repo` still wins, since that is what the user actually asked for. A `cd` into a directory that cannot be identified as a checkout now **allows** rather than judging the number against the wrong repo — declining to judge beats judging wrong, and judging wrong is the bug.

## 2. A crash in the checker read as "unresolved reviews"

`coderabbit_addressor.py` let exceptions escape. An unhandled traceback exits **1** — exactly the code the hook treats as a genuine unresolved-comment verdict. So any internal failure blocked the merge while claiming there were reviews to address.

This is not hypothetical, and it is not independent of the first bug: bug 1 sent the checker at a PR number that does not exist in the resolved repo, `gh api repos/FastLED/FastLED/pulls/1150/comments` failed, and the escaping traceback turned that into a block. The addressor now exits 2, which the hook already treats as "could not determine, allow".

## Verification

    cd <a clud worktree> && gh pr merge 1154 --squash    -> exit 0 (allow)   was: blocked
    gh pr merge 4147 --squash                            -> exit 2 (block)   unchanged

The second is a real verdict on a FastLED PR, so the guard is not weakened by this.

13 tests, including the exact command shape that misfired, ssh remotes, `--repo` precedence, the unchanged same-repo path, a non-repo directory, and a real subprocess run proving a failing check does not exit 1. Verified RED against the unfixed hook: the two `cd` tests fail, the other 10 pass.

`bash lint` clean.

> The `# noqa: SRC001` annotations are deliberate: `RunningProcess.run` merges stderr into stdout, which would splice a git warning into the URL `_repo_at` parses, and would put the checker's diagnostics into the channel the hook does not forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmbTgspd5g2xg49VaCcxiN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge review checks now correctly identify the repository when merge commands target another directory.
  * Explicit repository settings take precedence, while invalid repository targets no longer cause checks to inspect the wrong checkout.
  * Internal checker failures are distinguished from unresolved review comments, preventing unexpected merge blocks.

* **Tests**
  * Added coverage for alternate repositories, SSH remotes, explicit repository settings, invalid targets, and checker failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->