### PR TITLE
docs(color): define implementation contracts across pipeline phases

### DIFF
--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -2,6 +2,34 @@
 
 <!-- Add tasks here as checkable items -->
 
+## Profiled color pipeline (#4032 / #4034)
+
+- [x] Revalidate current master, phase issues, and #4156 review decisions.
+- [x] Assign P1, P2, and P4 to Terra agents in isolated checkouts.
+- [ ] Merge the cross-phase contract addendum and link it from the tracker.
+- [ ] P1 #4035: complete research/schema artifacts and merge its PR.
+- [ ] P2 #4036: complete profile/binding API and merge its PR.
+- [ ] P3 #4037: complete generator/ingestion/freshness tooling and merge its PR.
+- [ ] P4 #4038: complete media contract and playback integration and merge its PR.
+- [ ] P5 #4039: complete float64 reference/goldens/RED baseline and merge its PR.
+- [ ] P6 #4040: complete streaming core/brightness/power and merge its PR.
+- [ ] P7 #4041: complete gamut/device solve and merge its PR.
+- [ ] P8 #4042: complete native encoders/dithering and merge its PR.
+- [ ] P9 #4043: prove fixed-point/TINY/bloat/throughput gates and merge its PR.
+- [ ] P10 #4044: complete measured hardware/compatibility gates and merge its PR.
+- [ ] Audit every criterion, clean owned worktrees/artifacts, return to origin/master.
+
+### Evidence and constraints
+
+- Initial checkout and remote default are master at 9de01d3547; origin/main
+  does not exist. No pre-existing worktree changes were present.
+- P4's carry/validate layer landed in #4045; that does not satisfy playback.
+- Current port scan reports one healthy Espressif USB device at /dev/ttyACM0.
+  Calibration instrument and strip/measurement provenance still need validation.
+- Full requirement ownership remains #4034; implementation contracts are in
+  docs/color-pipeline-contracts.md. No phase is complete merely because an API
+  or test stub exists.
+
 ## Preserve FastLED imports for external Meson consumers
 
 - [x] Reproduce the foreign-working-directory `ModuleNotFoundError` in CI.

--- a/agents/tasks/todo.md
+++ b/agents/tasks/todo.md
@@ -6,7 +6,7 @@
 
 - [x] Revalidate current master, phase issues, and #4156 review decisions.
 - [x] Assign P1, P2, and P4 to Terra agents in isolated checkouts.
-- [ ] Merge the cross-phase contract addendum and link it from the tracker.
+- [ ] Merge the [cross-phase contract addendum](../../docs/color-pipeline-contracts.md) and link it from the tracker.
 - [ ] P1 #4035: complete research/schema artifacts and merge its PR.
 - [ ] P2 #4036: complete profile/binding API and merge its PR.
 - [ ] P3 #4037: complete generator/ingestion/freshness tooling and merge its PR.

--- a/docs/color-pipeline-contracts.md
+++ b/docs/color-pipeline-contracts.md
@@ -38,10 +38,12 @@ if red light is `d` and green light is `d*d`, quartering full-scale drive yields
 red light `1/4` but green light `1/16`. Quarter light requires drives `1/4` and
 `1/2` respectively. P5 golden vectors and P6/P8 integration must cover this.
 
-Source-profile defaults for ordinary managed RGB buffers are linear transfer,
-BT.709 primaries, and D65 white. This names the primary/white convention as well
-as the transfer; enabling management is explicit and can change appearance.
-With management disabled, existing byte output remains unchanged.
+Source-profile defaults for ordinary managed, containerless RGB buffers are
+linear transfer, BT.709 primaries, and D65 white. This applies to RGB8 buffers
+too; eight-bit storage alone does not imply sRGB transfer. In contrast,
+[RGB8 `.fled` input with absent metadata](#source-admission-and-playback-r1-r5-r6-r10)
+defaults to sRGB transfer. Enabling management is explicit and can change
+appearance. With management disabled, existing byte output remains unchanged.
 
 ### Container formats and generic storage
 

--- a/docs/color-pipeline-contracts.md
+++ b/docs/color-pipeline-contracts.md
@@ -1,0 +1,222 @@
+# Color pipeline implementation contracts
+
+This implementation addendum addresses the cross-phase findings in
+[review #4156](https://github.com/FastLED/FastLED/issues/4156). The program remains
+[tracker #4034](https://github.com/FastLED/FastLED/issues/4034), implementing
+[specification #4032](https://github.com/FastLED/FastLED/issues/4032) and its
+[decision record #4033](https://github.com/FastLED/FastLED/issues/4033).
+
+These are implementation requirements, not a statement that the managed output
+path is already available. Phase PRs must link their actual tests and artifacts.
+Unimplemented requirements remain open; accepting this document does not close
+any implementation phase or the hardware measurement gate.
+
+## Typed boundaries and stage ordering (R2, R5, D1)
+
+The managed path carries these distinct quantities:
+
+1. Encoded source view: storage format, component byte order, pixel stride,
+   immutable frame data, and an independent source-color profile.
+2. Linear source RGB: decode RGB8 directly to unsigned RGB16; preserve RGB16
+   source samples without an RGB8 intermediate.
+3. Signed, wide device-independent coordinates: source RGB to XYZ, white-point
+   adaptation, and gamut mapping. Negative intermediates must survive until
+   gamut mapping; signed multiplication uses wider products with defined
+   rounding and overflow admission checks.
+4. Linear emitter contributions: three, four, or five normalized light outputs
+   produced by the device solve, including white-channel allocation.
+5. Dimmed linear emitter contributions: multiply by brightness and the shared
+   power scalar once in this domain.
+6. Physical drive coordinates: inverse measured code-to-light response,
+   followed by chipset-specific current/brightness-field selection and final
+   quantization/dithering.
+
+Response inversion in step 6 is necessary physical calibration. It is not a
+second artistic gamma stage, and it must not stack with legacy correction.
+Multiplying already response-compensated drive codes by brightness is wrong:
+if red light is `d` and green light is `d*d`, quartering full-scale drive yields
+red light `1/4` but green light `1/16`. Quarter light requires drives `1/4` and
+`1/2` respectively. P5 golden vectors and P6/P8 integration must cover this.
+
+Source-profile defaults for ordinary managed RGB buffers are linear transfer,
+BT.709 primaries, and D65 white. This names the primary/white convention as well
+as the transfer; enabling management is explicit and can change appearance.
+With management disabled, existing byte output remains unchanged.
+
+### Container formats and generic storage
+
+`fl::fled::PixelFormat` owns the stable `.fled` wire identifiers. Generic
+`fl::PixelFormat` describes FastLED storage. The generic API is independent of
+the container. Matching numeric enum values are permitted but do not establish
+a casting or serialization contract.
+
+| Container format | Generic storage | Additional meaning |
+|---|---|---|
+| `Rgb8`, wire `0x00` | RGB8 | Source transfer/primaries from resolved metadata |
+| `Rgb16Linear`, wire `0x05` | RGB16 | Little-endian payload, linear transfer, full range |
+
+The `.fled` layer performs checked conversion. It retains the resolved source
+profile and payload byte order alongside the storage descriptor. Reverse
+serialization validates both storage and source semantics: generic RGB16 is
+not enough to label data `rgb16_linear`.
+
+`resolveVideoColor` remains a `.fled` operation and accepts the container enum
+through a public header. Unknown raw values are rejected at parsing/admission
+boundaries. Its byte-valued compatibility overload, if retained, has identical
+validation behavior.
+
+## Source admission and playback (R1, R5, R6, R10)
+
+Recognizing FLED magic commits a reader to container parsing. An unsupported
+version, format, or malformed/truncated envelope must not rewind into legacy
+raw RGB. Headerless RGB compatibility applies only when FLED magic is absent.
+Readers must document how non-seekable input is probed without losing bytes.
+Older deployed binaries cannot be assumed to reject newer formats safely.
+
+Loading a bundle, resolving its declaration, and admitting it for rendering
+are separate operations. Managed playback is strict by default. Unknown or
+unsupported explicit color semantics cause an error; best-effort fallback for
+advisory RGB formats requires explicit caller opt-in and a diagnostic. A
+mandatory unsupported format never falls back to a byte interpretation.
+
+Absent metadata resolves using these existing default tuples:
+
+- RGB8: BT.709 primaries, sRGB transfer, RGB matrix, full range.
+- RGB16-linear: BT.709 primaries, linear transfer, RGB matrix, full range.
+
+An explicit contradictory declaration is rejected. The term "mandatory" means
+that the format's semantics cannot be ignored, not that redundant default
+metadata must physically appear in every envelope.
+
+File metadata owns the source meaning for file playback. Channel defaults
+apply to ordinary buffers and do not silently override file metadata. An
+explicit override must be visible as such. Switching sources replaces the
+complete profile/view atomically between frames and invalidates derived
+caches. Two channels consuming the same source may have different emitter
+profiles without changing the source buffer.
+
+Same-space effect arithmetic retains its declared-space semantics. Mixed-space
+composition is rejected in v1 unless all inputs have first been converted to
+one explicitly typed wide working domain. A decode inside `show()` cannot
+retroactively correct an earlier RGB8 blend.
+
+On a playback error after a lit frame, a dark-output policy requires an actual
+black-frame submission and an observable error result. Skipping output alone
+leaves addressable LEDs displaying the previously latched frame.
+
+### Numerical admission
+
+Syntactic metadata validation is not numerical transform admission. Before a
+profile is installed, require finite values, usable white, nondegenerate source
+primaries, positive usable emitter capacities, and representable, sufficiently
+conditioned matrix coefficients. The embedded implementation publishes its
+coefficient bounds and tests their edges against the reference. Profiles
+outside those bounds fail explicitly; they do not become native-drive input.
+
+The initial physical-emitter domain uses realizable nonnegative chromaticities.
+Support for imaginary *source* primaries must be explicit and bounded by the
+same numerical admission checks, never inferred from successful JSON parsing.
+Measured response tables must be finite, bounded, monotone, and have defined
+endpoints. Inverse response uses a deterministic policy for plateaus and rejects
+unachievable targets rather than dividing by a zero response interval.
+
+## White and gamut coordinates (R7)
+
+Separate measured emitter XYZ capacities from the selected rendering white and
+its maximum achievable neutral luminance. All emitters at full drive are not
+necessarily that white, particularly for RGBWW and target-white overrides.
+
+Bradford adapts source-relative XYZ to the selected rendering white. Standard
+Oklab/OKLCh computations use D65-relative XYZ with white Y=1; see the
+[Oklab definition](https://bottosson.github.io/posts/oklab/). Therefore the mapper
+adapts both target XYZ and the entire feasible emitter gamut from rendering
+white to D65 for its objective, and transforms mapped results back before the
+device solve. The target and boundary must use exactly the same transforms.
+
+P5/P7 must publish the exact compression objective, luminance/chroma tradeoff,
+boundary tolerances, and deterministic tie-breaks as an executable reference.
+The algorithm must preserve feasible input exactly within the stated numerical
+budget, preserve the selected neutral axis, and be continuous at gamut and
+white-allocation boundaries. A named color space by itself is not an algorithm.
+Iterative optimization may run at profile/LUT construction, never per pixel in
+the embedded output path. RGBW/RGBWW feasibility includes all emitters.
+
+## Power and presentation (R3, R4, R8)
+
+The managed implementation uses two-pass streaming over stable frame inputs:
+
+1. Evaluate solved demand across every channel participating in a supply
+   budget; include response inversion, current-field policy, and quantization
+   reserve. Compute a wide shared power scalar without advancing dither state.
+2. Encode the same source/profile snapshot with that scalar and submit output.
+
+This requires no RGB16 framebuffer. Async drivers may continue owning their
+existing encoded wire buffers. The prepass and encode cost both count toward
+throughput budgets. Caller-owned source storage must not mutate during either
+pass; profile bindings are immutable snapshots until the frame ends.
+
+User brightness remains `b/255` in linear light. The internal power scalar is
+wide, not an eight-bit replacement brightness. Fixed controller/LED idle
+consumption is independent of that scalar. A budget below unavoidable baseline
+returns an infeasible-budget diagnostic and minimum controllable output; it
+does not claim zero total consumption. Mixed legacy and managed channels must
+be aggregated with their respective electrical models.
+
+The electrical contract bounds modeled demand for each latched output frame,
+including upward quantization/dither choices. It does not guarantee limits on
+unmodeled internal PWM transients or replace electrical supply protection.
+Nonlinear electrical models require a bounded/conservative scalar solution;
+assuming watts proportional to XYZ Y is not supported.
+
+### Fidelity accounting
+
+Report three distinct errors:
+
+- Numerical error before native quantization versus the float64 reference,
+  including source decode, mapping, solve, and brightness.
+- Native encoding error versus ideal emitter light, including quantization,
+  response inversion, and current-field effects.
+- Profile error versus measured physical output, including instrument
+  uncertainty and reference operating conditions.
+
+A reference quantized to the same wire format can prove implementation parity,
+but cannot prove ideal-light accuracy. Publish luminance normalization,
+relative-error denominators, black-floor treatment, and the exact corpus.
+Do not silently exclude difficult vectors to satisfy the issue's budgets.
+
+Dither accuracy is based on time-weighted emitted XYZ over a declared cadence
+and observation window, followed by perceptual error calculation. It is not
+an unweighted mean of frame codes or frame Delta E values. State advances on
+presentation according to the documented driver contract, with explicit tests
+for dropped submissions and irregular dwell. For scale: linear16 code 1 needs
+one native RGB8 code-1 frame per 257 equally timed frames to match its average
+on an ideal linear PWM device. At 60 Hz that is about 4.28 seconds. The native
+output report must state the resulting fidelity/flicker limitations.
+
+## Ownership and tiers (R9)
+
+Runtime bindings own immutable profile/configuration data, including response
+tables, or accept an explicitly lifetime-bound immutable source handle. Global
+defaults always own their values. Do not retain a pointer to a caller's stack
+temporary. Rebinding replaces a profile/cache identity, not fields behind an
+unchanged cache key.
+
+The TINY minimal configuration uses compile-time/static profile specialization
+with no additional per-controller runtime fields. Runtime profile storage is a
+separate capability on larger tiers. Prove disabled, static-minimal, and runtime
+layouts independently; default-null pointers are not zero added state.
+
+Managed-mode legacy exclusion covers correction, temperature, artistic gamma,
+and binary dithering. Binding configuration is distinguishable from active
+managed rendering; an API-only phase must not report calibrated output while
+the legacy encoder is still used.
+
+## Completion evidence
+
+Each phase has its own implementation PR, focused RED-to-GREEN evidence,
+appropriate review and regression checks, and verified merged state. A
+prerequisite slice may land separately, but it must not auto-close a phase
+whose acceptance criteria remain unmet. The overall program requires measured
+reports for representative clockless and high-precision strips, plus the
+specified platform budgets and legacy compatibility gates. Neither this
+addendum nor synthetic golden vectors substitutes for that evidence.


### PR DESCRIPTION
The color-pipeline phases currently disagree at several interfaces: dimming follows nonlinear response compensation, container formats lack a generic wide-source boundary, and the power/dither guarantees do not define what is measured. This addendum records the contracts needed to implement those phases consistently, including the agreed separate `.fled` wire enum and generic storage enum.

It also records phase ownership and completion gates. It does not claim that profile-managed output exists or close any implementation issue. Refs #4032, #4034, #4156.

Validation: inspected the referenced current code and issue contracts, checked the nonlinear-response and low-code counterexamples, and ran `git diff --check`. Documentation-only change; no executable tests were added or run for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added implementation contracts for the managed color pipeline, covering processing stages, validation rules, color adaptation, power handling, and runtime requirements.
  * Documented completion evidence and implementation constraints without indicating that the managed output path is available.
  * Linked the cross-phase contract addendum to the related documentation.

* **Chores**
  * Updated the development tracker with phase assignments, completed validation work, supporting evidence, and remaining merge and audit tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->