### PR TITLE
feat(color): Bradford chromatic adaptation in the working domain

### DIFF
--- a/src/fl/gfx/_build.cpp.hpp
+++ b/src/fl/gfx/_build.cpp.hpp
@@ -5,6 +5,7 @@
 
 // begin current directory includes
 #include "fl/gfx/blur.cpp.hpp"
+#include "fl/gfx/chromatic_adaptation.cpp.hpp"
 #include "fl/gfx/colorimetric_response.cpp.hpp"
 #include "fl/gfx/colorutils.cpp.hpp"
 #include "fl/gfx/corkscrew.cpp.hpp"

--- a/src/fl/gfx/chromatic_adaptation.cpp.hpp
+++ b/src/fl/gfx/chromatic_adaptation.cpp.hpp
@@ -20,6 +20,20 @@ const float kBradford[3][3] = {
     {0.0389f, -0.0685f, 1.0296f},
 };
 
+/// True only for a real, usable chromaticity.
+///
+/// `xyY_to_XYZ` guards `y < 1e-12f`, which NaN slips past because every
+/// comparison against NaN is false. It then propagates through the cone
+/// solve -- the zero-cone check below is comparison-based and lets it
+/// through for the same reason -- and reaches the float-to-i32 cast, where
+/// converting a NaN is undefined behaviour rather than a wrong number.
+bool isUsableChromaticity(Chromaticity c) FL_NO_EXCEPT {
+    // Self-comparison rejects NaN; the bounds reject infinities and values
+    // outside the chromaticity diagram.
+    return c.x == c.x && c.y == c.y && c.x > 0.0f && c.x < 1.0f &&
+           c.y > 1e-6f && c.y < 1.0f;
+}
+
 i32 quantizeAdaptationQ16(float v) FL_NO_EXCEPT {
     const float scaled = v * 65536.0f;
     return static_cast<i32>(scaled >= 0.0f ? scaled + 0.5f : scaled - 0.5f);
@@ -39,6 +53,10 @@ bool buildBradfordMatrixQ16(Chromaticity source_white,
                             Chromaticity destination_white,
                             AdaptationMatrixQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
+        return false;
+    }
+    if (!isUsableChromaticity(source_white) ||
+        !isUsableChromaticity(destination_white)) {
         return false;
     }
     float source_xyz[3];

--- a/src/fl/gfx/chromatic_adaptation.cpp.hpp
+++ b/src/fl/gfx/chromatic_adaptation.cpp.hpp
@@ -1,0 +1,113 @@
+// ok no header - implementation for fl/gfx/chromatic_adaptation.h
+
+#include "fl/gfx/chromatic_adaptation.h"
+
+#include "fl/gfx/colorimetric_response.h"
+
+namespace fl {
+
+namespace {
+
+// Helper names carry an `adaptation` qualifier because .cpp.hpp files are
+// concatenated into one translation unit by the unity build, so an anonymous
+// namespace does not isolate them from a same-named helper in a sibling file
+// -- source_xyz.cpp.hpp defines its own quantizer.
+
+/// ICC linear Bradford cone-response matrix.
+const float kBradford[3][3] = {
+    {0.8951f, 0.2664f, -0.1614f},
+    {-0.7502f, 1.7135f, 0.0367f},
+    {0.0389f, -0.0685f, 1.0296f},
+};
+
+i32 quantizeAdaptationQ16(float v) FL_NO_EXCEPT {
+    const float scaled = v * 65536.0f;
+    return static_cast<i32>(scaled >= 0.0f ? scaled + 0.5f : scaled - 0.5f);
+}
+
+i32 dotAdaptationRowQ16(const i32 (&row)[3], const i32 (&v)[3]) FL_NO_EXCEPT {
+    const i64 acc = static_cast<i64>(row[0]) * static_cast<i64>(v[0])
+                  + static_cast<i64>(row[1]) * static_cast<i64>(v[1])
+                  + static_cast<i64>(row[2]) * static_cast<i64>(v[2]);
+    return static_cast<i32>(acc >= 0 ? (acc + 32768) >> 16
+                                     : -((-acc + 32768) >> 16));
+}
+
+}  // namespace
+
+bool buildBradfordMatrixQ16(Chromaticity source_white,
+                            Chromaticity destination_white,
+                            AdaptationMatrixQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    float source_xyz[3];
+    float destination_xyz[3];
+    colorimetric_response::xyY_to_XYZ(source_white.x, source_white.y, 1.0f,
+                                      source_xyz);
+    colorimetric_response::xyY_to_XYZ(destination_white.x, destination_white.y,
+                                      1.0f, destination_xyz);
+
+    float source_cones[3];
+    float destination_cones[3];
+    colorimetric_response::matvec3(kBradford, source_xyz, source_cones);
+    colorimetric_response::matvec3(kBradford, destination_xyz,
+                                   destination_cones);
+
+    float scale[3];
+    for (int i = 0; i < 3; ++i) {
+        // A zero cone response would divide by zero. No physical white does
+        // this; a corrupt profile can.
+        if (source_cones[i] > -1e-9f && source_cones[i] < 1e-9f) {
+            return false;
+        }
+        scale[i] = destination_cones[i] / source_cones[i];
+    }
+
+    float inverse[3][3];
+    if (!colorimetric_response::invert3x3(kBradford, inverse)) {
+        return false;
+    }
+
+    // Collapse B_inv * diag(scale) * B into one matrix. Done once here so the
+    // per-pixel path never sees the cone space at all.
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            float sum = 0.0f;
+            for (int k = 0; k < 3; ++k) {
+                sum += inverse[row][k] * scale[k] * kBradford[k][col];
+            }
+            out->m[row][col] = quantizeAdaptationQ16(sum);
+        }
+    }
+    return true;
+}
+
+void adaptXyzQ16(const AdaptationMatrixQ16& matrix, const i32 (&xyz)[3],
+                 i32 (&out_xyz)[3]) FL_NO_EXCEPT {
+    const i32 in[3] = {xyz[0], xyz[1], xyz[2]};
+    out_xyz[0] = dotAdaptationRowQ16(matrix.m[0], in);
+    out_xyz[1] = dotAdaptationRowQ16(matrix.m[1], in);
+    out_xyz[2] = dotAdaptationRowQ16(matrix.m[2], in);
+}
+
+void foldAdaptationIntoSourceMatrix(const AdaptationMatrixQ16& adaptation,
+                                    SourceMatrixQ16* source) FL_NO_EXCEPT {
+    if (source == nullptr) {
+        return;
+    }
+    SourceMatrixQ16 result;
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            const i64 acc =
+                static_cast<i64>(adaptation.m[row][0]) * source->m[0][col]
+              + static_cast<i64>(adaptation.m[row][1]) * source->m[1][col]
+              + static_cast<i64>(adaptation.m[row][2]) * source->m[2][col];
+            result.m[row][col] = static_cast<i32>(
+                acc >= 0 ? (acc + 32768) >> 16 : -((-acc + 32768) >> 16));
+        }
+    }
+    *source = result;
+}
+
+}  // namespace fl

--- a/src/fl/gfx/chromatic_adaptation.h
+++ b/src/fl/gfx/chromatic_adaptation.h
@@ -29,8 +29,15 @@ bool buildBradfordMatrixQ16(Chromaticity source_white,
                             Chromaticity destination_white,
                             AdaptationMatrixQ16* out) FL_NO_EXCEPT;
 
-/// Adapt one XYZ triple. Provided for stage-by-stage bisection against the
-/// P5 golden vectors; the streaming path should fold instead.
+/// Adapt one XYZ triple.
+///
+/// Public because it is the only way to exercise adaptation on its own.
+/// `foldAdaptationIntoSourceMatrix` cannot carry it: that folds into a source
+/// matrix and never exposes an adapted XYZ, so there is no existing seam this
+/// could route through. The tracker asks P5's vectors to be "serialized per
+/// stage so embedded phases can bisect failures", and bisecting a stage
+/// requires being able to run that stage alone -- P7 and P8 will need this
+/// when their own budgets miss. The streaming path uses the fold.
 void adaptXyzQ16(const AdaptationMatrixQ16& matrix, const i32 (&xyz)[3],
                  i32 (&out_xyz)[3]) FL_NO_EXCEPT;
 

--- a/src/fl/gfx/chromatic_adaptation.h
+++ b/src/fl/gfx/chromatic_adaptation.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// Chromatic adaptation between white points (P6, #4040).
+//
+// B7 makes Bradford the normative CAT. The whole adaptation collapses to one
+// 3x3 matrix, built when a profile is bound, so nothing iterative or
+// trigonometric runs per pixel -- and folding it into the source matrix makes
+// it free, since the two then cost a single multiply together.
+
+#include "fl/gfx/color_profile.h"
+#include "fl/gfx/source_xyz.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// A collapsed adaptation transform in s16.16.
+///
+/// Entries exceed 1.0 -- the D50 to D65 Z scale is about 1.33 -- so this is
+/// s16.16 rather than a fractional-only format.
+struct AdaptationMatrixQ16 {
+    i32 m[3][3];
+};
+
+/// Build the Bradford transform from `source_white` to `destination_white`.
+/// False if either white has a zero cone response, which no real white does
+/// but a corrupt profile might.
+bool buildBradfordMatrixQ16(Chromaticity source_white,
+                            Chromaticity destination_white,
+                            AdaptationMatrixQ16* out) FL_NO_EXCEPT;
+
+/// Adapt one XYZ triple. Provided for stage-by-stage bisection against the
+/// P5 golden vectors; the streaming path should fold instead.
+void adaptXyzQ16(const AdaptationMatrixQ16& matrix, const i32 (&xyz)[3],
+                 i32 (&out_xyz)[3]) FL_NO_EXCEPT;
+
+/// Pre-multiply the adaptation into a source matrix, in place.
+///
+/// This is how the streaming path should use it: primaries and adaptation
+/// become one matrix at bind time, so the per-pixel cost of adaptation is
+/// zero rather than a second matrix multiply per channel.
+void foldAdaptationIntoSourceMatrix(const AdaptationMatrixQ16& adaptation,
+                                    SourceMatrixQ16* source) FL_NO_EXCEPT;
+
+}  // namespace fl

--- a/src/fl/gfx/source_xyz.cpp.hpp
+++ b/src/fl/gfx/source_xyz.cpp.hpp
@@ -8,6 +8,21 @@ namespace fl {
 
 namespace {
 
+/// True only for a real, usable chromaticity.
+///
+/// Named for this file because .cpp.hpp files share a translation unit under
+/// the unity build, so an anonymous namespace does not isolate it from the
+/// equivalent helper in chromatic_adaptation.cpp.hpp.
+///
+/// Neither `xyY_to_XYZ`'s `y < 1e-12f` guard nor `invert3x3`'s
+/// `fabs(det) < 1e-20f` guard stops a NaN, because comparisons against NaN
+/// are all false. It would reach the float-to-i32 cast below, where
+/// converting a NaN is undefined behaviour.
+bool isUsableSourceChromaticity(Chromaticity c) FL_NO_EXCEPT {
+    return c.x == c.x && c.y == c.y && c.x > 0.0f && c.x < 1.0f &&
+           c.y > 1e-6f && c.y < 1.0f;
+}
+
 /// Round-to-nearest quantization of a float into s16.16.
 i32 quantizeQ16(float v) FL_NO_EXCEPT {
     const float scaled = v * 65536.0f;
@@ -31,6 +46,12 @@ i32 dotRowQ16(const i32 (&row)[3], u16 r, u16 g, u16 b) FL_NO_EXCEPT {
 bool buildSourceMatrixQ16(const RgbPrimaries& primaries,
                           SourceMatrixQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
+        return false;
+    }
+    if (!isUsableSourceChromaticity(primaries.red) ||
+        !isUsableSourceChromaticity(primaries.green) ||
+        !isUsableSourceChromaticity(primaries.blue) ||
+        !isUsableSourceChromaticity(primaries.white)) {
         return false;
     }
     const float xy_r[2] = {primaries.red.x, primaries.red.y};

--- a/tests/fl/gfx/chromatic_adaptation.cpp
+++ b/tests/fl/gfx/chromatic_adaptation.cpp
@@ -1,0 +1,119 @@
+// Bradford chromatic-adaptation coverage for color pipeline P6 (#4040).
+//
+// The P5 golden corpus cannot exercise this stage: all three of its source
+// profiles use a D65 white, so source_xyz equals d65_xyz identically for all
+// 192 vectors. Expectations here are computed from the same authority the
+// corpus is generated from, ci/color_reference.py::bradford_adaptation.
+
+#include "fl/gfx/chromatic_adaptation.h"
+#include "fl/gfx/color_profile.h"
+#include "fl/gfx/source_xyz.h"
+#include "fl/stl/int.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+constexpr Chromaticity kD50(0.34567f, 0.35850f);
+constexpr Chromaticity kD65(0.3127f, 0.3290f);
+
+i32 q16(float v) { return static_cast<i32>(v * 65536.0f + (v >= 0 ? 0.5f : -0.5f)); }
+float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
+
+}  // namespace
+
+FL_TEST_CASE("Adapting a white to itself is the identity") {
+    AdaptationMatrixQ16 matrix;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD65, kD65, &matrix));
+
+    const i32 in[3] = {q16(0.3f), q16(0.6f), q16(0.9f)};
+    i32 out[3];
+    adaptXyzQ16(matrix, in, out);
+    for (int i = 0; i < 3; ++i) {
+        // Within one Q16 step; the collapsed matrix is B_inv * I * B.
+        FL_CHECK(out[i] >= in[i] - 1 && out[i] <= in[i] + 1);
+    }
+}
+
+FL_TEST_CASE("Adapting the source white lands on the destination white") {
+    // The defining property of a chromatic adaptation transform.
+    AdaptationMatrixQ16 matrix;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD50, kD65, &matrix));
+
+    // D50 white at Y=1, and D65 white at Y=1.
+    const i32 in[3] = {q16(0.96420f), q16(1.0f), q16(0.82491f)};
+    i32 out[3];
+    adaptXyzQ16(matrix, in, out);
+
+    FL_CHECK_CLOSE(toFloat(out[0]), 0.95043f, 0.001f);
+    FL_CHECK_CLOSE(toFloat(out[1]), 1.00000f, 0.001f);
+    FL_CHECK_CLOSE(toFloat(out[2]), 1.08867f, 0.001f);
+}
+
+FL_TEST_CASE("Fixed-point Bradford tracks the float64 reference") {
+    AdaptationMatrixQ16 matrix;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD50, kD65, &matrix));
+
+    struct Case { float in[3]; float out[3]; };
+    const Case cases[] = {
+        {{1.0f, 1.0f, 1.0f},       {0.995705078f, 1.002662625f, 1.322038361f}},
+        {{0.5f, 0.25f, 0.125f},    {0.479908114f, 0.240959235f, 0.167308221f}},
+    };
+    for (const Case& c : cases) {
+        const i32 in[3] = {q16(c.in[0]), q16(c.in[1]), q16(c.in[2])};
+        i32 out[3];
+        adaptXyzQ16(matrix, in, out);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_CLOSE(toFloat(out[i]), c.out[i], 0.0002f);
+        }
+    }
+}
+
+FL_TEST_CASE("Black is unchanged by adaptation") {
+    AdaptationMatrixQ16 matrix;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD50, kD65, &matrix));
+    const i32 in[3] = {0, 0, 0};
+    i32 out[3];
+    adaptXyzQ16(matrix, in, out);
+    FL_CHECK_EQ(out[0], 0);
+    FL_CHECK_EQ(out[1], 0);
+    FL_CHECK_EQ(out[2], 0);
+}
+
+FL_TEST_CASE("Folding into the source matrix equals applying both in sequence") {
+    // This is what makes adaptation free per pixel: one matrix instead of two.
+    SourceMatrixQ16 sequential;
+    FL_REQUIRE(buildSourceMatrixQ16(SourceProfile::bt2020().primaries, &sequential));
+    SourceMatrixQ16 folded = sequential;
+
+    AdaptationMatrixQ16 adaptation;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD50, kD65, &adaptation));
+    foldAdaptationIntoSourceMatrix(adaptation, &folded);
+
+    const u16 rgb[3] = {50000, 30000, 12000};
+    i32 staged[3];
+    linearRgbToXyzQ16(sequential, rgb[0], rgb[1], rgb[2], staged);
+    i32 adapted[3];
+    adaptXyzQ16(adaptation, staged, adapted);
+
+    i32 once[3];
+    linearRgbToXyzQ16(folded, rgb[0], rgb[1], rgb[2], once);
+
+    for (int i = 0; i < 3; ++i) {
+        // Folding rounds once instead of twice, so it can differ by a step
+        // or two -- it should never diverge further than that.
+        FL_CHECK(once[i] >= adapted[i] - 4 && once[i] <= adapted[i] + 4);
+    }
+}
+
+FL_TEST_CASE("A null out-pointer is rejected rather than dereferenced") {
+    FL_CHECK_FALSE(buildBradfordMatrixQ16(kD50, kD65, nullptr));
+    AdaptationMatrixQ16 matrix;
+    FL_REQUIRE(buildBradfordMatrixQ16(kD50, kD65, &matrix));
+    foldAdaptationIntoSourceMatrix(matrix, nullptr);  // must not crash
+}
+
+}  // FL_TEST_FILE

--- a/tests/fl/gfx/chromatic_adaptation.cpp
+++ b/tests/fl/gfx/chromatic_adaptation.cpp
@@ -9,6 +9,7 @@
 #include "fl/gfx/color_profile.h"
 #include "fl/gfx/source_xyz.h"
 #include "fl/stl/int.h"
+#include "fl/stl/limits.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -114,7 +115,7 @@ FL_TEST_CASE("Non-finite chromaticities are rejected, not converted") {
     // comparison against NaN is false. Without an explicit check it reaches
     // the float-to-i32 cast, and converting a NaN there is undefined
     // behaviour rather than merely a wrong colour.
-    const float nan_value = 0.0f / (sizeof(int) > 100 ? 1.0f : 0.0f);
+    const float nan_value = numeric_limits<float>::quiet_NaN();
     AdaptationMatrixQ16 matrix;
     FL_CHECK_FALSE(buildBradfordMatrixQ16(Chromaticity(nan_value, 0.3290f), kD65, &matrix));
     FL_CHECK_FALSE(buildBradfordMatrixQ16(kD50, Chromaticity(0.3127f, nan_value), &matrix));

--- a/tests/fl/gfx/chromatic_adaptation.cpp
+++ b/tests/fl/gfx/chromatic_adaptation.cpp
@@ -109,6 +109,23 @@ FL_TEST_CASE("Folding into the source matrix equals applying both in sequence") 
     }
 }
 
+FL_TEST_CASE("Non-finite chromaticities are rejected, not converted") {
+    // xyY_to_XYZ guards `y < 1e-12f`, which NaN slips past because every
+    // comparison against NaN is false. Without an explicit check it reaches
+    // the float-to-i32 cast, and converting a NaN there is undefined
+    // behaviour rather than merely a wrong colour.
+    const float nan_value = 0.0f / (sizeof(int) > 100 ? 1.0f : 0.0f);
+    AdaptationMatrixQ16 matrix;
+    FL_CHECK_FALSE(buildBradfordMatrixQ16(Chromaticity(nan_value, 0.3290f), kD65, &matrix));
+    FL_CHECK_FALSE(buildBradfordMatrixQ16(kD50, Chromaticity(0.3127f, nan_value), &matrix));
+    // y == 0 would divide by zero inside xyY_to_XYZ's guarded path.
+    FL_CHECK_FALSE(buildBradfordMatrixQ16(Chromaticity(0.3f, 0.0f), kD65, &matrix));
+    // Out of the chromaticity diagram entirely.
+    FL_CHECK_FALSE(buildBradfordMatrixQ16(Chromaticity(1.5f, 0.3f), kD65, &matrix));
+    // The valid pair still builds.
+    FL_CHECK(buildBradfordMatrixQ16(kD50, kD65, &matrix));
+}
+
 FL_TEST_CASE("A null out-pointer is rejected rather than dereferenced") {
     FL_CHECK_FALSE(buildBradfordMatrixQ16(kD50, kD65, nullptr));
     AdaptationMatrixQ16 matrix;

--- a/tests/fl/gfx/source_xyz.cpp
+++ b/tests/fl/gfx/source_xyz.cpp
@@ -3,6 +3,7 @@
 #include "fl/gfx/source_xyz.h"
 #include "fl/gfx/color_profile.h"
 #include "fl/stl/int.h"
+#include "fl/stl/limits.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -71,7 +72,7 @@ FL_TEST_CASE("Non-finite primaries are rejected, not converted") {
     // Neither xyY_to_XYZ's `y < 1e-12f` guard nor invert3x3's determinant
     // guard stops a NaN, since comparisons against NaN are all false. It
     // would reach the float-to-i32 cast, which is undefined behaviour.
-    const float nan_value = 0.0f / (sizeof(int) > 100 ? 1.0f : 0.0f);
+    const float nan_value = numeric_limits<float>::quiet_NaN();
     SourceMatrixQ16 matrix;
     RgbPrimaries bad = SourceProfile::srgbBt709().primaries;
     bad.red = Chromaticity(nan_value, 0.330f);

--- a/tests/fl/gfx/source_xyz.cpp
+++ b/tests/fl/gfx/source_xyz.cpp
@@ -67,6 +67,27 @@ FL_TEST_CASE("Collinear primaries are rejected rather than producing garbage") {
     FL_CHECK_FALSE(buildSourceMatrixQ16(SourceProfile::srgbBt709().primaries, nullptr));
 }
 
+FL_TEST_CASE("Non-finite primaries are rejected, not converted") {
+    // Neither xyY_to_XYZ's `y < 1e-12f` guard nor invert3x3's determinant
+    // guard stops a NaN, since comparisons against NaN are all false. It
+    // would reach the float-to-i32 cast, which is undefined behaviour.
+    const float nan_value = 0.0f / (sizeof(int) > 100 ? 1.0f : 0.0f);
+    SourceMatrixQ16 matrix;
+    RgbPrimaries bad = SourceProfile::srgbBt709().primaries;
+    bad.red = Chromaticity(nan_value, 0.330f);
+    FL_CHECK_FALSE(buildSourceMatrixQ16(bad, &matrix));
+
+    bad = SourceProfile::srgbBt709().primaries;
+    bad.white = Chromaticity(0.3127f, nan_value);
+    FL_CHECK_FALSE(buildSourceMatrixQ16(bad, &matrix));
+
+    bad = SourceProfile::srgbBt709().primaries;
+    bad.green = Chromaticity(0.300f, 0.0f);
+    FL_CHECK_FALSE(buildSourceMatrixQ16(bad, &matrix));
+
+    FL_CHECK(buildSourceMatrixQ16(SourceProfile::srgbBt709().primaries, &matrix));
+}
+
 FL_TEST_CASE("Fixed-point XYZ tracks the P5 float64 reference") {
     // Inputs are the golden corpus's linear_rgb quantized to u16; expectations
     // are its source_xyz. Tolerance is absolute because these span four orders


### PR DESCRIPTION
Fourth P6 stage (#4040), under #4034. Implements B7's normative chromatic adaptation transform.

## Design

The whole adaptation collapses to one 3×3 matrix — `B⁻¹ · diag(scale) · B` — built once when a profile is bound. Nothing per pixel ever touches cone space.

`foldAdaptationIntoSourceMatrix` pre-multiplies it into the primaries matrix, so **the streaming path pays nothing for adaptation**: primaries and adaptation become a single multiply together rather than two in sequence. A test asserts the folded result matches applying both stages separately.

## Why this is validated against the reference rather than the corpus

The P5 golden corpus **cannot exercise this stage**. All three of its source profiles use a D65 white, so `source_xyz` equals `d65_xyz` identically across all 192 vectors — I checked, the maximum difference is exactly `0.000e+00`. The corpus's `non_d65_white` is a *device* profile, which belongs to P7's side of the pipeline.

Shipping a transform whose only coverage is that it does nothing would be worthless. So expectations come from `ci/color_reference.py::bradford_adaptation` directly — the same authority the corpus is generated from, sampled where the corpus does not reach. I flagged this gap on #4170 before writing any of it.

## Tests

| case | asserts |
|---|---|
| D65 → D65 | identity within one Q16 step |
| D50 → D65 on D50's white | lands on D65's white — the defining property of a CAT |
| two reference triples | agree with float64 to 2e-4 |
| black | unchanged |
| fold vs. sequence | one matrix equals two, within rounding |
| null out-pointer | rejected, not dereferenced |

**Mutation-confirmed** by dropping the cone scale from the collapse: the two value-checking tests fail and the structural ones keep passing, which is exactly the split you would want.

## Unity-build note

Helpers are named `quantizeAdaptationQ16` / `dotAdaptationRowQ16` rather than the obvious short names. `.cpp.hpp` files are concatenated into one translation unit, so an anonymous namespace does **not** isolate them from a same-named helper in a sibling file — `source_xyz.cpp.hpp` already defines a `quantizeQ16`, and the short name is a redefinition error rather than a harmless shadow. Worth knowing before adding the next stage.

## Verification

- `bash test chromatic_adaptation` — 6/6
- `bash test transfer` / `source_xyz` / `flux_scalar` — all green
- `bash lint` — clean

## P6 status

Stages done: decode, source→XYZ, brightness/power, and now adaptation. Remaining is wiring the chain through `show()`, which needs P7's gamut mapping and device solve to be a complete path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bradford-based chromatic adaptation between color white points.
  * Added support for applying adaptation to color transformations, including D50-to-D65 conversions.

* **Bug Fixes**
  * Invalid, non-finite, or out-of-bounds color primaries and white-point values are now rejected safely.

* **Tests**
  * Added coverage for adaptation accuracy, identity conversions, black preservation, matrix composition, common white points, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->