### PR TITLE
feat(math): fixed-point cube root for the P7 gamut mapper (#4041)

### DIFF
--- a/ci/color_gamut_study.py
+++ b/ci/color_gamut_study.py
@@ -20,6 +20,7 @@ from typeguard import typechecked
 
 from ci.color_reference import (
     Matrix3,
+    Oklch,
     Xyz,
     _invert_3x3,
     _matvec,
@@ -201,6 +202,85 @@ def attainable_lightness(inverse: Matrix3, lightness: float) -> float:
         else:
             high = middle
     return low
+
+
+Q16_ONE = 65536
+
+
+@typechecked
+def integer_cube_root(value: int) -> int:
+    """Largest integer whose cube does not exceed `value`.
+
+    Mirrors `fl::icbrt64` in `src/fl/math/fixed_point/icbrt.h`, which is what
+    the embedded mapper calls. Modelled here so the accuracy claim behind that
+    implementation is measured rather than asserted.
+    """
+
+    if value < 0:
+        raise ValueError(f"cube root domain is non-negative, got {value}")
+    if value == 0:
+        return 0
+    root = 1 << ((value.bit_length() + 2) // 3)
+    while True:
+        lower = (2 * root + value // (root * root)) // 3
+        if lower >= root:
+            return root
+        root = lower
+
+
+@typechecked
+def cbrt_q16(value: float, ulp_error: int = 0) -> float:
+    """Signed cube root as the s16.16 path computes it.
+
+    For a Q16 raw `r` standing for r/2^16, the root `y` satisfies
+    (y/2^16)^3 = r/2^16, so y^3 = r * 2^32 -- the root is the integer cube
+    root of the raw value shifted left by 32. `ulp_error` perturbs the result
+    to measure how much accuracy the mapper actually needs.
+    """
+
+    sign = -1.0 if value < 0.0 else 1.0
+    raw = round(abs(value) * Q16_ONE)
+    root = integer_cube_root(raw << 32) + ulp_error
+    return sign * max(root, 0) / Q16_ONE
+
+
+_LMS_FROM_XYZ = (
+    (0.8190224432164319, 0.3619062562801221, -0.12887378261216414),
+    (0.0329836671980271, 0.9292868468965546, 0.03614466816999844),
+    (0.048177199566046255, 0.26423952494422764, 0.6335478258136937),
+)
+_OKLAB_FROM_LMS_ROOT = (
+    (0.2104542553, 0.7936177850, -0.0040720468),
+    (1.9779984951, -2.4285922050, 0.4505937099),
+    (0.0259040371, 0.7827717662, -0.8086757660),
+)
+
+
+@typechecked
+def oklch_q16(xyz: Xyz, ulp_error: int = 0) -> Oklch:
+    """(lightness, chroma, hue degrees) with every stage quantized to Q16.
+
+    The precision study previously reached OKLCh through float64 cube roots
+    even while quantizing everything around them, which measured the stages
+    on either side of the root and not the root itself. This closes that gap.
+    """
+
+    def quantize(value: float) -> float:
+        return round(value * Q16_ONE) / Q16_ONE
+
+    lms = [
+        quantize(sum(_LMS_FROM_XYZ[i][j] * xyz[j] for j in range(3))) for i in range(3)
+    ]
+    root = [quantize(cbrt_q16(value, ulp_error)) for value in lms]
+    lab = [
+        quantize(sum(_OKLAB_FROM_LMS_ROOT[i][j] * root[j] for j in range(3)))
+        for i in range(3)
+    ]
+    return Oklch(
+        lab[0],
+        math.hypot(lab[1], lab[2]),
+        math.degrees(math.atan2(lab[2], lab[1])) % 360.0,
+    )
 
 
 @typechecked

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -16,8 +16,11 @@ from ci.color_gamut_study import (
     CANDIDATES,
     D65_WHITE,
     attainable_lightness,
+    cbrt_q16,
     emitter_matrix,
+    integer_cube_root,
     is_feasible,
+    oklch_q16,
     score_candidate,
 )
 from ci.color_reference import Xyz, _invert_3x3, delta_e2000, xyz_to_lab
@@ -181,6 +184,131 @@ class TestColorGamutStudy(unittest.TestCase):
         # noticing, which is the regression this test exists to catch.
         S16_16_BASELINE = 0.152
         self.assertLess(worst, S16_16_BASELINE * 1.05)
+
+    def _map_with_fixed_point_root(
+        self: "TestColorGamutStudy", ulp_error: int
+    ) -> float:
+        """Worst dE2000 of the selected mapper, cube root included."""
+
+        import math
+
+        from ci.color_reference import _xyz_from_oklab
+
+        def quantize(value: float) -> float:
+            return round(value * 65536) / 65536
+
+        def quantized_point(lightness: float, a: float, b: float) -> Xyz:
+            point = _xyz_from_oklab((lightness, a, b))
+            return (quantize(point[0]), quantize(point[1]), quantize(point[2]))
+
+        def attainable_quantized(lightness: float) -> float:
+            if is_feasible(self.inverse, quantized_point(lightness, 0.0, 0.0)):
+                return quantize(lightness)
+            low, high = 0.0, lightness
+            for _ in range(30):
+                middle = quantize((low + high) / 2.0)
+                if is_feasible(self.inverse, quantized_point(middle, 0.0, 0.0)):
+                    low = middle
+                else:
+                    high = middle
+            return low
+
+        worst = 0.0
+        for target, reference in self.cases:
+            polar = oklch_q16(target, ulp_error)
+            lightness = attainable_quantized(polar.lightness)
+            hue = math.radians(polar.hue_degrees)
+            cosine, sine = quantize(math.cos(hue)), quantize(math.sin(hue))
+            low, high = 0.0, quantize(polar.chroma)
+            for _ in range(8):
+                trial_chroma = quantize((low + high) / 2.0)
+                trial = quantized_point(
+                    lightness,
+                    quantize(trial_chroma * cosine),
+                    quantize(trial_chroma * sine),
+                )
+                if is_feasible(self.inverse, trial):
+                    low = trial_chroma
+                else:
+                    high = trial_chroma
+            mapped = quantized_point(
+                lightness, quantize(low * cosine), quantize(low * sine)
+            )
+            self.assertTrue(is_feasible(self.inverse, mapped))
+            worst = max(
+                worst,
+                delta_e2000(
+                    xyz_to_lab(mapped, D65_WHITE), xyz_to_lab(reference, D65_WHITE)
+                ),
+            )
+        return worst
+
+    def test_integer_cube_root_is_exact(self: "TestColorGamutStudy") -> None:
+        # The defining property, not a float comparison: this models
+        # `fl::icbrt64`, and a model that inherited float's rounding would
+        # not be evidence about the integer implementation.
+        for value in [0, 1, 7, 8, 9, 26, 27, 28, 10**6, (1 << 63)]:
+            root = integer_cube_root(value)
+            self.assertLessEqual(root**3, value)
+            self.assertGreater((root + 1) ** 3, value)
+        self.assertEqual(integer_cube_root((1 << 64) - 1), 2642245)
+
+    def test_cbrt_q16_matches_the_real_cube_root(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        # Truncation toward zero, so the error is in [0, 1) ULP of Q16 --
+        # measured against the cube root of the *quantized* input, which is
+        # the only thing the fixed-point path is given. Comparing against the
+        # root of the real value instead folds in the input's own rounding,
+        # and near zero the cube root amplifies that sharply: at v = 0.01 the
+        # derivative is about 7, so half a ULP in turns into three and a half
+        # out. That is a property of the domain, not of this implementation.
+        for numerator in range(1, 400):
+            value = numerator / 97.0
+            quantized_input = round(value * 65536) / 65536
+            got = cbrt_q16(value)
+            want = quantized_input ** (1.0 / 3.0)
+            self.assertLessEqual(got, want)
+            self.assertGreater(got, want - 1.0 / 65536)
+        self.assertEqual(cbrt_q16(-8.0), -2.0)
+        self.assertEqual(cbrt_q16(27.0), 3.0)
+
+    def test_a_fixed_point_cube_root_does_not_degrade_the_mapper(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        """The claim `src/fl/math/fixed_point/icbrt.h` exists to support.
+
+        The earlier precision test quantized every stage *around* the cube
+        root while computing the root itself in float64 -- so it measured the
+        stages on either side of it. Driving the forward transform with the
+        integer root closes that gap.
+        """
+
+        S16_16_BASELINE = 0.152
+        self.assertLess(self._map_with_fixed_point_root(0), S16_16_BASELINE * 1.05)
+
+    def test_the_cube_root_accuracy_cliff_is_where_it_is_documented(
+        self: "TestColorGamutStudy",
+    ) -> None:
+        """Pins how much cube-root error the A1 budget can absorb.
+
+        This is what says the exact integer root is not merely sufficient but
+        has room to spare, and it keeps the door open for a cheaper
+        approximation: anything holding under ~64 ULP would also pass. Without
+        it, `icbrt.h`'s recorded table is an unverifiable comment.
+        """
+
+        A1_BUDGET = 0.5
+        for ulp_error in (64, -64):
+            with self.subTest(ulp_error=ulp_error):
+                self.assertLess(self._map_with_fixed_point_root(ulp_error), A1_BUDGET)
+        # And it is a real cliff, not an asymptote -- a root off by 1024 ULP
+        # blows the budget outright.
+        for ulp_error in (1024, -1024):
+            with self.subTest(ulp_error=ulp_error):
+                self.assertGreater(
+                    self._map_with_fixed_point_root(ulp_error), A1_BUDGET
+                )
 
     def test_over_bright_targets_are_mapped_into_the_hull(
         self: "TestColorGamutStudy",

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -9,6 +9,7 @@ by anything.
 from __future__ import annotations
 
 import json
+import math
 import unittest
 from pathlib import Path
 
@@ -23,7 +24,14 @@ from ci.color_gamut_study import (
     oklch_q16,
     score_candidate,
 )
-from ci.color_reference import Xyz, _invert_3x3, delta_e2000, xyz_to_lab
+from ci.color_reference import (
+    Xyz,
+    _invert_3x3,
+    _oklch_from_xyz,
+    _xyz_from_oklab,
+    delta_e2000,
+    xyz_to_lab,
+)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -130,10 +138,6 @@ class TestColorGamutStudy(unittest.TestCase):
         not survive.
         """
 
-        import math
-
-        from ci.color_reference import _oklch_from_xyz, _xyz_from_oklab
-
         def quantize(value: float) -> float:
             return round(value * 65536) / 65536
 
@@ -189,10 +193,6 @@ class TestColorGamutStudy(unittest.TestCase):
         self: "TestColorGamutStudy", ulp_error: int
     ) -> float:
         """Worst dE2000 of the selected mapper, cube root included."""
-
-        import math
-
-        from ci.color_reference import _xyz_from_oklab
 
         def quantize(value: float) -> float:
             return round(value * 65536) / 65536
@@ -338,10 +338,6 @@ class TestColorGamutStudy(unittest.TestCase):
         rather than asserted in prose. A coarse sweep on every run; the dense
         1.9M-sample sweep behind the report's claim is recorded there.
         """
-
-        import math
-
-        from ci.color_reference import _xyz_from_oklab
 
         for lightness_step in range(1, 10):
             lightness = lightness_step / 10.0

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -131,6 +131,42 @@ boundaries of a stage is not measuring that stage.
 s16.16 is what P6's stages already use, so the mapper needs no wider
 intermediate than the pipeline carries anyway.
 
+### The cube root was the last stage still running in float64
+
+The table above quantizes every value the mapper passes around, but it
+reached OKLCh through Python's own cube root. OKLab's forward transform
+needs three of those per pixel, and there was no fixed-point cube root in
+the tree to reach for -- so the study was, by its own standard above,
+measuring the stages on either side of the root rather than the root
+itself.
+
+`fl::icbrt64` (`src/fl/math/fixed_point/icbrt.h`) and `s16x16::cbrt` close
+that. The identity is the one `sqrt` already uses one power down: for a Q16
+raw `r`, the root satisfies `y^3 = r * 2^32`, so the root is an integer cube
+root of the raw value shifted left by 32 -- a 22-step bit-by-bit loop with
+no division and no float, exact to within one ULP.
+
+Re-scoring the mapper with that root in place, and then perturbing it to
+find out how much accuracy is actually required:
+
+| cube-root error | worst ΔE2000 |
+| --- | --- |
+| **exact** | **0.149** |
+| ± 64 ULP | 0.200 |
+| ± 256 ULP | 0.459 |
+| ± 1024 ULP | 1.717 |
+
+The exact root reproduces the recorded result, so the cube root costs the
+mapper nothing. A1's budget of 0.5 is not reached until roughly 256 ULP,
+which the exact root clears by more than two orders of magnitude.
+
+The perturbation is worth more than the reassurance. It says a *cheaper*
+root is still on the table -- anything holding under about 64 ULP would
+also pass -- so if 22 steps per root ever turns out to cost too much on an
+8-bit target, the budget for replacing it is known in advance rather than
+guessed at. Both ends are pinned by
+`ci/tests/test_color_gamut_study.py`.
+
 ## Is the feasible chroma ray actually connected?
 
 Bisection assumes it is. The reference does not, so the assumption was tested

--- a/src/fl/math/fixed_point/icbrt.h
+++ b/src/fl/math/fixed_point/icbrt.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Integer cube root for fixed-point types.
+// Bit-by-bit algorithm — no float, no division, no multiplication by a
+// non-constant.  Companion to isqrt.h; see that file for why the algorithm
+// is expressed as tail recursion (C++11 constexpr forbids loops) and why
+// FL_OPTIMIZE_FUNCTION is required to keep low optimization levels from
+// emitting a stack frame per iteration.
+//
+// The recurrence carries the running root `y` and its square `y2` so that
+// each step needs only shifts and adds:
+//
+//     y  <- 2y            y2 <- 4y2
+//     B  =  3(y2 + y) + 1
+//     if (x >> s) >= B  then  x -= B << s,  y += 1,  y2 += 2y + 1
+//
+// The comparison is written `(x >> s) >= B` rather than `x >= (B << s)`
+// because `B << s` overflows u64 on the first steps of a large input, while
+// the shifted-right form is exact for integers and never does.  `B << s` is
+// then only evaluated on the branch where it is known to be <= x.
+//
+// 22 steps (s = 63, 60, ... 0) cover the whole u64 domain; the result of
+// icbrt64 is therefore always below 2^22.
+
+#include "fl/stl/compiler_control.h" // FL_OPTIMIZE_FUNCTION
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+FL_OPTIMIZATION_LEVEL_O3_BEGIN
+
+namespace fl {
+
+FL_OPTIMIZE_FUNCTION constexpr inline u32 _icbrt64_step(u64 x, u64 y, u64 y2, int s) FL_NO_EXCEPT {
+    return s < 0
+        ? static_cast<u32>(y)
+        : ((x >> s) >= 3 * ((y2 << 2) + (y << 1)) + 1)
+            ? _icbrt64_step(x - ((3 * ((y2 << 2) + (y << 1)) + 1) << s),
+                            (y << 1) + 1,
+                            (y2 << 2) + (y << 2) + 1,
+                            s - 3)
+            : _icbrt64_step(x, y << 1, y2 << 2, s - 3);
+}
+
+// Largest u32 whose cube does not exceed x.
+FL_OPTIMIZE_FUNCTION constexpr inline u32 icbrt64(u64 x) FL_NO_EXCEPT {
+    return _icbrt64_step(x, 0, 0, 63);
+}
+
+} // namespace fl
+
+FL_OPTIMIZATION_LEVEL_O3_END

--- a/src/fl/math/fixed_point/s16x16.h
+++ b/src/fl/math/fixed_point/s16x16.h
@@ -5,6 +5,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/math/sin32.h"
+#include "fl/math/fixed_point/icbrt.h"
 #include "fl/math/fixed_point/isqrt.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/math/fixed_point/traits.h"
@@ -230,6 +231,24 @@ class s16x16 {
         return sqrt(x).mValue == 0
             ? s16x16()
             : from_raw(SCALE) / sqrt(x);
+    }
+
+    // Signed cube root, exact to within one ULP (it truncates toward zero).
+    //
+    // The identity is the same one `sqrt` uses one power down: for a Q16 raw
+    // value `r` representing r/2^16, the root `y` satisfies
+    // (y/2^16)^3 = r/2^16, i.e. y^3 = r * 2^32 -- so the root is the integer
+    // cube root of the raw value shifted left by 2*FRAC_BITS.
+    //
+    // The shift cannot overflow: the widest input, raw = INT32_MIN, gives
+    // 2^31 << 32 = 2^63, which is representable in u64, and the result
+    // 2^21 = 32.0 is well inside i32.
+    static constexpr FASTLED_FORCE_INLINE s16x16 cbrt(s16x16 x) FL_NO_EXCEPT {
+        return x.mValue < 0
+            ? from_raw(-static_cast<i32>(fl::icbrt64(
+                  static_cast<u64>(-static_cast<i64>(x.mValue)) << (2 * FRAC_BITS))))
+            : from_raw(static_cast<i32>(fl::icbrt64(
+                  static_cast<u64>(x.mValue) << (2 * FRAC_BITS))));
     }
 
     static FASTLED_FORCE_INLINE s16x16 pow(s16x16 base, s16x16 exp) FL_NO_EXCEPT {

--- a/tests/fl/math/fixed_point_misc.cpp
+++ b/tests/fl/math/fixed_point_misc.cpp
@@ -435,6 +435,125 @@ FL_TEST_CASE("pow boundary - far from 1.0 not snapped (#2969)") {
     FL_SUBCASE("u8x24  pow(2, 0.5)") { test_pow_above_one_unsigned_impl<u8x24>();  }
 }
 
+// =============================================================================
+// Integer and fixed-point cube root (#4041)
+// =============================================================================
+//
+// The P7 gamut mapper works in OKLab, whose forward transform needs three
+// cube roots per pixel. `docs/color-gamut-algorithm-selection.md` selects
+// eight OKLCh halvings in s16.16 and records the resulting worst error as
+// 0.152 dE2000 against an A1 budget of 0.5.
+//
+// How accurate the root has to be was measured against that budget by
+// perturbing it and re-scoring the mapper over the corpus's 20 out-of-gamut
+// vectors:
+//
+//     cube root error  |  worst dE2000
+//     ---------------- |  ------------
+//     exact            |     0.149
+//     +/-  64 ULP      |     0.200
+//     +/- 256 ULP      |     0.459   (A1's budget is 0.5 -- marginal)
+//     +/- 1024 ULP     |     1.717   (over budget)
+//
+// So ~256 ULP is the cliff and the implementation below, being exact to
+// within one ULP, clears it by more than two orders of magnitude. The point
+// of recording the curve is that a *cheaper* approximate root remains on the
+// table: anything holding under about 64 ULP would also do.
+
+FL_TEST_CASE("icbrt64 satisfies the defining property of a cube root") {
+    // y is the cube root of x exactly when y^3 <= x < (y+1)^3. Asserting the
+    // property rather than comparing against a reference means the test does
+    // not inherit a second implementation's bugs, and needs no float.
+    const fl::u64 kProbes[] = {
+        0u, 1u, 2u, 7u, 8u, 9u, 26u, 27u, 28u, 63u, 64u, 65u,
+        999u, 1000u, 1001u, 1000000u, 4294967296ull,
+        1ull << 32, 1ull << 48, 1ull << 62, 1ull << 63,
+        0xFFFFFFFFFFFFFFFFull,
+    };
+    for (fl::u64 x : kProbes) {
+        const fl::u64 y = fl::icbrt64(x);
+        FL_CHECK_LE(y * y * y, x);
+        // (y+1)^3 overflows u64 only past the largest root it can return.
+        if (y + 1 <= 2642245ull) {
+            FL_CHECK_GT((y + 1) * (y + 1) * (y + 1), x);
+        }
+    }
+}
+
+FL_TEST_CASE("icbrt64 is exact on perfect cubes and their neighbours") {
+    for (fl::u64 k = 1; k < 2000; ++k) {
+        const fl::u64 cube = k * k * k;
+        FL_CHECK_EQ(fl::icbrt64(cube), k);
+        FL_CHECK_EQ(fl::icbrt64(cube - 1), k - 1);
+        FL_CHECK_EQ(fl::icbrt64(cube + 1), k);
+    }
+    // The widest root the u64 domain can produce.
+    FL_CHECK_EQ(fl::icbrt64(0xFFFFFFFFFFFFFFFFull), 2642245u);
+}
+
+FL_TEST_CASE("s16x16 cbrt truncates toward zero, exactly") {
+    // Pins the identity the implementation rests on -- y^3 = raw * 2^32 --
+    // in integer arithmetic, so nothing here inherits float's rounding. This
+    // is what makes the error bound [0, 1) ULP rather than a tolerance.
+    for (int i = 1; i <= 4096; ++i) {
+        const fl::i32 raw = i * 524287;  // a stride coprime with 2, up to ~2^31
+        const fl::u64 x = static_cast<fl::u64>(raw) << 32;
+        const fl::u64 y = static_cast<fl::u64>(
+            fl::s16x16::cbrt(fl::s16x16::from_raw(raw)).raw());
+        FL_CHECK_LE(y * y * y, x);
+        FL_CHECK_GT((y + 1) * (y + 1) * (y + 1), x);
+    }
+}
+
+FL_TEST_CASE("s16x16 cbrt agrees with the float cube root") {
+    // A cross-check against an independent implementation. The slack is two
+    // ULPs rather than one because both sides carry error the fixed-point
+    // path does not: `s16x16(value)` truncates the input, and float32 `powf`
+    // is itself inexact near the top of the range. The exact bound is pinned
+    // in integer arithmetic by the test above.
+    for (int i = 1; i <= 4096; ++i) {
+        // 32767, not 32768: s16x16 tops out just below 2^15, and
+        // `s16x16(32768.0f)` overflows its i32 raw to INT32_MIN -- which
+        // this loop found the first time it ran to the endpoint.
+        const float value = static_cast<float>(i) * (32767.0f / 4096.0f);
+        const fl::s16x16 root = fl::s16x16::cbrt(fl::s16x16(value));
+        const float want = fl::powf(value, 1.0f / 3.0f);
+        FL_CHECK_LT(fl::fabsf(root.to_float() - want), 2.0f / 65536.0f);
+    }
+}
+
+FL_TEST_CASE("s16x16 cbrt is exact where the root is representable") {
+    FL_CHECK_EQ(fl::s16x16::cbrt(fl::s16x16(0.0f)).raw(), 0);
+    FL_CHECK_EQ(fl::s16x16::cbrt(fl::s16x16(1.0f)).raw(), fl::s16x16(1.0f).raw());
+    FL_CHECK_EQ(fl::s16x16::cbrt(fl::s16x16(8.0f)).raw(), fl::s16x16(2.0f).raw());
+    FL_CHECK_EQ(fl::s16x16::cbrt(fl::s16x16(27.0f)).raw(), fl::s16x16(3.0f).raw());
+    FL_CHECK_EQ(fl::s16x16::cbrt(fl::s16x16(-8.0f)).raw(), fl::s16x16(-2.0f).raw());
+}
+
+FL_TEST_CASE("s16x16 cbrt is odd, and its widest input does not overflow") {
+    for (int i = 1; i <= 512; ++i) {
+        const fl::s16x16 x = fl::s16x16::from_raw(i * 65536);
+        FL_CHECK_EQ(fl::s16x16::cbrt(-x).raw(), -fl::s16x16::cbrt(x).raw());
+    }
+    // INT32_MIN is the one input whose magnitude is not representable as a
+    // positive i32; negating it in 32 bits would be UB. The shift it feeds
+    // reaches exactly 2^63, the largest value the u64 domain accepts.
+    const fl::s16x16 widest = fl::s16x16::from_raw(-2147483647 - 1);
+    FL_CHECK_EQ(fl::s16x16::cbrt(widest).raw(), fl::s16x16(-32.0f).raw());
+}
+
+FL_TEST_CASE("icbrt64 and s16x16 cbrt are usable in constant expressions") {
+    // C++11 constexpr forbids loops, so both are written as tail recursion.
+    // A change that quietly makes either non-constexpr would still compile
+    // and still pass every runtime check above.
+    FL_STATIC_ASSERT(fl::icbrt64(27) == 3, "icbrt64 must be constexpr");
+    FL_STATIC_ASSERT(fl::icbrt64(0xFFFFFFFFFFFFFFFFull) == 2642245u,
+                     "icbrt64 must be constexpr across the whole domain");
+    FL_STATIC_ASSERT(fl::s16x16::cbrt(fl::s16x16::from_raw(8 * 65536)).raw() ==
+                         2 * 65536,
+                     "s16x16::cbrt must be constexpr");
+}
+
 } // anonymous namespace
 
 } // FL_TEST_FILE


### PR DESCRIPTION
The gamut mapper selected in `docs/color-gamut-algorithm-selection.md` works in OKLab, whose forward transform needs three cube roots per pixel. `s16x16` has `sqrt` but no `cbrt`, and the only cube root in the tree was `signedCubeRoot` in `colorutils.cpp.hpp` — float. This is the missing primitive.

## What it adds

`fl::icbrt64`, alongside `isqrt64`: a 22-step bit-by-bit integer cube root — no division, no multiplication by a non-constant, no float — written as tail recursion for the same C++11-constexpr reason `isqrt` is.

`s16x16::cbrt` builds on it through the identity `sqrt` already uses one power down: for a Q16 raw `r`, the root satisfies `y^3 = r * 2^32`, so it is the integer cube root of the raw shifted left by `2 * FRAC_BITS`.

One detail worth flagging for review: the comparison is `(x >> s) >= B`, not `x >= (B << s)`. The latter overflows u64 on the first steps of a large input. The shifted-right form is exact for integers, and `B << s` is then only evaluated on the branch where it is known to be `<= x`.

## The accuracy requirement was measured, not assumed

The precision table in the P7 report quantizes every value the mapper passes around — but it reached OKLCh through float64 cube roots. By that document's own standard ("a measurement that quantizes only the boundaries of a stage is not measuring that stage") it was measuring the stages on either side of the root rather than the root.

Re-scoring the corpus's 20 out-of-gamut vectors with the integer root in place, then perturbing it to find how much accuracy is actually needed:

| cube-root error | worst ΔE2000 |
| --- | --- |
| **exact** | **0.149** |
| ± 64 ULP | 0.200 |
| ± 256 ULP | 0.459 |
| ± 1024 ULP | 1.717 |

A1's budget is 0.5. The exact root reproduces the recorded 0.152, so the cube root costs the mapper nothing, and it clears the cliff by more than two orders of magnitude.

The perturbation is the more useful half. It says a *cheaper* approximate root is still on the table — anything holding under about 64 ULP would also pass — so if 22 steps per root ever proves too expensive on an 8-bit target, the replacement budget is known in advance rather than guessed at.

## Tests

Both ends are pinned rather than left as comments.

- `tests/fl/math/fixed_point_misc.cpp` asserts the *defining* property, `y^3 <= x < (y+1)^3`, in integer arithmetic — so it inherits no reference implementation's rounding and needs no float. Plus perfect cubes and neighbours, oddness, the `INT32_MIN` input (the one whose magnitude is not representable as a positive `i32`), and `FL_STATIC_ASSERT`s that both stay usable in constant expressions, since a change making them non-constexpr would still pass every runtime check.
- `ci/tests/test_color_gamut_study.py` pins the mapper scores at both ends of the table, so the numbers above stay checkable.

Two things the tests caught while being written, both mine: the float cross-check ran to exactly `32768.0`, which overflows `s16x16`'s float constructor to `INT32_MIN`; and the Python model's 1-ULP bound compared against the cube root of the *unquantized* input, which near zero is wrong by several ULP because the cube root amplifies input error (derivative ≈ 7 at v = 0.01).

Part of #4034 / #4041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added integer and fixed-point cube-root support for color calculations.
  - Added quantized OKLCh computation to improve gamut-mapping precision and consistency.

- **Documentation**
  - Documented fixed-point cube-root accuracy, color-mapping impact, and supported error budgets.

- **Tests**
  - Added comprehensive coverage for cube-root accuracy, negative values, edge cases, constexpr behavior, and color-mapping regression limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->