### PR TITLE
chore(deps): move the fbuild pin to 2.5.22 (fixes ESP32-S3 298MB SDK re-download)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,23 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.20. It carries hardened USB/deploy recovery, current
+    # Pin to fbuild 2.5.22. It carries hardened USB/deploy recovery, current
     # esptool probing, and the accumulated library/build fixes below.
     #
     # Pin history:
+    #   2.5.22 -- ESP32-S3 stops reinstalling its 298 MB SDK-libs archive on
+    #              every build. The completion check required
+    #              `<mcu>/lib/libfreertos.a`, which S3 alone does not ship
+    #              there (its FreeRTOS build is per flash/PSRAM mode, so the
+    #              archive lives under dio_opi/, qio_qspi/, ...), so the check
+    #              never passed. Measured on a bare S3 blink: no-op build
+    #              161.2s -> 0.3s, one-file fresh build 233.0s -> 7.1s
+    #              (FastLED/fbuild#1411/#1413).
+    #   2.5.21 -- exposes structured firmware artifacts to the Python API
+    #              (FastLED/fbuild#1402), fetches the ESP8266 core from a
+    #              release asset so its submodules come with it
+    #              (FastLED/fbuild#1398), and runs shared-code CI against a
+    #              core board set instead of all 80 (FastLED/fbuild#1397).
     #   2.5.20 -- fbuild provisions the Linux shared libraries Espressif QEMU
     #              needs (libslirp/libSDL2/libpixman) itself instead of
     #              requiring an apt-get step from the caller: it probes the
@@ -208,7 +221,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.21",
+    "fbuild==2.5.22",
     # Decodes the FastLED/boards `usb-vids.proto.zstd` registry artifact in
     # ci/util/audit_usb_registry.py. Declared explicitly rather than relied on
     # transitively (clang-tool-chain-bins pulls it in today) so the documented


### PR DESCRIPTION
Moves the pin to fbuild 2.5.22, which fixes the ESP32-S3 build slowness.

## The bug

fbuild's SDK-completion check required `<mcu>/lib/libfreertos.a`. ESP32-S3 is the one MCU that does not ship it there — its FreeRTOS build is per flash/PSRAM mode, so the archive lives under `dio_opi/`, `qio_qspi/`, and so on. The check therefore **never** passed, and every ESP32-S3 build re-downloaded and re-extracted the 298 MB SDK-libs archive before reaching the fast path.

Measured on a bare S3 blink against the published wheel:

| | before | after |
|---|---|---|
| no-op build | 161.2s | **0.3s** |
| one-file fresh build | 233.0s | **7.1s** |

Fixed upstream in FastLED/fbuild#1411 / #1413, released in v2.5.22 (2026-09-03T21:17Z).

## Why this matters more than the numbers suggest

The ESP32-S3 example sweep is sharded 8 ways, so CI was paying that 298 MB re-download **eight times per run**. On the run measured while preparing this PR, the eight shards took 25–43 minutes each — roughly 276 runner-minutes — against a pre-sharding whole-workflow runtime of 19m28s recorded in #3791. Every shard reported success, so nothing flagged it.

That sharding was itself the response to #3791 ("every esp32s3 run hangs in_progress and never completes"), which correctly guessed the cause was an unbounded wait. Sharding divided the symptom into eight pieces small enough to finish, but did not fix it and added no `timeout-minutes` — `build_esp32s3.yml` still has none, and only 10 of 118 workflows do.

## Notes

- `uv.lock` is gitignored here, so this pin is the only committed half. Run `uv lock && uv sync` locally or you keep running 2.5.21.
- The first build after this lands pays a one-time framework-core-cache warm, because the cache key moves with the fbuild version.
- `uv lock --check` passes on this pin.
- Original commit by another session; rebased off an unmerged branch onto master so it stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release-history notes for versions 2.5.21 and 2.5.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->