### PR TITLE
feat(fled): let the builder emit video.color

### DIFF
--- a/src/fl/fled/builder.cpp.hpp
+++ b/src/fl/fled/builder.cpp.hpp
@@ -5,6 +5,7 @@
 
 #include "fl/fled/builder.h"
 
+#include "fl/fled/color.h"
 #include "fl/fled/fled.h"
 #include "fl/stl/int.h"
 #include "fl/stl/move.h"
@@ -37,7 +38,8 @@ void appendString(fl::vector<fl::u8>& out, const fl::string& s) FL_NO_EXCEPT {
 // their canonical top-level keys. If no sections are configured the
 // envelope is "{}".
 fl::string buildEnvelope(const fl::string& screenMapJson,
-                         const fl::string& channelsJson) FL_NO_EXCEPT {
+                         const fl::string& channelsJson,
+                         const fl::string& videoColorJson) FL_NO_EXCEPT {
     fl::string out;
     out += '{';
     bool first = true;
@@ -52,7 +54,74 @@ fl::string buildEnvelope(const fl::string& screenMapJson,
         out += channelsJson;
         first = false;
     }
+    if (!videoColorJson.empty()) {
+        if (!first) out += ',';
+        out += "\"video\":{\"color\":";
+        out += videoColorJson;
+        out += '}';
+        first = false;
+    }
     out += '}';
+    return out;
+}
+
+// Spellings are the ones FLED_FORMAT.md defines. They are written here rather
+// than derived from the enum so that renaming a C++ enumerator cannot silently
+// change the wire format.
+const char* primariesName(ColorPrimaries p) FL_NO_EXCEPT {
+    switch (p) {
+    case ColorPrimaries::Bt709:     return "bt709";
+    case ColorPrimaries::DisplayP3: return "display-p3";
+    case ColorPrimaries::Bt2020:    return "bt2020";
+    case ColorPrimaries::Custom:    return nullptr;  // emitted as an object
+    }
+    return "bt709";
+}
+
+const char* transferName(ColorTransfer t) FL_NO_EXCEPT {
+    switch (t) {
+    case ColorTransfer::Srgb:   return "srgb";
+    case ColorTransfer::Bt709:  return "bt709";
+    case ColorTransfer::Linear: return "linear";
+    }
+    return "srgb";
+}
+
+// A CIE xy pair, four decimals -- enough for the D65 white point (0.3127,
+// 0.3290) to survive the round trip exactly.
+void appendXy(fl::string& out, float x, float y) FL_NO_EXCEPT {
+    out += '[';
+    out += fl::to_string(x, 4);
+    out += ',';
+    out += fl::to_string(y, 4);
+    out += ']';
+}
+
+fl::string serializeVideoColor(const VideoColor& c) FL_NO_EXCEPT {
+    fl::string out;
+    out += "{\"primaries\":";
+    const char* named = primariesName(c.primaries);
+    if (named != nullptr) {
+        out += '"';
+        out += named;
+        out += '"';
+    } else {
+        out += "{\"red\":";
+        appendXy(out, c.customPrimaries[0], c.customPrimaries[1]);
+        out += ",\"green\":";
+        appendXy(out, c.customPrimaries[2], c.customPrimaries[3]);
+        out += ",\"blue\":";
+        appendXy(out, c.customPrimaries[4], c.customPrimaries[5]);
+        out += ",\"white\":";
+        appendXy(out, c.customPrimaries[6], c.customPrimaries[7]);
+        out += '}';
+    }
+    out += ",\"transfer\":\"";
+    out += transferName(c.transfer);
+    // v1 defines exactly one value for each of matrix and range; the parser
+    // rejects anything else, so emitting them literally keeps producer and
+    // parser from drifting apart.
+    out += "\",\"matrix\":\"rgb\",\"range\":\"full\"}";
     return out;
 }
 
@@ -63,6 +132,7 @@ FledBuilder::FledBuilder() FL_NO_EXCEPT
       mPixelFormat(0),
       mScreenMapJson(),
       mChannelsJson(),
+      mVideoColorJson(),
       mPayload() {}
 
 FledBuilder& FledBuilder::setVersion(fl::u8 v) FL_NO_EXCEPT {
@@ -85,13 +155,19 @@ FledBuilder& FledBuilder::setChannelsJson(const char* json) FL_NO_EXCEPT {
     return *this;
 }
 
+FledBuilder& FledBuilder::setVideoColor(const VideoColor& color) FL_NO_EXCEPT {
+    mVideoColorJson = serializeVideoColor(color);
+    return *this;
+}
+
 FledBuilder& FledBuilder::setPayload(fl::span<const fl::u8> bytes) FL_NO_EXCEPT {
     mPayload.assign(bytes.begin(), bytes.end());
     return *this;
 }
 
 fl::Fled FledBuilder::build() const FL_NO_EXCEPT {
-    const fl::string envelope = buildEnvelope(mScreenMapJson, mChannelsJson);
+    const fl::string envelope =
+        buildEnvelope(mScreenMapJson, mChannelsJson, mVideoColorJson);
     const fl::u32 jsonLen = static_cast<fl::u32>(envelope.size());
 
     fl::vector<fl::u8> buf;

--- a/src/fl/fled/builder.h
+++ b/src/fl/fled/builder.h
@@ -10,6 +10,7 @@
 // Fled type itself stays at top-level fl::; every auxiliary moves to
 // the fl::fled namespace.
 
+#include "fl/fled/color.h"
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
 #include "fl/stl/span.h"
@@ -37,6 +38,19 @@ class FledBuilder {
     FledBuilder& setScreenMapJson(const char* json) FL_NO_EXCEPT;
     FledBuilder& setChannelsJson(const char* json) FL_NO_EXCEPT;
 
+    // Declare the source color tuple, emitted as `video.color` with the
+    // spelling FLED_FORMAT.md defines. This is the producer half of the
+    // contract the parser enforces: a payload whose numbers are not the
+    // default tuple has to say so, and hand-written JSON is the only other
+    // way to say it.
+    //
+    // The tuple is written out in full -- all four keys, never a partial
+    // object -- because inheritance of missing keys applies only to pixel
+    // formats that define a default tuple, and a producer should not have to
+    // reason about which those are. `declared` is ignored: calling this is
+    // the declaration.
+    FledBuilder& setVideoColor(const VideoColor& color) FL_NO_EXCEPT;
+
     // Optional frame payload (raw bytes appended after the envelope).
     // The builder copies the bytes.
     FledBuilder& setPayload(fl::span<const fl::u8> bytes) FL_NO_EXCEPT;
@@ -52,6 +66,7 @@ class FledBuilder {
     fl::u8             mPixelFormat;
     fl::string         mScreenMapJson;
     fl::string         mChannelsJson;
+    fl::string         mVideoColorJson;
     fl::vector<fl::u8> mPayload;
 };
 

--- a/tests/fl/fled/fled_builder.cpp
+++ b/tests/fl/fled/fled_builder.cpp
@@ -5,6 +5,7 @@
 
 #include "fl/channels/config.h"
 #include "fl/fled/builder.h"
+#include "fl/fled/color.h"
 #include "fl/fled/fled.h"
 #include "fl/math/screenmap.h"
 #include "fl/stl/int.h"
@@ -40,6 +41,98 @@ FL_TEST_CASE("FledBuilder - setVersion + setPixelFormat round-trip into Fled") {
     FL_CHECK(static_cast<bool>(f));
     FL_CHECK_EQ(f.version(), fl::u8(1));
     FL_CHECK_EQ(f.pixelFormat(), fl::u8(0x05));
+}
+
+namespace {
+fl::fled::VideoColor makeColor(fl::fled::ColorPrimaries p,
+                               fl::fled::ColorTransfer t) {
+    fl::fled::VideoColor c{};
+    c.primaries = p;
+    c.transfer  = t;
+    c.matrix    = fl::fled::ColorMatrix::Rgb;
+    c.range     = fl::fled::ColorRange::Full;
+    c.declared  = true;
+    return c;
+}
+}  // namespace
+
+// The producer half of the video.color contract: what setVideoColor() writes
+// has to survive the canonical parse path and come back as the same tuple.
+FL_TEST_CASE("FledBuilder - setVideoColor round-trips each named primaries value") {
+    struct Case {
+        fl::fled::ColorPrimaries primaries;
+        fl::fled::ColorTransfer  transfer;
+        fl::u8                   pixelFormat;
+    };
+    const Case cases[] = {
+        {fl::fled::ColorPrimaries::Bt709,     fl::fled::ColorTransfer::Srgb,   0x00},
+        {fl::fled::ColorPrimaries::DisplayP3, fl::fled::ColorTransfer::Bt709,  0x00},
+        {fl::fled::ColorPrimaries::Bt2020,    fl::fled::ColorTransfer::Linear, 0x05},
+    };
+    for (const Case& c : cases) {
+        fl::fled::FledBuilder b;
+        b.setPixelFormat(c.pixelFormat)
+         .setVideoColor(makeColor(c.primaries, c.transfer));
+        fl::Fled f = b.build();
+        FL_REQUIRE(static_cast<bool>(f));
+
+        fl::fled::VideoColor got{};
+        FL_REQUIRE_EQ(f.videoColor(&got), fl::fled::ColorStatus::Ok);
+        FL_CHECK_EQ(got.primaries, c.primaries);
+        FL_CHECK_EQ(got.transfer, c.transfer);
+        FL_CHECK_EQ(got.matrix, fl::fled::ColorMatrix::Rgb);
+        FL_CHECK_EQ(got.range, fl::fled::ColorRange::Full);
+        FL_CHECK(got.declared);
+    }
+}
+
+FL_TEST_CASE("FledBuilder - custom primaries survive as CIE xy pairs") {
+    fl::fled::VideoColor c = makeColor(fl::fled::ColorPrimaries::Custom,
+                                       fl::fled::ColorTransfer::Srgb);
+    // sRGB primaries with D65 white, written out explicitly.
+    const float xy[8] = {0.6400f, 0.3300f, 0.3000f, 0.6000f,
+                         0.1500f, 0.0600f, 0.3127f, 0.3290f};
+    for (int i = 0; i < 8; ++i) c.customPrimaries[i] = xy[i];
+
+    fl::fled::FledBuilder b;
+    b.setVideoColor(c);
+    fl::Fled f = b.build();
+    FL_REQUIRE(static_cast<bool>(f));
+
+    fl::fled::VideoColor got{};
+    FL_REQUIRE_EQ(f.videoColor(&got), fl::fled::ColorStatus::Ok);
+    FL_CHECK_EQ(got.primaries, fl::fled::ColorPrimaries::Custom);
+    for (int i = 0; i < 8; ++i) {
+        FL_CHECK_CLOSE(got.customPrimaries[i], xy[i], 0.0001f);
+    }
+}
+
+// A producer must not be able to emit a tuple its own parser rejects. rgb8
+// with a linear transfer is the rule the spec states most plainly.
+FL_TEST_CASE("FledBuilder - an emitted tuple that conflicts with the format is rejected on parse") {
+    fl::fled::FledBuilder b;
+    b.setPixelFormat(0x00)  // rgb8
+     .setVideoColor(makeColor(fl::fled::ColorPrimaries::Bt709,
+                              fl::fled::ColorTransfer::Linear));
+    fl::Fled f = b.build();
+    FL_REQUIRE(static_cast<bool>(f));
+
+    fl::fled::VideoColor got{};
+    FL_CHECK_EQ(f.videoColor(&got),
+                fl::fled::ColorStatus::TransferConflictsWithFormat);
+}
+
+FL_TEST_CASE("FledBuilder - omitting setVideoColor leaves the tuple undeclared") {
+    fl::fled::FledBuilder b;
+    fl::Fled f = b.build();
+    FL_REQUIRE(static_cast<bool>(f));
+
+    fl::fled::VideoColor got{};
+    FL_REQUIRE_EQ(f.videoColor(&got), fl::fled::ColorStatus::Ok);
+    // Absent metadata resolves to the default tuple for rgb8, and says so.
+    FL_CHECK_EQ(got.primaries, fl::fled::ColorPrimaries::Bt709);
+    FL_CHECK_EQ(got.transfer, fl::fled::ColorTransfer::Srgb);
+    FL_CHECK_FALSE(got.declared);
 }
 
 FL_TEST_CASE("FledBuilder - header + screenmap JSON yields a real ScreenMap") {


### PR DESCRIPTION
Completes the producer half of #4038 (Color pipeline P4), under #4034.

## The gap

#4160 landed the parser half: `.fled` files carry `video.color` and the parser validates it against the header's pixel format. But `FledBuilder` had only `setScreenMapJson()` and `setChannelsJson()` — no way to declare a source color tuple. The only way to emit one was to hand-write the envelope JSON, which is precisely the producer/parser drift the spec exists to prevent.

#4038 names the producer in both halves of its definition:

> **Scope:** bring mirror, builder, parser (`src/fl/fled/detail/parser.cpp.hpp`), and video consumer to the same contract
>
> **Acceptance:** `.fled` spec/**producer**/mirror/parser/playback carry and honor `video.color`

## What this adds

`FledBuilder::setVideoColor(const VideoColor&)`, writing the tuple under `video.color` with the spelling `FLED_FORMAT.md` defines.

Three choices worth calling out, because each is a place this could rot:

- **Wire spellings are literals in the serializer, not derived from the enumerators.** Renaming a C++ enum must not silently change the file format.
- **All four keys are always written**, never a partial object. Inheritance of missing keys applies only to pixel formats that define a default tuple, and a producer should not have to reason about which those are.
- **`matrix` and `range` are emitted literally** as the single value v1 permits for each, so producer and parser cannot drift apart.

Custom primaries serialize as CIE xy pairs at four decimals — enough for the D65 white point (0.3127, 0.3290) to round-trip exactly.

## Tests

All build through the canonical `Fled::loadFromVector()` path and read back via `Fled::videoColor()`, so they exercise the real parse, not a private hook:

| case | asserts |
|---|---|
| each named primaries value | `bt709` / `display-p3` / `bt2020` survive with their transfer |
| custom primaries | eight xy floats round-trip within 1e-4 |
| no `setVideoColor()` call | resolves to the default tuple with `declared == false` |
| rgb8 + `linear` transfer | parser returns `TransferConflictsWithFormat` |

That last one matters: a producer must not be able to emit a tuple its own parser rejects, and this proves the rejection is reachable from the builder.

**Confirmed by mutation** — spelling `DisplayP3` as `"bt709"` in the serializer fails the round-trip test at `fled_builder.cpp:81`, so the tests genuinely exercise the serializer rather than passing vacuously.

## Verification

- `bash test --cpp` — 287/287 unit, 84/84 examples
- `bash lint` — clean

## Not in this PR

The canonical ledmapper v1 spec lives in another repo; this changes FastLED's mirror and producer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional video color metadata configuration when building FLED content.
  - Video color information now supports primaries, transfer characteristics, matrix, range, and custom color coordinates.
  - Configured metadata is included in the generated video description and can be read back through the standard parsing flow.

- **Bug Fixes**
  - Conflicting video color settings are rejected during parsing.
  - When no video color is specified, the metadata remains undeclared and uses default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->