### PR TITLE
fix(ci): stop stripping release lint_cpp_rs binaries so soldr passes on macOS

### DIFF
--- a/ci/lint_cpp_rs/Cargo.toml
+++ b/ci/lint_cpp_rs/Cargo.toml
@@ -34,3 +34,13 @@ debug = "line-tables-only"
 # (cargo caches dep artifacts across crate-source edits).
 [profile.dev.package."*"]
 opt-level = 1
+
+# CI runs the crate's tests with `--release`. Since cargo 1.77 the release
+# profile defaults to `strip = "debuginfo"`, which makes rustc shell out to
+# `rust-objcopy` after every link. On the GitHub macOS runners that binary
+# dies at load time (`dyld: Library not loaded: @rpath/libLLVM.dylib`);
+# rustc only warns, but soldr >= 0.9.12 promotes the failed strip into a
+# build failure, which turned `unit tests macos` red on master. Nothing
+# consumes a stripped test binary, so opt out of stripping entirely.
+[profile.release]
+strip = "none"


### PR DESCRIPTION
## Summary

`unit tests macos` is red on master (https://github.com/FastLED/FastLED/actions/runs/33993978315). All 105 Rust lint tests pass, then soldr fails the step:

```
warning: stripping debug info with `rust-objcopy` failed: signal: 6 (SIGABRT)
  = note: dyld[32873]: Library not loaded: @rpath/libLLVM.dylib
soldr: requested artifact stripping with `rust-objcopy` failed; Soldr refuses to publish an unstripped artifact.
```

Since cargo 1.77 the release profile defaults to `strip = "debuginfo"`, which shells out to `rust-objcopy` after every link. On the macOS runners that binary cannot load, and soldr >= 0.9.12 promotes the failed strip into a hard failure.

Nothing consumes a stripped test binary, so this sets `strip = "none"` on the release profile of `ci/lint_cpp_rs/Cargo.toml`.

## Test plan
- [x] `uv run soldr cargo test --release --manifest-path ci/lint_cpp_rs/Cargo.toml` passes locally (105 passed)
- [x] `unit tests macos` green on this PR (https://github.com/FastLED/FastLED/actions/runs/33995038840/job/101383986118)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build reliability on macOS runners by preserving required release debugging information.
  - Prevented failures during release artifact processing for affected builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
