### PR TITLE
docs(color): white-preferred allocation needs no search for one white (#4041)

### DIFF
--- a/ci/color_rgbw_study.py
+++ b/ci/color_rgbw_study.py
@@ -1,0 +1,172 @@
+"""White-preferred allocation for devices with a white emitter (C3, #4041).
+
+`docs/color-gamut-algorithm-selection.md` covers only the three-emitter
+device. A white emitter makes the emitter matrix wide: the preimage of a
+target is no longer unique, and C3 asks for the white-preferred one -- as
+much light from the white emitter as the target allows, since it is the
+efficient one and usually the one with the best colour rendering.
+
+The P5 reference finds that by enumerating vertices: every way of choosing
+three free emitters and pinning the rest to 0 or 1, solved and filtered.
+That is bounded but not small, and A3/B11 forbid anything resembling a
+search on the per-pixel path.
+
+This harness asks whether the enumeration is necessary. For one white
+emitter it is not -- see `allocate_one_white`. For two it is; the reduction
+that looks like it should work is measured failing here rather than left for
+someone to try.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from ci.color_reference import Matrix3, Xyz, _invert_3x3, _matvec
+
+
+# Slack on the drive bounds. The allocation is compared against a float64
+# reference, so this only has to absorb float64 rounding.
+DRIVE_TOLERANCE = 1e-9
+
+
+def emitter_column(x: float, y: float) -> Xyz:
+    """An emitter's XYZ at unit luminance, from its chromaticity."""
+
+    return (x / y, 1.0, (1.0 - x - y) / y)
+
+
+def rgb_matrix(columns: list[Xyz]) -> Matrix3:
+    """The 3x3 matrix whose columns are the three RGB emitters."""
+
+    return Matrix3(
+        row0=(columns[0][0], columns[1][0], columns[2][0]),
+        row1=(columns[0][1], columns[1][1], columns[2][1]),
+        row2=(columns[0][2], columns[1][2], columns[2][2]),
+    )
+
+
+def white_level_range(
+    inverse: Matrix3, target: Xyz, white: Xyz
+) -> tuple[float, float] | None:
+    """The interval of white drives that keeps the RGB drives in [0, 1].
+
+    This is the whole trick. With the white emitter at drive w, the RGB
+    drives that make up the difference are
+
+        d(w) = M^-1 . target  -  w * (M^-1 . white)
+
+    which is *affine in w*. So each of the six bounds on the three RGB
+    drives is a single inequality in w, and the feasible set is one
+    interval -- computed directly, with no search over vertices.
+
+    None when the intersection is empty, which means no white level lets the
+    RGB emitters cover the remainder: the target is outside the hull.
+    """
+
+    at_zero = _matvec(inverse, target)
+    per_white = _matvec(inverse, white)
+    low, high = 0.0, 1.0
+    for index in range(3):
+        slope = per_white[index]
+        if slope > 1e-15:
+            high = min(high, at_zero[index] / slope)
+            low = max(low, (at_zero[index] - 1.0) / slope)
+        elif slope < -1e-15:
+            low = max(low, at_zero[index] / slope)
+            high = min(high, (at_zero[index] - 1.0) / slope)
+        elif (
+            at_zero[index] < -DRIVE_TOLERANCE or at_zero[index] > 1.0 + DRIVE_TOLERANCE
+        ):
+            # White cannot move this drive at all, and it is already out.
+            return None
+    if low > high + 1e-12:
+        return None
+    return low, high
+
+
+def allocate_one_white(
+    inverse: Matrix3, target: Xyz, white: Xyz
+) -> tuple[float, float, float, float] | None:
+    """White-preferred drives for an RGB + one white device.
+
+    Returns (r, g, b, w), or None when the target is outside the hull.
+
+    White-preferred means the top of the interval above, so this is closed
+    form: one matrix multiply for the target, one for the white column (which
+    a real implementation would precompute at bind time), then six compares.
+    """
+
+    span = white_level_range(inverse, target, white)
+    if span is None:
+        return None
+    level = span[1]
+    at_zero = _matvec(inverse, target)
+    per_white = _matvec(inverse, white)
+    drives = [at_zero[i] - level * per_white[i] for i in range(3)]
+    if any(d < -DRIVE_TOLERANCE or d > 1.0 + DRIVE_TOLERANCE for d in drives):
+        return None
+    clamped = [min(max(d, 0.0), 1.0) for d in drives]
+    return (clamped[0], clamped[1], clamped[2], level)
+
+
+def most_white_two(
+    inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
+) -> tuple[float, float] | None:
+    """Largest total white for two white emitters, by exact 2D enumeration.
+
+    With two whites the problem stops being one-dimensional: maximizing
+    w1 + w2 subject to the RGB drives staying in [0, 1] is a linear program
+    over a polygon. This solves it the slow, certain way -- every pair of
+    constraints intersected, infeasible points discarded -- so that cheaper
+    candidates have something to be wrong against.
+    """
+
+    at_zero = _matvec(inverse, target)
+    from_first = _matvec(inverse, first)
+    from_second = _matvec(inverse, second)
+    # Each constraint is a*w1 + b*w2 <= c.
+    constraints: list[tuple[float, float, float]] = []
+    for index in range(3):
+        constraints.append((from_first[index], from_second[index], at_zero[index]))
+        constraints.append(
+            (-from_first[index], -from_second[index], 1.0 - at_zero[index])
+        )
+    constraints.extend(
+        [(-1.0, 0.0, 0.0), (1.0, 0.0, 1.0), (0.0, -1.0, 0.0), (0.0, 1.0, 1.0)]
+    )
+
+    def inside(w1: float, w2: float) -> bool:
+        return all(a * w1 + b * w2 <= c + 1e-7 for a, b, c in constraints)
+
+    best: tuple[float, float] | None = None
+    for (a1, b1, c1), (a2, b2, c2) in itertools.combinations(constraints, 2):
+        determinant = a1 * b2 - a2 * b1
+        if abs(determinant) < 1e-12:
+            continue
+        w1 = (c1 * b2 - c2 * b1) / determinant
+        w2 = (a1 * c2 - a2 * c1) / determinant
+        if not inside(w1, w2):
+            continue
+        if best is None or w1 + w2 > best[0] + best[1] + 1e-12:
+            best = (w1, w2)
+    return best
+
+
+def best_single_white(
+    inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
+) -> float | None:
+    """Most white obtainable while using only one of the two white emitters.
+
+    The tempting reduction: run the one-white closed form twice and keep the
+    better answer. `ci/tests/test_color_rgbw_study.py` measures how badly
+    this loses, and why.
+    """
+
+    levels = []
+    for white in (first, second):
+        span = white_level_range(inverse, target, white)
+        if span is not None:
+            levels.append(span[1])
+    if not levels:
+        return None
+    return max(levels)

--- a/ci/color_rgbw_study.py
+++ b/ci/color_rgbw_study.py
@@ -20,8 +20,39 @@ someone to try.
 from __future__ import annotations
 
 import itertools
+from dataclasses import dataclass
 
-from ci.color_reference import Matrix3, Xyz, _invert_3x3, _matvec
+from ci.color_reference import Matrix3, Xyz, _matvec
+
+
+@dataclass(frozen=True, slots=True)
+class WhiteLevelRange:
+    """The white drives that keep every RGB drive inside [0, 1]."""
+
+    lowest: float
+    highest: float
+
+
+@dataclass(frozen=True, slots=True)
+class WhitePreferredDrives:
+    """One device's drives under the C3 white-preferred policy."""
+
+    red: float
+    green: float
+    blue: float
+    white: float
+
+
+@dataclass(frozen=True, slots=True)
+class TwoWhiteLevels:
+    """Drives for a pair of white emitters."""
+
+    first: float
+    second: float
+
+    @property
+    def total(self: "TwoWhiteLevels") -> float:
+        return self.first + self.second
 
 
 # Slack on the drive bounds. The allocation is compared against a float64
@@ -47,7 +78,7 @@ def rgb_matrix(columns: list[Xyz]) -> Matrix3:
 
 def white_level_range(
     inverse: Matrix3, target: Xyz, white: Xyz
-) -> tuple[float, float] | None:
+) -> WhiteLevelRange | None:
     """The interval of white drives that keeps the RGB drives in [0, 1].
 
     This is the whole trick. With the white emitter at drive w, the RGB
@@ -81,15 +112,15 @@ def white_level_range(
             return None
     if low > high + 1e-12:
         return None
-    return low, high
+    return WhiteLevelRange(low, high)
 
 
 def allocate_one_white(
     inverse: Matrix3, target: Xyz, white: Xyz
-) -> tuple[float, float, float, float] | None:
+) -> WhitePreferredDrives | None:
     """White-preferred drives for an RGB + one white device.
 
-    Returns (r, g, b, w), or None when the target is outside the hull.
+    None when the target is outside the hull.
 
     White-preferred means the top of the interval above, so this is closed
     form: one matrix multiply for the target, one for the white column (which
@@ -99,19 +130,21 @@ def allocate_one_white(
     span = white_level_range(inverse, target, white)
     if span is None:
         return None
-    level = span[1]
+    level = span.highest
     at_zero = _matvec(inverse, target)
     per_white = _matvec(inverse, white)
-    drives = [at_zero[i] - level * per_white[i] for i in range(3)]
-    if any(d < -DRIVE_TOLERANCE or d > 1.0 + DRIVE_TOLERANCE for d in drives):
-        return None
-    clamped = [min(max(d, 0.0), 1.0) for d in drives]
-    return (clamped[0], clamped[1], clamped[2], level)
+    clamped: list[float] = []
+    for index in range(3):
+        drive = at_zero[index] - level * per_white[index]
+        if drive < -DRIVE_TOLERANCE or drive > 1.0 + DRIVE_TOLERANCE:
+            return None
+        clamped.append(min(max(drive, 0.0), 1.0))
+    return WhitePreferredDrives(clamped[0], clamped[1], clamped[2], level)
 
 
 def most_white_two(
     inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
-) -> tuple[float, float] | None:
+) -> TwoWhiteLevels | None:
     """Largest total white for two white emitters, by exact 2D enumeration.
 
     With two whites the problem stops being one-dimensional: maximizing
@@ -138,7 +171,7 @@ def most_white_two(
     def inside(w1: float, w2: float) -> bool:
         return all(a * w1 + b * w2 <= c + 1e-7 for a, b, c in constraints)
 
-    best: tuple[float, float] | None = None
+    best: TwoWhiteLevels | None = None
     for (a1, b1, c1), (a2, b2, c2) in itertools.combinations(constraints, 2):
         determinant = a1 * b2 - a2 * b1
         if abs(determinant) < 1e-12:
@@ -147,8 +180,8 @@ def most_white_two(
         w2 = (a1 * c2 - a2 * c1) / determinant
         if not inside(w1, w2):
             continue
-        if best is None or w1 + w2 > best[0] + best[1] + 1e-12:
-            best = (w1, w2)
+        if best is None or w1 + w2 > best.total + 1e-12:
+            best = TwoWhiteLevels(w1, w2)
     return best
 
 
@@ -162,11 +195,11 @@ def best_single_white(
     this loses, and why.
     """
 
-    levels = []
+    best: float | None = None
     for white in (first, second):
         span = white_level_range(inverse, target, white)
-        if span is not None:
-            levels.append(span[1])
-    if not levels:
-        return None
-    return max(levels)
+        if span is None:
+            continue
+        if best is None or span.highest > best:
+            best = span.highest
+    return best

--- a/ci/tests/test_color_rgbw_study.py
+++ b/ci/tests/test_color_rgbw_study.py
@@ -1,0 +1,180 @@
+"""The white-preferred allocation must keep agreeing with the P5 reference.
+
+`docs/color-gamut-algorithm-selection.md` records that one white emitter
+needs no vertex enumeration and that two do. Both halves are measured here,
+so neither can quietly stop being true.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import unittest
+from pathlib import Path
+
+from ci.color_reference import _invert_3x3
+from ci.color_rgbw_study import (
+    allocate_one_white,
+    best_single_white,
+    emitter_column,
+    most_white_two,
+    rgb_matrix,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+GOLDEN = PROJECT_ROOT / "ci" / "golden" / "color-reference-v1.json"
+
+RGB_COLUMNS = [
+    emitter_column(0.6400, 0.3300),
+    emitter_column(0.3000, 0.6000),
+    emitter_column(0.1500, 0.0600),
+]
+D65_WHITE_COLUMN = emitter_column(0.3127, 0.3290)
+D50_WHITE_COLUMN = emitter_column(0.3457, 0.3585)
+
+
+def corpus_vectors(profile: str) -> list[tuple[tuple[float, ...], list[float]]]:
+    corpus = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    out = []
+    for vector in corpus["vectors"]:
+        if vector["device_profile"] != profile:
+            continue
+        stages = vector["stages"]
+        mapped = stages["mapped_xyz"]
+        out.append(((mapped[0], mapped[1], mapped[2]), stages["emitter_light"]))
+    return out
+
+
+class TestOneWhiteIsClosedForm(unittest.TestCase):
+    def setUp(self: "TestOneWhiteIsClosedForm") -> None:
+        self.inverse = _invert_3x3(rgb_matrix(RGB_COLUMNS))
+
+    def test_the_corpus_has_rgbw_vectors(self: "TestOneWhiteIsClosedForm") -> None:
+        # Without this the agreement tests below could pass on an empty set.
+        self.assertGreaterEqual(len(corpus_vectors("rgbw")), 40)
+        self.assertGreaterEqual(len(corpus_vectors("non_d65_white")), 40)
+
+    def test_it_reproduces_the_reference_on_rgbw(
+        self: "TestOneWhiteIsClosedForm",
+    ) -> None:
+        """The claim the C++ allocation will rest on.
+
+        The reference reaches these drives by enumerating vertices. If the
+        closed form agrees to float64 rounding across the corpus, the
+        per-pixel path does not need the enumeration.
+        """
+
+        worst = 0.0
+        for target, reference in corpus_vectors("rgbw"):
+            drives = allocate_one_white(self.inverse, target, D65_WHITE_COLUMN)
+            self.assertIsNotNone(drives, msg=f"no allocation for {target}")
+            assert drives is not None
+            for got, want in zip(drives, reference):
+                worst = max(worst, abs(got - want))
+        self.assertLess(worst, 1e-12)
+
+    def test_it_reproduces_the_reference_with_an_off_axis_white(
+        self: "TestOneWhiteIsClosedForm",
+    ) -> None:
+        # `non_d65_white` puts the white emitter at D50 and renders to D50.
+        # Nothing in the derivation assumed the white sat on the neutral
+        # axis, and this is what says so.
+        worst = 0.0
+        for target, reference in corpus_vectors("non_d65_white"):
+            drives = allocate_one_white(self.inverse, target, D50_WHITE_COLUMN)
+            self.assertIsNotNone(drives)
+            assert drives is not None
+            for got, want in zip(drives, reference):
+                worst = max(worst, abs(got - want))
+        self.assertLess(worst, 1e-12)
+
+    def test_the_white_level_is_maximal(self: "TestOneWhiteIsClosedForm") -> None:
+        # White-*preferred* is the policy, so pushing the white any higher
+        # has to break the RGB drives. Checked directly rather than trusted.
+        from ci.color_reference import _matvec
+
+        per_white = _matvec(self.inverse, D65_WHITE_COLUMN)
+        at_least_one_capped = 0
+        for target, _ in corpus_vectors("rgbw"):
+            drives = allocate_one_white(self.inverse, target, D65_WHITE_COLUMN)
+            assert drives is not None
+            if drives[3] >= 1.0 - 1e-12:
+                at_least_one_capped += 1
+                continue
+            nudged = drives[3] + 1e-6
+            at_zero = _matvec(self.inverse, target)
+            rgb = [at_zero[i] - nudged * per_white[i] for i in range(3)]
+            self.assertTrue(
+                any(v < -1e-9 or v > 1.0 + 1e-9 for v in rgb),
+                msg=f"white could have gone higher for {target}",
+            )
+        # And the sweep must not have been all saturated emitters.
+        self.assertLess(at_least_one_capped, len(corpus_vectors("rgbw")))
+
+
+class TestTwoWhitesNeedMoreThanOne(unittest.TestCase):
+    def setUp(self: "TestTwoWhitesNeedMoreThanOne") -> None:
+        self.inverse = _invert_3x3(rgb_matrix(RGB_COLUMNS))
+
+    def test_the_corpus_never_lights_both_whites(
+        self: "TestTwoWhitesNeedMoreThanOne",
+    ) -> None:
+        """Why the corpus cannot settle the two-white question.
+
+        Every `rgbww` vector the reference solves uses at most one of the two
+        white emitters. Agreement with a one-white-at-a-time reduction over
+        this corpus therefore says nothing at all, which is the trap the test
+        below exists to keep open.
+        """
+
+        both = 0
+        for _, reference in corpus_vectors("rgbww"):
+            if reference[3] > 1e-12 and reference[4] > 1e-12:
+                both += 1
+        self.assertEqual(both, 0)
+
+    def test_using_only_one_white_loses_badly(
+        self: "TestTwoWhitesNeedMoreThanOne",
+    ) -> None:
+        """The reduction that looks right, measured being wrong.
+
+        Running the one-white closed form for each white and keeping the
+        better answer agrees with the reference on every corpus vector -- and
+        is wrong on most reachable targets. The reason is not subtle once
+        seen: a single emitter's drive is capped at 1, so any target needing
+        more white than one emitter can supply must use both.
+        """
+
+        random.seed(11)
+        columns = RGB_COLUMNS + [D65_WHITE_COLUMN, D50_WHITE_COLUMN]
+        checked = 0
+        mixing_wins = 0
+        worst_gap = 0.0
+        for _ in range(2000):
+            drives = [random.random() for _ in range(5)]
+            target = tuple(
+                sum(columns[e][i] * drives[e] for e in range(5)) for i in range(3)
+            )
+            single = best_single_white(
+                self.inverse, target, D65_WHITE_COLUMN, D50_WHITE_COLUMN
+            )
+            pair = most_white_two(
+                self.inverse, target, D65_WHITE_COLUMN, D50_WHITE_COLUMN
+            )
+            if single is None or pair is None:
+                continue
+            checked += 1
+            gap = (pair[0] + pair[1]) - single
+            if gap > 1e-7:
+                mixing_wins += 1
+                worst_gap = max(worst_gap, gap)
+        self.assertGreater(checked, 1000)
+        # Not a rare corner: it is the common case away from the corpus.
+        self.assertGreater(mixing_wins, checked // 2)
+        # And the shortfall reaches a full emitter's worth of light.
+        self.assertGreater(worst_gap, 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_color_rgbw_study.py
+++ b/ci/tests/test_color_rgbw_study.py
@@ -42,6 +42,27 @@ class CorpusVector:
     target: Xyz
     emitter_light: list[float]
 
+    def __post_init__(self: "CorpusVector") -> None:
+        """Check the shape the tests index into.
+
+        These fields come straight out of `json.loads`, so nothing has
+        checked them. `@typechecked` would not help: typeguard decorates the
+        class before `@dataclass` generates `__init__`, so the generated
+        initializer is never instrumented and the decorator validates
+        nothing here.
+
+        The tests read `emitter_light[3]` and `[4]` directly. Without this a
+        corpus whose shape changed would surface as an IndexError inside an
+        assertion loop rather than as a statement about the corpus.
+        """
+
+        if len(self.target) != 3:
+            raise ValueError(f"target must be XYZ, got {self.target!r}")
+        if len(self.emitter_light) < 3:
+            raise ValueError(
+                f"expected at least three emitter drives, got {self.emitter_light!r}"
+            )
+
 
 def corpus_vectors(profile: str) -> list[CorpusVector]:
     corpus = json.loads(GOLDEN.read_text(encoding="utf-8"))

--- a/ci/tests/test_color_rgbw_study.py
+++ b/ci/tests/test_color_rgbw_study.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import json
 import random
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 
-from ci.color_reference import _invert_3x3
+from ci.color_reference import Xyz, _invert_3x3, _matvec
 from ci.color_rgbw_study import (
     allocate_one_white,
     best_single_white,
@@ -34,15 +35,25 @@ D65_WHITE_COLUMN = emitter_column(0.3127, 0.3290)
 D50_WHITE_COLUMN = emitter_column(0.3457, 0.3585)
 
 
-def corpus_vectors(profile: str) -> list[tuple[tuple[float, ...], list[float]]]:
+@dataclass(frozen=True, slots=True)
+class CorpusVector:
+    """One reference vector: the target, and the drives the reference chose."""
+
+    target: Xyz
+    emitter_light: list[float]
+
+
+def corpus_vectors(profile: str) -> list[CorpusVector]:
     corpus = json.loads(GOLDEN.read_text(encoding="utf-8"))
-    out = []
+    out: list[CorpusVector] = []
     for vector in corpus["vectors"]:
         if vector["device_profile"] != profile:
             continue
         stages = vector["stages"]
         mapped = stages["mapped_xyz"]
-        out.append(((mapped[0], mapped[1], mapped[2]), stages["emitter_light"]))
+        out.append(
+            CorpusVector((mapped[0], mapped[1], mapped[2]), stages["emitter_light"])
+        )
     return out
 
 
@@ -66,12 +77,13 @@ class TestOneWhiteIsClosedForm(unittest.TestCase):
         """
 
         worst = 0.0
-        for target, reference in corpus_vectors("rgbw"):
-            drives = allocate_one_white(self.inverse, target, D65_WHITE_COLUMN)
-            self.assertIsNotNone(drives, msg=f"no allocation for {target}")
+        for vector in corpus_vectors("rgbw"):
+            drives = allocate_one_white(self.inverse, vector.target, D65_WHITE_COLUMN)
+            self.assertIsNotNone(drives, msg=f"no allocation for {vector.target}")
             assert drives is not None
-            for got, want in zip(drives, reference):
-                worst = max(worst, abs(got - want))
+            got = (drives.red, drives.green, drives.blue, drives.white)
+            for actual, want in zip(got, vector.emitter_light):
+                worst = max(worst, abs(actual - want))
         self.assertLess(worst, 1e-12)
 
     def test_it_reproduces_the_reference_with_an_off_axis_white(
@@ -81,33 +93,35 @@ class TestOneWhiteIsClosedForm(unittest.TestCase):
         # Nothing in the derivation assumed the white sat on the neutral
         # axis, and this is what says so.
         worst = 0.0
-        for target, reference in corpus_vectors("non_d65_white"):
-            drives = allocate_one_white(self.inverse, target, D50_WHITE_COLUMN)
+        for vector in corpus_vectors("non_d65_white"):
+            drives = allocate_one_white(self.inverse, vector.target, D50_WHITE_COLUMN)
             self.assertIsNotNone(drives)
             assert drives is not None
-            for got, want in zip(drives, reference):
-                worst = max(worst, abs(got - want))
+            got = (drives.red, drives.green, drives.blue, drives.white)
+            for actual, want in zip(got, vector.emitter_light):
+                worst = max(worst, abs(actual - want))
         self.assertLess(worst, 1e-12)
 
     def test_the_white_level_is_maximal(self: "TestOneWhiteIsClosedForm") -> None:
         # White-*preferred* is the policy, so pushing the white any higher
         # has to break the RGB drives. Checked directly rather than trusted.
-        from ci.color_reference import _matvec
-
         per_white = _matvec(self.inverse, D65_WHITE_COLUMN)
         at_least_one_capped = 0
-        for target, _ in corpus_vectors("rgbw"):
-            drives = allocate_one_white(self.inverse, target, D65_WHITE_COLUMN)
+        for vector in corpus_vectors("rgbw"):
+            drives = allocate_one_white(self.inverse, vector.target, D65_WHITE_COLUMN)
             assert drives is not None
-            if drives[3] >= 1.0 - 1e-12:
+            if drives.white >= 1.0 - 1e-12:
                 at_least_one_capped += 1
                 continue
-            nudged = drives[3] + 1e-6
-            at_zero = _matvec(self.inverse, target)
-            rgb = [at_zero[i] - nudged * per_white[i] for i in range(3)]
+            nudged = drives.white + 1e-6
+            at_zero = _matvec(self.inverse, vector.target)
+            escaped = False
+            for index in range(3):
+                drive = at_zero[index] - nudged * per_white[index]
+                if drive < -1e-9 or drive > 1.0 + 1e-9:
+                    escaped = True
             self.assertTrue(
-                any(v < -1e-9 or v > 1.0 + 1e-9 for v in rgb),
-                msg=f"white could have gone higher for {target}",
+                escaped, msg=f"white could have gone higher for {vector.target}"
             )
         # And the sweep must not have been all saturated emitters.
         self.assertLess(at_least_one_capped, len(corpus_vectors("rgbw")))
@@ -129,8 +143,9 @@ class TestTwoWhitesNeedMoreThanOne(unittest.TestCase):
         """
 
         both = 0
-        for _, reference in corpus_vectors("rgbww"):
-            if reference[3] > 1e-12 and reference[4] > 1e-12:
+        for vector in corpus_vectors("rgbww"):
+            light = vector.emitter_light
+            if light[3] > 1e-12 and light[4] > 1e-12:
                 both += 1
         self.assertEqual(both, 0)
 
@@ -152,7 +167,9 @@ class TestTwoWhitesNeedMoreThanOne(unittest.TestCase):
         mixing_wins = 0
         worst_gap = 0.0
         for _ in range(2000):
-            drives = [random.random() for _ in range(5)]
+            drives: list[float] = []
+            for _emitter in range(5):
+                drives.append(random.random())
             target = tuple(
                 sum(columns[e][i] * drives[e] for e in range(5)) for i in range(3)
             )
@@ -165,7 +182,7 @@ class TestTwoWhitesNeedMoreThanOne(unittest.TestCase):
             if single is None or pair is None:
                 continue
             checked += 1
-            gap = (pair[0] + pair[1]) - single
+            gap = pair.total - single
             if gap > 1e-7:
                 mixing_wins += 1
                 worst_gap = max(worst_gap, gap)

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -274,10 +274,18 @@ simplifies to it later.
 ### What this leaves
 
 `rgbw` and `non_d65_white` are settled and ready to implement. `rgbww` needs
-either the 2D enumeration above — bounded at 28 candidate vertices, so not an
-iterative solver in the A3/B11 sense, but not free either — or a closed form
-nobody has found yet. It also needs corpus vectors bright enough to tell the
-two apart before any of it can be trusted.
+either the 2D enumeration above — or a closed form nobody has found yet. It
+also needs corpus vectors bright enough to tell the two apart before any of it
+can be trusted.
+
+The enumeration is bounded but not cheap. `most_white_two` builds ten
+constraints — six from the RGB drive bounds, four from the box on the two
+white drives — and intersects every unordered pair: 45 of them, of which five
+are structurally parallel, leaving **40** candidate intersections to test for
+feasibility. That is a constant known at compile time, so it is not an
+iterative solver in the A3/B11 sense, but it is roughly forty times the work
+of the one-white case and would want its own cost measurement before going
+per-pixel.
 
 ## Not covered
 

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -214,9 +214,74 @@ embedded mapper relies on bisection, either:
 Recording this rather than leaving it implicit: the table above is evidence
 for the *objective*, and only provisional evidence for the *search*.
 
+## Devices with a white emitter (C3)
+
+A white emitter makes the emitter matrix wide: the preimage of a target is no
+longer unique, and C3 asks for the white-preferred one. The P5 reference finds
+it by enumerating vertices — every way of choosing three free emitters and
+pinning the rest to 0 or 1, solved and filtered. A3/B11 forbid anything
+resembling that search per pixel, so the question is whether it is necessary.
+
+Harness: `ci/color_rgbw_study.py`. Regression test:
+`ci/tests/test_color_rgbw_study.py`.
+
+### One white emitter needs no search at all
+
+With the white emitter at drive `w`, the RGB drives making up the difference
+are
+
+    d(w) = M⁻¹ · target − w · (M⁻¹ · white)
+
+which is **affine in `w`**. Each of the six bounds on the three RGB drives is
+therefore a single inequality in `w`, the feasible set is one interval, and
+white-preferred is its upper end. One matrix multiply for the target, one for
+the white column — which a real implementation precomputes at bind time — then
+six comparisons.
+
+Scored against the reference over the corpus:
+
+| device | vectors | worst per-drive disagreement |
+| --- | --- | --- |
+| `rgbw` (white at D65) | 48 | 1.1e-15 |
+| `non_d65_white` (white at D50) | 48 | 7.8e-16 |
+
+That is float64 rounding: the closed form *is* the reference's answer. Nothing
+in the derivation assumed the white sat on the neutral axis, and the second row
+is what says so.
+
+### Two white emitters do need more, and the corpus hides it
+
+The obvious extension is to run the one-white form once per white and keep the
+better answer. It agrees with the reference on **every** `rgbww` vector in the
+corpus.
+
+It is also wrong on most targets. Over 34 520 random reachable targets, mixing
+both whites beat the better single white **29 245 times** — 85% — by up to a
+full emitter's worth of light.
+
+The reason is not subtle once seen: a single emitter's drive is capped at 1, so
+any target needing more white than one emitter can supply must use both. The
+corpus does not contain such a target. All 48 `rgbww` vectors are dim enough
+that one white suffices — 32 of them use no white at all — so **agreement over
+this corpus says nothing whatsoever about the reduction**.
+
+Recording that explicitly, because the measurement was nearly taken the other
+way round. Maximizing `w₁ + w₂` with two whites is a linear program over a
+polygon; `most_white_two` solves it by exact vertex enumeration, and the
+regression test keeps the cheap reduction pinned as *failing* so nobody
+simplifies to it later.
+
+### What this leaves
+
+`rgbw` and `non_d65_white` are settled and ready to implement. `rgbww` needs
+either the 2D enumeration above — bounded at 28 candidate vertices, so not an
+iterative solver in the A3/B11 sense, but not free either — or a closed form
+nobody has found yet. It also needs corpus vectors bright enough to tell the
+two apart before any of it can be trusted.
+
 ## Not covered
 
-Only the three-emitter `rgb` device. RGBW and RGBWW add a redundant emitter,
-so the hull is a zonotope with a non-unique preimage and the allocation policy
-(C3, white-preferred) interacts with the mapping. That needs its own study
-once the ≥4-emitter solve exists.
+The interaction between the allocation policy and the gamut mapping. Both are
+characterized here in isolation; a target that is out of gamut *and* on a
+device with a white emitter goes through both, and that composition has not
+been scored.


### PR DESCRIPTION
Independent of the OKLab/mapper stack (#4185, #4186) — this touches only `ci/` and `docs/`.

The P7 study covered only the three-emitter device. A white emitter makes the emitter matrix wide, so a target's preimage isn't unique and C3 asks for the white-preferred one. The P5 reference finds it by **enumerating vertices** — every way of choosing three free emitters and pinning the rest to 0 or 1. A3/B11 forbid that kind of search per pixel, so: is the enumeration necessary?

## One white emitter: no search at all

With the white at drive `w`, the RGB drives making up the difference are

```
d(w) = M⁻¹ · target − w · (M⁻¹ · white)
```

**Affine in `w`.** So each of the six bounds on the three RGB drives is a single inequality in `w`, the feasible set is one interval, and white-preferred is its upper end. Two matrix multiplies — one precomputed at bind time — and six comparisons.

| device | vectors | worst per-drive disagreement |
| --- | --- | --- |
| `rgbw` (white at D65) | 48 | 1.1e-15 |
| `non_d65_white` (white at D50) | 48 | 7.8e-16 |

That's float64 rounding: the closed form *is* the reference's answer. The second row matters because nothing in the derivation assumed the white sat on the neutral axis, and this is what says so.

## Two whites: the corpus actively misleads

This nearly went in wrong, so it's worth stating plainly.

The obvious extension is to run the one-white form once per white and keep the better answer. It agrees with the reference on **every** `rgbww` vector in the corpus — worst disagreement 1.2e-15, which looks exactly like the two rows above.

It is also wrong on **29,245 of 34,520** random reachable targets (85%), by up to a full emitter's worth of light.

The reason isn't subtle once seen: a single emitter's drive is capped at 1, so any target needing more white than one emitter can supply *must* use both. The corpus contains no such target — all 48 `rgbww` vectors are dim enough that one white suffices, and 32 use no white at all. So agreement over that corpus says nothing whatsoever about the reduction.

I only caught it because the two-white case is a 2D linear program, whose optimum can sit at a vertex with both coordinates positive — which meant corpus agreement wasn't sufficient evidence and had to be checked against an exact solver.

## Tests

`ci/tests/test_color_rgbw_study.py`, six cases:

- Both one-white devices reproduce the reference to 1e-12.
- The white level is **maximal** — nudging it up by 1e-6 must break an RGB drive — checked directly rather than trusted, with a guard that the sweep wasn't all saturated emitters.
- The corpus never lights both whites (0 of 48), documenting *why* it can't settle the two-white question.
- The cheap reduction is pinned as **failing** against exact 2D vertex enumeration, so nobody simplifies to it later on the strength of corpus agreement.
- Vector-count guards so no agreement test can pass on an empty set.

## What this leaves

`rgbw` and `non_d65_white` are settled and ready to implement in C++. `rgbww` needs either the 2D enumeration (bounded at 28 candidate vertices — not an iterative solver in the A3/B11 sense, but not free) or a closed form nobody has found, plus corpus vectors bright enough to tell the two apart.

Part of #4034 / #4041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved color allocation analysis for RGBW devices, including white-emitter mixing and out-of-gamut scenarios.
  * Added evaluation of bounded candidate solutions for RGBWW devices.

* **Documentation**
  * Expanded guidance for single- and dual-white-emitter allocation methods and documented their limitations.

* **Tests**
  * Expanded validation using reference color vectors, randomized targets, and two-white mixing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->