### PR TITLE
feat(fled): carry source color and storage metadata

### DIFF
--- a/agents/docs/fled-format.md
+++ b/agents/docs/fled-format.md
@@ -22,7 +22,7 @@
 FastLED has **two** `.fled` readers, and adding an enum value to one leaves the other behind:
 
 1. `src/fl/fled/pixel_format.h` — the public on-device C++ wire-format reader and checked mapping to generic storage.
-2. `src/platforms/wasm/compiler/package.json` pins `@fastled/gfx` to a **released tarball** (currently `gfx-v0.1.1`), whose bundled reader carries its own bytes-per-LED table. Until that pin moves, the WASM preview rejects any format the release predates.
+2. `src/platforms/wasm/compiler/package.json` **and** `src/platforms/wasm/compiler/package-lock.json` pin `@fastled/gfx` to a **released tarball** (currently `gfx-v0.1.1`), whose bundled reader carries its own bytes-per-LED table. Both files carry the pin and both must move together. Until they do, the WASM preview rejects any format the release predates.
 3. The canonical ledmapper spec + producer.
 
 `rgb16_linear` (`0x05`) is in this state today: FastLED admits it through typed ingress, but `gfx-v0.1.1` predates the corresponding browser-preview support. The preview must fail loudly rather than misparse; the pin moves only after a released producer/parser implementation. The ordering is fixed: **ledmapper merge → gfx release → bump both FastLED package manifests here**.

--- a/agents/docs/fled-format.md
+++ b/agents/docs/fled-format.md
@@ -14,15 +14,15 @@
 - Absent metadata resolves to the default tuple `{bt709, srgb, rgb, full}` for formats that define one; that is the historical interpretation and must keep working. Only a declaration that is *present and invalid* is rejected.
 - Key inheritance is scoped to formats with a default tuple (the display-encoded RGB family plus `rgb16_linear`). `gray8`/`rgbw8` are all-or-nothing — this is what stops a future YCbCr format from silently inheriting `matrix: "rgb"`.
 - `pixel_format` `0x05` is `rgb16_linear` (6 B/LED) and requires `transfer: "linear"`. Reserved values now start at `0x06`.
-- FastLED **carries and validates** this declaration; it does not yet transform pixels by it. Read side: `fl::fled::resolveVideoColor()` / `Fled::videoColor()` in `src/fl/fled/color.h`, tests in `tests/fl/fled/fled_color.cpp`.
+- FastLED **carries and validates** this declaration; it does not yet transform pixels by it. Its public FLED wire enum is `fl::fled::PixelFormat`; the independent generic storage descriptor is `fl::PixelFormat` plus explicit component byte order. `fl::fled::resolveVideoColor()` / `Fled::videoColor()` report source semantics, while `Fled::videoFrame()` and `Video::readSample()` preserve RGB16 little-endian samples without an RGB8 intermediate. The legacy `Video::draw()` path refuses RGB16 and clears its destination until the managed transform phase lands.
 - The producer-side enforcement lives in ledmapper (`packages/gfx/src/render/fled-color.ts` + `tests/unit/fled-color.test.ts`). The two suites are halves of one cross-repo contract: change a rule in one and the other must move in the same change.
 
 ### Adding a pixel format is a three-hop cascade
 
 FastLED has **two** `.fled` readers, and adding an enum value to one leaves the other behind:
 
-1. `src/fl/fled/detail/pixel_format.h` — the on-device C++ reader.
+1. `src/fl/fled/pixel_format.h` — the public on-device C++ wire-format reader and checked mapping to generic storage.
 2. `src/platforms/wasm/compiler/package.json` pins `@fastled/gfx` to a **released tarball** (currently `gfx-v0.1.1`), whose bundled reader carries its own bytes-per-LED table. Until that pin moves, the WASM preview rejects any format the release predates.
 3. The canonical ledmapper spec + producer.
 
-`rgb16_linear` (`0x05`) is in this state today: it resolves on device but `gfx-v0.1.1` returns `unknown-format` for it in the browser preview. That fails loudly rather than misparsing, which is why it was allowed to land — but the pin must move once ledmapper cuts a release containing the format, and the ordering is fixed: **ledmapper merge → gfx release → bump the pin here**.
+`rgb16_linear` (`0x05`) is in this state today: FastLED admits it through typed ingress, but `gfx-v0.1.1` predates the corresponding browser-preview support. The preview must fail loudly rather than misparse; the pin moves only after a released producer/parser implementation. The ordering is fixed: **ledmapper merge → gfx release → bump both FastLED package manifests here**.

--- a/src/fl/codec/pixel.h
+++ b/src/fl/codec/pixel.h
@@ -8,7 +8,11 @@ enum class PixelFormat {
     RGB565,     // 16-bit RGB: RRRRR GGGGGG BBBBB
     RGB888,     // 24-bit RGB: RRRRRRRR GGGGGGGG BBBBBBBB
     RGBA8888,   // 32-bit RGBA: RRRRRRRR GGGGGGGG BBBBBBBB AAAAAAAA
-    YUV420      // YUV 4:2:0 format (mainly for internal use)
+    YUV420,     // YUV 4:2:0 format (mainly for internal use)
+    // Generic storage formats. These do not encode transfer function,
+    // primaries, component byte order, or any container wire identifier.
+    Rgb8 = RGB888,
+    Rgb16 = 4,
 };
 
 // Calculate bytes per pixel for given format
@@ -18,7 +22,8 @@ inline fl::u8 getBytesPerPixel(PixelFormat format) {
         case PixelFormat::RGB888: return 3;
         case PixelFormat::RGBA8888: return 4;
         case PixelFormat::YUV420: return 1; // Simplified for luminance component
-        default: return 3;
+        case PixelFormat::Rgb16: return 6;
+        default: return 0;
     }
 }
 

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -52,7 +52,7 @@ Values `0x00` through `0x05` are defined for FLED v1. Values `0x06` through
 
 | Value | Name | Bytes per LED | Payload byte order | Notes |
 | ---: | --- | ---: | --- | --- |
-| `0x00` | `rgb8` | 3 | `R, G, B` | Current FastLED reader support and the preferred v1 video payload. |
+| `0x00` | `rgb8` | 3 | `R, G, B` | FastLED legacy CRGB playback and typed ingress support. |
 | `0x01` | `gray8` | 1 | `Y` | 8-bit luminance. Consumers expand to RGB as needed. |
 | `0x02` | `rgba8` | 4 | `R, G, B, A` | 8-bit RGB plus alpha. Alpha handling is consumer-defined. |
 | `0x03` | `rgbw8` | 4 | `R, G, B, W` | 8-bit RGB plus white channel. |
@@ -180,8 +180,10 @@ Rejecting a *declaration* is not the same as refusing a *file*:
   consumer must refuse rather than guess.
 
 Producers and validation tooling always take the strict reading. `resolveVideoColor()`
-reports every violation; the latitude above is a playback-consumer policy, and
-FastLED does not exercise it yet because nothing here renders from the profile.
+reports every violation. FastLED playback is strict by default; an application
+may explicitly select best-effort only for advisory `rgb8` color metadata, and
+that path emits a warning. A malformed or truncated container, and every
+mandatory `rgb16_linear` color failure, remain hard errors.
 
 ### Validation rules
 
@@ -237,9 +239,10 @@ payload is identical to the legacy headerless `.rgb` layout after the FLED
 header and JSON envelope are skipped.
 
 Consumers that only support a subset of pixel formats should reject unsupported
-`pixel_format` values before reading frame bytes. FastLED's legacy video reader
-currently accepts `rgb8` FLED v1 files and falls back to headerless `.rgb` when
-the `FLED` magic is absent.
+`pixel_format` values before reading frame bytes. FastLED admits `rgb8` for
+legacy CRGB playback and exposes `rgb16_linear` via typed little-endian samples;
+the CRGB draw path fails dark for RGB16 until the managed transform phase lands.
+It falls back to headerless `.rgb` only when the `FLED` magic is absent.
 
 ## Growth Notes
 

--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -250,6 +250,50 @@ ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
     return ColorStatus::Ok;
 }
 
+bool toFledPixelFormat(const PixelStorage& storage, const VideoColor& color,
+                       PixelFormat* out) FL_NO_EXCEPT {
+    if (!out) {
+        return false;
+    }
+    const bool validPrimaries = color.primaries == ColorPrimaries::Bt709 ||
+        color.primaries == ColorPrimaries::DisplayP3 ||
+        color.primaries == ColorPrimaries::Bt2020 ||
+        color.primaries == ColorPrimaries::Custom;
+    const bool validTransfer = color.transfer == ColorTransfer::Srgb ||
+        color.transfer == ColorTransfer::Bt709 ||
+        color.transfer == ColorTransfer::Linear;
+    if (!validPrimaries || !validTransfer || color.matrix != ColorMatrix::Rgb ||
+        color.range != ColorRange::Full) {
+        return false;
+    }
+    if (color.primaries == ColorPrimaries::Custom) {
+        for (fl::size_t i = 0; i < 8; ++i) {
+            const float value = color.customPrimaries[i];
+            if (!(value == value) || value <= 0.0f || value > 1.0f) {
+                return false;
+            }
+        }
+    }
+    switch (storage.mFormat) {
+    case fl::PixelFormat::Rgb8:
+        if (storage.mComponentByteOrder != ComponentByteOrder::NotApplicable ||
+            color.transfer == ColorTransfer::Linear) {
+            return false;
+        }
+        *out = PixelFormat::Rgb8;
+        return true;
+    case fl::PixelFormat::Rgb16:
+        if (storage.mComponentByteOrder != ComponentByteOrder::LittleEndian ||
+            color.transfer != ColorTransfer::Linear) {
+            return false;
+        }
+        *out = PixelFormat::Rgb16Linear;
+        return true;
+    default:
+        return false;
+    }
+}
+
 const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT {
     switch (status) {
     case ColorStatus::Ok:

--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -250,6 +250,11 @@ ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
     return ColorStatus::Ok;
 }
 
+ColorStatus resolveVideoColor(const fl::json& envelope, PixelFormat pixelFormat,
+                              VideoColor* out) FL_NO_EXCEPT {
+    return resolveVideoColor(envelope, static_cast<fl::u8>(pixelFormat), out);
+}
+
 bool toFledPixelFormat(const PixelStorage& storage, const VideoColor& color,
                        PixelFormat* out) FL_NO_EXCEPT {
     if (!out) {

--- a/src/fl/fled/color.h
+++ b/src/fl/fled/color.h
@@ -109,11 +109,10 @@ bool defaultVideoColor(fl::u8 pixelFormat, VideoColor* out) FL_NO_EXCEPT;
 ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
                               VideoColor* out) FL_NO_EXCEPT;
 
-inline ColorStatus resolveVideoColor(const fl::json& envelope,
-                                     PixelFormat pixelFormat,
-                                     VideoColor* out) FL_NO_EXCEPT {
-    return resolveVideoColor(envelope, static_cast<fl::u8>(pixelFormat), out);
-}
+// Typed overload. Kept in the public API because callers hold a PixelFormat
+// and should not have to cast to the wire byte to resolve a color tuple.
+ColorStatus resolveVideoColor(const fl::json& envelope, PixelFormat pixelFormat,
+                              VideoColor* out) FL_NO_EXCEPT;
 
 // Stable human-readable text for a status, for diagnostics. Never null.
 const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT;

--- a/src/fl/fled/color.h
+++ b/src/fl/fled/color.h
@@ -11,6 +11,7 @@
 
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
+#include "fl/fled/pixel_format.h"
 
 namespace fl {
 
@@ -107,6 +108,12 @@ bool defaultVideoColor(fl::u8 pixelFormat, VideoColor* out) FL_NO_EXCEPT;
 // *out is left untouched and the status names the rejection reason.
 ColorStatus resolveVideoColor(const fl::json& envelope, fl::u8 pixelFormat,
                               VideoColor* out) FL_NO_EXCEPT;
+
+inline ColorStatus resolveVideoColor(const fl::json& envelope,
+                                     PixelFormat pixelFormat,
+                                     VideoColor* out) FL_NO_EXCEPT {
+    return resolveVideoColor(envelope, static_cast<fl::u8>(pixelFormat), out);
+}
 
 // Stable human-readable text for a status, for diagnostics. Never null.
 const char* colorStatusMessage(ColorStatus status) FL_NO_EXCEPT;

--- a/src/fl/fled/detail/parser.cpp.hpp
+++ b/src/fl/fled/detail/parser.cpp.hpp
@@ -39,6 +39,9 @@ bool parseHeaderAndEnvelope(const fl::u8* data, fl::size len,
     if (ver != kVersionV1) {
         return false;
     }
+    if (data[6] != 0 || data[7] != 0) {
+        return false;
+    }
     const fl::u8 pixelFormat = data[5];
     const fl::u32 jsonLen =
         static_cast<fl::u32>(data[8]) |

--- a/src/fl/fled/detail/pixel_format.cpp.hpp
+++ b/src/fl/fled/detail/pixel_format.cpp.hpp
@@ -17,10 +17,6 @@ fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT {
     }
 }
 
-fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT {
-    return bytesPerLed(static_cast<fl::u8>(pf));
-}
-
 bool toPixelStorage(PixelFormat fledFormat, PixelStorage* out) FL_NO_EXCEPT {
     if (!out) {
         return false;

--- a/src/fl/fled/detail/pixel_format.cpp.hpp
+++ b/src/fl/fled/detail/pixel_format.cpp.hpp
@@ -17,5 +17,23 @@ fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT {
     }
 }
 
+bool toPixelStorage(PixelFormat fledFormat, PixelStorage* out) FL_NO_EXCEPT {
+    if (!out) {
+        return false;
+    }
+    switch (fledFormat) {
+    case PixelFormat::Rgb8:
+        out->mFormat = fl::PixelFormat::Rgb8;
+        out->mComponentByteOrder = ComponentByteOrder::NotApplicable;
+        return true;
+    case PixelFormat::Rgb16Linear:
+        out->mFormat = fl::PixelFormat::Rgb16;
+        out->mComponentByteOrder = ComponentByteOrder::LittleEndian;
+        return true;
+    default:
+        return false;
+    }
+}
+
 }  // namespace fled
 }  // namespace fl

--- a/src/fl/fled/detail/pixel_format.cpp.hpp
+++ b/src/fl/fled/detail/pixel_format.cpp.hpp
@@ -17,6 +17,10 @@ fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT {
     }
 }
 
+fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT {
+    return bytesPerLed(static_cast<fl::u8>(pf));
+}
+
 bool toPixelStorage(PixelFormat fledFormat, PixelStorage* out) FL_NO_EXCEPT {
     if (!out) {
         return false;

--- a/src/fl/fled/detail/pixel_format.h
+++ b/src/fl/fled/detail/pixel_format.h
@@ -1,33 +1,5 @@
 #pragma once
 
-// Pixel-format enum + bytes-per-LED lookup for the .fled v1 container.
-// See FLED_FORMAT.md "Pixel Format Enum" section for the canonical table.
-// Values are the on-disk byte at header offset 5.
-
-#include "fl/stl/int.h"
-#include "fl/stl/noexcept.h"
-
-namespace fl {
-namespace fled {
-
-enum class PixelFormat : fl::u8 {
-    Rgb8        = 0x00,  // 3 bpp - R, G, B
-    Gray8       = 0x01,  // 1 bpp - Y
-    Rgba8       = 0x02,  // 4 bpp - R, G, B, A
-    Rgbw8       = 0x03,  // 4 bpp - R, G, B, W
-    Rgb565Le    = 0x04,  // 2 bpp - little-endian RGB565
-    Rgb16Linear = 0x05,  // 6 bpp - R, G, B as u16le, linear light
-};
-
-// Returns the bytes-per-LED for a v1 pixel-format byte.
-// Returns 0 for unknown / reserved formats (0x06 - 0xff) - callers should
-// treat 0 as "consumer does not support this pixel_format" and reject
-// before reading frame bytes per FLED_FORMAT.md.
-fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT;
-
-inline fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT {
-    return bytesPerLed(static_cast<fl::u8>(pf));
-}
-
-}  // namespace fled
-}  // namespace fl
+// Compatibility include for existing internal users. New users must include
+// the supported public FLED pixel-format header instead.
+#include "fl/fled/pixel_format.h"

--- a/src/fl/fled/fled.cpp.hpp
+++ b/src/fl/fled/fled.cpp.hpp
@@ -144,6 +144,45 @@ fled::ColorStatus Fled::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
     return fled::resolveVideoColor(mImpl->envelope(), pixelFormat(), out);
 }
 
+bool Fled::videoFrame(fl::size frameIndex, fl::size ledCount,
+                      fled::VideoFrameView *out) const FL_NO_EXCEPT {
+    if (!mImpl || !out || ledCount == 0) {
+        return false;
+    }
+    fled::PixelStorage storage;
+    if (!fled::toPixelStorage(static_cast<fled::PixelFormat>(pixelFormat()),
+                              &storage)) {
+        return false;
+    }
+    fled::VideoColor color;
+    if (videoColor(&color) != fled::ColorStatus::Ok) {
+        return false;
+    }
+    const fl::size bytesPerLed = fled::bytesPerLed(pixelFormat());
+    const fl::size payloadBytes = mImpl->payloadLen();
+    if (bytesPerLed == 0 || ledCount > payloadBytes / bytesPerLed) {
+        return false;
+    }
+    const fl::size stride = ledCount * bytesPerLed;
+    if (stride == 0 || payloadBytes % stride != 0 ||
+        frameIndex >= payloadBytes / stride) {
+        return false;
+    }
+    fl::size completePayloadBytes = 0;
+    fl::shared_ptr<const fl::u8> payload = blob("frame_payload",
+                                                &completePayloadBytes);
+    if (!payload) {
+        return false;
+    }
+    const fl::size offset = frameIndex * stride;
+    out->mStorage = storage;
+    out->mColor = color;
+    out->mPayload = fl::shared_ptr<const fl::u8>(payload, payload.get() + offset);
+    out->mPayloadBytes = stride;
+    out->mStride = stride;
+    return true;
+}
+
 // ---- blobs ----
 
 fl::shared_ptr<const fl::u8> Fled::blob(const char *sectionName,

--- a/src/fl/fled/fled.h
+++ b/src/fl/fled/fled.h
@@ -31,6 +31,34 @@ struct MultiChannelConfig;
 
 namespace fled {
 class FledImpl;
+
+// A typed, zero-copy video frame. The payload owner keeps Fled's owned bytes
+// alive; static-input callers still retain the lifetime obligation documented
+// by loadFromStatic(). Rgb16 components are decoded from little-endian bytes,
+// never reinterpreted as native-endian words.
+struct VideoFrameView {
+    PixelStorage mStorage = {fl::PixelFormat::Rgb8,
+                            ComponentByteOrder::NotApplicable};
+    VideoColor mColor = {ColorPrimaries::Bt709, ColorTransfer::Srgb,
+                        ColorMatrix::Rgb, ColorRange::Full, false, {}};
+    fl::shared_ptr<const fl::u8> mPayload;
+    fl::size mPayloadBytes = 0;
+    fl::size mStride = 0;
+
+    fl::u16 component16(fl::size led, fl::u8 component) const FL_NO_EXCEPT {
+        if (!mPayload || mStorage.mFormat != fl::PixelFormat::Rgb16 ||
+            mStorage.mComponentByteOrder != ComponentByteOrder::LittleEndian ||
+            component >= 3 || led >= mPayloadBytes / 6) {
+            return 0;
+        }
+        const fl::size offset = led * 6 + static_cast<fl::size>(component) * 2;
+        if (offset >= mPayloadBytes - 1) {
+            return 0;
+        }
+        return static_cast<fl::u16>(mPayload.get()[offset]) |
+               (static_cast<fl::u16>(mPayload.get()[offset + 1]) << 8);
+    }
+};
 }
 
 class Fled {
@@ -91,6 +119,13 @@ class Fled {
     // This only reports what the file declares its numbers to mean. FastLED
     // does not yet transform pixels according to that declaration.
     fled::ColorStatus videoColor(fled::VideoColor *out) const FL_NO_EXCEPT;
+
+    // Opens a typed zero-copy view of one video frame. The view preserves
+    // storage precision, component layout, and the resolved FLED source color
+    // tuple. Returns false for unsupported storage, invalid color metadata,
+    // incomplete frames, or an out-of-range frame index.
+    bool videoFrame(fl::size frameIndex, fl::size ledCount,
+                    fled::VideoFrameView *out) const FL_NO_EXCEPT;
 
     // Parsed JSON envelope. For null Fled, returns a reference to a static
     // empty json (safe to chain into).

--- a/src/fl/fled/pixel_format.h
+++ b/src/fl/fled/pixel_format.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Public pixel-format boundary for .fled v1 containers. PixelFormat owns
+// stable serialized wire identifiers; fl::PixelFormat describes generic
+// storage and deliberately has a separate numeric domain.
+
+#include "fl/codec/pixel.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+namespace fled {
+
+struct VideoColor;
+
+enum class PixelFormat : fl::u8 {
+    Rgb8        = 0x00,  // 3 bpp - R, G, B
+    Gray8       = 0x01,  // 1 bpp - Y
+    Rgba8       = 0x02,  // 4 bpp - R, G, B, A
+    Rgbw8       = 0x03,  // 4 bpp - R, G, B, W
+    Rgb565Le    = 0x04,  // 2 bpp - little-endian RGB565
+    Rgb16Linear = 0x05,  // 6 bpp - R, G, B as u16le, linear light
+};
+
+// The component byte order travels with generic storage. In particular,
+// Rgb16 alone never authorizes treating FLED's u16le payload as native words.
+enum class ComponentByteOrder : fl::u8 {
+    NotApplicable = 0,
+    LittleEndian,
+    Native,
+};
+
+struct PixelStorage {
+    fl::PixelFormat mFormat;
+    ComponentByteOrder mComponentByteOrder;
+};
+
+// Returns bytes per LED for a v1 pixel-format byte, or zero when the value is
+// unknown/reserved. Callers must reject zero before reading payload bytes.
+fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT;
+
+inline fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT {
+    return bytesPerLed(static_cast<fl::u8>(pf));
+}
+
+// Checked conversion between FLED's wire enum and generic storage. Only
+// direct RGB storage has a mapping today. The source color declaration is
+// resolved separately with resolveVideoColor() and must stay paired with this
+// descriptor through playback or serialization.
+bool toPixelStorage(PixelFormat fledFormat, PixelStorage* out) FL_NO_EXCEPT;
+bool toFledPixelFormat(const PixelStorage& storage, const VideoColor& color,
+                       PixelFormat* out) FL_NO_EXCEPT;
+
+}  // namespace fled
+}  // namespace fl

--- a/src/fl/fled/pixel_format.h
+++ b/src/fl/fled/pixel_format.h
@@ -39,9 +39,9 @@ struct PixelStorage {
 // unknown/reserved. Callers must reject zero before reading payload bytes.
 fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT;
 
-inline fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT {
-    return bytesPerLed(static_cast<fl::u8>(pf));
-}
+// Typed overload. Kept in the public API because callers hold a PixelFormat
+// and should not have to cast to the wire byte to ask this question.
+fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT;
 
 // Checked conversion between FLED's wire enum and generic storage. Only
 // direct RGB storage has a mapping today. The source color declaration is

--- a/src/fl/fled/pixel_format.h
+++ b/src/fl/fled/pixel_format.h
@@ -39,10 +39,6 @@ struct PixelStorage {
 // unknown/reserved. Callers must reject zero before reading payload bytes.
 fl::u8 bytesPerLed(fl::u8 pixelFormat) FL_NO_EXCEPT;
 
-// Typed overload. Kept in the public API because callers hold a PixelFormat
-// and should not have to cast to the wire byte to ask this question.
-fl::u8 bytesPerLed(PixelFormat pf) FL_NO_EXCEPT;
-
 // Checked conversion between FLED's wire enum and generic storage. Only
 // direct RGB storage has a mapping today. The source color declaration is
 // resolved separately with resolveVideoColor() and must stay paired with this

--- a/src/fl/fx/video.cpp.hpp
+++ b/src/fl/fx/video.cpp.hpp
@@ -41,8 +41,15 @@ bool Video::begin(filebuf_ptr handle) {
                      "must include full parameters.");
         return false;
     }
+    // Drop a previous admission failure before evaluating this attempt.
+    // Rejecting one source says nothing about the next; only a persistent
+    // setError() failure keeps blocking.
+    if (mAdmissionError) {
+        mError.clear();
+        mAdmissionError = false;
+    }
     if (!handle) {
-        mError = "filebuf is null";
+        setAdmissionError("filebuf is null");
         FL_DBG_F("%s", mError.c_str());
         return false;
     }
@@ -50,9 +57,8 @@ bool Video::begin(filebuf_ptr handle) {
         FL_DBG_F("%s", mError.c_str());
         return false;
     }
-    mError.clear();
     if (!mImpl->begin(handle)) {
-        mError = "unsupported or malformed FLED container";
+        setAdmissionError("unsupported or malformed FLED container");
         return false;
     }
     return true;

--- a/src/fl/fx/video.cpp.hpp
+++ b/src/fl/fx/video.cpp.hpp
@@ -51,11 +51,20 @@ bool Video::begin(filebuf_ptr handle) {
         return false;
     }
     mError.clear();
-    mImpl->begin(handle);
+    if (!mImpl->begin(handle)) {
+        mError = "unsupported or malformed FLED container";
+        return false;
+    }
     return true;
 }
 
 bool Video::draw(fl::u32 now, fl::span<CRGB> leds) {
+    if (!mError.empty()) {
+        for (fl::size_t i = 0; i < leds.size(); ++i) {
+            leds[i] = CRGB::Black;
+        }
+        return false;
+    }
     if (!mImpl) {
         FL_WARN_F_IF(!mError.empty(), "%s", mError.c_str());
         return false;
@@ -69,11 +78,7 @@ bool Video::draw(fl::u32 now, fl::span<CRGB> leds) {
 }
 
 void Video::draw(DrawContext context) {
-    if (!mImpl) {
-        FL_WARN_F_IF(!mError.empty(), "%s", mError.c_str());
-        return;
-    }
-    mImpl->draw(context.now, context.leds);
+    draw(context.now, context.leds);
 }
 
 i32 Video::durationMicros() const {
@@ -86,10 +91,10 @@ i32 Video::durationMicros() const {
 string Video::fxName() const { return "Video"; }
 
 bool Video::draw(fl::u32 now, Frame *frame) {
-    if (!mImpl) {
+    if (!frame) {
         return false;
     }
-    return mImpl->draw(now, frame);
+    return draw(now, frame->rgb());
 }
 
 void Video::end() {
@@ -113,6 +118,24 @@ float Video::timeScale() const {
 }
 
 string Video::error() const { return mError; }
+
+bool Video::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
+    return mImpl && mImpl->videoColor(out);
+}
+
+bool Video::pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT {
+    return mImpl && mImpl->pixelStorage(out);
+}
+
+bool Video::readSample(video::PixelSample *out) FL_NO_EXCEPT {
+    return mImpl && mImpl->readSample(out);
+}
+
+void Video::setFledPlaybackMode(FledPlaybackMode mode) FL_NO_EXCEPT {
+    if (mImpl) {
+        mImpl->setBestEffortFled(mode == FledPlaybackMode::BestEffort);
+    }
+}
 
 size_t Video::pixelsPerFrame() const {
     if (!mImpl) {

--- a/src/fl/fx/video.h
+++ b/src/fl/fx/video.h
@@ -7,6 +7,7 @@
 #include "fl/stl/string.h"
 #include "fl/stl/detail/memory_file_handle.h"
 #include "fl/fx/fx1d.h"
+#include "fl/video/pixel_sample.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -26,6 +27,11 @@ class VideoImpl;
 } // namespace video
 using VideoImpl = video::VideoImpl;
 using VideoImplPtr = fl::shared_ptr<VideoImpl>;
+
+enum class FledPlaybackMode : fl::u8 {
+    Strict,
+    BestEffort,
+};
 
 // Video represents a video file that can be played back on a LED strip.
 // The video file is expected to be a sequence of frames. Pass any filebuf
@@ -77,6 +83,10 @@ class Video : public Fx1d { // Fx1d because video can be irregular.
     // Spec: https://github.com/zackees/ledmapper/blob/main/docs/fled-format.md
     bool hasEmbeddedScreenMap() const FL_NO_EXCEPT;
     const fl::string &embeddedScreenMapJson() const FL_NO_EXCEPT;
+    bool videoColor(fled::VideoColor *out) const FL_NO_EXCEPT;
+    bool pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT;
+    bool readSample(video::PixelSample *out) FL_NO_EXCEPT;
+    void setFledPlaybackMode(FledPlaybackMode mode) FL_NO_EXCEPT;
     void pause(fl::u32 now) override;
     void resume(fl::u32 now) override;
     void setFade(fl::u32 fadeInTime, fl::u32 fadeOutTime);

--- a/src/fl/fx/video.h
+++ b/src/fl/fx/video.h
@@ -74,7 +74,13 @@ class Video : public Fx1d { // Fx1d because video can be irregular.
     void setTimeScale(float timeScale);
     float timeScale() const;
     string error() const;
-    void setError(const string &error) { mError = error; }
+    // A caller-supplied error is persistent: it blocks admission until the
+    // caller clears it. Admission errors recorded by begin() are not -- see
+    // mAdmissionError.
+    void setError(const string &error) FL_NO_EXCEPT {
+        mError = error;
+        mAdmissionError = false;
+    }
     size_t pixelsPerFrame() const;
 
     // FLED v1 container (issue #3072): true / non-empty only when begin()
@@ -96,7 +102,16 @@ class Video : public Fx1d { // Fx1d because video can be irregular.
     operator bool() const { return mImpl.get(); }
 
   private:
+    // True when mError was recorded by a failed begin() rather than by
+    // setError(). Such a failure describes one rejected source, not a dead
+    // object, so the next begin() clears it and admits a new handle.
+    void setAdmissionError(const string &error) FL_NO_EXCEPT {
+        mError = error;
+        mAdmissionError = true;
+    }
+
     bool mFinished = false;
+    bool mAdmissionError = false;
     VideoImplPtr mImpl;
     string mError;
     string mName;

--- a/src/fl/video/pixel_sample.h
+++ b/src/fl/video/pixel_sample.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "fl/fled/color.h"
+#include "fl/stl/int.h"
+
+namespace fl {
+namespace video {
+
+// One decoded source sample. Storage/layout and source metadata remain
+// separate: generic storage says how bytes are arranged; FLED color says what
+// the values mean. P6 consumes this without an intermediate CRGB conversion.
+struct PixelSample {
+    fled::PixelStorage mStorage;
+    fled::VideoColor mColor;
+    fl::u16 mComponents[3] = {};
+};
+
+} // namespace video
+} // namespace fl

--- a/src/fl/video/pixel_stream.cpp.hpp
+++ b/src/fl/video/pixel_stream.cpp.hpp
@@ -3,6 +3,7 @@
 #include "fl/log/log.h"
 #include "fl/stl/limits.h"
 #include "fl/stl/noexcept.h"
+#include "fl/stl/json.h"
 
 #define DBG FL_DBG
 
@@ -14,42 +15,70 @@ namespace video {
 namespace {
 constexpr fl::u8 kFledMagic[4] = {'F', 'L', 'E', 'D'};
 constexpr fl::u8 kFledVersionV1 = 1;
-constexpr fl::u8 kFledPixelFormatRgb8 = 0x00;
 constexpr fl::size_t kFledHeaderBytes = 12;
 // Defensive cap on the embedded JSON to bound the worst-case heap
 // allocation if a malformed file claims a giant json_length. Real
 // screenmaps run ~500 B – ~50 KB; 1 MiB is well above that.
 constexpr fl::size_t kFledMaxJsonBytes = 1u * 1024u * 1024u;
+
+bool isFledMagicPrefix(const fl::u8* bytes, fl::size_t size) FL_NO_EXCEPT {
+    for (fl::size_t i = 0; i < size; ++i) {
+        if (bytes[i] != kFledMagic[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 } // namespace
 
-PixelStream::PixelStream(int bytes_per_frame)
-    : mbytesPerFrame(bytes_per_frame), mType(kFile) {}
+PixelStream::PixelStream(int bytes_per_frame) FL_NO_EXCEPT
+    : mbytesPerFrame(bytes_per_frame), mBaseBytesPerFrame(bytes_per_frame),
+      mType(kFile) {}
 
 PixelStream::~PixelStream() FL_NO_EXCEPT { close(); }
 
-bool PixelStream::begin(filebuf_ptr h) {
+bool PixelStream::begin(filebuf_ptr h) FL_NO_EXCEPT {
     close();
+    if (!h || mBaseBytesPerFrame <= 0) {
+        return false;
+    }
     mHandle = h;
+    mbytesPerFrame = mBaseBytesPerFrame;
     mPayloadOffset = 0;
     mEmbeddedScreenMapJson.clear();
+    mFledPixelFormat = 0;
+    mFledBytesPerLed = 0;
+    mHasVideoColor = false;
+    mHasFledContainer = false;
+    mStreamingPrefixSize = 0;
+    mStreamingPrefixPos = 0;
+    mStreamingProbePending = false;
+    mStreamingRejected = false;
     // Probe seekability: if seek-to-start succeeds, this is a seekable file.
     mType = mHandle->seek(0, seek_dir::beg) ? kFile : kStreaming;
     if (mType == kFile) {
-        // Try to detect a FLED v1 container. Anything that fails the header
-        // check (wrong magic, wrong version, unsupported pixel_format,
-        // truncated) falls back to legacy headerless RGB — zero behavior
-        // change for existing files.
-        if (mHandle->size() >= kFledHeaderBytes) {
+        // A file without FLED magic remains a legacy headerless RGB stream.
+        // Once magic is recognized, though, every invalidity is a container
+        // error: falling back would render its header bytes as LEDs.
+        if (mHandle->size() >= 4) {
             char hdr[kFledHeaderBytes];
             fl::size_t got = mHandle->read(hdr, kFledHeaderBytes);
-            bool isFled = got == kFledHeaderBytes
+            const bool hasFledMagic = got >= 4
                 && static_cast<fl::u8>(hdr[0]) == kFledMagic[0]
                 && static_cast<fl::u8>(hdr[1]) == kFledMagic[1]
                 && static_cast<fl::u8>(hdr[2]) == kFledMagic[2]
-                && static_cast<fl::u8>(hdr[3]) == kFledMagic[3]
+                && static_cast<fl::u8>(hdr[3]) == kFledMagic[3];
+            if (hasFledMagic) {
+                const bool supportedFled = got == kFledHeaderBytes
                 && static_cast<fl::u8>(hdr[4]) == kFledVersionV1
-                && static_cast<fl::u8>(hdr[5]) == kFledPixelFormatRgb8;
-            if (isFled) {
+                && static_cast<fl::u8>(hdr[6]) == 0
+                && static_cast<fl::u8>(hdr[7]) == 0
+                && fled::bytesPerLed(static_cast<fl::u8>(hdr[5])) != 0;
+                if (!supportedFled) {
+                    close();
+                    return false;
+                }
+                const fl::u8 pixelFormat = static_cast<fl::u8>(hdr[5]);
                 const fl::u32 jsonLen =
                     static_cast<fl::u32>(static_cast<fl::u8>(hdr[8]))
                     | (static_cast<fl::u32>(static_cast<fl::u8>(hdr[9])) << 8)
@@ -70,41 +99,172 @@ bool PixelStream::begin(filebuf_ptr h) {
                         : 0;
                     if (jr == jsonLenSz) {
                         mPayloadOffset = kFledHeaderBytes + jsonLenSz;
+                        mFledPixelFormat = pixelFormat;
+                        mFledBytesPerLed = fled::bytesPerLed(pixelFormat);
+                        mHasFledContainer = true;
+                        if (mbytesPerFrame % 3 != 0) {
+                            close();
+                            return false;
+                        }
+                        const fl::i32 ledCount = mbytesPerFrame / 3;
+                        const fl::i32 bytesPerLed =
+                            static_cast<fl::i32>(mFledBytesPerLed);
+                        if (ledCount > (fl::numeric_limits<fl::i32>::max)() /
+                                bytesPerLed) {
+                            close();
+                            return false;
+                        }
+                        mbytesPerFrame = ledCount * bytesPerLed;
+                        if ((fileSize - mPayloadOffset) %
+                            static_cast<fl::size_t>(mbytesPerFrame) != 0) {
+                            close();
+                            return false;
+                        }
+                        fl::json envelope;
+                        if (!mEmbeddedScreenMapJson.empty()) {
+                            envelope = fl::json::parse(mEmbeddedScreenMapJson);
+                        }
+                        const bool validEnvelope = mEmbeddedScreenMapJson.empty() ||
+                            (envelope.has_value() && envelope.is_object());
+                        if (!validEnvelope) {
+                            close();
+                            return false;
+                        }
+                        const bool colorOk =
+                            fled::resolveVideoColor(envelope, mFledPixelFormat,
+                                                    &mVideoColor) ==
+                            fled::ColorStatus::Ok;
+                        mHasVideoColor = colorOk;
+                        if (!colorOk) {
+                            fled::PixelStorage storage;
+                            const bool advisoryRgb8 = pixelStorage(&storage) &&
+                                storage.mFormat == fl::PixelFormat::Rgb8;
+                            if (!mBestEffortFled || !advisoryRgb8) {
+                                close();
+                                return false;
+                            }
+                            FL_WARN_F("FLED video.color rejected; using explicit best-effort RGB8 playback");
+                        }
                         // Stream is now positioned at the first frame byte.
                         return mHandle->available();
                     }
-                    // JSON slurp short-read — abandon FLED interpretation.
                     mEmbeddedScreenMapJson.clear();
                 }
+                // FLED magic was recognized, so malformed/truncated
+                // containers must not become headerless raw RGB.
+                close();
+                return false;
             }
-            // Not a FLED file (or header rejected). Rewind so subsequent
-            // reads see the file from byte 0 as raw RGB triplets.
+            // No magic: rewind so subsequent reads see raw RGB triplets.
             mHandle->seek(0, seek_dir::beg);
         }
         return mHandle->available();
     }
-    return mHandle->available(mbytesPerFrame);
+    // A partial FLED prefix stays buffered until enough bytes arrive to
+    // classify it. A raw mismatch is replayed through readBytes().
+    mStreamingProbePending = true;
+    if (!probeStreamingMagic()) {
+        close();
+        return false;
+    }
+    return true;
 }
 
 void PixelStream::close() {
     mHandle.reset();
+    mbytesPerFrame = mBaseBytesPerFrame;
+    mPayloadOffset = 0;
+    mEmbeddedScreenMapJson.clear();
+    mFledPixelFormat = 0;
+    mFledBytesPerLed = 0;
+    mHasFledContainer = false;
+    mHasVideoColor = false;
+    mStreamingPrefixSize = 0;
+    mStreamingPrefixPos = 0;
+    mStreamingProbePending = false;
+    mStreamingRejected = false;
+}
+
+bool PixelStream::probeStreamingMagic() const FL_NO_EXCEPT {
+    if (!mStreamingProbePending) {
+        return !mStreamingRejected;
+    }
+    while (mStreamingPrefixSize < 4 && mHandle && mHandle->available()) {
+        const fl::size_t want = 4 - mStreamingPrefixSize;
+        const fl::size_t got = mHandle->read(mStreamingPrefix + mStreamingPrefixSize,
+                                             want);
+        if (got == 0) {
+            break;
+        }
+        mStreamingPrefixSize += got;
+        if (!isFledMagicPrefix(mStreamingPrefix, mStreamingPrefixSize)) {
+            mStreamingProbePending = false;
+            return true;
+        }
+    }
+    if (mStreamingPrefixSize == 4) {
+        mStreamingProbePending = false;
+        mStreamingRejected = true;
+        return false;
+    }
+    return true;
 }
 
 i32 PixelStream::bytesPerFrame() { return mbytesPerFrame; }
 
 bool PixelStream::readPixel(CRGB *dst) {
-    return mHandle->read(&dst->r, 1) && mHandle->read(&dst->g, 1) &&
-           mHandle->read(&dst->b, 1);
+    if (!mHandle || !dst) {
+        return false;
+    }
+    if (!isRgb8Playback()) {
+        return false;
+    }
+    return readBytes(&dst->r, 3) == 3;
+}
+
+bool PixelStream::readSample(PixelSample *out) FL_NO_EXCEPT {
+    if (!mHandle || !out) {
+        return false;
+    }
+    fled::PixelStorage storage;
+    fled::VideoColor color;
+    if (!pixelStorage(&storage) || !videoColor(&color) ||
+        storage.mFormat != fl::PixelFormat::Rgb16 ||
+        storage.mComponentByteOrder != fled::ComponentByteOrder::LittleEndian) {
+        return false;
+    }
+    fl::u8 bytes[6];
+    if (readBytes(bytes, sizeof(bytes)) != sizeof(bytes)) {
+        return false;
+    }
+    out->mStorage = storage;
+    out->mColor = color;
+    for (fl::u8 i = 0; i < 3; ++i) {
+        const fl::size_t offset = static_cast<fl::size_t>(i) * 2;
+        out->mComponents[i] = static_cast<fl::u16>(bytes[offset]) |
+            (static_cast<fl::u16>(bytes[offset + 1]) << 8);
+    }
+    return true;
 }
 
 bool PixelStream::available() const {
+    if (!mHandle) {
+        return false;
+    }
     if (mType == kStreaming) {
-        return mHandle->available(mbytesPerFrame);
+        if (!probeStreamingMagic() || mStreamingProbePending) {
+            return false;
+        }
+        return mStreamingPrefixPos < mStreamingPrefixSize ||
+               mHandle->available(mbytesPerFrame);
     }
     return mHandle->available();
 }
 
 bool PixelStream::atEnd() const {
+    if (!mHandle) {
+        return true;
+    }
     if (mType == kStreaming) {
         return false;
     }
@@ -112,13 +272,20 @@ bool PixelStream::atEnd() const {
 }
 
 bool PixelStream::readFrame(Frame *frame) {
-    if (!frame) {
+    if (!mHandle || !frame) {
         return false;
     }
     if (mType == kFile && !framesRemaining()) {
         return false;
     }
-    size_t n = mHandle->readRGB8(frame->rgb());
+    if (!isRgb8Playback()) {
+        return false;
+    }
+    size_t n = 0;
+    const fl::size_t pixels = static_cast<fl::size_t>(mbytesPerFrame) / 3;
+    fl::span<CRGB> dst = frame->rgb();
+    for (; n < pixels && n < dst.size() && readPixel(&dst[n]); ++n) {
+    }
     if (mType == kFile) {
         DBG("pos: " << mHandle->pos());
     }
@@ -126,6 +293,9 @@ bool PixelStream::readFrame(Frame *frame) {
 }
 
 bool PixelStream::hasFrame(fl::u32 frameNumber) {
+    if (!mHandle) {
+        return false;
+    }
     if (mType == kStreaming) {
         // Streaming handle doesn't support seeking
         DBG("Not implemented and therefore always returns true");
@@ -141,9 +311,12 @@ bool PixelStream::hasFrame(fl::u32 frameNumber) {
 }
 
 bool PixelStream::readFrameAt(fl::u32 frameNumber, Frame *frame) {
-    if (mType == kStreaming) {
+    if (!mHandle || !frame || mType == kStreaming) {
         // Streaming handle doesn't support seeking
         FL_DBG_F("Streaming handle doesn't support seeking");
+        return false;
+    }
+    if (!isRgb8Playback()) {
         return false;
     }
     fl::size_t frameBytes = static_cast<fl::size_t>(frameNumber)
@@ -175,6 +348,9 @@ i32 PixelStream::framesRemaining() const {
 }
 
 i32 PixelStream::framesDisplayed() const {
+    if (!mHandle) {
+        return 0;
+    }
     if (mType == kStreaming) {
         return -1;
     }
@@ -187,6 +363,9 @@ i32 PixelStream::framesDisplayed() const {
 }
 
 i32 PixelStream::bytesRemaining() const {
+    if (!mHandle) {
+        return 0;
+    }
     if (mType == kStreaming) {
         // Use (max)() to prevent macro expansion by Arduino.h's max macro
         return (fl::numeric_limits<i32>::max)();
@@ -202,7 +381,7 @@ i32 PixelStream::bytesRemainingInFrame() const {
 }
 
 bool PixelStream::rewind() {
-    if (mType == kStreaming) {
+    if (!mHandle || mType == kStreaming) {
         return false;
     }
     // Rewind to the start of the payload, not the start of the file —
@@ -223,10 +402,38 @@ const fl::string &PixelStream::embeddedScreenMapJson() const FL_NO_EXCEPT {
     return mEmbeddedScreenMapJson;
 }
 
+bool PixelStream::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
+    if (!out || !mHasFledContainer || !mHasVideoColor) {
+        return false;
+    }
+    *out = mVideoColor;
+    return true;
+}
+
+bool PixelStream::pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT {
+    return mHasFledContainer && out && fled::toPixelStorage(
+        static_cast<fled::PixelFormat>(mFledPixelFormat), out);
+}
+
+bool PixelStream::isRgb8Playback() const FL_NO_EXCEPT {
+    return !mHasFledContainer ||
+        mFledPixelFormat == static_cast<fl::u8>(fled::PixelFormat::Rgb8);
+}
+
 size_t PixelStream::readBytes(u8 *dst, size_t len) {
+    if (!mHandle || !dst) {
+        return 0;
+    }
+    if (mType == kStreaming &&
+        (!probeStreamingMagic() || mStreamingProbePending)) {
+        return 0;
+    }
     u16 bytesRead = 0;
+    while (bytesRead < len && mStreamingPrefixPos < mStreamingPrefixSize) {
+        dst[bytesRead++] = mStreamingPrefix[mStreamingPrefixPos++];
+    }
     if (mType == kStreaming) {
-        while (bytesRead < len && mHandle->available(len)) {
+        while (bytesRead < len && mHandle->available(len - bytesRead)) {
             if (mHandle->read(dst + bytesRead, 1)) {
                 bytesRead++;
             } else {

--- a/src/fl/video/pixel_stream.h
+++ b/src/fl/video/pixel_stream.h
@@ -5,6 +5,7 @@
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/string.h"
+#include "fl/video/pixel_sample.h"
 namespace fl {
 class filebuf;
 using filebuf_ptr = fl::shared_ptr<filebuf>;
@@ -31,15 +32,16 @@ class PixelStream {
         kFile,      // Seekable (e.g. posix_filebuf, SD card)
     };
 
-    explicit PixelStream(int bytes_per_frame);
+    explicit PixelStream(int bytes_per_frame) FL_NO_EXCEPT;
 
     // Opens a handle. Streaming vs seekable is auto-detected:
     // seek(0, beg) succeeds → kFile, fails → kStreaming.
-    bool begin(fl::filebuf_ptr h);
+    bool begin(fl::filebuf_ptr h) FL_NO_EXCEPT;
 
     void close();
     i32 bytesPerFrame();
     bool readPixel(CRGB *dst);
+    bool readSample(PixelSample *out) FL_NO_EXCEPT;
     size_t readBytes(u8 *dst, size_t len);
 
     bool readFrame(Frame *frame);
@@ -59,9 +61,16 @@ class PixelStream {
     // a valid FLED header on a seekable handle; otherwise empty / false.
     bool hasEmbeddedScreenMap() const FL_NO_EXCEPT;
     const fl::string &embeddedScreenMapJson() const FL_NO_EXCEPT;
+    bool videoColor(fled::VideoColor *out) const FL_NO_EXCEPT;
+    bool pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT;
+    // True only when the active source can be consumed by the legacy CRGB
+    // playback path. Typed formats require a separate ingress consumer.
+    bool isRgb8Playback() const FL_NO_EXCEPT;
+    void setBestEffortFled(bool enabled) FL_NO_EXCEPT { mBestEffortFled = enabled; }
 
   private:
     fl::i32 mbytesPerFrame;
+    const fl::i32 mBaseBytesPerFrame;
     fl::filebuf_ptr mHandle;
     Type mType;
 
@@ -69,6 +78,22 @@ class PixelStream {
     // `.rgb` files; 12 + jsonLength for FLED-formatted files.
     fl::size_t mPayloadOffset = 0;
     fl::string mEmbeddedScreenMapJson;
+    fl::u8 mFledPixelFormat = 0;
+    fl::u8 mFledBytesPerLed = 0;
+    bool mHasFledContainer = false;
+    fled::VideoColor mVideoColor = {};
+    bool mHasVideoColor = false;
+    bool mBestEffortFled = false;
+
+    // Non-seekable handles need a small magic probe. Raw stream bytes read
+    // for that probe are replayed before the underlying handle is consumed.
+    mutable fl::u8 mStreamingPrefix[4] = {};
+    mutable fl::size_t mStreamingPrefixSize = 0;
+    mutable fl::size_t mStreamingPrefixPos = 0;
+    mutable bool mStreamingProbePending = false;
+    mutable bool mStreamingRejected = false;
+
+    bool probeStreamingMagic() const FL_NO_EXCEPT;
 
   public:
     virtual ~PixelStream() FL_NO_EXCEPT;

--- a/src/fl/video/video_impl.cpp.hpp
+++ b/src/fl/video/video_impl.cpp.hpp
@@ -54,11 +54,16 @@ bool VideoImpl::needsFrame(fl::u32 now) const {
 
 VideoImpl::~VideoImpl() FL_NO_EXCEPT { end(); }
 
-void VideoImpl::begin(filebuf_ptr h) {
+bool VideoImpl::begin(filebuf_ptr h) FL_NO_EXCEPT {
     end();
     mStream = fl::make_shared<PixelStream>(mPixelsPerFrame * kSizeRGB8);
-    mStream->begin(h);
+    mStream->setBestEffortFled(mBestEffortFled);
+    if (!mStream->begin(h)) {
+        mStream.reset();
+        return false;
+    }
     mPrevNow = 0;
+    return true;
 }
 
 void VideoImpl::end() {
@@ -95,6 +100,12 @@ bool VideoImpl::draw(fl::u32 now, fl::span<CRGB> leds) {
     now = mTime->update(now);
     if (!mStream) {
         FL_WARN_F("no stream");
+        return false;
+    }
+    if (!mStream->isRgb8Playback()) {
+        for (fl::size_t i = 0; i < leds.size(); ++i) {
+            leds[i] = CRGB::Black;
+        }
         return false;
     }
     bool ok = updateBufferIfNecessary(mPrevNow, now);
@@ -146,6 +157,18 @@ bool VideoImpl::draw(fl::u32 now, fl::span<CRGB> leds) {
         }
     }
     return true;
+}
+
+bool VideoImpl::videoColor(fled::VideoColor *out) const FL_NO_EXCEPT {
+    return mStream && mStream->videoColor(out);
+}
+
+bool VideoImpl::pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT {
+    return mStream && mStream->pixelStorage(out);
+}
+
+bool VideoImpl::readSample(PixelSample *out) FL_NO_EXCEPT {
+    return mStream && mStream->readSample(out);
 }
 
 bool VideoImpl::updateBufferFromStream(fl::u32 now) {

--- a/src/fl/video/video_impl.h
+++ b/src/fl/video/video_impl.h
@@ -21,6 +21,7 @@ namespace video {
 
 class FrameInterpolator;
 class PixelStream;
+struct PixelSample;
 
 FASTLED_SHARED_PTR(VideoImpl);
 FASTLED_SHARED_PTR(FrameInterpolator);
@@ -38,7 +39,8 @@ class VideoImpl {
               size_t frameHistoryCount = 0);
     ~VideoImpl() FL_NO_EXCEPT;
     // Api
-    void begin(fl::filebuf_ptr h);
+    bool begin(fl::filebuf_ptr h) FL_NO_EXCEPT;
+    void setBestEffortFled(bool enabled) FL_NO_EXCEPT { mBestEffortFled = enabled; }
     void setFade(fl::u32 fadeInTime, fl::u32 fadeOutTime);
     bool draw(fl::u32 now, fl::span<CRGB> leds);
     void end();
@@ -58,6 +60,9 @@ class VideoImpl {
     // empty / false for legacy headerless `.rgb` files.
     bool hasEmbeddedScreenMap() const FL_NO_EXCEPT;
     const fl::string &embeddedScreenMapJson() const FL_NO_EXCEPT;
+    bool videoColor(fled::VideoColor *out) const FL_NO_EXCEPT;
+    bool pixelStorage(fled::PixelStorage *out) const FL_NO_EXCEPT;
+    bool readSample(PixelSample *out) FL_NO_EXCEPT;
 
   private:
     bool updateBufferIfNecessary(fl::u32 prev, fl::u32 now);
@@ -71,6 +76,7 @@ class VideoImpl {
     fl::u32 mFadeInTime = 1000;
     fl::u32 mFadeOutTime = 1000;
     float mTimeScale = 1.0f;
+    bool mBestEffortFled = false;
 };
 
 } // namespace video

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -1,4 +1,4 @@
-// Tests for the .fled v1 `video.color` source-color contract.
+// Tests for the .fled v1 `video.mColor` source-color contract.
 //
 // The normative rules live in src/fl/fled/FLED_FORMAT.md ("Source Color
 // Metadata"), which mirrors the canonical ledmapper spec. This file walks
@@ -16,7 +16,7 @@
 // pixels are transformed by it.
 
 #include "fl/fled/color.h"
-#include "fl/fled/detail/pixel_format.h"
+#include "fl/fled/pixel_format.h"
 #include "fl/fled/fled.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/int.h"
@@ -71,11 +71,20 @@ FL_TEST_CASE("FLED_COLOR - rgb16_linear is 6 bytes per LED") {
     FL_CHECK_EQ(fl::fled::bytesPerLed(static_cast<fl::u8>(0xff)), 0);
 }
 
+FL_TEST_CASE("FLED_COLOR - typed resolveVideoColor accepts the public wire enum") {
+    VideoColor color;
+    fl::json envelope = fl::json::parse(fl::string("{}"));
+    FL_REQUIRE_EQ(fl::fled::resolveVideoColor(envelope, PixelFormat::Rgb16Linear,
+                                              &color),
+                  ColorStatus::Ok);
+    FL_CHECK_EQ(color.transfer, ColorTransfer::Linear);
+}
+
 // ============================================================================
 // Default tuple + absent metadata
 // ============================================================================
 
-FL_TEST_CASE("FLED_COLOR - absent video.color resolves to the default tuple") {
+FL_TEST_CASE("FLED_COLOR - absent video.mColor resolves to the default tuple") {
     VideoColor c;
     FL_CHECK(resolve("{}", kRgb8, &c) == ColorStatus::Ok);
     FL_CHECK(c.primaries == ColorPrimaries::Bt709);
@@ -252,7 +261,7 @@ FL_TEST_CASE("FLED_COLOR - non-string scalars are rejected, not coerced") {
                      kRgb8, &c) == ColorStatus::UnknownRange);
 }
 
-FL_TEST_CASE("FLED_COLOR - video.color must be an object") {
+FL_TEST_CASE("FLED_COLOR - video.mColor must be an object") {
     VideoColor c;
     FL_CHECK(resolve("{\"video\":{\"color\":\"bt709\"}}", kRgb8, &c) ==
              ColorStatus::NotAnObject);
@@ -510,7 +519,7 @@ FL_TEST_CASE("FLED_COLOR - the serialized envelope carries the whole metadata") 
     FL_CHECK(static_cast<bool>(fps));
     FL_CHECK(*fps == 60.0f);
 
-    // The color tuple survives under video.color, key by key.
+    // The color tuple survives under video.mColor, key by key.
     const fl::json color = round["video"]["color"];
     FL_CHECK(color.is_object());
     struct { const char* key; const char* value; } expected[4] = {

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -1,4 +1,4 @@
-// Tests for the .fled v1 `video.mColor` source-color contract.
+// Tests for the .fled v1 `video.color` source-color contract.
 //
 // The normative rules live in src/fl/fled/FLED_FORMAT.md ("Source Color
 // Metadata"), which mirrors the canonical ledmapper spec. This file walks
@@ -84,7 +84,7 @@ FL_TEST_CASE("FLED_COLOR - typed resolveVideoColor accepts the public wire enum"
 // Default tuple + absent metadata
 // ============================================================================
 
-FL_TEST_CASE("FLED_COLOR - absent video.mColor resolves to the default tuple") {
+FL_TEST_CASE("FLED_COLOR - absent video.color resolves to the default tuple") {
     VideoColor c;
     FL_CHECK(resolve("{}", kRgb8, &c) == ColorStatus::Ok);
     FL_CHECK(c.primaries == ColorPrimaries::Bt709);
@@ -261,7 +261,7 @@ FL_TEST_CASE("FLED_COLOR - non-string scalars are rejected, not coerced") {
                      kRgb8, &c) == ColorStatus::UnknownRange);
 }
 
-FL_TEST_CASE("FLED_COLOR - video.mColor must be an object") {
+FL_TEST_CASE("FLED_COLOR - video.color must be an object") {
     VideoColor c;
     FL_CHECK(resolve("{\"video\":{\"color\":\"bt709\"}}", kRgb8, &c) ==
              ColorStatus::NotAnObject);
@@ -519,7 +519,7 @@ FL_TEST_CASE("FLED_COLOR - the serialized envelope carries the whole metadata") 
     FL_CHECK(static_cast<bool>(fps));
     FL_CHECK(*fps == 60.0f);
 
-    // The color tuple survives under video.mColor, key by key.
+    // The color tuple survives under video.color, key by key.
     const fl::json color = round["video"]["color"];
     FL_CHECK(color.is_object());
     struct { const char* key; const char* value; } expected[4] = {

--- a/tests/fl/fled/fled_format.cpp
+++ b/tests/fl/fled/fled_format.cpp
@@ -13,7 +13,7 @@
 //
 // All bundles are hand-assembled in memory; no on-disk fixtures.
 
-#include "fl/fled/detail/pixel_format.h"
+#include "fl/fled/pixel_format.h"
 #include "fl/fled/fled.h"
 #include "fl/math/screenmap.h"
 #include "fl/stl/int.h"
@@ -101,6 +101,133 @@ FL_TEST_CASE("FLED_FORMAT - PixelFormat enum overload agrees with raw u8") {
     FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgba8),    fl::u8(4));
     FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgbw8),    fl::u8(4));
     FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgb565Le), fl::u8(2));
+}
+
+FL_TEST_CASE("FLED_FORMAT - container formats map explicitly to generic storage") {
+    using fl::fled::ComponentByteOrder;
+    using fl::fled::PixelFormat;
+    using fl::fled::PixelStorage;
+
+    // These are wire values. The generic fl::PixelFormat values are a
+    // separate API and are intentionally not compared numerically.
+    FL_CHECK_EQ(static_cast<fl::u8>(PixelFormat::Rgb8), fl::u8(0x00));
+    FL_CHECK_EQ(static_cast<fl::u8>(PixelFormat::Rgb16Linear), fl::u8(0x05));
+
+    PixelStorage storage;
+    FL_REQUIRE(fl::fled::toPixelStorage(PixelFormat::Rgb8, &storage));
+    FL_CHECK_EQ(storage.mFormat, fl::PixelFormat::Rgb8);
+    FL_CHECK_EQ(storage.mComponentByteOrder, ComponentByteOrder::NotApplicable);
+
+    FL_REQUIRE(fl::fled::toPixelStorage(PixelFormat::Rgb16Linear, &storage));
+    FL_CHECK_EQ(storage.mFormat, fl::PixelFormat::Rgb16);
+    FL_CHECK_EQ(storage.mComponentByteOrder, ComponentByteOrder::LittleEndian);
+
+    PixelFormat roundTrip = PixelFormat::Rgb8;
+    fl::fled::VideoColor linearColor = {
+        fl::fled::ColorPrimaries::Bt709,
+        fl::fled::ColorTransfer::Linear,
+        fl::fled::ColorMatrix::Rgb,
+        fl::fled::ColorRange::Full,
+        false,
+        {},
+    };
+    FL_REQUIRE(fl::fled::toFledPixelFormat(storage, linearColor, &roundTrip));
+    FL_CHECK_EQ(roundTrip, PixelFormat::Rgb16Linear);
+
+    linearColor.transfer = fl::fled::ColorTransfer::Srgb;
+    FL_CHECK_FALSE(fl::fled::toFledPixelFormat(storage, linearColor, &roundTrip));
+
+    storage.mComponentByteOrder = ComponentByteOrder::Native;
+    FL_CHECK_FALSE(fl::fled::toFledPixelFormat(storage, linearColor, &roundTrip));
+    FL_CHECK_FALSE(fl::fled::toPixelStorage(static_cast<PixelFormat>(0x06),
+                                             &storage));
+    FL_CHECK_EQ(fl::getBytesPerPixel(static_cast<fl::PixelFormat>(0xff)), 0);
+}
+
+FL_TEST_CASE("FLED_FORMAT - typed RGB16 frame ingress preserves low bits and metadata") {
+    const char envelope[] =
+        "{\"video\":{\"color\":{\"primaries\":\"display-p3\","
+        "\"transfer\":\"linear\",\"matrix\":\"rgb\",\"range\":\"full\"}}}";
+    // Two adjacent linear values must not pass through CRGB/RGB8 on ingress.
+    const fl::u8 payload[] = {
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+        0x01, 0x12, 0x03, 0x12, 0x04, 0x12,
+    };
+    Fled fled = Fled::loadFromVector(buildBundle(
+        1, static_cast<fl::u8>(fl::fled::PixelFormat::Rgb16Linear), envelope,
+        sizeof(envelope) - 1, payload, sizeof(payload)));
+    FL_REQUIRE(fled);
+
+    fl::fled::VideoFrameView frame;
+    FL_REQUIRE(fled.videoFrame(0, 2, &frame));
+    FL_CHECK_EQ(frame.mStorage.mFormat, fl::PixelFormat::Rgb16);
+    FL_CHECK_EQ(frame.mStorage.mComponentByteOrder,
+                fl::fled::ComponentByteOrder::LittleEndian);
+    FL_CHECK_EQ(frame.mColor.primaries, fl::fled::ColorPrimaries::DisplayP3);
+    FL_CHECK_EQ(frame.mColor.transfer, fl::fled::ColorTransfer::Linear);
+    FL_CHECK_EQ(frame.component16(0, 0), fl::u16(0x1200));
+    FL_CHECK_EQ(frame.component16(1, 0), fl::u16(0x1201));
+}
+
+FL_TEST_CASE("FLED_FORMAT - typed ingress validates color and owns its payload view") {
+    fl::fled::VideoFrameView empty;
+    FL_CHECK_EQ(empty.component16(0, 0), fl::u16(0));
+
+    fl::fled::PixelStorage storage = {
+        fl::PixelFormat::Rgb16,
+        fl::fled::ComponentByteOrder::LittleEndian,
+    };
+    fl::fled::VideoColor invalidColor = {
+        static_cast<fl::fled::ColorPrimaries>(0xff),
+        fl::fled::ColorTransfer::Linear,
+        fl::fled::ColorMatrix::Rgb,
+        fl::fled::ColorRange::Full,
+        false,
+        {},
+    };
+    fl::fled::PixelFormat wire = fl::fled::PixelFormat::Rgb8;
+    FL_CHECK_FALSE(fl::fled::toFledPixelFormat(storage, invalidColor, &wire));
+
+    const char envelope[] = "{}";
+    const fl::u8 payload[] = {0x00, 0x12, 0, 0, 0, 0};
+    fl::fled::VideoFrameView frame;
+    {
+        Fled fled = Fled::loadFromVector(buildBundle(
+            1, static_cast<fl::u8>(fl::fled::PixelFormat::Rgb16Linear),
+            envelope, sizeof(envelope) - 1, payload, sizeof(payload)));
+        FL_REQUIRE(fled.videoFrame(0, 1, &frame));
+    }
+    FL_CHECK_EQ(frame.component16(0, 0), fl::u16(0x1200));
+}
+
+FL_TEST_CASE("FLED_FORMAT - typed frame view rejects a trailing partial frame") {
+    const char envelope[] = "{}";
+    const fl::u8 rgb8Tail[] = {1, 2, 3, 4};
+    const fl::u8 rgb16Tail[] = {1, 2, 3, 4, 5, 6, 7};
+
+    Fled rgb8 = Fled::loadFromVector(buildBundle(
+        1, static_cast<fl::u8>(fl::fled::PixelFormat::Rgb8), envelope,
+        sizeof(envelope) - 1, rgb8Tail, sizeof(rgb8Tail)));
+    Fled rgb16 = Fled::loadFromVector(buildBundle(
+        1, static_cast<fl::u8>(fl::fled::PixelFormat::Rgb16Linear), envelope,
+        sizeof(envelope) - 1, rgb16Tail, sizeof(rgb16Tail)));
+    fl::fled::VideoFrameView frame;
+    FL_REQUIRE(rgb8);
+    FL_REQUIRE(rgb16);
+    FL_CHECK_FALSE(rgb8.videoFrame(0, 1, &frame));
+    FL_CHECK_FALSE(rgb16.videoFrame(0, 1, &frame));
+}
+
+FL_TEST_CASE("FLED_FORMAT - reserved header bytes must be zero") {
+    const char envelope[] = "{}";
+    const fl::u8 payload[] = {1, 2, 3};
+    for (fl::size reservedOffset = 6; reservedOffset <= 7; ++reservedOffset) {
+        fl::vector<fl::u8> bundle = buildBundle(
+            1, static_cast<fl::u8>(fl::fled::PixelFormat::Rgb8), envelope,
+            sizeof(envelope) - 1, payload, sizeof(payload));
+        bundle[reservedOffset] = 1;
+        FL_CHECK_FALSE(Fled::loadFromVector(fl::move(bundle)));
+    }
 }
 
 // ============================================================================

--- a/tests/fl/fled/fled_format.cpp
+++ b/tests/fl/fled/fled_format.cpp
@@ -137,6 +137,10 @@ FL_TEST_CASE("FLED_FORMAT - container formats map explicitly to generic storage"
     linearColor.transfer = fl::fled::ColorTransfer::Srgb;
     FL_CHECK_FALSE(fl::fled::toFledPixelFormat(storage, linearColor, &roundTrip));
 
+    // Restore the transfer first: Rgb16 with an Srgb transfer is rejected
+    // before byte order is ever consulted, so leaving it set would let the
+    // previous assertion's cause satisfy this one.
+    linearColor.transfer = fl::fled::ColorTransfer::Linear;
     storage.mComponentByteOrder = ComponentByteOrder::Native;
     FL_CHECK_FALSE(fl::fled::toFledPixelFormat(storage, linearColor, &roundTrip));
     FL_CHECK_FALSE(fl::fled::toPixelStorage(static_cast<PixelFormat>(0x06),

--- a/tests/fl/fled/fled_format.cpp
+++ b/tests/fl/fled/fled_format.cpp
@@ -94,15 +94,6 @@ FL_TEST_CASE("FLED_FORMAT - bytesPerLed for reserved values returns 0") {
     FL_CHECK_EQ(fl::fled::bytesPerLed(fl::u8(0xff)), fl::u8(0));
 }
 
-FL_TEST_CASE("FLED_FORMAT - PixelFormat enum overload agrees with raw u8") {
-    using fl::fled::PixelFormat;
-    FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgb8),     fl::u8(3));
-    FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Gray8),    fl::u8(1));
-    FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgba8),    fl::u8(4));
-    FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgbw8),    fl::u8(4));
-    FL_CHECK_EQ(fl::fled::bytesPerLed(PixelFormat::Rgb565Le), fl::u8(2));
-}
-
 FL_TEST_CASE("FLED_FORMAT - container formats map explicitly to generic storage") {
     using fl::fled::ComponentByteOrder;
     using fl::fled::PixelFormat;

--- a/tests/fl/fx/video.cpp
+++ b/tests/fl/fx/video.cpp
@@ -169,6 +169,45 @@ FL_TEST_CASE("Video Frame draw fails dark after rejected FLED admission") {
     FL_CHECK_EQ(frame.rgb()[0], CRGB::Black);
 }
 
+FL_TEST_CASE("Video admits a valid source after a rejected FLED container") {
+    FakeFilebufPtr bad = fl::make_shared<FakeFilebuf>();
+    const uint8_t invalidFled[] = {
+        'F', 'L', 'E', 'D', 1, 0x00, 1, 0, 0, 0, 0, 0, 1, 2, 3,
+    };
+    FL_REQUIRE_EQ(bad->writeData(invalidFled, sizeof(invalidFled)),
+                  sizeof(invalidFled));
+
+    fl::Video video(1, 30, 1);
+    FL_REQUIRE_FALSE(video.begin(bad));
+    FL_REQUIRE(video.error().size());
+
+    // Rejecting one container describes that source, not the instance. The
+    // same Video has to admit a valid handle afterwards, and must not carry
+    // the previous rejection forward as its error state.
+    FakeFilebufPtr good = fl::make_shared<FakeFilebuf>();
+    const uint8_t raw[] = {0x11, 0x22, 0x33};
+    FL_REQUIRE_EQ(good->writeData(raw, sizeof(raw)), sizeof(raw));
+
+    FL_CHECK(video.begin(good));
+    FL_CHECK(video.error().empty());
+    FL_CHECK_FALSE(video.hasEmbeddedScreenMap());
+}
+
+FL_TEST_CASE("Video setError blocks admission until the caller clears it") {
+    FakeFilebufPtr good = fl::make_shared<FakeFilebuf>();
+    const uint8_t raw[] = {0x11, 0x22, 0x33};
+    FL_REQUIRE_EQ(good->writeData(raw, sizeof(raw)), sizeof(raw));
+
+    fl::Video video(1, 30, 1);
+    // A caller-supplied error is persistent, unlike a begin() rejection.
+    video.setError("persistent failure");
+    FL_CHECK_FALSE(video.begin(good));
+    FL_CHECK_EQ(video.error(), fl::string("persistent failure"));
+
+    video.setError("");
+    FL_CHECK(video.begin(good));
+}
+
 FL_TEST_CASE("PixelStream rejects an unsupported FLED format instead of reading its header as RGB") {
     FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
     // A complete FLED header for rgb16_linear followed by one six-byte

--- a/tests/fl/fx/video.cpp
+++ b/tests/fl/fx/video.cpp
@@ -16,10 +16,14 @@
 #include "fl/gfx/crgb.h"
 #include "fl/fx/fx.h"
 #include "fl/fx/fx2d.h"
+#include "fl/fx/frame.h"
 #include "fl/stl/move.h"
 #include "fl/stl/string.h"
+#include "fl/stl/cstring.h"
 #include "fl/math/xymap.h"
 #include "fl/video/pixel_stream.h"
+#include "fl/fled/color.h"
+#include "fl/fled/pixel_format.h"
 #include "FastLED.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -82,26 +86,417 @@ class FakeFilebuf : public fl::filebuf {
     size_t mPos = 0;
 };
 
-FL_TEST_CASE("PixelStream zero frame size reports no displayed frames") {
+class NonSeekableFakeFilebuf : public FakeFilebuf {
+  public:
+    bool seek(size_t, fl::seek_dir) override { return false; }
+};
+
+FL_TEST_CASE("PixelStream rejects zero and negative base frame sizes") {
     FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
     const uint8_t byte = 0x42;
     FL_REQUIRE_EQ(fileHandle->writeData(&byte, 1), 1);
 
-    fl::PixelStream stream(0);
-    FL_REQUIRE(stream.begin(fileHandle));
-    FL_CHECK_EQ(stream.framesDisplayed(), 0);
-    FL_CHECK_EQ(stream.bytesRemainingInFrame(), 0);
+    FL_SUBCASE("zero") {
+        fl::PixelStream stream(0);
+        FL_CHECK_FALSE(stream.begin(fileHandle));
+        FL_CHECK_FALSE(stream.available());
+    }
+    FL_SUBCASE("negative") {
+        fl::PixelStream stream(-3);
+        FL_CHECK_FALSE(stream.begin(fileHandle));
+        FL_CHECK_FALSE(stream.available());
+    }
 }
 
-FL_TEST_CASE("PixelStream zero frame size preserves streaming semantics") {
-    fl::memorybufPtr memoryStream = fl::make_shared<fl::memorybuf>(3);
-    const CRGB pixel = CRGB::Red;
-    FL_REQUIRE_EQ(memoryStream->writeCRGB(&pixel, 1), 1);
+FL_TEST_CASE("PixelStream rejects RGB16 FLED stride that overflows i32") {
+    FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+    const uint8_t rgb16Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+    };
+    FL_REQUIRE_EQ(fileHandle->writeData(rgb16Fled, sizeof(rgb16Fled)),
+                  sizeof(rgb16Fled));
 
-    fl::PixelStream stream(0);
-    FL_REQUIRE(stream.begin(memoryStream));
-    FL_CHECK_EQ(stream.getType(), fl::PixelStream::kStreaming);
-    FL_CHECK_EQ(stream.framesDisplayed(), -1);
+    // This positive RGB8 base stride is divisible by three, but multiplying
+    // its LED count by RGB16's six-byte storage does not fit in i32.
+    fl::PixelStream stream(2147483646);
+    FL_CHECK_FALSE(stream.begin(fileHandle));
+    FL_CHECK_FALSE(stream.available());
+}
+
+FL_TEST_CASE("PixelStream rejects partial FLED frames and reserved header bytes") {
+    struct InvalidFled {
+        fl::u8 format;
+        fl::u8 payloadBytes;
+        fl::u8 reservedOffset;
+    };
+    const InvalidFled invalid[] = {
+        {0x00, 4, 0}, // rgb8 tail
+        {0x05, 7, 0}, // rgb16 tail
+        {0x00, 3, 6}, // reserved byte 0
+        {0x00, 3, 7}, // reserved byte 1
+    };
+    for (const InvalidFled& item : invalid) {
+        FakeFilebufPtr file = fl::make_shared<FakeFilebuf>();
+        fl::vector<fl::u8> bytes(12 + item.payloadBytes, 0);
+        bytes[0] = 'F'; bytes[1] = 'L'; bytes[2] = 'E'; bytes[3] = 'D';
+        bytes[4] = 1;
+        bytes[5] = item.format;
+        if (item.reservedOffset != 0) {
+            bytes[item.reservedOffset] = 1;
+        }
+        FL_REQUIRE_EQ(file->writeData(bytes.data(), bytes.size()), bytes.size());
+        fl::PixelStream stream(3);
+        CRGB pixel = CRGB::Red;
+        FL_CHECK_FALSE(stream.begin(file));
+        FL_CHECK_FALSE(stream.available());
+        FL_CHECK_FALSE(stream.readPixel(&pixel));
+        FL_CHECK_EQ(pixel, CRGB::Red);
+    }
+}
+
+FL_TEST_CASE("Video Frame draw fails dark after rejected FLED admission") {
+    FakeFilebufPtr file = fl::make_shared<FakeFilebuf>();
+    const uint8_t invalidFled[] = {
+        'F', 'L', 'E', 'D', 1, 0x00, 1, 0, 0, 0, 0, 0, 1, 2, 3,
+    };
+    FL_REQUIRE_EQ(file->writeData(invalidFled, sizeof(invalidFled)),
+                  sizeof(invalidFled));
+    fl::Video video(1, 30, 1);
+    FL_CHECK_FALSE(video.begin(file));
+    fl::Frame frame(1);
+    frame.rgb()[0] = CRGB::Red;
+    FL_CHECK_FALSE(video.draw(0, &frame));
+    FL_CHECK_EQ(frame.rgb()[0], CRGB::Black);
+}
+
+FL_TEST_CASE("PixelStream rejects an unsupported FLED format instead of reading its header as RGB") {
+    FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+    // A complete FLED header for rgb16_linear followed by one six-byte
+    // sample. PixelStream only renders RGB8 today, so recognizing the magic
+    // must reject this container rather than rewinding and exposing "FLE".
+    const uint8_t fledRgb16[] = {
+        'F', 'L', 'E', 'D', 1, 0xff, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    FL_REQUIRE_EQ(fileHandle->writeData(fledRgb16, sizeof(fledRgb16)),
+                  sizeof(fledRgb16));
+
+    fl::PixelStream stream(3);
+    FL_CHECK_FALSE(stream.begin(fileHandle));
+    CRGB pixel;
+    FL_CHECK_FALSE(stream.available());
+    FL_CHECK_FALSE(stream.readPixel(&pixel));
+}
+
+FL_TEST_CASE("PixelStream FLED recognition only falls back when magic is absent") {
+    FL_SUBCASE("raw RGB remains playable") {
+        FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+        const uint8_t raw[] = {0x11, 0x22, 0x33};
+        FL_REQUIRE_EQ(fileHandle->writeData(raw, sizeof(raw)), sizeof(raw));
+
+        fl::PixelStream stream(3);
+        FL_REQUIRE(stream.begin(fileHandle));
+        CRGB pixel;
+        FL_REQUIRE(stream.readPixel(&pixel));
+        FL_CHECK_EQ(pixel, CRGB(0x11, 0x22, 0x33));
+    }
+
+    FL_SUBCASE("valid RGB8 FLED skips the header") {
+        FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+        const uint8_t fledRgb8[] = {
+            'F', 'L', 'E', 'D', 1, 0x00, 0, 0, 0, 0, 0, 0,
+            0x11, 0x22, 0x33,
+        };
+        FL_REQUIRE_EQ(fileHandle->writeData(fledRgb8, sizeof(fledRgb8)),
+                      sizeof(fledRgb8));
+
+        fl::PixelStream stream(3);
+        FL_REQUIRE(stream.begin(fileHandle));
+        CRGB pixel;
+        FL_REQUIRE(stream.readPixel(&pixel));
+        FL_CHECK_EQ(pixel, CRGB(0x11, 0x22, 0x33));
+    }
+
+    FL_SUBCASE("future format version and truncation are rejected") {
+        const uint8_t invalidHeaders[][12] = {
+            {'F', 'L', 'E', 'D', 1, 0x06, 0, 0, 0, 0, 0, 0},
+            {'F', 'L', 'E', 'D', 2, 0x00, 0, 0, 0, 0, 0, 0},
+            {'F', 'L', 'E', 'D', 1, 0x00, 0, 0, 1, 0, 0, 0},
+        };
+        for (fl::size i = 0; i < sizeof(invalidHeaders) / sizeof(invalidHeaders[0]); ++i) {
+            FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+            FL_REQUIRE_EQ(fileHandle->writeData(invalidHeaders[i],
+                                                sizeof(invalidHeaders[i])),
+                          sizeof(invalidHeaders[i]));
+            fl::PixelStream stream(3);
+            FL_CHECK_FALSE(stream.begin(fileHandle));
+        }
+
+        FakeFilebufPtr truncated = fl::make_shared<FakeFilebuf>();
+        const uint8_t magicOnly[] = {'F', 'L', 'E', 'D', 1};
+        FL_REQUIRE_EQ(truncated->writeData(magicOnly, sizeof(magicOnly)),
+                      sizeof(magicOnly));
+        fl::PixelStream stream(3);
+        FL_CHECK_FALSE(stream.begin(truncated));
+    }
+}
+
+FL_TEST_CASE("PixelStream rejects FLED magic on a non-seekable input") {
+    fl::shared_ptr<NonSeekableFakeFilebuf> fileHandle =
+        fl::make_shared<NonSeekableFakeFilebuf>();
+    const uint8_t fledRgb16[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    FL_REQUIRE_EQ(fileHandle->writeData(fledRgb16, sizeof(fledRgb16)),
+                  sizeof(fledRgb16));
+
+    fl::PixelStream stream(3);
+    FL_CHECK_FALSE(stream.begin(fileHandle));
+    FL_CHECK_FALSE(stream.available());
+}
+
+FL_TEST_CASE("Video carries RGB16 FLED source metadata and darkens rejected playback") {
+    FakeFilebufPtr rgb16 = fl::make_shared<FakeFilebuf>();
+    const uint8_t rgb16Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    FL_REQUIRE_EQ(rgb16->writeData(rgb16Fled, sizeof(rgb16Fled)),
+                  sizeof(rgb16Fled));
+    fl::Video video(1, 30, 1);
+    FL_REQUIRE(video.begin(rgb16));
+
+    fl::fled::VideoColor color;
+    fl::fled::PixelStorage storage;
+    FL_REQUIRE(video.videoColor(&color));
+    FL_REQUIRE(video.pixelStorage(&storage));
+    FL_CHECK_EQ(storage.mFormat, fl::PixelFormat::Rgb16);
+    FL_CHECK_EQ(storage.mComponentByteOrder,
+                fl::fled::ComponentByteOrder::LittleEndian);
+    FL_CHECK_EQ(color.transfer, fl::fled::ColorTransfer::Linear);
+
+    CRGB leds[] = {CRGB::Red};
+    FL_CHECK_FALSE(video.draw(0, leds));
+    FL_CHECK_EQ(leds[0], CRGB::Black);
+}
+
+FL_TEST_CASE("Known non-RGB8 FLED formats never reach RGB8 playback") {
+    struct UnsupportedFormat {
+        fl::u8 mFormat;
+        fl::u8 bytesPerLed;
+    };
+    const UnsupportedFormat formats[] = {
+        {0x01, 1}, // gray8
+        {0x02, 4}, // rgba8
+        {0x03, 4}, // rgbw8
+        {0x04, 2}, // rgb565_le
+    };
+    const char metadata[] =
+        "{\"video\":{\"color\":{\"primaries\":\"bt709\",\"transfer\":\"srgb\","
+        "\"matrix\":\"rgb\",\"range\":\"full\"}}}";
+
+    for (const UnsupportedFormat& format : formats) {
+        fl::vector<uint8_t> bytes(12 + sizeof(metadata) - 1 + format.bytesPerLed, 0);
+        bytes[0] = 'F'; bytes[1] = 'L'; bytes[2] = 'E'; bytes[3] = 'D';
+        bytes[4] = 1;
+        bytes[5] = format.mFormat;
+        bytes[8] = sizeof(metadata) - 1;
+        for (fl::size i = 0; i < sizeof(metadata) - 1; ++i) {
+            bytes[12 + i] = metadata[i];
+        }
+        for (fl::size i = 0; i < format.bytesPerLed; ++i) {
+            bytes[12 + sizeof(metadata) - 1 + i] = static_cast<uint8_t>(i + 1);
+        }
+
+        FakeFilebufPtr streamFile = fl::make_shared<FakeFilebuf>();
+        FL_REQUIRE_EQ(streamFile->writeData(bytes.data(), bytes.size()), bytes.size());
+        fl::PixelStream stream(3);
+        FL_REQUIRE(stream.begin(streamFile));
+        CRGB legacy = CRGB::Red;
+        FL_CHECK_FALSE(stream.readPixel(&legacy));
+        FL_CHECK_EQ(legacy, CRGB::Red);
+
+        FakeFilebufPtr videoFile = fl::make_shared<FakeFilebuf>();
+        FL_REQUIRE_EQ(videoFile->writeData(bytes.data(), bytes.size()), bytes.size());
+        fl::Video video(1, 30, 1);
+        FL_REQUIRE(video.begin(videoFile));
+        CRGB leds[] = {CRGB::Red};
+        FL_CHECK_FALSE(video.draw(0, leds));
+        FL_CHECK_EQ(leds[0], CRGB::Black);
+    }
+}
+
+FL_TEST_CASE("PixelStream reads RGB16 FLED through a typed sample only") {
+    FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+    const uint8_t rgb16Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    FL_REQUIRE_EQ(fileHandle->writeData(rgb16Fled, sizeof(rgb16Fled)),
+                  sizeof(rgb16Fled));
+
+    fl::PixelStream stream(3);
+    FL_REQUIRE(stream.begin(fileHandle));
+    CRGB legacy;
+    FL_CHECK_FALSE(stream.readPixel(&legacy));
+
+    fl::video::PixelSample sample;
+    FL_REQUIRE(stream.readSample(&sample));
+    FL_CHECK_EQ(sample.mStorage.mFormat, fl::PixelFormat::Rgb16);
+    FL_CHECK_EQ(sample.mStorage.mComponentByteOrder,
+                fl::fled::ComponentByteOrder::LittleEndian);
+    FL_CHECK_EQ(sample.mColor.transfer, fl::fled::ColorTransfer::Linear);
+    FL_CHECK_EQ(sample.mComponents[0], fl::u16(0x1200));
+    FL_CHECK_EQ(sample.mComponents[1], fl::u16(0x1201));
+    FL_CHECK_EQ(sample.mComponents[2], fl::u16(0x1202));
+}
+
+FL_TEST_CASE("PixelStream resets FLED metadata and stride across reopen") {
+    const uint8_t rgb16Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    const uint8_t rgb8Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x00, 0, 0, 0, 0, 0, 0,
+        0x12, 0x34, 0x56,
+    };
+    fl::PixelStream stream(3);
+    fl::fled::PixelStorage storage;
+    for (int i = 0; i < 2; ++i) {
+        FakeFilebufPtr file = fl::make_shared<FakeFilebuf>();
+        FL_REQUIRE_EQ(file->writeData(rgb16Fled, sizeof(rgb16Fled)),
+                      sizeof(rgb16Fled));
+        FL_REQUIRE(stream.begin(file));
+        FL_REQUIRE(stream.pixelStorage(&storage));
+        FL_CHECK_EQ(storage.mFormat, fl::PixelFormat::Rgb16);
+        FL_CHECK_EQ(stream.bytesPerFrame(), 6);
+    }
+    stream.close();
+    FL_CHECK_FALSE(stream.pixelStorage(&storage));
+
+    FakeFilebufPtr rgb8 = fl::make_shared<FakeFilebuf>();
+    FL_REQUIRE_EQ(rgb8->writeData(rgb8Fled, sizeof(rgb8Fled)), sizeof(rgb8Fled));
+    FL_REQUIRE(stream.begin(rgb8));
+    FL_REQUIRE(stream.pixelStorage(&storage));
+    FL_CHECK_EQ(storage.mFormat, fl::PixelFormat::Rgb8);
+    FL_CHECK_EQ(stream.bytesPerFrame(), 3);
+
+    FakeFilebufPtr raw = fl::make_shared<FakeFilebuf>();
+    const uint8_t rawBytes[] = {1, 2, 3};
+    FL_REQUIRE_EQ(raw->writeData(rawBytes, sizeof(rawBytes)), sizeof(rawBytes));
+    FL_REQUIRE(stream.begin(raw));
+    FL_CHECK_FALSE(stream.pixelStorage(&storage));
+    FL_CHECK_EQ(stream.bytesPerFrame(), 3);
+
+    fl::PixelStream nullStream(3);
+    FL_CHECK_FALSE(nullStream.begin(fl::filebuf_ptr()));
+
+    FakeFilebufPtr truncated = fl::make_shared<FakeFilebuf>();
+    const uint8_t truncatedHeader[] = {'F', 'L', 'E', 'D', 1};
+    FL_REQUIRE_EQ(truncated->writeData(truncatedHeader, sizeof(truncatedHeader)),
+                  sizeof(truncatedHeader));
+    FL_CHECK_FALSE(stream.begin(truncated));
+    FL_CHECK_FALSE(stream.pixelStorage(&storage));
+}
+
+FL_TEST_CASE("Video requires explicit best effort for invalid advisory RGB8 metadata") {
+    const char metadata[] =
+        "{\"video\":{\"color\":{\"primaries\":\"not-a-space\"}}}";
+    FakeFilebufPtr strictFile = fl::make_shared<FakeFilebuf>();
+    fl::vector<uint8_t> bytes(12 + sizeof(metadata) - 1 + 3, 0);
+    bytes[0] = 'F'; bytes[1] = 'L'; bytes[2] = 'E'; bytes[3] = 'D';
+    bytes[4] = 1;
+    bytes[8] = sizeof(metadata) - 1;
+    for (fl::size i = 0; i < sizeof(metadata) - 1; ++i) {
+        bytes[12 + i] = metadata[i];
+    }
+    bytes[12 + sizeof(metadata) - 1] = 0x12;
+    bytes[13 + sizeof(metadata) - 1] = 0x34;
+    bytes[14 + sizeof(metadata) - 1] = 0x56;
+    FL_REQUIRE_EQ(strictFile->writeData(bytes.data(), bytes.size()), bytes.size());
+
+    fl::Video strict(1, 30, 1);
+    FL_CHECK_FALSE(strict.begin(strictFile));
+    CRGB leds[] = {CRGB::Red};
+    strict.draw(fl::DrawContext(0, leds));
+    FL_CHECK_EQ(leds[0], CRGB::Black);
+
+    FakeFilebufPtr bestEffortFile = fl::make_shared<FakeFilebuf>();
+    FL_REQUIRE_EQ(bestEffortFile->writeData(bytes.data(), bytes.size()), bytes.size());
+    fl::Video bestEffort(1, 30, 1);
+    bestEffort.setFade(0, 0);
+    bestEffort.setFledPlaybackMode(fl::FledPlaybackMode::BestEffort);
+    FL_REQUIRE(bestEffort.begin(bestEffortFile));
+    FL_REQUIRE(bestEffort.draw(0, leds));
+    FL_CHECK_EQ(leds[0], CRGB(0x12, 0x34, 0x56));
+}
+
+FL_TEST_CASE("Video best effort never admits malformed FLED envelopes") {
+    const char* const envelopes[] = {"{", "[]"};
+    for (fl::size index = 0; index < sizeof(envelopes) / sizeof(envelopes[0]);
+         ++index) {
+        const char* envelope = envelopes[index];
+        const fl::size length = fl::strlen(envelope);
+        FakeFilebufPtr file = fl::make_shared<FakeFilebuf>();
+        fl::vector<uint8_t> bytes(12 + length + 3, 0);
+        bytes[0] = 'F'; bytes[1] = 'L'; bytes[2] = 'E'; bytes[3] = 'D';
+        bytes[4] = 1;
+        bytes[8] = static_cast<uint8_t>(length);
+        for (fl::size i = 0; i < length; ++i) {
+            bytes[12 + i] = static_cast<uint8_t>(envelope[i]);
+        }
+        FL_REQUIRE_EQ(file->writeData(bytes.data(), bytes.size()), bytes.size());
+        fl::Video video(1, 30, 1);
+        video.setFledPlaybackMode(fl::FledPlaybackMode::BestEffort);
+        FL_CHECK_FALSE(video.begin(file));
+    }
+}
+
+FL_TEST_CASE("Video exposes typed RGB16 samples without CRGB conversion") {
+    FakeFilebufPtr fileHandle = fl::make_shared<FakeFilebuf>();
+    const uint8_t rgb16Fled[] = {
+        'F', 'L', 'E', 'D', 1, 0x05, 0, 0, 0, 0, 0, 0,
+        0x00, 0x12, 0x01, 0x12, 0x02, 0x12,
+    };
+    FL_REQUIRE_EQ(fileHandle->writeData(rgb16Fled, sizeof(rgb16Fled)),
+                  sizeof(rgb16Fled));
+    fl::Video video(1, 30, 1);
+    FL_REQUIRE(video.begin(fileHandle));
+    fl::video::PixelSample sample;
+    FL_REQUIRE(video.readSample(&sample));
+    FL_CHECK_EQ(sample.mComponents[0], fl::u16(0x1200));
+    FL_CHECK_EQ(sample.mComponents[1], fl::u16(0x1201));
+}
+
+FL_TEST_CASE("PixelStream defers fragmented stream classification without losing raw bytes") {
+    fl::shared_ptr<NonSeekableFakeFilebuf> fled =
+        fl::make_shared<NonSeekableFakeFilebuf>();
+    const uint8_t partialMagic[] = {'F', 'L', 'E'};
+    FL_REQUIRE_EQ(fled->writeData(partialMagic, sizeof(partialMagic)),
+                  sizeof(partialMagic));
+    fl::PixelStream fledStream(3);
+    FL_REQUIRE(fledStream.begin(fled));
+    FL_CHECK_FALSE(fledStream.available());
+
+    const uint8_t finalMagic = 'D';
+    FL_REQUIRE_EQ(fled->writeData(&finalMagic, 1), 1);
+    FL_CHECK_FALSE(fledStream.available());
+    CRGB pixel;
+    FL_CHECK_FALSE(fledStream.readPixel(&pixel));
+
+    fl::shared_ptr<NonSeekableFakeFilebuf> raw =
+        fl::make_shared<NonSeekableFakeFilebuf>();
+    const uint8_t rawBytes[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    FL_REQUIRE_EQ(raw->writeData(rawBytes, sizeof(rawBytes)), sizeof(rawBytes));
+    fl::PixelStream rawStream(3);
+    FL_REQUIRE(rawStream.begin(raw));
+    uint8_t replayed[sizeof(rawBytes)] = {};
+    FL_REQUIRE_EQ(rawStream.readBytes(replayed, sizeof(replayed)),
+                  sizeof(replayed));
+    for (fl::size i = 0; i < sizeof(rawBytes); ++i) {
+        FL_CHECK_EQ(replayed[i], rawBytes[i]);
+    }
 }
 
 FL_TEST_CASE("video with memory stream") {


### PR DESCRIPTION
Implements the #4038 metadata-carriage slice of #4034.\n\nValidated locally:\n- 0.05 ── 🔍 Discovery ─────────────────────────────────────
0.09 Found: fled_format (tests/fl/fled/fled_format.cpp) [unit]
✅ All tests passed (1/1 cached)
Total: 0.12s — 23/23\n- 0.07 ── 🔍 Discovery ─────────────────────────────────────
0.10 Found: video (tests/fl/fx/video.cpp) [unit]
✅ All tests passed (1/1 cached)
Total: 0.14s\n- [0;34mFAST FastLED TypeScript Linting (ESLint + TypeScript Type Checking - FAST!)[0m
[0;34mChecking if TypeScript files need linting...[0m
All checks passed!
🚀 Running FastLED Comprehensive Linting Suite
==============================================

⚡ PARALLEL LINTING (7 stages)
================================
Running ruff check (linting + import sorting)
  Started python_pipeline (PID 2744128)

🔧 C++ LINTING
---------------
  Started cpp_linting (PID 2744128)

🌐 JAVASCRIPT LINTING & TYPE CHECKING
--------------------------------------
  Started javascript_linting (PID 2744128)
  Started meson_linting (PID 2744128)
  Started platformio_internal_usage (PID 2744128)
  Started root_platformio_ini_lockdown (PID 2744128)
  Started size_thresholds_locked (PID 2744128)

[0;34m🚀 Using fast JavaScript linting (Node.js + ESLint)[0m
✅ Size-thresholds lockdown: all 10 check_*_size.yml workflow(s) match frozen values.
0.08 ✓ No C++ changes detected - skipping linting
All checks passed!
1 file left unchanged
0.04 ✓ No changes in JavaScript/TypeScript directories - skipping lint
[0;32mNo changes detected - skipping TypeScript linting[0m
477 files left unchanged
NOTE: 2 baselined subprocess usage(s) are now gone. Re-run with --update-baseline to lock in the improvement.
No new raw-subprocess usage. Baseline entries: 161
All checks passed!
⏭️  C++ linting skipped (no changes)

🔍 INCLUDE-WHAT-YOU-USE ANALYSIS
---------------------------------
⏭️  IWYU skipped (use --full or --iwyu to enable)

🔍 CLANG-TIDY STATIC ANALYSIS
------------------------------
⏭️  clang-tidy skipped (use --tidy to enable)

C++ AST CHECKS
--------------
Handled by the default unified C++ linter: ci/tools/check_noexcept.py and ci/tools/check_array_params.py
Running ruff format (formatting)
Running KeyboardInterrupt handler checks
Running sys.path.insert/append checks
Running dict type annotation checks
Running raw-subprocess ratchet checks
✅ PlatformIO-internal-usage check: no violations
Running pyserial ban checks (AutoResearch complex)
✅ ruff passed
Running ty (fast type check)
✅ ty passed
⏭️  pyright skipped (use --strict to enable)
  ✅ python_pipeline completed
  ✅ cpp_linting completed
  ✅ javascript_linting completed
  ✅ meson_linting completed
  ✅ platformio_internal_usage completed
  ✅ root_platformio_ini_lockdown completed
  ✅ size_thresholds_locked completed

  Parallel phase completed in 4s

🎉 All linting completed!

Linting Execution Summary:
-----------------------------+-------------------------
Linter Name                  |                 Duration
-----------------------------+-------------------------
python_pipeline              |                       4s
cpp_linting                  |                       0s
javascript_linting           |                       0s
meson_linting                |                       2s
platformio_internal_usage    |                       2s
root_platformio_ini_lockdown |                       0s
size_thresholds_locked       |                       0s
-----------------------------+-------------------------

💡 FOR AI AGENTS:
  - Use 'bash lint' for comprehensive linting (Python, C++, and JavaScript)
  - Use 'bash lint --strict' to also run pyright + IWYU (strict type & include checking)
  - Use 'bash lint --js' for JavaScript linting only
  - Use 'bash lint --cpp' for C++ linting only
  - C++ linting uses the Rust-backed `fastled-lint` binary by default; pass --no-rust to fall back to the legacy Python-only path
  - Use 'bash lint --full' to include IWYU (Include-What-You-Use) analysis
  - Use 'bash lint --iwyu' to run IWYU analysis only
  - Use 'bash lint --iwyu --fix' to auto-fix IWYU violations
  - Use 'bash lint --tidy' to run clang-tidy static analysis on src/fl
  - Python linting includes: ruff (lint + format) + KBI checker + ty
  - Use --strict to also run pyright (strict type checking)
  - C++ linting includes: clang-format, custom checkers, and default AST ratchets for FL_NO_EXCEPT and decayed array parameters
  - IWYU runs with --full, --iwyu, or --strict flags
  - clang-tidy runs with --tidy flag
  - JavaScript linting: FAST ONLY (no slow fallback)
  - To enable fast JavaScript linting: uv run ci/setup-js-linting-fast.py
  - Use 'bash lint --help' for usage information\n\nIncludes strict malformed FLED rejection, checked wire/storage mapping, RGB16 metadata carriage, and failure darkening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RGB16 linear pixel support for FLED video containers.
  * Added typed frame and sample access while preserving color metadata and component values.
  * Added strict and best-effort playback modes for advisory color metadata.
  * Added expanded pixel-format metadata, conversion, and validation support.

* **Bug Fixes**
  * Malformed containers, invalid headers, incomplete frames, and unsupported formats are rejected safely.
  * Legacy LED drawing now fails safely and clears output for unsupported formats.
  * Transient video-source admission failures can now be retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->