### PR TITLE
fix(rp): report PIO/DMA/pin contention instead of failing silently (#1471)

### DIFF
--- a/src/platforms/arm/rp/rpcommon/clockless_rp_pio.h
+++ b/src/platforms/arm/rp/rpcommon/clockless_rp_pio.h
@@ -32,6 +32,7 @@
 
 #include "platforms/arm/rp/rpcommon/pio_gen.h"
 #include "platforms/arm/rp/rpcommon/rp_pio_dma_resource_manager.h"
+#include "fl/log/log.h"
 #include "fl/stl/allocator.h"
 #include "fl/stl/cstring.h"
 #include "fl/stl/noexcept.h"
@@ -182,7 +183,17 @@ public:
             }
             break;
         }
-        if (offset == -1) return;
+        if (offset == -1) {
+            // Every PIO state machine (or all program space) is already
+            // claimed by other code -- Adafruit TinyUSB is the common case on
+            // RP2040. Report it: silently returning here leaves the strip dark
+            // with no explanation. See FastLED#1471.
+            FL_WARN_F("[RP PIO] no free PIO state machine for pin %d; "
+                      "another library holds them all. Set "
+                      "FASTLED_RP2040_CLOCKLESS_PIO 0 to bit-bang instead.",
+                      int(DATA_PIN));
+            return;
+        }
 
         // Store PIO, state machine, and offset for later use
         mPio = pio;
@@ -190,6 +201,9 @@ public:
         mPioOffset = offset;
 
         if (!resources.claimDmaChannel(&dma_channel)) {
+            FL_WARN_F("[RP PIO] no free DMA channel for pin %d; "
+                      "output disabled on this pin.",
+                      int(DATA_PIN));
             resources.releasePioStateMachine(mPio, mSm);
             mPio = nullptr;
             mSm = -1;
@@ -197,6 +211,9 @@ public:
         }
 
         if (!resources.claimPins(DATA_PIN, 1)) {
+            FL_WARN_F("[RP PIO] pin %d is already claimed by other code; "
+                      "output disabled on this pin.",
+                      int(DATA_PIN));
             resources.releaseDmaChannel(dma_channel);
             resources.releasePioStateMachine(mPio, mSm);
             dma_channel = -1;


### PR DESCRIPTION
Addresses the diagnosability half of #1471 (FastLED + Adafruit TinyUSB on RP2040).

## Background

The reporter in #1471 saw random-colored LEDs when linking FastLED alongside Adafruit TinyUSB, and found empirically that `#define FASTLED_RP2040_CLOCKLESS_PIO 0` fixed it. The thread correctly identified PIO state-machine contention as the cause — TinyUSB claims state machines, and so does FastLED.

The **contention itself is already handled correctly** on current master: `ClocklessController` acquires its resources through `RpPioDmaResourceManager`, which uses the SDK claims system (`pio_claim_unused_sm(pio, false)` — non-panicking). If nothing is free it releases whatever it took and returns. FastLED does not steal TinyUSB's state machines.

What is *not* handled is telling anyone. All three claim-failure paths returned silently, so the symptom is a dark strip with zero diagnostic output. That is why this issue stayed open and confusing for years.

## Change

Add `FL_WARN_F` on each of the three claim-failure paths, naming the affected pin:

- no free PIO state machine / program space — also points at `FASTLED_RP2040_CLOCKLESS_PIO 0`, the bit-bang fallback users found on their own
- no free DMA channel
- pin already claimed

No behavior change: the paths still release what they claimed and return. Cost is ~100 bytes of flash on rp2040 (309.01 KB → 309.11 KB).

## Verification

- `bash compile rp2040 --examples Blink` — succeeded, flash 309.11 KB / 2.00 MB, RAM 57.04 KB / 256.00 KB
- `bash compile rp2350 --examples Blink` — succeeded, flash 563.20 KB / 2.00 MB, RAM 56.70 KB / 512.00 KB
- Confirmed all three format strings are present in each `firmware.elf` (not merely compiled away)
- `bash test --cpp` — 287/287 unit, 84/84 examples passed
- `bash lint` — all checks passed

Not verified on hardware: no RP2040/RP2350 is currently enumerated on the bench (only the ESP32-C6, `303A:1001`). Reproducing the original fault also needs a TinyUSB sketch that exhausts the PIO state machines. This change is diagnostics-only and does not alter the resource-acquisition logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warning messages when LED controller initialization cannot claim a PIO state machine, DMA channel, or requested pin on RP2040/RP2350 platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->