### PR TITLE
test(autoresearch): arm the boot-loop bootloader escape (#3713)

### DIFF
--- a/examples/AutoResearch/AutoResearch.ino
+++ b/examples/AutoResearch/AutoResearch.ino
@@ -374,6 +374,14 @@ uint32_t frame_counter = 0;
 // Keeping the extern "C" hook out of this .ino avoids Arduino prototype
 // generation with C++ linkage during fbuild deploy.
 
+// Consecutive watchdog resets before AutoResearch gives up and drops into the
+// bootloader (#3713). Three tolerates a one-off glitch or a deliberate
+// watchdog-recovery test while still escaping quickly enough to matter on an
+// unattended bench.
+#ifndef AUTORESEARCH_BOOTLOADER_ESCAPE_RESETS
+#define AUTORESEARCH_BOOTLOADER_ESCAPE_RESETS 3
+#endif
+
 void setup() {
     // Arm the WDT before doing any real work so a hang here (RPC bind
     // null-deref, stalled static-init, wedged Serial handshake) auto-
@@ -381,6 +389,19 @@ void setup() {
     // dead sketch. FL_WATCHDOG_AUTO() at loop() re-arms with the
     // shorter loop-scoped timeout once setup() has finished.
     fl::Watchdog::instance().begin(AUTORESEARCH_SETUP_WATCHDOG_TIMEOUT_MS);
+
+    // Boot-loop escape (#3713). The WDT above turns a hang into a reboot, but
+    // a hang that recurs every boot just reboots forever and the board is only
+    // ever briefly enumerated -- unattended, that is indistinguishable from a
+    // brick. After N consecutive watchdog resets, drop to the bootloader
+    // instead, where the board re-enumerates as a flashable target and a host
+    // can push working firmware without anyone holding BOOTSEL.
+    //
+    // Placed immediately after begin() so it runs before anything that could
+    // hang -- serial, RPC bind, or a peripheral absent on this board variant.
+    fl::Watchdog::instance().setBootloaderEscapeThreshold(
+        AUTORESEARCH_BOOTLOADER_ESCAPE_RESETS);
+    fl::Watchdog::instance().escapeToBootloaderIfLooping();
 
     // Initialize serial buffers with platform-specific configuration
     // Must be called BEFORE Serial.begin()


### PR DESCRIPTION
Enables the boot-loop escape from #4167 in AutoResearch, and records the RP2350W bring-up evidence #3899 asked for.

## Change

One block in `setup()`, immediately after `Watchdog::begin()`:

```cpp
fl::Watchdog::instance().setBootloaderEscapeThreshold(AUTORESEARCH_BOOTLOADER_ESCAPE_RESETS);
fl::Watchdog::instance().escapeToBootloaderIfLooping();
```

The WDT armed just above turns a hang into a reboot. But a hang that recurs *every* boot just reboots forever — the board is only ever briefly enumerated, and unattended that is indistinguishable from a brick. After three consecutive watchdog resets the board now drops into the bootloader, where it re-enumerates as a flashable target and the host can push working firmware without anyone holding BOOTSEL.

Placement matters: before serial, RPC bind, or any peripheral that may be absent on this board variant. Three tolerates a one-off glitch and the deliberate `--watchdog-soak` recovery test while still escaping fast enough to matter.

## Why this was worth doing first

It was the parachute that made the `rp2350w` bring-up safe to attempt. The bench board's variant was genuinely unknown — the ROM reports `Board-ID: RP2350` for both, and the `Pico 2` product string on the running firmware came from the `rpipico2` definition that had been flashed, not the silicon. Flashing W firmware onto a plain Pico 2 risks a CYW43 hang with no CDC and no software recovery. With the escape armed, a wrong guess self-recovers into BOOTSEL instead.

## Hardware results

Validated the escape on the **known-good non-W build first**, before relying on it:

- `rp2350`: RPC smoke **PASS**, `lastResetCause: SOFTWARE`, `lastResetWasWatchdog: False` — no misfire on a healthy boot.
- `rp2350w`: RPC smoke **PASS** after a cross-variant reflash.

**The board is a Pico 2 W**, which #3899 listed as unestablished:

```
2e8a:f00f  'Pico 2W'                                    # rpipico2w application CDC
status    -> platform: "Raspberry Pi Pico 2 W (RP2350)"
wifiStatus-> {"status": "IDLE", "success": true}        # was UNSUPPORTED on the non-W build
```

`2E8A:F00F` matches the identity recorded in #3899/#3832 and published in the FastLED/boards registry.

Other results from the same session, for the record:

- **PIO0, PIO1, PIO2 all pass 4/4** — including the RP2350-only third PIO block.
- Bridge confirmed live via `findConnectedPins` as **TX GPIO0 → RX GPIO1**, which #3899 required be proven rather than assumed.
- `--net-peer` deploys both boards and completes 6/10 cycles before an intermittent serial-RPC reply drop (`No response with ID 115 within 2.54s`). Not a crash and not a network fault; both boards stayed enumerated. That is the same class `ci/autoresearch/rpc_bench.py` documents and #4097 targeted — reported separately rather than folded in here.

## Note on cross-variant reflash

The first `rp2350w` deploy failed clean, without flashing:

```
deploy error: RP-series picotool deployment requires the selected runtime USB serial
so fbuild can bind the BOOTSEL operation to one board
```

Correct behavior — the running non-W identity did not match the `rp2350w` environment, so fbuild would not guess which board to touch. Passing `--upload-port` explicitly resolved it, which is what #3899 prescribes for this case.

## Verification

- `bash lint` — all checks passed
- Built and run on real hardware for both RP2350 variants (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable boot-loop escape mechanism to the AutoResearch example.
  - Boards that repeatedly restart due to watchdog resets now enter the bootloader, allowing recovery and reflashing instead of restarting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->