### PR TITLE
fix(autoresearch): read RP HTTP responses to completion, not to a deadline (#4173)

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -759,6 +759,7 @@ void pollNetServer() {}
 #include "fl/net/wifi.h"
 #include "fl/stl/array.h"
 #include "fl/stl/cstdio.h"
+#include "fl/stl/cstdlib.h"  // fl::atol for Content-Length
 #include "fl/stl/cstring.h"
 #include "fl/stl/singleton.h"
 #include "fl/stl/unique_ptr.h"
@@ -871,16 +872,83 @@ fl::json runRpHttpRequestTest(const char* host_ip, uint16_t port,
         }
     }
     status_line[length] = '\0';
-    char response[256] = {};
-    size_t response_length = 0;
-    while (static_cast<int32_t>(millis() - deadline_ms) < 0 &&
-           (client.connected() || client.available())) {
-        while (client.available() && response_length + 1 < sizeof(response)) {
+
+    // Read one header line at a time, honouring the deadline. Returns false
+    // only when the deadline expires with the line unfinished.
+    auto read_header_line = [&](char* out, size_t out_size) -> bool {
+        size_t used = 0;
+        while (static_cast<int32_t>(millis() - deadline_ms) < 0) {
+            if (!client.available()) {
+                if (!client.connected()) {
+                    break;
+                }
+                FastLED.watchdog().feed();
+                delay(1);
+                continue;
+            }
             const int ch = client.read();
             if (ch < 0) {
                 break;
             }
-            response[response_length++] = static_cast<char>(ch);
+            if (ch == '\n') {
+                out[used] = '\0';
+                return true;
+            }
+            if (ch != '\r' && used + 1 < out_size) {
+                out[used++] = static_cast<char>(ch);
+            }
+        }
+        out[used] = '\0';
+        return false;
+    };
+
+    // Consume headers and capture Content-Length. Stopping on the body's
+    // declared length is what makes this terminate promptly: the request asks
+    // for `Connection: close`, but `client.connected()` does not go false
+    // quickly enough to end the read, so the old loop waited out its whole 2 s
+    // deadline on every request -- ~2.2 s x 12 requests = the 26.5 s measured
+    // in FastLED#4173, almost all of it idle.
+    long content_length = -1;
+    char header[128];
+    while (read_header_line(header, sizeof(header))) {
+        if (header[0] == '\0') {
+            break;  // blank line: headers done
+        }
+        if (content_length < 0 &&
+            fl::strncmp(header, "Content-Length:", 15) == 0) {
+            const char* value = header + 15;
+            while (*value == ' ') {
+                ++value;
+            }
+            content_length = fl::atol(value);
+        }
+    }
+
+    // Record the body only. It used to hold headers *and* body, so a response
+    // with long headers could push the fragment being asserted out of the
+    // 256-byte window entirely.
+    char response[256] = {};
+    size_t response_length = 0;
+    long body_read = 0;
+    while (static_cast<int32_t>(millis() - deadline_ms) < 0) {
+        if (content_length >= 0 && body_read >= content_length) {
+            break;  // complete -- do not wait on the connection state
+        }
+        if (client.available()) {
+            const int ch = client.read();
+            if (ch < 0) {
+                break;
+            }
+            ++body_read;
+            // Keep draining past the buffer so the socket is not abandoned
+            // mid-response; only the first 256 bytes are recorded.
+            if (response_length + 1 < sizeof(response)) {
+                response[response_length++] = static_cast<char>(ch);
+            }
+            continue;
+        }
+        if (!client.connected()) {
+            break;  // server closed and nothing buffered: body is done
         }
         FastLED.watchdog().feed();
         delay(1);


### PR DESCRIPTION
Addresses the root cause found in #4173. **Please do not merge on the timing improvement alone** — see Validation gap below.

## Root cause

`runRpHttpRequestTest` drained each response like this:

```cpp
const uint32_t deadline_ms = millis() + 2000;
while (millis() - deadline_ms < 0 && (client.connected() || client.available()))
```

It exits on the 2 s deadline or on the peer closing. The request *does* send `Connection: close`, but `client.connected()` does not go false promptly enough to end the read — so the loop waits out the remaining deadline on **every request, after the body has already arrived**.

`runNetClientTest` issues 12 requests. That is ~2.2 s each and the **26.57 s** measured on hardware, almost all of it idle. The caller allows `max_wait=30.0` and the peer cycle makes two such calls, so a healthy first cycle has ~3.4 s of headroom.

That reframes #4173: not a resource exhausting at exactly cycle 7, but an operation **marginal from cycle 1** that eventually loses a race it was always close to.

## Change

Stop on completeness rather than silence:

- parse headers, capture `Content-Length`, stop at the blank line
- read exactly that many body bytes, then break **without consulting connection state**
- keep the 2 s deadline as the ceiling for a server that never replies
- keep draining past the 256-byte buffer so the socket is not abandoned mid-response

It also separates headers from body. `response[256]` previously held **both**, so a response with long headers could push the asserted fragment out of the window entirely — a failure mode independent of timing, and a plausible source of flaky content checks.

## Measurements (RP2350W ↔ ESP32-C6 SoftAP)

| | per `runNetClientTest` | cycles fully passing |
| --- | --- | --- |
| before | 26.57 s | 1/1 measured |
| this change | 8.1 – 20.4 s | 6/9 |
| focused re-run | — | 3/3 at 12/12 sub-tests |

## Validation gap — the reason this is not "ready"

**I have not established the baseline pass rate.** My only pre-change data point is a single `ok=True` cycle, which says nothing about how the unmodified build scores over nine. So I cannot currently tell whether 6/9 is:

- equal correctness plus a ~2.3× speedup (worth landing), or
- flakiness I introduced (should be rejected)

The comparison run was cut short by host memory pressure mid-deploy, and the board's flashed build became indeterminate, so I stopped rather than report a number I could not stand behind. Note the harness itself fails at cycle 7, so the baseline may well be flaky too.

**What would settle it:** flash unmodified `master`, run the same 9-cycle probe, compare pass rates. If baseline is also ~6/9, this is a clean win.

For context, an earlier attempt of mine — stopping on 150 ms peer idle — was 2.8× faster with `ok=False` on 7 of 8 cycles. I reverted it. That is why correctness, not speed, is the bar here.

## Verification done

- `bash lint` — clean
- `rp2350w` builds; RPC smoke PASS on hardware
- Both boards healthy throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51
