### PR TITLE
ci(codec): record the SIMD ratio on passing runs too (#4183)

### DIFF
--- a/.github/workflows/mp3_cpu_audit.yml
+++ b/.github/workflows/mp3_cpu_audit.yml
@@ -81,8 +81,24 @@ jobs:
       # scalar integer code and would measure the compiler instead of the
       # kernel. The default unit-test build is -O0, so it is run here in
       # release explicitly.
+      # The SIMD-vs-scalar ratio this job gates on depends on which runner
+      # GitHub hands out: 1.080x on one, 0.904x on another, a 19% spread
+      # across a fleet that is not one machine. Recording the CPU is what
+      # lets those be told apart rather than argued about as noise.
+      # See FastLED#4183.
+      - name: Record the runner CPU
+        if: always()
+        run: |
+          lscpu | grep -E "Model name|Vendor ID|Flags" | cut -c1-400 || true
+
+      # --verbose because the harness echoes a test's stdout only when it
+      # fails, and the ratio this step prints is the whole point of it. A
+      # passing run used to record nothing, which left a green result
+      # indistinguishable from one where the comparison returned early for
+      # want of integer SIMD and passed vacuously. That ambiguity is what
+      # stalled FastLED#4183; with this, every run says which it was.
       - name: Verify the fixed-point SIMD is not slower than scalar
-        run: bash test fl_codec --cpp --build-mode release
+        run: bash test fl_codec --cpp --build-mode release --verbose
 
       # Measure before gating, so a red gate still produces the numbers needed
       # to diagnose it -- and so that adding a backend can bootstrap its

--- a/tests/fl/codec/mp3_fixed_point.hpp
+++ b/tests/fl/codec/mp3_fixed_point.hpp
@@ -357,8 +357,18 @@ FL_TEST_CASE("minimp3 fixed-point SIMD is not slower than scalar") {
     const double ratio = simd_us ? static_cast<double>(scalar_us) /
                                        static_cast<double>(simd_us)
                                  : 0.0;
-    printf("[simd-perf] scalar=%u us  simd=%u us  speedup=%.3fx over %d reps\n",
-           scalar_us, simd_us, ratio, kReps);
+    // Whether the ratio is enforced is printed with it, deliberately. This
+    // line is emitted before the `dspUsesSimd()` check below, so a ratio on
+    // its own says nothing about whether the gate ran: a target with no
+    // integer SIMD prints one too and then returns without asserting. Making
+    // each line say which it is means a CI log can be read on its own,
+    // instead of by cross-referencing whether the exactness test happened to
+    // print its own "no integer SIMD" note.
+    printf("[simd-perf] scalar=%u us  simd=%u us  speedup=%.3fx over %d reps "
+           "(integer SIMD: %s)\n",
+           scalar_us, simd_us, ratio, kReps,
+           fl::Minimp3FixedVariant::dspUsesSimd() ? "yes, ratio enforced"
+                                                  : "no, ratio not enforced");
     FL_CHECK_GT(scalar_us, 0u);
     FL_CHECK_GT(simd_us, 0u);
 


### PR DESCRIPTION
One line, aimed at unsticking #4183 — and with it #4175, which has been sitting on that red gate without touching anything it measures.

## The problem

The test harness echoes a test's stdout **only when it fails**. The whole value of the "Verify the fixed-point SIMD is not slower than scalar" step is the ratio it prints, so a *passing* run records nothing at all.

That matters because the gate can also pass **vacuously**: the comparison returns early on a target with no integer SIMD (`if (!dspUsesSimd()) return;`). A green result is therefore indistinguishable from a skipped measurement.

## Why it's blocking a decision

Every run that has ever reported a ratio here reported a **failing** one:

| run | scalar (8 reps) | ratio |
| --- | --- | --- |
| #4175 first | 113 407 µs | 0.945 |
| #4175 rerun | 109 703 µs | 0.920 |
| `master` 09-06 | 74 199 µs | 0.904 |
| `master` 09-04 | 95 892 µs | 0.924 |

Nine other runs passed and recorded nothing. Those nine are either healthy measurements or skipped ones, and which they are decides the question #4183 is stuck on: whether the SIMD kernel is genuinely slower on GitHub's runners, or the gate is merely noisy.

I originally called it a flake and had to correct that — the four failures cluster in a 0.04 band, and the run with the *fastest* scalar time (74 199 µs, well faster than my own Ryzen 7 3700X at 107 917 µs) produced the *worst* ratio. Contention doesn't do that. But I still can't distinguish "genuinely slower" from "nine healthy runs and four unlucky ones" without seeing the passing ratios.

`--verbose` makes the harness print the output regardless, so the next audit run answers it either way.

## Cost

One extra test binary's stdout in the log — roughly the fifty lines the failing runs already print.

Related: #4183, #4175, #4055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved performance verification output with more detailed, verbose results for successful runs.
  * Added clearer reporting to distinguish enforced performance ratios from early exits on targets without integer SIMD support.
  * Added runner CPU model, vendor, and feature details to help interpret performance measurements across different environments.
  * Documented that measured SIMD-versus-scalar performance can vary depending on runner hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->