### PR TITLE
chore(deps): move the fbuild pin to 2.5.23, restoring the SAMD boards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,23 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    # Pin to fbuild 2.5.22. It carries hardened USB/deploy recovery, current
+    # Pin to fbuild 2.5.23. It carries hardened USB/deploy recovery, current
     # esptool probing, and the accumulated library/build fixes below.
     #
     # Pin history:
+    #   2.5.23 -- restores the five SAMD boards. samd-core was fetched from
+    #              GitHub's auto-generated source archive, which omits
+    #              submodules by design; tag 1.7.16 declares two under
+    #              `libraries/` (Adafruit_TinyUSB_Arduino, Adafruit_ZeroDMA).
+    #              That was harmless until 2.5.22's unpack-time submodule
+    #              check (FastLED/fbuild#1401), which fires on the package
+    #              rather than on use -- so metro_m4, samd21, samd21_zero,
+    #              samd51j and samd51p all failed before a compiler ran, even
+    #              though none of their sketches include either library. The
+    #              core now comes from Adafruit's board-index bundle, which
+    #              does ship the submodule trees, with its sha256 pinned and
+    #              verified (the old URL had no checksum at all)
+    #              (FastLED/fbuild#1418, closes FastLED/fbuild#1400).
     #   2.5.22 -- ESP32-S3 stops reinstalling its 298 MB SDK-libs archive on
     #              every build. The completion check required
     #              `<mcu>/lib/libfreertos.a`, which S3 alone does not ship
@@ -221,7 +234,7 @@ dependencies = [
     # primitive (FastLED/fbuild#532, #577/#580), and an
     # http-connect-timeout fix on the managed-zccache client
     # (FastLED/fbuild#573).
-    "fbuild==2.5.22",
+    "fbuild==2.5.23",
     # Decodes the FastLED/boards `usb-vids.proto.zstd` registry artifact in
     # ci/util/audit_usb_registry.py. Declared explicitly rather than relied on
     # transitively (clang-tool-chain-bins pulls it in today) so the documented


### PR DESCRIPTION
## What broke

2.5.22 turned a latent packaging bug into five red boards. `samd-core` was fetched from GitHub's auto-generated source archive, which omits submodules by design; tag 1.7.16 declares two under `libraries/` — `Adafruit_TinyUSB_Arduino` and `Adafruit_ZeroDMA`.

That never mattered here: FastLED's SAMD sketches include neither library, so these boards were green for months. Then 2.5.22 shipped FastLED/fbuild#1401, an unpack-time submodule check that fires on the **package** rather than on use, so `metro_m4`, `samd21`, `samd21_zero`, `samd51j` and `samd51p` all began failing before a compiler ran:

```
build error: package error: samd-core unpacked without its submodule contents.
  - libraries/Adafruit_TinyUSB_Arduino
  - libraries/Adafruit_ZeroDMA
```

Last green master `samd21` was `39947bbce`; the first run after the 2.5.22 pin landed failed.

## The fix

2.5.23 fetches the core from Adafruit's board-index bundle, which **does** carry the submodule trees (368 files under `Adafruit_TinyUSB_Arduino/`, 25 under `Adafruit_ZeroDMA/`), with its sha256 pinned and verified — the old URL passed no checksum at all. FastLED/fbuild#1418, closes FastLED/fbuild#1400.

## Why not just revert to 2.5.21

That was the other way to unbreak these five, but 2.5.22 is also what cut ESP32-S3 shard time from 34–43 min to 13–14 min (FastLED/fbuild#1413):

| run | date | shard time |
|---|---|---|
| `33711963539` | 09-03 | 37–38 min |
| `33820032021` | 09-04 | 35–43 min |
| `33993978241` | 09-05 (2.5.22) | **13–14 min** |

Going forward was the only option that keeps both.

## Verification

- `bash compile metro_m4 --examples Blink` — succeeds, flash 28.90KB, unpacking the core to `adafruit-samd-1.7.16/`.
- Upstream, `fbuild build tests/platform/samd21 -e samd21` succeeds (flash 11420 B / RAM 3828 B).
- `uv sync` installs 2.5.23; `uv.lock` is gitignored here, so this pin is the only committed half of the cascade.

## Still latent upstream

Two other cores are on GitHub archives and declare submodules — `silabs-core` (`extra/core-api`) and `ch32v-core` (`libraries/Adafruit_TinyUSB_Arduino`). Neither is in FastLED's CI matrix, so neither is red today; both are the same shape SAMD had before 2.5.22. Documented on FastLED/fbuild#1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored support for five SAMD boards.
  - Improved board setup reliability by using a verified core package source, preventing installation failures caused by missing submodules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->