### PR TITLE
test(gfx): measure whether the gamut mapper is smooth enough to animate (#4041)

### DIFF
--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -258,6 +258,54 @@ embedded mapper relies on bisection, either:
 Recording this rather than leaving it implicit: the table above is evidence
 for the *objective*, and only provisional evidence for the *search*.
 
+## Is the mapping continuous enough to animate?
+
+#4041's acceptance criteria ask that out-of-gamut mapping be continuous.
+Strictly, it is not. The halving search returns a quantized scale factor, so
+a target crossing the gamut boundary steps rather than glides. The question
+worth answering is how large the step is against the output's own
+quantization, so that is what was measured — worst summed change across the
+three drives between adjacent samples, at the shipped eight halvings:
+
+| path | worst | as 8-bit codes | worst / mean step |
+| --- | --- | --- | --- |
+| neutral → deep red | 0.002914 | 0.74 | 1.3x |
+| **boundary crossing (4 000 samples)** | 0.003128 | **0.80** | **42.8x** |
+| hue sweep, fully out of gamut | 0.003189 | 0.81 | 4.6x |
+| neutral luminance ramp | 0.004028 | 1.03 | 1.2x |
+
+The 42.8x in the third column is the discontinuity showing itself: on the
+boundary crossing the worst step is forty-odd times the typical one, which
+is exactly what a jump looks like. It is still under one 8-bit code, which
+is why nothing bands.
+
+### More halvings do not remove it
+
+The obvious response is to spend halvings on it. That was measured too, and
+it buys less than it looks:
+
+| halvings | worst on the boundary crossing | as 8-bit codes |
+| --- | --- | --- |
+| 6 | 0.012482 | 3.18 |
+| **8** | **0.003128** | **0.80** |
+| 10 | 0.001160 | 0.30 |
+| 12 | 0.000992 | 0.25 |
+| 14 | 0.000916 | 0.23 |
+
+It falls to a floor rather than to zero, and past ten halvings the worst
+step also moves to a different point on the path. So the search resolution
+is part of the discontinuity and not all of it; the rest is the entry
+check's rounding slack and s16.16 itself. Worth knowing before anyone
+spends per-pixel work trying to smooth this out.
+
+Eight halvings keeps every path under about one 8-bit code. At a wider
+output depth the step is proportionally more visible — 0.31% of full drive
+is roughly 13 codes at 12-bit — so a device driving finer than 8 bits
+through a slow gradient is the case that would want re-measuring.
+
+`tests/fl/gfx/gamut_map.cpp` pins the bound at 1.5 codes, which six halvings
+fails.
+
 ## Devices with a white emitter (C3)
 
 A white emitter makes the emitter matrix wide: the preimage of a target is no

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -274,10 +274,10 @@ three drives between adjacent samples, at the shipped eight halvings:
 | hue sweep, fully out of gamut | 0.003189 | 0.81 | 4.6x |
 | neutral luminance ramp | 0.004028 | 1.03 | 1.2x |
 
-The 42.8x in the third column is the discontinuity showing itself: on the
-boundary crossing the worst step is forty-odd times the typical one, which
-is exactly what a jump looks like. It is still under one 8-bit code, which
-is why nothing bands.
+The last column is the discontinuity showing itself: on the boundary
+crossing the worst step is forty-odd times the typical one, which is exactly
+what a jump looks like. It is still under one 8-bit code, which is why
+nothing bands.
 
 ### More halvings do not remove it
 

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -421,6 +421,118 @@ FL_TEST_CASE("Gamut map survives a profile bright enough to overflow the scale")
     }
 }
 
+FL_TEST_CASE("Gamut map moves smoothly enough to animate") {
+    // #4041's acceptance criteria ask that out-of-gamut mapping be
+    // continuous. Strictly it is not: the halving search returns a quantized
+    // scale factor, so crossing the gamut boundary steps rather than glides.
+    // What matters is the size of the step against the output's own
+    // quantization, so that is what this measures.
+    //
+    // Measured at the shipped eight halvings, worst summed change in the
+    // three drives between adjacent samples:
+    //
+    //   path                     worst      as 8-bit codes   worst / mean
+    //   ------------------------ ---------- ---------------- ------------
+    //   neutral -> deep red      0.002914   0.74             1.3x
+    //   boundary crossing (fine) 0.003128   0.80             42.8x
+    //   hue sweep, out of gamut  0.003189   0.81             4.6x
+    //   neutral luminance ramp   0.004028   1.03             1.2x
+    //
+    // The 42.8x on the boundary crossing is the discontinuity showing: the
+    // worst step there is forty-odd times the typical one. It is still under
+    // one 8-bit code, which is why it does not band.
+    //
+    // Raising the halving count shrinks it to a floor rather than to zero --
+    // 0.30 codes at ten halvings, 0.25 at twelve, 0.23 at fourteen -- and the
+    // worst step moves elsewhere on the path. So the search resolution is
+    // part of it and not all of it; the residual is the entry check's slack
+    // boundary and Q16 itself. Worth knowing before anyone spends halvings
+    // trying to smooth this out.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+
+    struct Path {
+        float x0, y0, x1, y1;
+        float luminance;  // zero means ramp it instead of the chromaticity
+        int steps;
+    };
+    const Path kPaths[] = {
+        {0.3127f, 0.3290f, 0.72f, 0.26f, 0.4f, 400},
+        {0.55f, 0.33f, 0.62f, 0.30f, 0.4f, 4000},
+        {0.70f, 0.28f, 0.10f, 0.70f, 0.4f, 2000},
+        {0.3127f, 0.3290f, 0.3127f, 0.3290f, 0.0f, 400},
+    };
+
+    for (const auto& path : kPaths) {
+        i32 previous[3] = {0, 0, 0};
+        float worst = 0.0f;
+        for (int step = 0; step <= path.steps; ++step) {
+            const float t = static_cast<float>(step) / path.steps;
+            const float x = path.x0 + t * (path.x1 - path.x0);
+            const float y = path.y0 + t * (path.y1 - path.y0);
+            const float luminance =
+                path.luminance > 0.0f ? path.luminance : (0.02f + t * 1.6f);
+            i32 xyz[3];
+            xyzAt(x, y, luminance, xyz);
+            i32 drives[3];
+            mapAndSolveDrivesQ16(map, xyz, drives);
+            if (step > 0) {
+                float jump = 0.0f;
+                for (int i = 0; i < 3; ++i) {
+                    jump += fl::fabsf(toFloat(drives[i] - previous[i]));
+                }
+                if (jump > worst) {
+                    worst = jump;
+                }
+            }
+            for (int i = 0; i < 3; ++i) {
+                previous[i] = drives[i];
+            }
+        }
+        // 1.5 codes at 8-bit: about twice the worst measured, so platform
+        // float differences do not make this flaky, while a mapper that
+        // started stepping by a visible amount would fail.
+        FL_CHECK_LT(worst, 1.5f / 255.0f);
+    }
+}
+
+FL_TEST_CASE("Gamut map leaves an in-gamut ramp exactly where it found it") {
+    // The other half of #4041's acceptance criteria: in-gamut vectors
+    // preserve chromaticity, and neutral ramps stay neutral. A mapper that
+    // compressed slightly even inside the hull would pass the continuity
+    // check above while quietly desaturating everything.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+
+    int exercised = 0;
+    for (int step = 1; step <= 40; ++step) {
+        const float luminance = static_cast<float>(step) / 40.0f;
+        i32 xyz[3];
+        xyzAt(0.3127f, 0.3290f, luminance, xyz);
+        i32 plain[3];
+        solveRgbDrivesQ16(map.solve, xyz, plain);
+        bool in_range = true;
+        for (int i = 0; i < 3; ++i) {
+            if (plain[i] < 0 || plain[i] > kFullDrive) {
+                in_range = false;
+            }
+        }
+        if (!in_range) {
+            continue;
+        }
+        ++exercised;
+        i32 drives[3];
+        mapAndSolveDrivesQ16(map, xyz, drives);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_EQ(drives[i], plain[i]);
+        }
+        // Neutral in means the drives keep the neutral's fixed ratios.
+        const float ratio = toFloat(drives[1]) / toFloat(plain[1]);
+        FL_CHECK_LT(fl::fabsf(ratio - 1.0f), 1e-6f);
+    }
+    FL_CHECK_GT(exercised, 20);
+}
+
 FL_TEST_CASE("Gamut map rejects a degenerate profile") {
     EmitterProfile collinear = rgbDevice();
     collinear.xy_g[0] = 0.6400f;

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -466,6 +466,7 @@ FL_TEST_CASE("Gamut map moves smoothly enough to animate") {
     for (const auto& path : kPaths) {
         i32 previous[3] = {0, 0, 0};
         float worst = 0.0f;
+        int mapped_samples = 0;
         for (int step = 0; step <= path.steps; ++step) {
             const float t = static_cast<float>(step) / path.steps;
             const float x = path.x0 + t * (path.x1 - path.x0);
@@ -474,6 +475,14 @@ FL_TEST_CASE("Gamut map moves smoothly enough to animate") {
                 path.luminance > 0.0f ? path.luminance : (0.02f + t * 1.6f);
             i32 xyz[3];
             xyzAt(x, y, luminance, xyz);
+            i32 plain[3];
+            solveRgbDrivesQ16(map.solve, xyz, plain);
+            for (int i = 0; i < 3; ++i) {
+                if (plain[i] < 0 || plain[i] > kFullDrive) {
+                    ++mapped_samples;
+                    break;
+                }
+            }
             i32 drives[3];
             mapAndSolveDrivesQ16(map, xyz, drives);
             if (step > 0) {
@@ -489,6 +498,11 @@ FL_TEST_CASE("Gamut map moves smoothly enough to animate") {
                 previous[i] = drives[i];
             }
         }
+        // Every path has to actually cross into the mapped branch. A fixture
+        // or solve change that left one entirely in gamut would leave this
+        // measuring the plain solve's smoothness and saying nothing at all
+        // about the mapper.
+        FL_REQUIRE_GT(mapped_samples, 0);
         // 1.5 codes at 8-bit: about twice the worst measured, so platform
         // float differences do not make this flaky, while a mapper that
         // started stepping by a visible amount would fail.
@@ -526,9 +540,28 @@ FL_TEST_CASE("Gamut map leaves an in-gamut ramp exactly where it found it") {
         for (int i = 0; i < 3; ++i) {
             FL_CHECK_EQ(drives[i], plain[i]);
         }
-        // Neutral in means the drives keep the neutral's fixed ratios.
-        const float ratio = toFloat(drives[1]) / toFloat(plain[1]);
-        FL_CHECK_LT(fl::fabsf(ratio - 1.0f), 1e-6f);
+        // And the light those drives actually make is still D65. Comparing
+        // drives against the plain solve, as above, cannot show this: the
+        // two are equal by assertion, so any ratio between them is 1 by
+        // construction. Pushing the drives back through the emitter columns
+        // and checking the chromaticity is independent of the solve, and is
+        // what would catch a wrong matrix that happened to be applied
+        // consistently.
+        float reproduced[3] = {0.0f, 0.0f, 0.0f};
+        const float emitters[3][2] = {
+            {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+        for (int e = 0; e < 3; ++e) {
+            float column[3];
+            colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                              column);
+            for (int i = 0; i < 3; ++i) {
+                reproduced[i] += toFloat(drives[e]) * column[i];
+            }
+        }
+        const float sum = reproduced[0] + reproduced[1] + reproduced[2];
+        FL_REQUIRE_GT(sum, 1e-4f);
+        FL_CHECK_LT(fl::fabsf(reproduced[0] / sum - 0.3127f), 0.002f);
+        FL_CHECK_LT(fl::fabsf(reproduced[1] / sum - 0.3290f), 0.002f);
     }
     FL_CHECK_GT(exercised, 20);
 }


### PR DESCRIPTION
Independent of #4188 — this covers #4041's remaining acceptance criteria against the mapper now on master.

#4041 asks that out-of-gamut mapping be *continuous*. Strictly it isn't, and saying so with a number is more useful than asserting it is: the halving search returns a quantized scale factor, so a target crossing the gamut boundary steps rather than glides.

What matters is the size of that step against the output's own quantization. Worst summed change across the three drives between adjacent samples, at the shipped eight halvings:

| path | worst | as 8-bit codes | worst / mean step |
| --- | --- | --- | --- |
| neutral → deep red | 0.002914 | 0.74 | 1.3x |
| **boundary crossing (4 000 samples)** | 0.003128 | **0.80** | **42.8x** |
| hue sweep, fully out of gamut | 0.003189 | 0.81 | 4.6x |
| neutral luminance ramp | 0.004028 | 1.03 | 1.2x |

The **42.8x** is the discontinuity showing itself — on the boundary crossing the worst step is forty-odd times the typical one, which is exactly what a jump looks like. It stays under one 8-bit code, which is why nothing bands.

## More halvings don't remove it

The obvious response is to spend halvings. Measured, it buys less than it looks:

| halvings | worst on the boundary crossing | 8-bit codes |
| --- | --- | --- |
| 6 | 0.012482 | 3.18 |
| **8 (shipped)** | **0.003128** | **0.80** |
| 10 | 0.001160 | 0.30 |
| 12 | 0.000992 | 0.25 |
| 14 | 0.000916 | 0.23 |

It falls to a **floor**, not to zero, and past ten halvings the worst step also moves to a different point on the path. So the search resolution is part of the discontinuity and not all of it — the rest is the entry check's rounding slack and s16.16 itself. That seemed worth recording before someone spends per-pixel work trying to smooth out something the search doesn't control.

At a wider output depth the step is proportionally more visible (0.31% of full drive is ~13 codes at 12-bit), so a device driving finer than 8 bits through a slow gradient is the case that would want re-measuring. Noted in the doc.

## Tests

- **Continuity** across four paths, bounded at 1.5 codes — about twice the worst measured, so platform float differences won't make it flaky, and tight enough that six halvings fails. Verified by mutation: at six halvings this test and the model cross-check both fail.
- **Preservation**, which nothing covered: an in-gamut neutral ramp must come back *exactly* as the plain solve gives it, with a vacuity guard. A mapper that compressed slightly even inside the hull would pass the continuity check while quietly desaturating everything.

Part of #4034 / #4041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify gamut mapping changes smoothly enough for animation across representative color paths.
  - Added checks that in-gamut neutral ramps remain unchanged and preserve their drive ratios.

- **Documentation**
  - Documented continuity measurements for gamut mapping and the effects of increasing search precision.
  - Recorded guidance that the current precision keeps paths within approximately one 8-bit code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->