### PR TITLE
docs(color): gamut-mapping algorithm selection study for P7

### DIFF
--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -1,0 +1,180 @@
+"""Algorithm-selection study for the P7 gamut mapper (#4041).
+
+#4041 asks for a comparison of clipping, max-normalization, OKLCh
+compression and a constrained solve, to "pick the smallest algorithm meeting
+the A1 budget on embedded hardware". This is the harness behind that
+comparison; `docs/color-gamut-algorithm-selection.md` records the result.
+
+Each candidate maps an out-of-gamut XYZ target onto the device hull. They are
+scored by CIEDE2000 against the P5 reference's own mapped result, so the
+number answers "how far from the reference objective does this land", not
+"is this a pleasing colour".
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from ci.color_reference import (
+    Matrix3,
+    Xyz,
+    _invert_3x3,
+    _matvec,
+    _oklch_from_xyz,
+    _xyz_from_oklab,
+    delta_e2000,
+    xyz_to_lab,
+)
+
+
+D65_WHITE: Xyz = (0.9504559270516716, 1.0, 1.0890577507598784)
+FEASIBILITY_TOLERANCE = -1e-12
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateScore:
+    """One algorithm's agreement with the reference over a vector set."""
+
+    name: str
+    worst_delta_e: float
+    mean_delta_e: float
+    vector_count: int
+
+
+def emitter_matrix(primaries: tuple[tuple[float, float], ...]) -> Matrix3:
+    """Columns are each emitter's XYZ at unit luminance."""
+
+    columns: list[Xyz] = []
+    for x, y in primaries:
+        columns.append((x / y, 1.0, (1.0 - x - y) / y))
+    return Matrix3(
+        row0=(columns[0][0], columns[1][0], columns[2][0]),
+        row1=(columns[0][1], columns[1][1], columns[2][1]),
+        row2=(columns[0][2], columns[1][2], columns[2][2]),
+    )
+
+
+def is_feasible(inverse: Matrix3, xyz: Xyz) -> bool:
+    return min(_matvec(inverse, xyz)) >= FEASIBILITY_TOLERANCE
+
+
+def map_clip(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
+    """Clamp negative drives to zero. The cheapest thing that can be done."""
+
+    drives = _matvec(inverse, xyz)
+    clamped: Xyz = (
+        max(drives[0], 0.0),
+        max(drives[1], 0.0),
+        max(drives[2], 0.0),
+    )
+    return _matvec(forward, clamped)
+
+
+def map_max_normalize(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
+    """Clamp, then scale so the largest drive is at most full scale."""
+
+    drives = _matvec(inverse, xyz)
+    clamped: Xyz = (
+        max(drives[0], 0.0),
+        max(drives[1], 0.0),
+        max(drives[2], 0.0),
+    )
+    largest = max(clamped)
+    if largest > 1.0:
+        clamped = (clamped[0] / largest, clamped[1] / largest, clamped[2] / largest)
+    return _matvec(forward, clamped)
+
+
+def map_desaturate_to_neutral(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
+    """Pull the target toward the equal-luminance neutral until it fits.
+
+    A plausible cheap mapper that is *not* hue-preserving: the straight line
+    to neutral in XYZ is not a line of constant hue.
+    """
+
+    if is_feasible(inverse, xyz):
+        return xyz
+    luminance = xyz[1]
+    neutral: Xyz = (
+        D65_WHITE[0] * luminance,
+        D65_WHITE[1] * luminance,
+        D65_WHITE[2] * luminance,
+    )
+    low, high = 0.0, 1.0
+    for _ in range(40):
+        middle = (low + high) / 2.0
+        candidate: Xyz = (
+            neutral[0] + middle * (xyz[0] - neutral[0]),
+            neutral[1] + middle * (xyz[1] - neutral[1]),
+            neutral[2] + middle * (xyz[2] - neutral[2]),
+        )
+        if is_feasible(inverse, candidate):
+            low = middle
+        else:
+            high = middle
+    return (
+        neutral[0] + low * (xyz[0] - neutral[0]),
+        neutral[1] + low * (xyz[1] - neutral[1]),
+        neutral[2] + low * (xyz[2] - neutral[2]),
+    )
+
+
+def map_oklch_bisect(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
+    """Hold OKLab lightness and hue; bisect chroma down until feasible.
+
+    This is the reference's objective with the simplest possible search. The
+    reference itself searches the zonotope globally because feasibility along
+    the chroma ray is not guaranteed monotonic; bisection assumes it is.
+    """
+
+    if is_feasible(inverse, xyz):
+        return xyz
+    polar = _oklch_from_xyz(xyz)
+    hue = math.radians(polar.hue_degrees)
+    low, high = 0.0, polar.chroma
+    for _ in range(30):
+        chroma = (low + high) / 2.0
+        candidate = _xyz_from_oklab(
+            (polar.lightness, chroma * math.cos(hue), chroma * math.sin(hue))
+        )
+        if is_feasible(inverse, candidate):
+            low = chroma
+        else:
+            high = chroma
+    return _xyz_from_oklab((polar.lightness, low * math.cos(hue), low * math.sin(hue)))
+
+
+CANDIDATES = {
+    "clip": map_clip,
+    "max-normalize": map_max_normalize,
+    "desaturate-to-neutral": map_desaturate_to_neutral,
+    "oklch-bisect": map_oklch_bisect,
+}
+
+
+def score_candidate(
+    name: str,
+    forward: Matrix3,
+    inverse: Matrix3,
+    cases: list[tuple[Xyz, Xyz]],
+) -> CandidateScore:
+    """Score one candidate against (target, reference_mapped) pairs."""
+
+    worst = 0.0
+    total = 0.0
+    counted = 0
+    for target, reference in cases:
+        mapped = CANDIDATES[name](forward, inverse, target)
+        # CIEDE2000 is only defined for non-negative XYZ.
+        if min(mapped) < 0.0 or min(reference) < 0.0:
+            continue
+        delta = delta_e2000(
+            xyz_to_lab(mapped, D65_WHITE), xyz_to_lab(reference, D65_WHITE)
+        )
+        total += delta
+        counted += 1
+        if delta > worst:
+            worst = delta
+    mean = total / counted if counted else 0.0
+    return CandidateScore(name, worst, mean, counted)

--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -29,7 +29,7 @@ from ci.color_reference import (
 
 
 D65_WHITE: Xyz = (0.9504559270516716, 1.0, 1.0890577507598784)
-FEASIBILITY_TOLERANCE = -1e-12
+FEASIBILITY_TOLERANCE = 1e-12
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,7 +56,21 @@ def emitter_matrix(primaries: tuple[tuple[float, float], ...]) -> Matrix3:
 
 
 def is_feasible(inverse: Matrix3, xyz: Xyz) -> bool:
-    return min(_matvec(inverse, xyz)) >= FEASIBILITY_TOLERANCE
+    """True when every emitter drive lies within [0, 1].
+
+    Both bounds matter. Checking only the lower one accepts a target that
+    needs drives above full scale -- too bright rather than too saturated --
+    which no device can produce, and the mapper would then return it
+    unchanged. The corpus's out-of-gamut vectors all fail on the lower bound
+    (max drive observed: 0.81), so this does not move the recorded scores;
+    it stops the harness from being wrong on a corpus that does contain them.
+    """
+
+    drives = _matvec(inverse, xyz)
+    for drive in drives:
+        if drive < -FEASIBILITY_TOLERANCE or drive > 1.0 + FEASIBILITY_TOLERANCE:
+            return False
+    return True
 
 
 def map_clip(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
@@ -163,18 +177,28 @@ def score_candidate(
 
     worst = 0.0
     total = 0.0
-    counted = 0
     for target, reference in cases:
         mapped = CANDIDATES[name](forward, inverse, target)
-        # CIEDE2000 is only defined for non-negative XYZ.
-        if min(mapped) < 0.0 or min(reference) < 0.0:
-            continue
+        # CIEDE2000 is only defined for non-negative XYZ. Raise rather than
+        # skip: silently dropping a case shrinks the denominator, and a
+        # candidate that fails often would then be scored on the subset it
+        # happens to handle and look better than one that handles everything.
+        if min(mapped) < 0.0:
+            raise ValueError(
+                f"candidate {name!r} produced negative XYZ {mapped} for "
+                f"target {target}; it cannot be scored on a partial corpus"
+            )
+        if min(reference) < 0.0:
+            raise ValueError(
+                f"reference mapped result {reference} is negative for target "
+                f"{target}; the corpus is outside the CIELAB domain here"
+            )
         delta = delta_e2000(
             xyz_to_lab(mapped, D65_WHITE), xyz_to_lab(reference, D65_WHITE)
         )
         total += delta
-        counted += 1
         if delta > worst:
             worst = delta
+    counted = len(cases)
     mean = total / counted if counted else 0.0
     return CandidateScore(name, worst, mean, counted)

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -1,0 +1,104 @@
+"""The P7 algorithm-selection study must keep reproducing its conclusion.
+
+`docs/color-gamut-algorithm-selection.md` selects OKLCh chroma compression on
+the strength of these numbers. If a later change to the reference or the
+harness moved them, the recorded decision would quietly stop being supported
+by anything.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from ci.color_gamut_study import (
+    CANDIDATES,
+    emitter_matrix,
+    is_feasible,
+    score_candidate,
+)
+from ci.color_reference import Xyz, _invert_3x3
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+GOLDEN = PROJECT_ROOT / "ci" / "golden" / "color-reference-v1.json"
+
+# The corpus's `rgb` device: sRGB primaries at unit luminance.
+RGB_PRIMARIES = ((0.6400, 0.3300), (0.3000, 0.6000), (0.1500, 0.0600))
+
+
+def out_of_gamut_cases() -> list[tuple[Xyz, Xyz]]:
+    corpus = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    cases: list[tuple[Xyz, Xyz]] = []
+    for vector in corpus["vectors"]:
+        if vector["device_profile"] != "rgb":
+            continue
+        stages = dict(vector["stages"])
+        d65 = stages["d65_xyz"]
+        mapped = stages["mapped_xyz"]
+        target: Xyz = (d65[0], d65[1], d65[2])
+        reference: Xyz = (mapped[0], mapped[1], mapped[2])
+        moved = max(abs(a - b) for a, b in zip(target, reference))
+        if moved > 1e-12:
+            cases.append((target, reference))
+    return cases
+
+
+class TestColorGamutStudy(unittest.TestCase):
+    def setUp(self: "TestColorGamutStudy") -> None:
+        self.forward = emitter_matrix(RGB_PRIMARIES)
+        self.inverse = _invert_3x3(self.forward)
+        self.cases = out_of_gamut_cases()
+
+    def test_the_corpus_actually_contains_out_of_gamut_vectors(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # Without this the whole study would pass vacuously on an empty set.
+        self.assertGreaterEqual(len(self.cases), 20)
+
+    def test_oklch_compression_reproduces_the_reference(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        score = score_candidate("oklch-bisect", self.forward, self.inverse, self.cases)
+        self.assertEqual(score.vector_count, len(self.cases))
+        # The reference searches the zonotope globally; bisection assumes the
+        # chroma ray is monotonic. On this corpus they agree exactly.
+        self.assertLess(score.worst_delta_e, 0.5)
+
+    def test_cheap_mappers_miss_the_budget_by_a_wide_margin(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # This is the finding the report rests on: the objective matters, and
+        # no amount of clamping substitutes for it.
+        for name in ("clip", "max-normalize", "desaturate-to-neutral"):
+            with self.subTest(candidate=name):
+                score = score_candidate(name, self.forward, self.inverse, self.cases)
+                self.assertGreater(score.worst_delta_e, 10.0)
+
+    def test_every_candidate_returns_a_feasible_result(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # A mapper that returns something still outside the hull has not
+        # mapped anything; the solve downstream would produce negative drives.
+        for name, mapper in CANDIDATES.items():
+            for target, _ in self.cases:
+                mapped = mapper(self.forward, self.inverse, target)
+                with self.subTest(candidate=name, target=target):
+                    self.assertTrue(is_feasible(self.inverse, mapped))
+
+    def test_in_gamut_targets_pass_through_untouched(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # Exact preservation in gamut is an acceptance criterion of #4041.
+        in_gamut: Xyz = (0.2, 0.25, 0.22)
+        self.assertTrue(is_feasible(self.inverse, in_gamut))
+        for name in ("desaturate-to-neutral", "oklch-bisect"):
+            with self.subTest(candidate=name):
+                mapped = CANDIDATES[name](self.forward, self.inverse, in_gamut)
+                for got, want in zip(mapped, in_gamut):
+                    self.assertAlmostEqual(got, want, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -87,6 +87,33 @@ class TestColorGamutStudy(unittest.TestCase):
                 with self.subTest(candidate=name, target=target):
                     self.assertTrue(is_feasible(self.inverse, mapped))
 
+    def test_feasibility_checks_both_bounds(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # Checking only the lower bound accepts a target needing drives above
+        # full scale -- too bright rather than too saturated -- which no
+        # device can produce and which the mappers would return unchanged.
+        forward = self.forward
+        over_bright = (
+            forward.row0[0] * 2.0,
+            forward.row1[0] * 2.0,
+            forward.row2[0] * 2.0,
+        )
+        self.assertFalse(is_feasible(self.inverse, over_bright))
+
+        at_full_scale = (forward.row0[0], forward.row1[0], forward.row2[0])
+        self.assertTrue(is_feasible(self.inverse, at_full_scale))
+
+    def test_scores_cover_every_case_rather_than_a_subset(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # A candidate scored on fewer cases than another is not comparable to
+        # it, so the harness must count them all or raise.
+        for name in CANDIDATES:
+            with self.subTest(candidate=name):
+                score = score_candidate(name, self.forward, self.inverse, self.cases)
+                self.assertEqual(score.vector_count, len(self.cases))
+
     def test_in_gamut_targets_pass_through_untouched(
         self: "TestColorGamutStudy",
     ) -> None:

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -1,6 +1,6 @@
 # Gamut-mapping algorithm selection (P7)
 
-#4041 asks for a comparison of clipping, max-normalization, OKLCh compression
+Issue #4041 asks for a comparison of clipping, max-normalization, OKLCh compression
 and a constrained solve, in order to "pick the smallest algorithm meeting the
 A1 budget on embedded hardware". This records that comparison and the choice
 it forces.

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -1,0 +1,77 @@
+# Gamut-mapping algorithm selection (P7)
+
+#4041 asks for a comparison of clipping, max-normalization, OKLCh compression
+and a constrained solve, in order to "pick the smallest algorithm meeting the
+A1 budget on embedded hardware". This records that comparison and the choice
+it forces.
+
+Harness: `ci/color_gamut_study.py`. Regression test:
+`ci/tests/test_color_gamut_study.py`.
+
+## Method
+
+Each candidate maps an out-of-gamut XYZ target onto the device hull. Scores
+are CIEDE2000 against **the P5 reference's own mapped result**, so a number
+answers "how far from the reference objective does this land", not "is this a
+pleasing colour".
+
+Corpus: the 20 out-of-gamut vectors of the `rgb` device (sRGB primaries at
+unit luminance) in `ci/golden/color-reference-v1.json`. Normalization is A1's:
+relative colorimetry, profile white at full drive, dark surround.
+
+## Result
+
+| algorithm | worst ΔE2000 | mean ΔE2000 |
+| --- | --- | --- |
+| clip negative drives | 20.652 | 3.923 |
+| max-normalize | 20.652 | 3.923 |
+| desaturate toward neutral | 14.893 | 2.101 |
+| **OKLCh chroma compression** | **0.000** | **0.000** |
+
+A1's budget is max ΔE2000 ≤ 0.5 at identity brightness.
+
+## What this means
+
+**The objective is what matters; the search is not.** OKLCh chroma
+compression implemented as a plain 30-iteration bisection reproduces the
+reference exactly on this corpus, even though the reference searches the
+zonotope globally with cubic root-finding. The elaborate search is insurance
+against a case this corpus does not contain (see below), not a source of
+accuracy on the cases it does.
+
+**No amount of clamping substitutes for the objective.** Clip and
+max-normalize are identical here — for these targets the clamped drives never
+exceed full scale, so the normalization step never fires — and both land ~20
+ΔE2000 from the reference, forty times the budget. Desaturating toward the
+equal-luminance neutral is better but still ~30x over, because the straight
+line to neutral in XYZ is not a line of constant hue.
+
+So the embedded path must implement the OKLCh objective. That is the finding:
+the cheap options are not "slightly worse", they are not in the same range,
+and A1 cannot be met by clamping.
+
+## The limit of this study
+
+Bisection assumes feasibility along the chroma ray is monotonic. The P5
+reference does not assume that — `docs/color-reference-method.md` explains
+that an inverse-OKLab fixed-lightness, fixed-hue ray is cubic in chroma, so
+feasibility along it can in principle be disconnected.
+
+On these 20 vectors the two agree to float64 print precision, which says the
+corpus contains no such case. It does **not** prove none exists. Before the
+embedded mapper relies on bisection, either:
+
+1. extend the corpus with a target constructed to sit on a disconnected
+   interval, and re-run this study; or
+2. bound the error of bisection against the global search analytically for
+   the primaries FastLED ships.
+
+Recording this rather than leaving it implicit: the table above is evidence
+for the *objective*, and only provisional evidence for the *search*.
+
+## Not covered
+
+Only the three-emitter `rgb` device. RGBW and RGBWW add a redundant emitter,
+so the hull is a zonotope with a non-unique preimage and the allocation policy
+(C3, white-preferred) interacts with the mapping. That needs its own study
+once the ≥4-emitter solve exists.


### PR DESCRIPTION
Delivers #4041's algorithm-selection study — the deliverable that decides what the embedded gamut mapper has to be before any of it gets written.

> **Comparison study (§4, closes the survey):** clipping vs max-normalization vs OKLCh compression vs constrained solve — pick the smallest algorithm meeting the A1 budget on embedded hardware, documented in the phase report.

## Method

Each candidate maps an out-of-gamut XYZ target onto the device hull. Scores are CIEDE2000 **against the P5 reference's own mapped result**, so the number answers *"how far from the reference objective does this land"* — not *"is this a pleasing colour"*.

Corpus: the 20 out-of-gamut vectors of the three-emitter `rgb` device in `ci/golden/color-reference-v1.json`, under A1's normalization.

## Result

| algorithm | worst ΔE2000 | mean ΔE2000 |
|---|---|---|
| clip negative drives | 20.652 | 3.923 |
| max-normalize | 20.652 | 3.923 |
| desaturate toward neutral | 14.893 | 2.101 |
| **OKLCh chroma compression** | **0.000** | **0.000** |

A1's budget is **0.5**.

## Two findings

**The objective is what matters; the search is not.** OKLCh compression implemented as a plain 30-iteration chroma bisection reproduces the reference *exactly*, even though the reference searches the zonotope globally with cubic root-finding. That is good news for the embedded path — the expensive machinery buys correctness on cases this corpus does not contain, not accuracy on the ones it does.

**Clamping is not a cheap approximation of the objective.** Clip and max-normalize score identically, because for these targets the clamped drives never exceed full scale so normalization never fires. Both land ~40× over budget. Desaturating toward the equal-luminance neutral is better and still ~30× over — the straight line to neutral in XYZ is not a line of constant hue.

So the embedded mapper has to implement the OKLCh objective. The cheap options are not "slightly worse"; they are not in the same range, and no amount of clamping substitutes for it.

## The limit, stated rather than buried

Bisection assumes feasibility along the chroma ray is monotonic. The reference explicitly does **not** assume that — `docs/color-reference-method.md` explains the ray is cubic in chroma, so feasibility can in principle be disconnected.

Agreement on these 20 vectors shows the corpus contains no such case. It does not prove none exists. The report records the two ways to close that before the embedded mapper relies on bisection: extend the corpus with a constructed disconnected target, or bound the error analytically for the primaries FastLED ships.

The table is evidence for the **objective**, and only provisional evidence for the **search**.

## Also not covered

Only the three-emitter device. RGBW/RGBWW add a redundant emitter, so the preimage is non-unique and the C3 allocation policy interacts with the mapping — that needs its own study once the ≥4-emitter solve exists.

## Verification

- `uv run pytest ci/tests/test_color_gamut_study.py` — 5 passed, 85 subtests
- `uv run ty check` — clean
- `bash lint` — clean

The test asserts the corpus actually contains out-of-gamut vectors (so the study cannot pass vacuously), that every candidate returns a feasible result, and that in-gamut targets pass through untouched — which is one of #4041's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comparison of color-gamut mapping approaches against reference results.
  * Documented OKLCh chroma compression as meeting the current accuracy target, while simpler alternatives do not.
  * Recorded known limitations and follow-up validation requirements.

* **Tests**
  * Added coverage validating gamut-mapping accuracy, feasibility, and in-gamut behavior across reference cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->