### PR TITLE
feat(gfx): white-preferred allocation for one white emitter (C3, #4041)

### DIFF
--- a/src/fl/gfx/_build.cpp.hpp
+++ b/src/fl/gfx/_build.cpp.hpp
@@ -32,6 +32,7 @@
 #include "fl/gfx/tile2x2.cpp.hpp"
 #include "fl/gfx/transfer.cpp.hpp"
 #include "fl/gfx/upscale.cpp.hpp"
+#include "fl/gfx/white_allocation.cpp.hpp"
 #include "fl/gfx/xypath.cpp.hpp"
 #include "fl/gfx/xypath_impls.cpp.hpp"
 #include "fl/gfx/xypath_renderer.cpp.hpp"

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -1,0 +1,131 @@
+// ok no header - implementation for fl/gfx/white_allocation.h
+
+#include "fl/gfx/white_allocation.h"
+
+namespace fl {
+
+namespace {
+
+/// Full drive, as an s16.16 raw value.
+constexpr i32 kWhiteFullDrive = 65536;
+
+/// Slack on the drive bounds, in s16.16 raw units.
+///
+/// The same reason the gamut mapper carries one: a colour the device
+/// reproduces exactly does not solve to exactly 0 or 1, and without slack
+/// the allocation would reject targets it can actually hit. 64 raw units is
+/// a quarter of one code at 8-bit output.
+constexpr i32 kWhiteSlack = 64;
+
+/// `(numerator << 16) / denominator`, in s16.16, with `denominator` non-zero.
+///
+/// Named for this file because .cpp.hpp files share a translation unit under
+/// the unity build, so an anonymous namespace does not isolate it.
+///
+/// The shift happens in i64: a numerator near i32's range shifted left by 16
+/// needs 47 bits, which is exactly the overflow this exists to avoid.
+i32 divideWhiteQ16(i32 numerator, i32 denominator) FL_NO_EXCEPT {
+    const i64 scaled = static_cast<i64>(numerator) << 16;
+    return static_cast<i32>(scaled / static_cast<i64>(denominator));
+}
+
+/// Scale an s16.16 value by an s16.16 factor, rounding to nearest.
+i32 scaleWhiteQ16(i32 value, i32 factor) FL_NO_EXCEPT {
+    const i64 product = static_cast<i64>(value) * static_cast<i64>(factor);
+    return static_cast<i32>((product + 32768) >> 16);
+}
+
+}  // namespace
+
+bool buildWhiteAllocationQ16(const EmitterProfile& profile,
+                             const i32 (&white_xyz)[3],
+                             WhiteAllocationQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    if (!buildRgbSolveMatrixQ16(profile, &out->rgb_solve)) {
+        return false;
+    }
+    solveRgbDrivesQ16(out->rgb_solve, white_xyz, out->per_white);
+
+    // A white emitter the primaries cannot express at all leaves nothing for
+    // the allocation to trade against, and every bound below would divide by
+    // zero or be vacuous.
+    bool expressible = false;
+    for (int i = 0; i < 3; ++i) {
+        if (out->per_white[i] != 0) {
+            expressible = true;
+        }
+    }
+    return expressible;
+}
+
+bool allocateWhitePreferredQ16(const WhiteAllocationQ16& allocation,
+                               const i32 (&xyz)[3],
+                               i32 (&drives)[4]) FL_NO_EXCEPT {
+    i32 at_zero[3];
+    solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
+
+    // The interval of white levels that keeps every RGB drive in range.
+    // Each bound is one inequality in the white level because d(w) is affine
+    // in w -- that is the whole reason no search is needed here.
+    //
+    // Strict bounds, deliberately. Slack here would be *spent* rather than
+    // merely tolerated: the policy maximizes white, so widening the bounds
+    // by 64 raw units lets it take 64 units out of every RGB drive on every
+    // pixel. That is not a rounding allowance, it is a systematic colour
+    // shift -- measured at white = 886 where the reference says 0. The
+    // slack lives on the drive check below, which is what actually decides
+    // feasibility.
+    i32 low = 0;
+    i32 high = kWhiteFullDrive;
+    for (int i = 0; i < 3; ++i) {
+        const i32 slope = allocation.per_white[i];
+        if (slope != 0) {
+            // Dividing by a negative slope swaps which bound is which.
+            const i32 first = divideWhiteQ16(at_zero[i], slope);
+            const i32 second = divideWhiteQ16(at_zero[i] - kWhiteFullDrive, slope);
+            const i32 upper = slope > 0 ? first : second;
+            const i32 lower = slope > 0 ? second : first;
+            if (upper < high) {
+                high = upper;
+            }
+            if (lower > low) {
+                low = lower;
+            }
+        } else if (at_zero[i] < -kWhiteSlack ||
+                   at_zero[i] > kWhiteFullDrive + kWhiteSlack) {
+            // White cannot move this drive at all, and it is already out.
+            return false;
+        }
+    }
+    // At the dark floor the solve rounds a drive to -1 raw on a colour the
+    // device reproduces exactly -- corpus target (4, 1, 19) solves to
+    // (0, -1, 1) -- which drags `high` below zero. Clamp rather than refuse;
+    // the drive check below decides whether the target is really reachable.
+    if (high < 0) {
+        high = 0;
+    }
+    if (low > high) {
+        return false;
+    }
+
+    // White-preferred: the top of the interval.
+    const i32 level = high;
+    i32 rgb[3];
+    for (int i = 0; i < 3; ++i) {
+        const i32 drive = at_zero[i] - scaleWhiteQ16(allocation.per_white[i], level);
+        if (drive < -kWhiteSlack || drive > kWhiteFullDrive + kWhiteSlack) {
+            return false;
+        }
+        rgb[i] = drive < 0 ? 0 : (drive > kWhiteFullDrive ? kWhiteFullDrive : drive);
+    }
+    drives[0] = rgb[0];
+    drives[1] = rgb[1];
+    drives[2] = rgb[2];
+    drives[3] = level < 0 ? 0
+                          : (level > kWhiteFullDrive ? kWhiteFullDrive : level);
+    return true;
+}
+
+}  // namespace fl

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -23,10 +23,27 @@ constexpr i32 kWhiteSlack = 64;
 /// the unity build, so an anonymous namespace does not isolate it.
 ///
 /// The shift happens in i64: a numerator near i32's range shifted left by 16
-/// needs 47 bits, which is exactly the overflow this exists to avoid.
+/// needs 47 bits.
+///
+/// The quotient is clamped before narrowing, and that is not theoretical. A
+/// dim white emitter gives a small `per_white` slope -- at a slope of one
+/// raw unit and a full-scale numerator the quotient is 2^32, past i32, where
+/// narrowing is implementation-defined and could turn a valid upper bound
+/// into zero and suppress the white entirely.
+///
+/// Clamping at full drive is decision-preserving rather than a fudge: the
+/// caller only ever takes `min` against full drive and `max` against zero,
+/// so a bound outside +/-1.0 already says "this constraint does not bind"
+/// or "infeasible", and it still says that after the clamp.
 i32 divideWhiteQ16(i32 numerator, i32 denominator) FL_NO_EXCEPT {
     const i64 scaled = static_cast<i64>(numerator) << 16;
-    return static_cast<i32>(scaled / static_cast<i64>(denominator));
+    i64 quotient = scaled / static_cast<i64>(denominator);
+    if (quotient > kWhiteFullDrive) {
+        quotient = kWhiteFullDrive;
+    } else if (quotient < -static_cast<i64>(kWhiteFullDrive)) {
+        quotient = -kWhiteFullDrive;
+    }
+    return static_cast<i32>(quotient);
 }
 
 /// Scale an s16.16 value by an s16.16 factor, rounding to nearest.

--- a/src/fl/gfx/white_allocation.h
+++ b/src/fl/gfx/white_allocation.h
@@ -1,0 +1,80 @@
+#pragma once
+
+// White-preferred allocation for a device with a white emitter (C3, #4041).
+//
+// A white emitter makes the emitter matrix wide: a target's preimage is no
+// longer unique, and C3 asks for the white-preferred one -- as much light
+// from the white emitter as the target allows.
+//
+// The P5 reference finds it by enumerating vertices, which A3/B11 forbid per
+// pixel. It does not need to be. With the white emitter at drive w, the RGB
+// drives making up the difference are
+//
+//     d(w) = M^-1 . target  -  w * (M^-1 . white)
+//
+// which is affine in w. Each of the six bounds on the three RGB drives is
+// therefore one inequality in w, the feasible set is a single interval, and
+// white-preferred is its upper end.
+//
+// `docs/color-gamut-algorithm-selection.md` records the measurement: over
+// the corpus's `rgbw` and `non_d65_white` devices this reproduces the
+// reference's drives to 1.1e-15 and 7.8e-16 respectively -- float64
+// rounding. The derivation never assumed the white sat on the neutral axis,
+// which is what the second device checks.
+//
+// This covers exactly one white emitter. Two are a different problem:
+// maximizing w1 + w2 is a linear program over a polygon, and the obvious
+// reduction -- run this twice and keep the better answer -- agrees with the
+// reference on every corpus vector while being wrong on 85% of random
+// reachable targets, because a single emitter's drive is capped at 1. See
+// the same document.
+
+#include "fl/gfx/device_solve.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// Everything the per-pixel allocation needs, derived once when a profile
+/// binds.
+struct WhiteAllocationQ16 {
+    /// Inverse RGB emitter matrix.
+    EmitterSolveMatrixQ16 rgb_solve;
+
+    /// `M^-1 . white`: the RGB drives one unit of white light replaces.
+    ///
+    /// Precomputing this is what leaves the per-pixel path with a single
+    /// matrix multiply. It does not depend on the pixel.
+    i32 per_white[3];
+};
+
+/// Derive the allocation for a three-primary profile plus one white emitter.
+///
+/// `white_xyz` is the white emitter's XYZ at full drive, in s16.16 -- the
+/// same working domain the rest of the pipeline carries.
+///
+/// False on the profiles `buildRgbSolveMatrixQ16` rejects, and on a white
+/// emitter the RGB primaries cannot express at all.
+bool buildWhiteAllocationQ16(const EmitterProfile& profile,
+                             const i32 (&white_xyz)[3],
+                             WhiteAllocationQ16* out) FL_NO_EXCEPT;
+
+/// One pixel: XYZ in s16.16 to four drives, white as large as the target
+/// allows. Order is red, green, blue, white.
+///
+/// False when no white level keeps the RGB drives in range, which means the
+/// target is outside the device hull -- the gamut mapper's job, not this
+/// one's. `drives` is not written in that case.
+///
+/// Cost note, recorded rather than optimized away on a guess: this performs
+/// up to six s16.16 divisions per pixel, and is the only stage in the
+/// pipeline that divides per pixel at all. Each bound can instead be
+/// compared by cross-multiplication, leaving one division for the chosen
+/// level, at the price of i64 multiplies that are not obviously cheaper on
+/// an 8-bit target. Nobody has measured which wins, so the straightforward
+/// version is what ships.
+bool allocateWhitePreferredQ16(const WhiteAllocationQ16& allocation,
+                               const i32 (&xyz)[3],
+                               i32 (&drives)[4]) FL_NO_EXCEPT;
+
+}  // namespace fl

--- a/tests/fl/gfx/white_allocation.cpp
+++ b/tests/fl/gfx/white_allocation.cpp
@@ -97,47 +97,93 @@ FL_TEST_CASE("White allocation reproduces the reference with an off-axis white")
 }
 
 FL_TEST_CASE("White allocation prefers white as far as the target allows") {
-    // White-*preferred* is the policy, so nudging the white level up has to
-    // push an RGB drive out of range. Checked directly rather than trusted.
+    // White-*preferred* is the policy, so the returned level must be the
+    // largest one the RGB bounds permit -- compared against that bound
+    // computed independently in float here, rather than against a nudge.
+    //
+    // A nudge cannot do this job. The earlier version pushed the level up by
+    // 1024 units and asked whether an RGB drive left a 2-unit window; with
+    // the smallest slope here at 0.072, that accepts about 1022 units of
+    // under-allocation before it notices, and the reconstruction test does
+    // not catch the difference because the RGB drives absorb it.
     WhiteAllocationQ16 allocation;
     FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
 
     int exercised = 0;
     for (int step = 1; step <= 12; ++step) {
-        // Neutral-ish targets at a range of luminances, where white has the
-        // most to offer.
         const float luminance = static_cast<float>(step) / 12.0f;
         float xyz_f[3];
         colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, luminance, xyz_f);
         const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
         i32 drives[4];
         FL_REQUIRE(allocateWhitePreferredQ16(allocation, xyz, drives));
-        if (drives[3] >= kFullDrive) {
+
+        i32 at_zero[3];
+        solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
+        float largest_allowed = 1.0f;
+        for (int i = 0; i < 3; ++i) {
+            const float slope = toFloat(allocation.per_white[i]);
+            const float start_drive = toFloat(at_zero[i]);
+            if (slope > 0.0f) {
+                if (start_drive / slope < largest_allowed) {
+                    largest_allowed = start_drive / slope;
+                }
+            } else if (slope < 0.0f) {
+                if ((start_drive - 1.0f) / slope < largest_allowed) {
+                    largest_allowed = (start_drive - 1.0f) / slope;
+                }
+            }
+        }
+        if (largest_allowed >= 1.0f) {
             continue;  // capped by the emitter, not by the RGB bounds
         }
         ++exercised;
-        i32 at_zero[3];
-        solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
-        // The nudge has to be big enough that the *binding* drive clears the
-        // escape window, and the binding one may have a small slope: blue
-        // carries only 0.072 of a unit of white here, so a 256-unit nudge
-        // moves it 18 and would look like no escape at all. 1024 moves it 74,
-        // against a window of 2 units for the division's truncation.
-        const i32 nudged = drives[3] + 1024;
-        bool escaped = false;
-        for (int i = 0; i < 3; ++i) {
-            const i64 product =
-                static_cast<i64>(allocation.per_white[i]) * static_cast<i64>(nudged);
-            const i32 drive = at_zero[i] - static_cast<i32>((product + 32768) >> 16);
-            if (drive < -2 || drive > kFullDrive + 2) {
-                escaped = true;
-            }
-        }
-        FL_CHECK(escaped);
+        // 16 raw units covers the division's truncation on three bounds.
+        FL_CHECK_LT(fl::fabsf(toFloat(drives[3]) - largest_allowed),
+                    16.0f / 65536.0f);
     }
     // Guard against the sweep finding only capped cases, which would make
     // every check above vacuous.
     FL_CHECK_GT(exercised, 4);
+}
+
+FL_TEST_CASE("White allocation survives a white emitter dim enough to overflow") {
+    // Regression. The bounds are (drive << 16) / slope, and `slope` is the
+    // RGB drive one unit of white replaces -- small for a dim white emitter.
+    // At a slope of one raw unit and a full-scale numerator the quotient is
+    // 2^32, past i32, where narrowing is implementation-defined and could
+    // turn a valid upper bound into zero and suppress the white entirely.
+    //
+    // A white emitter at a ten-thousandth of the primaries' luminance puts
+    // the slopes down in the single raw units.
+    const i32 dim_white[3] = {6, 7, 7};
+
+    WhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), dim_white, &allocation));
+    // Pin that the fixture really does reach the small-slope case, so this
+    // cannot go quiet if the solve or the constants move.
+    i32 largest_slope = 0;
+    for (int i = 0; i < 3; ++i) {
+        if (allocation.per_white[i] > largest_slope) {
+            largest_slope = allocation.per_white[i];
+        }
+    }
+    FL_REQUIRE_GT(largest_slope, 0);
+    FL_REQUIRE_LE(largest_slope, 16);
+
+    float xyz_f[3];
+    colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, 0.5f, xyz_f);
+    const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+    i32 drives[4];
+    FL_REQUIRE(allocateWhitePreferredQ16(allocation, xyz, drives));
+    for (int i = 0; i < 4; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+    // A white this dim cannot displace much, so the RGB drives must still
+    // carry the colour -- the failure mode here is not a wrong white level
+    // but a wrapped bound that suppresses or saturates it.
+    FL_CHECK_GT(drives[0] + drives[1] + drives[2], kFullDrive / 4);
 }
 
 FL_TEST_CASE("White allocation reproduces the target it was given") {

--- a/tests/fl/gfx/white_allocation.cpp
+++ b/tests/fl/gfx/white_allocation.cpp
@@ -1,0 +1,213 @@
+// White-preferred allocation coverage for color pipeline P7 / C3 (#4041).
+
+#include "fl/gfx/white_allocation.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/math/math.h"
+#include "fl/stl/int.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+/// The corpus's RGB primaries: sRGB chromaticities, unit luminance each.
+EmitterProfile rgbDevice() {
+    EmitterProfile p = {};
+    p.xy_r[0] = 0.6400f; p.xy_r[1] = 0.3300f;
+    p.xy_g[0] = 0.3000f; p.xy_g[1] = 0.6000f;
+    p.xy_b[0] = 0.1500f; p.xy_b[1] = 0.0600f;
+    p.lum_r = 1.0f; p.lum_g = 1.0f; p.lum_b = 1.0f;
+    p.native_code_depth = 8;
+    return p;
+}
+
+/// The two white emitters the corpus uses, at unit luminance, in s16.16.
+constexpr i32 kWhiteD65[3] = {62289, 65536, 71372};
+constexpr i32 kWhiteD50[3] = {63196, 65536, 54074};
+
+constexpr i32 kFullDrive = 65536;
+
+i32 q16(float v) { return static_cast<i32>(v * 65536.0f + (v >= 0 ? 0.5f : -0.5f)); }
+float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
+
+struct Vector {
+    i32 xyz[3];
+    i32 drives[4];
+};
+
+/// Sampled from `ci/golden/color-reference-v1.json` -- the brightest six and
+/// the two dimmest of each device, so the set spans full-drive white, a
+/// saturated primary mix, and the dark floor.
+const Vector kRgbwVectors[] = {
+    {{  51661,  61565,   9162}, { 14505, 47060,     0,     0}},
+    {{  50461,  60805,   9078}, { 13936, 46869,     0,     0}},
+    {{  49779,  60243,   9006}, { 13657, 46586,     0,     0}},
+    {{  55122,  57995,  63160}, {     0,     0,     0, 57995}},
+    {{  54277,  57106,  62192}, {     0,     0,     0, 57106}},
+    {{      4,      2,     21}, {     0,     0,     2,     0}},
+    {{      4,      1,     19}, {     0,     0,     1,     0}},
+};
+
+const Vector kNonD65Vectors[] = {
+    {{  55145,  62281,   9117}, { 16677, 45605,     0,     0}},
+    {{  53903,  61489,   9029}, { 16089, 45401,     0,     0}},
+    {{  53189,  60913,   8956}, { 15794, 45119,     0,     0}},
+    {{  55924,  57995,  47852}, {     0,     0,     0, 57995}},
+    {{  55067,  57106,  47118}, {     0,     0,     0, 57106}},
+    {{      3,      1,     16}, {     0,     0,     1,     0}},
+    {{      3,      1,     14}, {     0,     0,     1,     0}},
+};
+
+void checkAgainstReference(const i32 (&white)[3], const Vector* vectors,
+                           int count) {
+    WhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), white, &allocation));
+    for (int v = 0; v < count; ++v) {
+        i32 drives[4];
+        FL_REQUIRE(allocateWhitePreferredQ16(allocation, vectors[v].xyz, drives));
+        for (int i = 0; i < 4; ++i) {
+            // 256 raw units is one code at 8-bit output. The reference
+            // inverts in float64; this quantizes the matrix first, so
+            // bit-exactness is not the claim.
+            FL_CHECK_LT(fl::fabsf(toFloat(drives[i] - vectors[v].drives[i])),
+                        256.0f / 65536.0f);
+        }
+    }
+}
+
+}  // namespace
+
+FL_TEST_CASE("White allocation reproduces the reference on rgbw") {
+    // The claim the closed form rests on. The reference reaches these drives
+    // by enumerating vertices; if this agrees, the per-pixel path does not
+    // need the enumeration. See docs/color-gamut-algorithm-selection.md.
+    checkAgainstReference(kWhiteD65,
+                          kRgbwVectors,
+                          static_cast<int>(sizeof(kRgbwVectors) / sizeof(Vector)));
+}
+
+FL_TEST_CASE("White allocation reproduces the reference with an off-axis white") {
+    // Nothing in the derivation assumed the white sat on the neutral axis.
+    // This device puts it at D50, and is what says so.
+    checkAgainstReference(kWhiteD50,
+                          kNonD65Vectors,
+                          static_cast<int>(sizeof(kNonD65Vectors) / sizeof(Vector)));
+}
+
+FL_TEST_CASE("White allocation prefers white as far as the target allows") {
+    // White-*preferred* is the policy, so nudging the white level up has to
+    // push an RGB drive out of range. Checked directly rather than trusted.
+    WhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+
+    int exercised = 0;
+    for (int step = 1; step <= 12; ++step) {
+        // Neutral-ish targets at a range of luminances, where white has the
+        // most to offer.
+        const float luminance = static_cast<float>(step) / 12.0f;
+        float xyz_f[3];
+        colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, luminance, xyz_f);
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+        i32 drives[4];
+        FL_REQUIRE(allocateWhitePreferredQ16(allocation, xyz, drives));
+        if (drives[3] >= kFullDrive) {
+            continue;  // capped by the emitter, not by the RGB bounds
+        }
+        ++exercised;
+        i32 at_zero[3];
+        solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
+        // The nudge has to be big enough that the *binding* drive clears the
+        // escape window, and the binding one may have a small slope: blue
+        // carries only 0.072 of a unit of white here, so a 256-unit nudge
+        // moves it 18 and would look like no escape at all. 1024 moves it 74,
+        // against a window of 2 units for the division's truncation.
+        const i32 nudged = drives[3] + 1024;
+        bool escaped = false;
+        for (int i = 0; i < 3; ++i) {
+            const i64 product =
+                static_cast<i64>(allocation.per_white[i]) * static_cast<i64>(nudged);
+            const i32 drive = at_zero[i] - static_cast<i32>((product + 32768) >> 16);
+            if (drive < -2 || drive > kFullDrive + 2) {
+                escaped = true;
+            }
+        }
+        FL_CHECK(escaped);
+    }
+    // Guard against the sweep finding only capped cases, which would make
+    // every check above vacuous.
+    FL_CHECK_GT(exercised, 4);
+}
+
+FL_TEST_CASE("White allocation reproduces the target it was given") {
+    // The allocation must be a *solve*, not an approximation: pushing the
+    // four drives back through the emitter columns has to land on the
+    // target. This is what would break if the white column were subtracted
+    // with the wrong sign or scale.
+    WhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    for (const auto& vector : kRgbwVectors) {
+        i32 drives[4];
+        FL_REQUIRE(allocateWhitePreferredQ16(allocation, vector.xyz, drives));
+        float reproduced[3] = {0.0f, 0.0f, 0.0f};
+        for (int e = 0; e < 3; ++e) {
+            float column[3];
+            colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                              column);
+            for (int i = 0; i < 3; ++i) {
+                reproduced[i] += toFloat(drives[e]) * column[i];
+            }
+        }
+        for (int i = 0; i < 3; ++i) {
+            reproduced[i] += toFloat(drives[3]) * toFloat(kWhiteD65[i]);
+        }
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(vector.xyz[i])), 0.01f);
+        }
+    }
+}
+
+FL_TEST_CASE("White allocation refuses a target outside the hull") {
+    WhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+
+    // A saturated chromaticity well outside the sRGB triangle, and an
+    // over-bright neutral. Neither has a white level that rescues it, and
+    // saying so is this function's job -- clamping belongs to the mapper.
+    int refused = 0;
+    const float outside[][3] = {
+        {0.7500f, 0.2400f, 0.5f},
+        {0.0800f, 0.8000f, 0.5f},
+        {0.3127f, 0.3290f, 40.0f},
+    };
+    for (const auto& sample : outside) {
+        float xyz_f[3];
+        colorimetric_response::xyY_to_XYZ(sample[0], sample[1], sample[2], xyz_f);
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+        i32 drives[4];
+        if (!allocateWhitePreferredQ16(allocation, xyz, drives)) {
+            ++refused;
+        }
+    }
+    FL_CHECK_EQ(refused, 3);
+}
+
+FL_TEST_CASE("White allocation rejects profiles it cannot work with") {
+    WhiteAllocationQ16 allocation;
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, nullptr));
+
+    EmitterProfile collinear = rgbDevice();
+    collinear.xy_g[0] = 0.6400f;
+    collinear.xy_g[1] = 0.3300f;
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(collinear, kWhiteD65, &allocation));
+
+    // A white emitter with no light in it leaves nothing to trade against.
+    const i32 dark[3] = {0, 0, 0};
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), dark, &allocation));
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
The C++ side of the closed form established in #4187. Independent of the mapper PR (#4186) — this depends only on `device_solve.h`, which is on master.

With the white emitter at drive `w`, the RGB drives making up the difference are

```
d(w) = M⁻¹ · target − w · (M⁻¹ · white)
```

**Affine in `w`**, so each of the six bounds on the three RGB drives is one inequality in `w`, the feasible set is a single interval, and white-preferred is its upper end. `M⁻¹ · white` doesn't depend on the pixel and is precomputed at bind time, leaving one matrix multiply per pixel — no vertex enumeration, which is what A3/B11 rule out.

## Tested against the reference, not just for self-consistency

Vectors sampled from `ci/golden/color-reference-v1.json` for both `rgbw` and `non_d65_white`, spanning full-drive white, a saturated primary mix and the dark floor. The second device is the one that matters: nothing in the derivation assumed the white sat on the neutral axis, and that's what checks it.

Also asserted: the allocation actually *reproduces* its target when the four drives are pushed back through the emitter columns (what would break if the white column were subtracted with the wrong sign or scale), that the white level is genuinely maximal, and that out-of-gamut targets are refused rather than clamped — clamping is the mapper's job.

## Two bugs the tests caught, both mine

**The dark floor refused targets the device reproduces exactly.** Corpus target `(4, 1, 19)` solves to RGB drives `(0, −1, 1)`. That `−1` is pure rounding, but it dragged the interval's upper end below zero and the target came back as out of gamut. The upper end is now clamped up to zero, with the drive check deciding feasibility.

**Slack must not reach the bounds.** My first fix widened the interval bounds by the same 64 raw units the drive check tolerates. That looks symmetric and isn't: the policy *maximizes* white, so the allowance gets **spent** rather than tolerated — 64 units taken out of every RGB drive on every pixel. Measured as white = 886 where the reference says 0, on three separate vectors. The bounds are strict now; only the final drive check carries slack.

A third, smaller one was in the test itself: the maximality check nudged white by 256 units and then required a drive to escape by more than 256 — but a drive moves by `slope × nudge`, and blue carries only 0.072 of a unit of white here, so it moved 18. The nudge is now 1024 against a 2-unit window for division truncation.

## Cost, recorded rather than guessed at

Up to six s16.16 divisions per pixel — the only per-pixel division in the pipeline. Each bound can instead be compared by cross-multiplication, leaving one division for the chosen level, at the price of i64 multiplies that aren't obviously cheaper on an 8-bit target. Nobody has measured which wins, so the straightforward version ships and the header says so.

## Scope

Exactly one white emitter. Two are a different problem, and #4187 measured why: maximizing `w₁ + w₂` is a linear program over a polygon, and running this twice and keeping the better answer agrees with the reference on every corpus vector while being wrong on 85% of random reachable targets.

Part of #4034 / #4041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added white-preferred RGBW color allocation for compatible emitter profiles.
  - Converts XYZ color targets into RGB and white drive levels while maximizing white output within valid drive limits.
  - Supports different white points, including D65 and D50.
  - Rejects unsupported targets and invalid emitter configurations instead of producing out-of-range results.

- **Bug Fixes**
  - Improved handling of very low white-emitter output to prevent invalid drive calculations.

- **Tests**
  - Expanded coverage for reference colors, boundary conditions, white-point variations, exact target reproduction, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->