### PR TITLE
test(ci): lock RP port selection to fbuild in driver mode (#3836)

### DIFF
--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -20,6 +20,7 @@ from ci.autoresearch.args import Args
 from ci.autoresearch.build_driver import BuildDriver, DeployResult
 from ci.autoresearch.context import QuietContext, RunContext
 from ci.autoresearch.phases import (
+    RP2XXX_ENVIRONMENTS,
     _build_environment_for_mode,
     _is_valid_rp_concurrency_result,
     _parse_args_and_build_commands,
@@ -1592,6 +1593,44 @@ class TestResolvePortAndEnvironment:
             final_environment=environment,
             upload_port=None,
             rpc_smoke_mode=True,
+        )
+
+        with (
+            patch(f"{_PATCH_MOD}.auto_detect_upload_port") as auto_detect,
+            patch(
+                f"{_PATCH_MOD}.select_build_driver",
+                return_value=_make_mock_driver(),
+            ),
+        ):
+            rc = asyncio.run(_resolve_port_and_environment(ctx))
+
+        assert rc is None
+        assert ctx.upload_port is None
+        auto_detect.assert_not_called()
+
+    @pytest.mark.parametrize("environment", sorted(RP2XXX_ENVIRONMENTS))
+    def test_rp2xxx_driver_mode_delegates_port_selection_to_fbuild(
+        self, environment: str
+    ) -> None:
+        """Driver runs defer RP port selection to fbuild too (#3836).
+
+        RP USB identities are published by FastLED/boards and reach us
+        through fbuild, so a local ``auto_detect_upload_port`` scan would be
+        re-deriving data we already have. Deferral was once granted only to
+        ``--rpc-smoke``/``--watchdog-soak``, which left driver modes such as
+        ``--parlio`` resolving the port locally.
+        """
+        args = _make_args(
+            environment=environment,
+            upload_port=None,
+            parlio=True,
+            rpc_smoke=False,
+        )
+        ctx = _make_ctx(
+            args=args,
+            final_environment=environment,
+            upload_port=None,
+            rpc_smoke_mode=False,
         )
 
         with (


### PR DESCRIPTION
Closes the last open code gap on #3836.

## Context

RP2xxx USB identities (`2E8A:000A/F00A/000F/F00F`, ROM BOOTSEL `2E8A:0003`) are published by [FastLED/boards](https://github.com/FastLED/boards) and reach FastLED through fbuild. `_resolve_port_and_environment` must therefore never re-derive them with a local `auto_detect_upload_port` scan.

Deferral was originally granted only to `--rpc-smoke` / `--watchdog-soak`, which left driver modes such as `--parlio` resolving the port locally. The production fix — `defer_port_selection_to_fbuild = bool(ctx.final_environment)` (`ci/autoresearch/phases.py:1336`) — has since landed, and the legacy `ENVIRONMENT_TO_VCOM_VID_PIDS` table was retired in #4070.

What never landed is the regression test #3836 called for: it lived on `fix/3836-fbuild-rp-port-resolution`, which no longer exists on the remote. Nothing currently pins the behavior, so the local-scan path can silently come back.

## Change

Adds `test_rp2xxx_driver_mode_delegates_port_selection_to_fbuild`, parametrized over all seven entries of `RP2XXX_ENVIRONMENTS` (`rp2040`, `rpipico`, `rpipicow`, `rp2350`, `rpipico2`, `rp2350w`, `rpipico2w`). It asserts a driver-mode run leaves `upload_port` unset and never calls `auto_detect_upload_port`.

Test-only — no production code is touched.

## Verification

- **RED**: stubbing `defer_port_selection_to_fbuild = False` fails all 7 environments.
- **GREEN**: restoring it passes all 7.
- `uv run pytest ci/tests/test_autoresearch_phases.py` — 177 passed.
- `bash lint` — all checks passed.
- `bash compile rp2350w --examples Blink` — build succeeded, flash 584.90 KB / 4.00 MB, RAM 58.48 KB / 512.00 KB.

Note: hardware-in-the-loop was not exercised — no RP2350 is currently enumerated on the bench (only the ESP32-C6, `303A:1001`). This change is host-side only and does not need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for RP2xxx driver-mode runs across all supported environments.
  * Verified that port selection is delegated appropriately and local port auto-detection is not invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->