### PR TITLE
fix(autoresearch): name the board that failed the peer-OTA handshake (#3956)

### DIFF
--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -79,7 +79,24 @@ async def _settle_link(
             # KBI002: this repo requires the handler notify the main thread.
             handle_keyboard_interrupt(ki)
             raise
-        except (RpcError, RpcTimeoutError) as exc:
+        except (RpcError, RpcTimeoutError, RuntimeError) as exc:
+            # RuntimeError is here because a failed *write* arrives as one:
+            # `PyserialMonitor.write` converts `serial.SerialException` into
+            # `RuntimeError("Serial write error: ...")`, and `RpcClient.send`
+            # only retries `RpcTimeoutError`, so it comes straight out. Left
+            # uncaught it defeats the point of this helper twice over -- no
+            # retry, and a bare transport error naming neither the board nor
+            # the call, which is exactly the failure #3956 was about.
+            #
+            # Normalizing that at the `RpcClient.send` boundary would be the
+            # better home for it, and is not this change's to make: 31
+            # modules use RpcClient, and some of them (ci/autoresearch/
+            # decode.py) rely on a bare `except RuntimeError` to report
+            # transport failures cleanly. Filed separately.
+            #
+            # The cost of the wider catch is that a genuine bug retries twice
+            # before surfacing. It still surfaces: the raised error carries
+            # the original text.
             last = exc
             print(f"  {label} did not answer ping (attempt {attempt}/3): {exc}")
             # No backoff after the final attempt -- it would just delay the

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import hashlib
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -46,18 +47,27 @@ def _served_request_count(status: dict[str, Any]) -> int:
     return value if value >= 0 else 0
 
 
-async def _settle_link(client: "RpcClient", label: str) -> None:
+async def _settle_link(
+    client: "RpcClient",
+    label: str,
+    remaining_timeout: "Callable[[], float]",
+) -> None:
     """Ping `client` until it answers, or raise naming the board that did not.
 
     Exists because the opening request of the peer-OTA run could time out
     against a device that was demonstrably healthy on both sides of the
     window. Without this the failure surfaced as a bare
     `No response with ID 1`, which names neither the board nor the call.
+
+    `remaining_timeout` is the run's own budget helper. Settling must not
+    invent a window of its own: three fixed 10 s pings plus their backoffs
+    could outlast a shorter caller deadline, so each ping is clamped to
+    whatever the run has left and raises once that is exhausted.
     """
     last: Exception | None = None
     for attempt in range(1, 4):
         try:
-            await client.send("ping", {}, timeout=10.0)
+            await client.send("ping", {}, timeout=min(10.0, remaining_timeout()))
             if attempt > 1:
                 print(f"  {label} link settled after {attempt} attempts")
             return
@@ -72,7 +82,10 @@ async def _settle_link(client: "RpcClient", label: str) -> None:
         except (RpcError, RpcTimeoutError) as exc:
             last = exc
             print(f"  {label} did not answer ping (attempt {attempt}/3): {exc}")
-            await asyncio.sleep(2.0)
+            # No backoff after the final attempt -- it would just delay the
+            # error by 2 s.
+            if attempt < 3:
+                await asyncio.sleep(2.0)
     raise RpcTimeoutError(
         f"{label} did not answer ping after 3 attempts; last error: {last}"
     )
@@ -146,8 +159,8 @@ async def run_ota_peer_autoresearch(
         # served a schema fetch (FastLED#3956). One dropped opening request
         # should not sink the whole run, so ping with a bounded retry and
         # report which link is at fault when it genuinely is unreachable.
-        await _settle_link(primary, "RP2350W")
-        await _settle_link(peer, "ESP32-C6")
+        await _settle_link(primary, "RP2350W", rpc_timeout)
+        await _settle_link(peer, "ESP32-C6", rpc_timeout)
 
         primary_status = await rpc_data(primary, "status", {})
         peer_status = await rpc_data(peer, "status", {})

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -20,7 +20,7 @@ import httpx
 from colorama import Fore, Style
 
 from ci.autoresearch.net import create_wifi_manager
-from ci.rpc_client import RpcClient, RpcTimeoutError
+from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
@@ -44,6 +44,30 @@ def _served_request_count(status: dict[str, Any]) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         return 0
     return value if value >= 0 else 0
+
+
+async def _settle_link(client: "RpcClient", label: str) -> None:
+    """Ping `client` until it answers, or raise naming the board that did not.
+
+    Exists because the opening request of the peer-OTA run could time out
+    against a device that was demonstrably healthy on both sides of the
+    window. Without this the failure surfaced as a bare
+    `No response with ID 1`, which names neither the board nor the call.
+    """
+    last: Exception | None = None
+    for attempt in range(1, 4):
+        try:
+            await client.send("ping", {}, timeout=10.0)
+            if attempt > 1:
+                print(f"  {label} link settled after {attempt} attempts")
+            return
+        except (RpcError, RpcTimeoutError) as exc:
+            last = exc
+            print(f"  {label} did not answer ping (attempt {attempt}/3): {exc}")
+            await asyncio.sleep(2.0)
+    raise RpcTimeoutError(
+        f"{label} did not answer ping after 3 attempts; last error: {last}"
+    )
 
 
 async def run_ota_peer_autoresearch(
@@ -106,6 +130,16 @@ async def run_ota_peer_autoresearch(
         )
         await primary.connect(boot_wait=3.0, drain_boot=True)
         await peer.connect(boot_wait=3.0, drain_boot=True)
+
+        # Settle both links before the first real call. The peer flash runs
+        # for ~60-90 s after the primary's, and the first request on the
+        # primary was timing out even though the device answered `status`
+        # immediately when queried standalone a moment later, and had just
+        # served a schema fetch (FastLED#3956). One dropped opening request
+        # should not sink the whole run, so ping with a bounded retry and
+        # report which link is at fault when it genuinely is unreachable.
+        await _settle_link(primary, "RP2350W")
+        await _settle_link(peer, "ESP32-C6")
 
         primary_status = await rpc_data(primary, "status", {})
         peer_status = await rpc_data(peer, "status", {})

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -61,6 +61,14 @@ async def _settle_link(client: "RpcClient", label: str) -> None:
             if attempt > 1:
                 print(f"  {label} link settled after {attempt} attempts")
             return
+        except KeyboardInterrupt as ki:
+            # Not strictly required -- KeyboardInterrupt derives from
+            # BaseException, so the tuple below never catches it. Kept
+            # explicit so a later widening of that tuple cannot silently
+            # start swallowing Ctrl-C mid-retry. A bare `raise` would trip
+            # KBI002: this repo requires the handler notify the main thread.
+            handle_keyboard_interrupt(ki)
+            raise
         except (RpcError, RpcTimeoutError) as exc:
             last = exc
             print(f"  {label} did not answer ping (attempt {attempt}/3): {exc}")

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -129,6 +129,8 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
             "wifiStatus": {"connected": True},
             "applyOtaArtifact": {"success": True},
             "stopNet": {"success": True},
+            # `_settle_link` pings each board before the first real call.
+            "ping": {"success": True},
         }
         return _response(responses[method])
 
@@ -138,6 +140,7 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
     async def peer_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
         responses = {
             "status": {"platform": "ESP32-C6 (RISC-V)"},
+            "ping": {"success": True},
             "beginOtaArtifact": {"success": True},
             "writeOtaArtifact": {"success": True},
             "finishOtaArtifact": {
@@ -187,7 +190,11 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
 
     assert result == 0
     encode.assert_called_once_with(b"firmware")
-    assert peer.send.await_args_list[1].args[0] == "beginOtaArtifact"
+    # Order, not index: `_settle_link` pings before the first real call, and a
+    # fixed position breaks whenever a step is added ahead of this one.
+    peer_methods = [call.args[0] for call in peer.send.await_args_list]
+    assert "beginOtaArtifact" in peer_methods
+    assert peer_methods.index("status") < peer_methods.index("beginOtaArtifact")
     write_calls = []
     for call in peer.send.await_args_list:
         if call.args[0] == "writeOtaArtifact":

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ci.autoresearch.net import run_net_peer_autoresearch
-from ci.autoresearch.ota import run_ota_peer_autoresearch
+from ci.autoresearch.ota import _settle_link, run_ota_peer_autoresearch
+from ci.rpc_client import RpcTimeoutError
 
 
 def _response(data: dict[str, Any]) -> MagicMock:
@@ -201,3 +202,41 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
             write_calls.append(call)
     assert len(write_calls) == 1
     assert write_calls[0].args[1] == ""
+
+
+def test_settle_link_retries_a_failed_serial_write() -> None:
+    """A failed write must be retried, and must name the board when it isn't.
+
+    `PyserialMonitor.write` converts `serial.SerialException` into
+    `RuntimeError("Serial write error: ...")`, and `RpcClient.send` only
+    retries `RpcTimeoutError` -- so a write failure arrives here as a bare
+    `RuntimeError`. Before this was caught, it escaped the retry entirely and
+    surfaced as a transport error naming neither the board nor the call,
+    which is the failure #3956 exists to fix.
+    """
+    client = MagicMock()
+    client.send = AsyncMock(side_effect=RuntimeError("Serial write error: boom"))
+
+    with pytest.raises(RpcTimeoutError) as caught:
+        asyncio.run(_settle_link(client, "primary (COM18)", lambda: 30.0))
+
+    message = str(caught.value)
+    # Names the board, the number of attempts, and keeps the original cause.
+    assert "primary (COM18)" in message
+    assert "3 attempts" in message
+    assert "Serial write error: boom" in message
+    # All three attempts were made rather than one throw escaping.
+    assert client.send.await_count == 3
+
+
+def test_settle_link_returns_once_the_board_answers() -> None:
+    """The retry stops at the first success, and does not raise."""
+    client = MagicMock()
+    client.send = AsyncMock(
+        side_effect=[
+            RuntimeError("Serial write error: boom"),
+            _response({"success": True}),
+        ]
+    )
+    asyncio.run(_settle_link(client, "peer (COM9)", lambda: 30.0))
+    assert client.send.await_count == 2


### PR DESCRIPTION
Diagnostics only. Found while attempting #3956's hardware criterion on the bench.

## Problem

`--net-peer --ota` failed with:

```
OTA peer autoresearch failed: No response with ID 1 within 20.0s
```

That names neither the board nor the call. I read `ID 1` as the `status` call on `primary` and investigated a **healthy RP2350W** — it answered `ping` and `status` immediately when queried standalone, and had just served a 71-method schema fetch. The failing board was the ESP32-C6.

## Change

Ping each link with a bounded retry before the first real call, and say which one did not answer:

```
  ESP32-C6 did not answer ping (attempt 1/3): No response with ID 1 within 10.0s
  ESP32-C6 did not answer ping (attempt 2/3): No response with ID 2 within 10.0s
  ESP32-C6 did not answer ping (attempt 3/3): No response with ID 3 within 10.0s
OTA peer autoresearch failed: ESP32-C6 did not answer ping after 3 attempts; ...
```

Retry rather than a bare probe, for two reasons: the peer flash runs 25–95 s after the primary's, so the opening request lands immediately after a deploy; and the device demonstrably answered on both sides of the failure window, so one dropped opening request should not sink a run that has not started any OTA work.

It stays bounded and still fails loudly — three attempts, then raise naming the board. It does not mask an unreachable device.

No change to the OTA flow itself.

## What this does not fix

The underlying failure. That looks like **FastLED/fbuild#1426**: `fbuild-daemon` keeps the serial fd after a deploy, so the next client gets `EBUSY` on a board that is enumerated and healthy. Four distinct daemon pids did this across one session (414394, 434691, 544820, 551628), and `open()` took 13.3 s while held versus 0.00 s after killing the holder.

The duration correlation explains why this mode fails and plain `--net-peer` does not:

| Mode | C6 deploy | Outcome |
| --- | --- | --- |
| `--net-peer` | 96.5 s | works — 6 full cycles, bidirectional HTTP |
| `--net-peer --ota` | 25.7 s | first RPC to the C6 times out |

A short deploy loses the race with the leaked handle; a long one wins it. Which is exactly why the fault looked like OTA logic when it is serial lifetime — and why naming the board matters.

So #3961's hardening still has not been exercised on silicon; the run dies at the handshake, before `beginOtaArtifact`.

## Verification

- `bash lint` — clean
- Exercised on hardware: RP2350W (`2E8A:F00F`) and ESP32-C6 (`303A:1001`); the new output above is from that run
- Both boards left healthy and on known-good builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer connection setup by confirming both RPC links are responsive before proceeding.
  * Added retries for initial connectivity checks to reduce failures caused by transient issues.
  * Connection checks now respect the overall RPC timeout, preventing them from exceeding the caller’s deadline.
  * Eliminated unnecessary waiting after the final failed connection attempt, allowing timeout errors to be reported immediately.
  * Serial write failures during OTA operations are now retried and reported with clearer timeout details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->