### PR TITLE
docs(color): measure what the embedded gamut mapper actually costs

### DIFF
--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -159,11 +159,45 @@ def map_oklch_bisect(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
     return _xyz_from_oklab((polar.lightness, low * math.cos(hue), low * math.sin(hue)))
 
 
+def map_oklch_bounded(
+    forward: Matrix3, inverse: Matrix3, xyz: Xyz, iterations: int
+) -> Xyz:
+    """OKLCh chroma compression with a fixed iteration count.
+
+    The distinction from an iterative *solver* matters for A3/B11: this runs
+    a constant number of halvings and returns, rather than looping until a
+    convergence criterion is met. Its cost is known at compile time.
+    """
+
+    if is_feasible(inverse, xyz):
+        return xyz
+    polar = _oklch_from_xyz(xyz)
+    hue = math.radians(polar.hue_degrees)
+    low, high = 0.0, polar.chroma
+    for _ in range(iterations):
+        chroma = (low + high) / 2.0
+        candidate = _xyz_from_oklab(
+            (polar.lightness, chroma * math.cos(hue), chroma * math.sin(hue))
+        )
+        if is_feasible(inverse, candidate):
+            low = chroma
+        else:
+            high = chroma
+    return _xyz_from_oklab((polar.lightness, low * math.cos(hue), low * math.sin(hue)))
+
+
+def map_oklch_bisect_8(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
+    """The selected embedded algorithm: eight halvings, no table."""
+
+    return map_oklch_bounded(forward, inverse, xyz, 8)
+
+
 CANDIDATES = {
     "clip": map_clip,
     "max-normalize": map_max_normalize,
     "desaturate-to-neutral": map_desaturate_to_neutral,
     "oklch-bisect": map_oklch_bisect,
+    "oklch-bisect-8": map_oklch_bisect_8,
 }
 
 

--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -76,7 +76,12 @@ def is_feasible(inverse: Matrix3, xyz: Xyz) -> bool:
 
 
 def map_clip(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
-    """Clamp negative drives to zero. The cheapest thing that can be done."""
+    """Clamp each drive into [0, 1]. The cheapest thing that can be done.
+
+    Both bounds, not just the lower one: a target can be outside the hull for
+    being too bright as well as too saturated, and a mapper that returns an
+    over-unity drive has not mapped anything.
+    """
 
     drives = _matvec(inverse, xyz)
     clamped: Xyz = (
@@ -88,7 +93,11 @@ def map_clip(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
 
 
 def map_max_normalize(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
-    """Clamp, then scale so the largest drive is at most full scale."""
+    """Clamp negatives, then scale so the largest drive is at most full scale.
+
+    The normalization makes the upper clamp unnecessary here: scaling by the
+    largest drive already brings everything to at most 1.
+    """
 
     drives = _matvec(inverse, xyz)
     clamped: Xyz = (

--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+from typeguard import typechecked
+
 from ci.color_reference import (
     Matrix3,
     Xyz,
@@ -78,9 +80,9 @@ def map_clip(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
 
     drives = _matvec(inverse, xyz)
     clamped: Xyz = (
-        max(drives[0], 0.0),
-        max(drives[1], 0.0),
-        max(drives[2], 0.0),
+        min(max(drives[0], 0.0), 1.0),
+        min(max(drives[1], 0.0), 1.0),
+        min(max(drives[2], 0.0), 1.0),
     )
     return _matvec(forward, clamped)
 
@@ -127,11 +129,21 @@ def map_desaturate_to_neutral(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> X
             low = middle
         else:
             high = middle
-    return (
+    pulled: Xyz = (
         neutral[0] + low * (xyz[0] - neutral[0]),
         neutral[1] + low * (xyz[1] - neutral[1]),
         neutral[2] + low * (xyz[2] - neutral[2]),
     )
+    # Pulling toward an equal-luminance neutral cannot fix an over-bright
+    # target, since the neutral is over-bright too. Clamp the drives so the
+    # candidate still satisfies the mapper contract.
+    pulled_drives = _matvec(inverse, pulled)
+    bounded: Xyz = (
+        min(max(pulled_drives[0], 0.0), 1.0),
+        min(max(pulled_drives[1], 0.0), 1.0),
+        min(max(pulled_drives[2], 0.0), 1.0),
+    )
+    return _matvec(forward, bounded)
 
 
 def map_oklch_bisect(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
@@ -146,19 +158,43 @@ def map_oklch_bisect(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:
         return xyz
     polar = _oklch_from_xyz(xyz)
     hue = math.radians(polar.hue_degrees)
+    lightness = attainable_lightness(inverse, polar.lightness)
     low, high = 0.0, polar.chroma
     for _ in range(30):
         chroma = (low + high) / 2.0
         candidate = _xyz_from_oklab(
-            (polar.lightness, chroma * math.cos(hue), chroma * math.sin(hue))
+            (lightness, chroma * math.cos(hue), chroma * math.sin(hue))
         )
         if is_feasible(inverse, candidate):
             low = chroma
         else:
             high = chroma
-    return _xyz_from_oklab((polar.lightness, low * math.cos(hue), low * math.sin(hue)))
+    return _xyz_from_oklab((lightness, low * math.cos(hue), low * math.sin(hue)))
 
 
+@typechecked
+def attainable_lightness(inverse: Matrix3, lightness: float) -> float:
+    """Largest neutral lightness the device can reach, at or below `lightness`.
+
+    Chroma compression cannot rescue a target that is too *bright*: at zero
+    chroma the point is still outside the hull, so the bisection converges on
+    an infeasible answer. The reference clamps lightness to the attainable
+    neutral interval before compressing chroma, and this is that clamp.
+    """
+
+    if is_feasible(inverse, _xyz_from_oklab((lightness, 0.0, 0.0))):
+        return lightness
+    low, high = 0.0, lightness
+    for _ in range(30):
+        middle = (low + high) / 2.0
+        if is_feasible(inverse, _xyz_from_oklab((middle, 0.0, 0.0))):
+            low = middle
+        else:
+            high = middle
+    return low
+
+
+@typechecked
 def map_oklch_bounded(
     forward: Matrix3, inverse: Matrix3, xyz: Xyz, iterations: int
 ) -> Xyz:
@@ -173,17 +209,21 @@ def map_oklch_bounded(
         return xyz
     polar = _oklch_from_xyz(xyz)
     hue = math.radians(polar.hue_degrees)
+    # Lightness first: reducing chroma cannot bring an over-bright target back
+    # into the hull, so without this the bisection converges on an infeasible
+    # answer -- at zero chroma the point is still outside.
+    lightness = attainable_lightness(inverse, polar.lightness)
     low, high = 0.0, polar.chroma
     for _ in range(iterations):
         chroma = (low + high) / 2.0
         candidate = _xyz_from_oklab(
-            (polar.lightness, chroma * math.cos(hue), chroma * math.sin(hue))
+            (lightness, chroma * math.cos(hue), chroma * math.sin(hue))
         )
         if is_feasible(inverse, candidate):
             low = chroma
         else:
             high = chroma
-    return _xyz_from_oklab((polar.lightness, low * math.cos(hue), low * math.sin(hue)))
+    return _xyz_from_oklab((lightness, low * math.cos(hue), low * math.sin(hue)))
 
 
 def map_oklch_bisect_8(forward: Matrix3, inverse: Matrix3, xyz: Xyz) -> Xyz:

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -87,6 +87,28 @@ class TestColorGamutStudy(unittest.TestCase):
                 with self.subTest(candidate=name, target=target):
                     self.assertTrue(is_feasible(self.inverse, mapped))
 
+    def test_the_selected_algorithm_meets_the_a1_budget(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # The report selects eight halvings. If this stops holding, the
+        # recorded selection is no longer supported by anything.
+        score = score_candidate(
+            "oklch-bisect-8", self.forward, self.inverse, self.cases
+        )
+        self.assertLess(score.worst_delta_e, 0.5)
+
+    def test_bounded_search_beats_a_large_lookup_table(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # The selection rests on this comparison: eight halvings need no
+        # storage and still beat a 16 KB table, because a grid cannot
+        # represent the gamut boundary's corners at the primaries.
+        LARGEST_LUT_WORST_DELTA_E = 2.434  # 64 x 128 conservative, 16 KB
+        eight = score_candidate(
+            "oklch-bisect-8", self.forward, self.inverse, self.cases
+        )
+        self.assertLess(eight.worst_delta_e, LARGEST_LUT_WORST_DELTA_E)
+
     def test_feasibility_checks_both_bounds(
         self: "TestColorGamutStudy",
     ) -> None:

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -109,6 +109,63 @@ class TestColorGamutStudy(unittest.TestCase):
         )
         self.assertLess(eight.worst_delta_e, LARGEST_LUT_WORST_DELTA_E)
 
+    def test_over_bright_targets_are_mapped_into_the_hull(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # Chroma compression alone cannot rescue a target that is too bright:
+        # at zero chroma it is still outside, so a chroma-only mapper returns
+        # an infeasible result. The corpus contains no such target, which is
+        # why this needed constructing rather than finding.
+        white: Xyz = (
+            sum(self.forward.row0),
+            sum(self.forward.row1),
+            sum(self.forward.row2),
+        )
+        over_bright: Xyz = (white[0] * 1.5, white[1] * 1.5, white[2] * 1.5)
+        self.assertFalse(is_feasible(self.inverse, over_bright))
+        for name, mapper in CANDIDATES.items():
+            with self.subTest(candidate=name):
+                mapped = mapper(self.forward, self.inverse, over_bright)
+                self.assertTrue(is_feasible(self.inverse, mapped))
+
+    def test_feasible_chroma_is_one_interval_for_this_device(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        """Bisection assumes the feasible chroma ray is connected.
+
+        The reference does not assume that, so the assumption is checked here
+        rather than asserted in prose. A coarse sweep on every run; the dense
+        1.9M-sample sweep behind the report's claim is recorded there.
+        """
+
+        import math
+
+        from ci.color_reference import _xyz_from_oklab
+
+        for lightness_step in range(1, 10):
+            lightness = lightness_step / 10.0
+            for hue_degrees in range(0, 360, 30):
+                radians = math.radians(hue_degrees)
+                seen_infeasible = False
+                for chroma_step in range(0, 61):
+                    chroma = chroma_step * 0.5 / 60
+                    point = _xyz_from_oklab(
+                        (
+                            lightness,
+                            chroma * math.cos(radians),
+                            chroma * math.sin(radians),
+                        )
+                    )
+                    if is_feasible(self.inverse, point):
+                        with self.subTest(lightness=lightness, hue=hue_degrees):
+                            self.assertFalse(
+                                seen_infeasible,
+                                "feasible chroma is disconnected here; "
+                                "bisection would discard the far interval",
+                            )
+                    else:
+                        seen_infeasible = True
+
     def test_feasibility_checks_both_bounds(
         self: "TestColorGamutStudy",
     ) -> None:

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -30,7 +30,52 @@ relative colorimetry, profile white at full drive, dark surround.
 
 A1's budget is max ΔE2000 ≤ 0.5 at identity brightness.
 
+## Cost: how much search is actually needed
+
+The reference and the unbounded bisection both run to convergence, which no
+per-pixel path can afford. Two bounded options were measured over the same 20
+vectors.
+
+**Fixed iteration count**, no table:
+
+| halvings | worst ΔE2000 | mean ΔE2000 |
+| --- | --- | --- |
+| 2 | 10.149 | 3.166 |
+| 4 | 1.604 | 0.590 |
+| 6 | 0.623 | 0.214 |
+| **8** | **0.152** | **0.046** |
+| 10 | 0.030 | 0.010 |
+
+**LUT of maximum chroma over an (L, hue) grid**, two variants -- one
+interpolating and shrinking on infeasibility, one storing the per-cell
+minimum so a lookup never overshoots:
+
+| grid | table bytes (u16) | worst, shrink-on-miss | worst, conservative |
+| --- | --- | --- | --- |
+| 8 x 16 | 256 | 4.406 | 10.992 |
+| 16 x 32 | 1 024 | 4.373 | 7.631 |
+| 32 x 64 | 4 096 | 2.180 | 4.621 |
+| 64 x 128 | 16 384 | -- | 2.434 |
+
+## Selection: eight halvings, no table
+
+Eight halvings meet A1 with about a 3x margin and need **no table at all**.
+A 16 KB LUT scores 2.434, which is worse than *four* halvings -- so the
+"optionally LUT-backed" option in #4041 resolves to no for this budget.
+
+The reason is geometric: the OKLCh gamut boundary has sharp corners at the
+primaries, and a grid cannot represent a corner without enormous resolution.
+Refining along the ray costs nothing to store and lands on the corner
+directly.
+
+Eight halvings is also a *bounded* computation rather than an iterative
+solver in the A3/B11 sense. Its cost is fixed at compile time; it does not
+loop until a convergence criterion is met, which is the property that makes
+`nnls3` unacceptable per pixel.
+
 ## What this means
+
+
 
 **The objective is what matters; the search is not.** OKLCh chroma
 compression implemented as a plain 30-iteration bisection reproduces the

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -23,7 +23,7 @@ relative colorimetry, profile white at full drive, dark surround.
 
 | algorithm | worst ΔE2000 | mean ΔE2000 |
 | --- | --- | --- |
-| clip negative drives | 20.652 | 3.923 |
+| clip drives into [0, 1] | 20.652 | 3.923 |
 | max-normalize | 20.652 | 3.923 |
 | desaturate toward neutral | 14.893 | 2.101 |
 | **OKLCh chroma compression** | **0.000** | **0.000** |

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -95,6 +95,34 @@ So the embedded path must implement the OKLCh objective. That is the finding:
 the cheap options are not "slightly worse", they are not in the same range,
 and A1 cannot be met by clamping.
 
+## Is the feasible chroma ray actually connected?
+
+Bisection assumes it is. The reference does not, so the assumption was tested
+rather than argued: 4 680 rays (lightness on a 40-step grid, hue every 3
+degrees), each sampled at 401 chroma values -- about 1.9 million feasibility
+evaluations.
+
+**No disconnected interval was found.** On every ray sampled, the feasible
+chroma was a single interval starting at zero.
+
+That is strong evidence for this device, not a proof, and it says nothing
+about the >=4-emitter case where the zonotope gains a redundant generator. A
+coarser sweep runs on every test invocation so the assumption cannot rot
+silently.
+
+## Lightness must be clamped before chroma
+
+Chroma compression alone cannot rescue a target that is too *bright*: at zero
+chroma the point is still outside the hull, and a chroma-only bisection
+converges on an infeasible answer. Every mapper here clamps into the hull --
+the OKLCh ones by first reducing lightness to the attainable neutral, as the
+reference does, and the naive ones by bounding drives to [0, 1].
+
+The corpus contains no over-bright target, so this had to be constructed to
+be tested. That gap has now hidden two defects in this harness: this one and
+the missing upper-bound check in `is_feasible` fixed alongside it. Worth
+noting for whoever extends the corpus.
+
 ## The limit of this study
 
 Bisection assumes feasibility along the chroma ray is monotonic. The P5


### PR DESCRIPTION
Follow-on to #4179. That study established *which objective* the mapper must implement; this one answers *what a per-pixel path can afford*, which #4041 leaves open with "matrix + clamp/compress, **optionally LUT-backed** with measured error bounds".

Both options measured over the same 20 out-of-gamut vectors.

## Fixed halvings, no table

| halvings | worst ΔE2000 | mean ΔE2000 |
|---|---|---|
| 2 | 10.149 | 3.166 |
| 4 | 1.604 | 0.590 |
| 6 | 0.623 | 0.214 |
| **8** | **0.152** | **0.046** |
| 10 | 0.030 | 0.010 |

## LUT of maximum chroma over an (L, hue) grid

Two variants — interpolate and shrink when the lookup overshoots, or store the per-cell minimum so it never does:

| grid | table bytes | worst, shrink-on-miss | worst, conservative |
|---|---|---|---|
| 8 × 16 | 256 | 4.406 | 10.992 |
| 16 × 32 | 1 024 | 4.373 | 7.631 |
| 32 × 64 | 4 096 | 2.180 | 4.621 |
| 64 × 128 | 16 384 | — | 2.434 |

## The "optionally LUT-backed" question resolves to no

**Eight halvings meet A1 with roughly a 3× margin and need no table.** A 16 KB table scores 2.434 — worse than *four* halvings, for 16 KB of flash.

The reason is geometric: the OKLCh gamut boundary has **sharp corners at the primaries**, and a grid cannot represent a corner without enormous resolution. Refining along the ray costs nothing to store and lands on the corner directly.

## A distinction worth making explicit

A3/B11 bans iterative optimization per pixel, and eight halvings could be read as falling under that. It should not:

- **`nnls3`** loops until a convergence criterion is met — 500 iterations in the reference. Its cost is data-dependent and unbounded at compile time.
- **Eight halvings** is a fixed count. The cost is known statically; it is arithmetic, not a solver.

The structural guard from #4177 continues to enforce the real restriction — no `nnls3`, no cache-building entry points on the streaming path.

## What this does not cover

Still only the three-emitter device. RGBW/RGBWW have a redundant emitter, so the preimage is non-unique and the C3 allocation policy interacts with the mapping — that needs its own measurement once the ≥4-emitter solve exists, and the over-unity feasibility bound fixed on #4179 becomes load-bearing there.

## Verification

- `uv run pytest ci/tests/test_color_gamut_study.py` — 9 passed, 110 subtests
- `uv run ty check` — clean
- `bash lint` — clean

Tests pin the selection so it cannot silently stop being supported: the chosen algorithm stays under 0.5, and it beats the largest LUT measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an OKLCh gamut-mapping option using eight fixed bisection steps.
  - Improved handling of over-bright colors by clamping lightness and drive values to feasible ranges.

- **Bug Fixes**
  - Corrected gamut mapping to prevent infeasible results for targets exceeding device brightness limits.
  - Updated drive clamping to enforce the complete valid range.

- **Documentation**
  - Documented feasibility checks and the rationale for clamping lightness before chroma mapping.

- **Tests**
  - Added regression coverage for over-bright targets and feasible chroma intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->