### PR TITLE
feat(gfx): the RGB-preferred allocation override (C3, #4041)

### DIFF
--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -106,7 +106,7 @@ struct RgbwFeasible {
 
     bool operator()(const i32 (&xyz)[3]) const FL_NO_EXCEPT {
         i32 drives[4];
-        return allocateWhitePreferredQ16(allocation, xyz, drives);
+        return allocateEmitterDrivesQ16(allocation, xyz, drives);
     }
 };
 
@@ -227,11 +227,12 @@ void mapAndSolveDrivesQ16(const GamutMapQ16& map, const i32 (&xyz)[3],
 
 bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
                           const i32 (&white_xyz)[3],
+                          WhiteAllocationPolicy policy,
                           GamutMapRgbwQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
         return false;
     }
-    if (!buildWhiteAllocationQ16(profile, white_xyz, &out->allocation)) {
+    if (!buildWhiteAllocationQ16(profile, white_xyz, policy, &out->allocation)) {
         return false;
     }
 
@@ -299,7 +300,7 @@ bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
                 scaleGamutQ16(kGamutD65Q16[2], trial_scale),
             };
             i32 trial_drives[4];
-            if (allocateWhitePreferredQ16(out->allocation, trial, trial_drives)) {
+            if (allocateEmitterDrivesQ16(out->allocation, trial, trial_drives)) {
                 low = middle;
             } else {
                 high = middle;
@@ -322,7 +323,7 @@ bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
 
 void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
                            i32 (&drives)[4]) FL_NO_EXCEPT {
-    if (allocateWhitePreferredQ16(map.allocation, xyz, drives)) {
+    if (allocateEmitterDrivesQ16(map.allocation, xyz, drives)) {
         // Already inside the device's hull -- which, with a white emitter,
         // is a good deal larger than the RGB one.
         return;
@@ -342,7 +343,7 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
         largestFeasibleChroma(lab, lightness, RgbwFeasible{map.allocation});
     i32 mapped_xyz[3];
     chromaCandidateXyz(lab, lightness, factor, mapped_xyz);
-    if (allocateWhitePreferredQ16(map.allocation, mapped_xyz, drives)) {
+    if (allocateEmitterDrivesQ16(map.allocation, mapped_xyz, drives)) {
         return;
     }
     // The accepted candidate can fall a few ULP outside on the final
@@ -351,7 +352,7 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
     const i32 neutral_lab[3] = {lightness, 0, 0};
     i32 neutral_xyz[3];
     oklabToXyzQ16(neutral_lab, neutral_xyz);
-    if (!allocateWhitePreferredQ16(map.allocation, neutral_xyz, drives)) {
+    if (!allocateEmitterDrivesQ16(map.allocation, neutral_xyz, drives)) {
         drives[0] = 0;
         drives[1] = 0;
         drives[2] = 0;

--- a/src/fl/gfx/gamut_map.h
+++ b/src/fl/gfx/gamut_map.h
@@ -88,8 +88,12 @@ struct GamutMapRgbwQ16 {
 /// Derive the mapper for a three-primary profile plus one white emitter.
 ///
 /// `white_xyz` is the white emitter's XYZ at full drive, in s16.16.
+/// `policy` is C3's per-profile choice of which end of the feasible white
+/// interval to take; it changes the drives, never which targets are
+/// reachable, so the hull this maps onto is the same either way.
 bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
                           const i32 (&white_xyz)[3],
+                          WhiteAllocationPolicy policy,
                           GamutMapRgbwQ16* out) FL_NO_EXCEPT;
 
 /// One pixel: XYZ in s16.16 to four in-gamut drives, red, green, blue, white.

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -56,10 +56,12 @@ i32 scaleWhiteQ16(i32 value, i32 factor) FL_NO_EXCEPT {
 
 bool buildWhiteAllocationQ16(const EmitterProfile& profile,
                              const i32 (&white_xyz)[3],
+                             WhiteAllocationPolicy policy,
                              WhiteAllocationQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
         return false;
     }
+    out->policy = policy;
     if (!buildRgbSolveMatrixQ16(profile, &out->rgb_solve)) {
         return false;
     }
@@ -77,9 +79,9 @@ bool buildWhiteAllocationQ16(const EmitterProfile& profile,
     return expressible;
 }
 
-bool allocateWhitePreferredQ16(const WhiteAllocationQ16& allocation,
-                               const i32 (&xyz)[3],
-                               i32 (&drives)[4]) FL_NO_EXCEPT {
+bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
+                              const i32 (&xyz)[3],
+                              i32 (&drives)[4]) FL_NO_EXCEPT {
     i32 at_zero[3];
     solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
 
@@ -127,8 +129,9 @@ bool allocateWhitePreferredQ16(const WhiteAllocationQ16& allocation,
         return false;
     }
 
-    // White-preferred: the top of the interval.
-    const i32 level = high;
+    // Either end reproduces the target exactly; which one is policy.
+    const i32 level =
+        allocation.policy == WhiteAllocationPolicy::RgbPreferred ? low : high;
     i32 rgb[3];
     for (int i = 0; i < 3; ++i) {
         const i32 drive = at_zero[i] - scaleWhiteQ16(allocation.per_white[i], level);

--- a/src/fl/gfx/white_allocation.h
+++ b/src/fl/gfx/white_allocation.h
@@ -35,6 +35,28 @@
 
 namespace fl {
 
+/// Which end of the feasible white interval to take (C3).
+///
+/// The interval exists because the preimage is not unique: any white level
+/// inside it reproduces the target exactly, with the RGB drives making up
+/// the difference. Picking an end is a policy, not a calculation, which is
+/// why it is per profile rather than per pixel.
+enum class WhiteAllocationPolicy {
+    /// As much white as the target allows. C3's default -- the white emitter
+    /// is usually the efficient one and the better colour renderer.
+    WhitePreferred,
+
+    /// As little as the target allows, which for most targets is none. The
+    /// per-profile override C3 asks for: a device whose white emitter
+    /// renders worse than its primaries, or whose primaries are wanted for
+    /// saturation, takes this end instead.
+    ///
+    /// Not the same as ignoring the white emitter. Where RGB alone cannot
+    /// reach the target, this returns the *smallest* white level that makes
+    /// it reachable rather than failing.
+    RgbPreferred,
+};
+
 /// Everything the per-pixel allocation needs, derived once when a profile
 /// binds.
 struct WhiteAllocationQ16 {
@@ -46,6 +68,9 @@ struct WhiteAllocationQ16 {
     /// Precomputing this is what leaves the per-pixel path with a single
     /// matrix multiply. It does not depend on the pixel.
     i32 per_white[3];
+
+    /// Which end of the interval this profile takes.
+    WhiteAllocationPolicy policy;
 };
 
 /// Derive the allocation for a three-primary profile plus one white emitter.
@@ -57,10 +82,12 @@ struct WhiteAllocationQ16 {
 /// emitter the RGB primaries cannot express at all.
 bool buildWhiteAllocationQ16(const EmitterProfile& profile,
                              const i32 (&white_xyz)[3],
+                             WhiteAllocationPolicy policy,
                              WhiteAllocationQ16* out) FL_NO_EXCEPT;
 
-/// One pixel: XYZ in s16.16 to four drives, white as large as the target
-/// allows. Order is red, green, blue, white.
+/// One pixel: XYZ in s16.16 to four drives, in the order red, green, blue,
+/// white, at whichever end of the feasible interval the profile's policy
+/// names.
 ///
 /// False when no white level keeps the RGB drives in range, which means the
 /// target is outside the device hull -- the gamut mapper's job, not this
@@ -73,8 +100,8 @@ bool buildWhiteAllocationQ16(const EmitterProfile& profile,
 /// level, at the price of i64 multiplies that are not obviously cheaper on
 /// an 8-bit target. Nobody has measured which wins, so the straightforward
 /// version is what ships.
-bool allocateWhitePreferredQ16(const WhiteAllocationQ16& allocation,
-                               const i32 (&xyz)[3],
-                               i32 (&drives)[4]) FL_NO_EXCEPT;
+bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
+                              const i32 (&xyz)[3],
+                              i32 (&drives)[4]) FL_NO_EXCEPT;
 
 }  // namespace fl

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -586,7 +586,8 @@ FL_TEST_CASE("RGBW mapper leaves alone what the RGB hull wrongly rejects") {
     };
 
     GamutMapRgbwQ16 rgbw;
-    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65, &rgbw));
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
     GamutMapQ16 rgb_only;
     FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &rgb_only));
 
@@ -611,7 +612,7 @@ FL_TEST_CASE("RGBW mapper leaves alone what the RGB hull wrongly rejects") {
         i32 drives[4];
         mapAndAllocateRgbwQ16(rgbw, xyz, drives);
         i32 direct[4];
-        FL_REQUIRE(allocateWhitePreferredQ16(rgbw.allocation, xyz, direct));
+        FL_REQUIRE(allocateEmitterDrivesQ16(rgbw.allocation, xyz, direct));
         for (int i = 0; i < 4; ++i) {
             FL_CHECK_EQ(drives[i], direct[i]);
             FL_CHECK_GE(drives[i], 0);
@@ -627,7 +628,8 @@ FL_TEST_CASE("RGBW lightness bound is the brighter one the white emitter buys") 
     // at the three-emitter value would leave the mapper dimming RGBW
     // neutrals for no reason.
     GamutMapRgbwQ16 rgbw;
-    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65, &rgbw));
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
     GamutMapQ16 rgb_only;
     FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &rgb_only));
 
@@ -647,14 +649,14 @@ FL_TEST_CASE("RGBW lightness bound is the brighter one the white emitter buys") 
 
     // And that neutral must actually be reachable, while 5% brighter is not.
     i32 drives[4];
-    FL_CHECK(allocateWhitePreferredQ16(rgbw.allocation, expected_neutral, drives));
+    FL_CHECK(allocateEmitterDrivesQ16(rgbw.allocation, expected_neutral, drives));
     const i32 too_bright[3] = {
         static_cast<i32>(expected_neutral[0] * 1.05f),
         static_cast<i32>(expected_neutral[1] * 1.05f),
         static_cast<i32>(expected_neutral[2] * 1.05f),
     };
     FL_CHECK_FALSE(
-        allocateWhitePreferredQ16(rgbw.allocation, too_bright, drives));
+        allocateEmitterDrivesQ16(rgbw.allocation, too_bright, drives));
 }
 
 FL_TEST_CASE("RGBW lightness bound stays reachable for a skewed white") {
@@ -672,7 +674,8 @@ FL_TEST_CASE("RGBW lightness bound stays reachable for a skewed white") {
     const i32 skewed_white[3] = {q16(1.8955f), q16(1.0f), q16(0.74847f)};
 
     GamutMapRgbwQ16 rgbw;
-    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), skewed_white, &rgbw));
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), skewed_white,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
 
     // Pin the premise: this fixture really is the awkward shape, so the test
     // cannot go quiet if the emitter columns or the solve move.
@@ -687,7 +690,7 @@ FL_TEST_CASE("RGBW lightness bound stays reachable for a skewed white") {
         oklabToXyzQ16(lab, brightest);
     }
     i32 drives[4];
-    FL_CHECK(allocateWhitePreferredQ16(rgbw.allocation, brightest, drives));
+    FL_CHECK(allocateEmitterDrivesQ16(rgbw.allocation, brightest, drives));
 
     // And the mapper must not collapse a real colour to black through it.
     i32 xyz[3];
@@ -703,7 +706,8 @@ FL_TEST_CASE("RGBW lightness bound stays reachable for a skewed white") {
 
 FL_TEST_CASE("RGBW mapper always returns drives inside [0, 1]") {
     GamutMapRgbwQ16 rgbw;
-    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65, &rgbw));
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
 
     int exercised = 0;
     for (int hue = 0; hue < 36; ++hue) {
@@ -717,7 +721,7 @@ FL_TEST_CASE("RGBW mapper always returns drives inside [0, 1]") {
             i32 xyz[3];
             xyzAt(x, y, luminance, xyz);
             i32 probe[4];
-            if (allocateWhitePreferredQ16(rgbw.allocation, xyz, probe)) {
+            if (allocateEmitterDrivesQ16(rgbw.allocation, xyz, probe)) {
                 continue;  // nothing for the mapper to do
             }
             ++exercised;

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -704,6 +704,53 @@ FL_TEST_CASE("RGBW lightness bound stays reachable for a skewed white") {
     }
 }
 
+FL_TEST_CASE("RGBW mapper honours the allocation policy") {
+    // Nothing else here exercises RgbPreferred through the mapper, so a
+    // regression that dropped `policy` on the floor in buildGamutMapRgbwQ16
+    // -- leaving every device white-preferred -- would pass the whole file.
+    GamutMapRgbwQ16 white_first;
+    GamutMapRgbwQ16 rgb_first;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                    WhiteAllocationPolicy::WhitePreferred,
+                                    &white_first));
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                    WhiteAllocationPolicy::RgbPreferred,
+                                    &rgb_first));
+
+    // The policy must reach the stored allocation.
+    FL_CHECK(white_first.allocation.policy ==
+             WhiteAllocationPolicy::WhitePreferred);
+    FL_CHECK(rgb_first.allocation.policy == WhiteAllocationPolicy::RgbPreferred);
+
+    // It changes the drives, never which targets are reachable, so the
+    // lightness bound has to come out the same either way.
+    FL_CHECK_EQ(white_first.max_neutral_lightness,
+                rgb_first.max_neutral_lightness);
+
+    int differed = 0;
+    for (int step = 1; step <= 10; ++step) {
+        i32 xyz[3];
+        xyzAt(0.3127f, 0.3290f, static_cast<float>(step) / 10.0f, xyz);
+
+        i32 with_white[4];
+        i32 with_rgb[4];
+        mapAndAllocateRgbwQ16(white_first, xyz, with_white);
+        mapAndAllocateRgbwQ16(rgb_first, xyz, with_rgb);
+
+        FL_CHECK_LE(with_rgb[3], with_white[3]);
+        if (with_rgb[3] < with_white[3]) {
+            ++differed;
+        }
+        for (int i = 0; i < 4; ++i) {
+            FL_CHECK_GE(with_rgb[i], 0);
+            FL_CHECK_LE(with_rgb[i], kFullDrive);
+        }
+    }
+    // Guard against the two never diverging, which would make the checks
+    // above pass whatever the mapper did with the policy.
+    FL_CHECK_GT(differed, 5);
+}
+
 FL_TEST_CASE("RGBW mapper always returns drives inside [0, 1]") {
     GamutMapRgbwQ16 rgbw;
     FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,

--- a/tests/fl/gfx/white_allocation.cpp
+++ b/tests/fl/gfx/white_allocation.cpp
@@ -63,10 +63,12 @@ const Vector kNonD65Vectors[] = {
 void checkAgainstReference(const i32 (&white)[3], const Vector* vectors,
                            int count) {
     WhiteAllocationQ16 allocation;
-    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), white, &allocation));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), white,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
     for (int v = 0; v < count; ++v) {
         i32 drives[4];
-        FL_REQUIRE(allocateWhitePreferredQ16(allocation, vectors[v].xyz, drives));
+        FL_REQUIRE(allocateEmitterDrivesQ16(allocation, vectors[v].xyz, drives));
         for (int i = 0; i < 4; ++i) {
             // 256 raw units is one code at 8-bit output. The reference
             // inverts in float64; this quantizes the matrix first, so
@@ -107,7 +109,9 @@ FL_TEST_CASE("White allocation prefers white as far as the target allows") {
     // under-allocation before it notices, and the reconstruction test does
     // not catch the difference because the RGB drives absorb it.
     WhiteAllocationQ16 allocation;
-    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
 
     int exercised = 0;
     for (int step = 1; step <= 12; ++step) {
@@ -116,7 +120,7 @@ FL_TEST_CASE("White allocation prefers white as far as the target allows") {
         colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, luminance, xyz_f);
         const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
         i32 drives[4];
-        FL_REQUIRE(allocateWhitePreferredQ16(allocation, xyz, drives));
+        FL_REQUIRE(allocateEmitterDrivesQ16(allocation, xyz, drives));
 
         i32 at_zero[3];
         solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
@@ -159,7 +163,9 @@ FL_TEST_CASE("White allocation survives a white emitter dim enough to overflow")
     const i32 dim_white[3] = {6, 7, 7};
 
     WhiteAllocationQ16 allocation;
-    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), dim_white, &allocation));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), dim_white,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
     // Pin that the fixture really does reach the small-slope case, so this
     // cannot go quiet if the solve or the constants move.
     i32 largest_slope = 0;
@@ -175,7 +181,7 @@ FL_TEST_CASE("White allocation survives a white emitter dim enough to overflow")
     colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, 0.5f, xyz_f);
     const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
     i32 drives[4];
-    FL_REQUIRE(allocateWhitePreferredQ16(allocation, xyz, drives));
+    FL_REQUIRE(allocateEmitterDrivesQ16(allocation, xyz, drives));
     for (int i = 0; i < 4; ++i) {
         FL_CHECK_GE(drives[i], 0);
         FL_CHECK_LE(drives[i], kFullDrive);
@@ -192,13 +198,15 @@ FL_TEST_CASE("White allocation reproduces the target it was given") {
     // target. This is what would break if the white column were subtracted
     // with the wrong sign or scale.
     WhiteAllocationQ16 allocation;
-    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
 
     const float emitters[3][2] = {
         {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
     for (const auto& vector : kRgbwVectors) {
         i32 drives[4];
-        FL_REQUIRE(allocateWhitePreferredQ16(allocation, vector.xyz, drives));
+        FL_REQUIRE(allocateEmitterDrivesQ16(allocation, vector.xyz, drives));
         float reproduced[3] = {0.0f, 0.0f, 0.0f};
         for (int e = 0; e < 3; ++e) {
             float column[3];
@@ -219,7 +227,9 @@ FL_TEST_CASE("White allocation reproduces the target it was given") {
 
 FL_TEST_CASE("White allocation refuses a target outside the hull") {
     WhiteAllocationQ16 allocation;
-    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, &allocation));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
 
     // A saturated chromaticity well outside the sRGB triangle, and an
     // over-bright neutral. Neither has a white level that rescues it, and
@@ -235,25 +245,127 @@ FL_TEST_CASE("White allocation refuses a target outside the hull") {
         colorimetric_response::xyY_to_XYZ(sample[0], sample[1], sample[2], xyz_f);
         const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
         i32 drives[4];
-        if (!allocateWhitePreferredQ16(allocation, xyz, drives)) {
+        if (!allocateEmitterDrivesQ16(allocation, xyz, drives)) {
             ++refused;
         }
     }
     FL_CHECK_EQ(refused, 3);
 }
 
+FL_TEST_CASE("RGB-preferred takes the other end of the same interval") {
+    // C3's per-profile override. Both policies reproduce the target exactly
+    // -- they pick different points on the same feasible interval -- so the
+    // test is that they differ in white and agree in the light they make.
+    WhiteAllocationQ16 white_first;
+    WhiteAllocationQ16 rgb_first;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &white_first));
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::RgbPreferred,
+                                       &rgb_first));
+
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    int differed = 0;
+    for (int step = 1; step <= 12; ++step) {
+        const float luminance = static_cast<float>(step) / 12.0f;
+        float xyz_f[3];
+        colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, luminance, xyz_f);
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+
+        i32 with_white[4];
+        i32 with_rgb[4];
+        FL_REQUIRE(allocateEmitterDrivesQ16(white_first, xyz, with_white));
+        FL_REQUIRE(allocateEmitterDrivesQ16(rgb_first, xyz, with_rgb));
+
+        // RGB-preferred never uses more white than white-preferred.
+        FL_CHECK_LE(with_rgb[3], with_white[3]);
+        if (with_rgb[3] < with_white[3]) {
+            ++differed;
+        }
+
+        // Both must land on the same colour. Reconstructed through the
+        // emitter columns rather than compared drive by drive, since the
+        // whole point is that the drives differ.
+        for (int which = 0; which < 2; ++which) {
+            const i32* drives = which == 0 ? with_white : with_rgb;
+            float made[3] = {0.0f, 0.0f, 0.0f};
+            for (int e = 0; e < 3; ++e) {
+                float column[3];
+                colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1],
+                                                  1.0f, column);
+                for (int i = 0; i < 3; ++i) {
+                    made[i] += toFloat(drives[e]) * column[i];
+                }
+            }
+            for (int i = 0; i < 3; ++i) {
+                made[i] += toFloat(drives[3]) * toFloat(kWhiteD65[i]);
+            }
+            for (int i = 0; i < 3; ++i) {
+                FL_CHECK_LT(fl::fabsf(made[i] - toFloat(xyz[i])), 0.01f);
+            }
+        }
+    }
+    // Guard against the two policies never actually diverging, which would
+    // make every check above vacuous. A D65 neutral is exactly the case
+    // where white can do all the work or none of it.
+    FL_CHECK_GT(differed, 8);
+}
+
+FL_TEST_CASE("RGB-preferred still uses white when RGB alone cannot reach") {
+    // The override is not "ignore the white emitter". Where the primaries
+    // cannot reach the target on their own, this must return the smallest
+    // white level that makes it reachable rather than failing.
+    WhiteAllocationQ16 rgb_first;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::RgbPreferred,
+                                       &rgb_first));
+
+    // Brighter than the RGB primaries can manage alone, but inside the
+    // four-emitter hull.
+    float xyz_f[3];
+    colorimetric_response::xyY_to_XYZ(0.3127f, 0.3290f, 2.0f, xyz_f);
+    const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+
+    // Pin the premise: RGB alone really cannot do this one.
+    i32 rgb_only[3];
+    solveRgbDrivesQ16(rgb_first.rgb_solve, xyz, rgb_only);
+    bool rgb_alone_fails = false;
+    for (int i = 0; i < 3; ++i) {
+        if (rgb_only[i] > kFullDrive) {
+            rgb_alone_fails = true;
+        }
+    }
+    FL_REQUIRE(rgb_alone_fails);
+
+    i32 drives[4];
+    FL_REQUIRE(allocateEmitterDrivesQ16(rgb_first, xyz, drives));
+    FL_CHECK_GT(drives[3], 0);
+    for (int i = 0; i < 4; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+}
+
 FL_TEST_CASE("White allocation rejects profiles it cannot work with") {
     WhiteAllocationQ16 allocation;
-    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65, nullptr));
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                        WhiteAllocationPolicy::WhitePreferred,
+                                        nullptr));
 
     EmitterProfile collinear = rgbDevice();
     collinear.xy_g[0] = 0.6400f;
     collinear.xy_g[1] = 0.3300f;
-    FL_CHECK_FALSE(buildWhiteAllocationQ16(collinear, kWhiteD65, &allocation));
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(collinear, kWhiteD65,
+                                        WhiteAllocationPolicy::WhitePreferred,
+                                        &allocation));
 
     // A white emitter with no light in it leaves nothing to trade against.
     const i32 dark[3] = {0, 0, 0};
-    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), dark, &allocation));
+    FL_CHECK_FALSE(buildWhiteAllocationQ16(rgbDevice(), dark,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &allocation));
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/gfx/white_allocation.cpp
+++ b/tests/fl/gfx/white_allocation.cpp
@@ -341,11 +341,46 @@ FL_TEST_CASE("RGB-preferred still uses white when RGB alone cannot reach") {
 
     i32 drives[4];
     FL_REQUIRE(allocateEmitterDrivesQ16(rgb_first, xyz, drives));
-    FL_CHECK_GT(drives[3], 0);
     for (int i = 0; i < 4; ++i) {
         FL_CHECK_GE(drives[i], 0);
         FL_CHECK_LE(drives[i], kFullDrive);
     }
+
+    // The *smallest* white that works, not merely some white. Checking only
+    // that the level is above zero would pass for any feasible answer,
+    // including the white-preferred one, which is the whole thing this test
+    // is supposed to distinguish.
+    //
+    // Derived here from the drives RGB alone would need: every channel above
+    // full scale has to be brought down, and the one needing the most white
+    // to get there sets the floor.
+    float smallest_that_works = 0.0f;
+    for (int i = 0; i < 3; ++i) {
+        const float slope = toFloat(rgb_first.per_white[i]);
+        const float start = toFloat(rgb_only[i]);
+        float needed = 0.0f;
+        if (slope > 0.0f) {
+            needed = (start - 1.0f) / slope;
+        } else if (slope < 0.0f) {
+            needed = start / slope;
+        }
+        if (needed > smallest_that_works) {
+            smallest_that_works = needed;
+        }
+    }
+    FL_REQUIRE_GT(smallest_that_works, 0.0f);
+    FL_CHECK_LT(fl::fabsf(toFloat(drives[3]) - smallest_that_works),
+                16.0f / 65536.0f);
+
+    // And it really is less than what white-preferred would have chosen, so
+    // the two policies are distinguishable on this target.
+    WhiteAllocationQ16 white_first;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &white_first));
+    i32 white_drives[4];
+    FL_REQUIRE(allocateEmitterDrivesQ16(white_first, xyz, white_drives));
+    FL_CHECK_LT(drives[3], white_drives[3]);
 }
 
 FL_TEST_CASE("White allocation rejects profiles it cannot work with") {


### PR DESCRIPTION
> **Stacked on #4190**, which it needs. Base moves to `master` when that merges.

C3 asks for white-preferred by default with a **per-profile RGB-preferred override**. Only the default existed; this is the last named deliverable in P7's scope.

## Why it's a policy and not a calculation

The preimage isn't unique: any white level inside the feasible interval reproduces the target exactly, with the RGB drives making up the difference. Both policies are correct answers to the same question — they just pick different ends of the same interval.

So the policy lives on `WhiteAllocationQ16` (decided once at bind time) with **one** entry point, `allocateEmitterDrivesQ16`, rather than two functions a caller could pick between inconsistently. That's the rename in the diff.

## RGB-preferred is not "ignore the white emitter"

Where the primaries can't reach a target alone, it returns the *smallest* white level that makes it reachable — the bottom of the interval, not zero. A test covers that case specifically, and **pins its premise** (that RGB alone really does fail there) so it can't pass by the target turning out to be RGB-reachable after all.

## Tests

- **Equivalence**: both policies land on the same colour, reconstructed through the emitter columns rather than compared drive-by-drive — since the whole point is that the drives differ. RGB-preferred never uses more white. Guarded against the two policies never actually diverging, which would make it vacuous.
- **The non-trivial case** above.
- Verified by mutation: ignoring the policy fails the equivalence test.

`buildGamutMapRgbwQ16` threads the policy through. It changes the drives, never which targets are reachable, so the hull the mapper works against is identical either way.

Part of #4034 / #4041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable white-allocation policies for RGB-preferred or white-preferred rendering.
  * RGB-preferred rendering minimizes white-emitter use while preserving the requested color.
  * Gamut mapping continues to support targets unreachable through RGB emitters alone by using white emission when necessary.
* **Tests**
  * Added coverage for both allocation policies, including equivalent-color output and fallback behavior for difficult targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->