### PR TITLE
fix(codec): preserve constexpr secants in table generation

### DIFF
--- a/ci/codec_tables/generate_minimp3_fixed_tables.py
+++ b/ci/codec_tables/generate_minimp3_fixed_tables.py
@@ -336,9 +336,19 @@ def scalar_constants() -> list[tuple[str, int, int, str]]:
 
 
 def emit_array(
-    ctype: str, name: str, values: list[int], per_line: int, comment: str
+    ctype: str,
+    name: str,
+    values: list[int],
+    per_line: int,
+    comment: str,
+    *,
+    constexpr: bool = False,
 ) -> str:
-    lines = [f"/* {comment} */", f"static const {ctype} {name}[{len(values)}] = {{"]
+    qualifier: str = "constexpr" if constexpr else "const"
+    lines: list[str] = [
+        f"/* {comment} */",
+        f"static {qualifier} {ctype} {name}[{len(values)}] = {{",
+    ]
     for start in range(0, len(values), per_line):
         chunk = values[start : start + per_line]
         lines.append("    " + ",".join(str(v) for v in chunk) + ",")
@@ -460,6 +470,8 @@ def render() -> str:
             sec_q27(),
             6,
             "DCT-32 secants 1/(2 cos theta), Q27 (values reach 10.19)",
+            # The fixed DCT uses these coefficients as template arguments.
+            constexpr=True,
         )
     )
     parts.append(


### PR DESCRIPTION
## Summary
Repair an existing Python regression discovered while verifying the color pipeline work (#4032).

The DCT optimization in db8a3be322 made g_sec_q27 constexpr because its coefficients are template arguments. The generator still emitted const, so its exact-output regression test failed and regeneration would undo that requirement.

Add an explicit keyword-only constexpr emission option and enable it only for g_sec_q27. All numeric constants and the committed generated header remain unchanged. This does not implement or close a color-pipeline phase.

## Verification
- Existing codec fixed-table test reproduced RED on the base checkout (1 failed, 2 passed).
- After fix: all 3 codec table tests pass; generator --check confirms exact output and upstream agreement.
- bash lint passes; independent local review clean.
- bash test --cpp: 288/288 unit targets and 84/84 examples pass.
- Separate fbuild QEMU smoke rerun in this clean checkout passes; the earlier color-worktree link failure is not represented as fixed by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of fixed-point audio codec tables so DCT coefficients can be used as compile-time template arguments.
  * Updated the generated DCT-32 secant table to use compile-time constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->