### PR TITLE
feat(gfx): compose the streaming pipeline core (P6, #4040)

### DIFF
--- a/ci/tests/test_no_rgb8_intermediate.py
+++ b/ci/tests/test_no_rgb8_intermediate.py
@@ -40,14 +40,36 @@ PER_PIXEL_STAGES = (
 # array is the hand-rolled version of the same thing.
 FORBIDDEN_TYPES = ("CRGB", "CRGBW")
 
-# `u8 name[` -- an 8-bit buffer. Single `u8` scalars are fine and common
-# (a code coming in, a channel count), which is why this looks for the
-# array form specifically rather than for the type.
-U8_BUFFER = re.compile(r"\bu8\s+\w+\s*\[")
+# An 8-bit buffer. Single `u8` scalars are fine and common -- a code coming
+# in, a channel count -- so this looks for the array form rather than the
+# type.
+#
+# The scan runs from `u8` to the first `[`, refusing to cross `;{}()` or `=`.
+# Crossing `;` would let one statement's `u8` match the next statement's
+# subscript; refusing `=` is what keeps `u8 value = table[i];` from reading
+# as a declaration, since there the bracket is a subscript on the right-hand
+# side. What it does catch, and the simpler `u8 \w+ \[` did not, is the
+# second declarator in `u8 code, intermediate[3];`.
+U8_BUFFER = re.compile(r"\bu8\s+[^;{}()=]*\[")
+
+
+# One pass over the four lexical forms that can contain each other's
+# delimiters, so precedence is decided by which starts first rather than by
+# the order of separate substitutions. Stripping comments before strings
+# would treat the `//` in a URL literal as a comment and eat the rest of the
+# line; stripping strings before comments would treat a quote inside a
+# comment as opening one.
+_LEXICAL = re.compile(
+    r'"(?:[^"\\\n]|\\.)*"'
+    r"|'(?:[^'\\\n]|\\.)*'"
+    r"|/\*.*?\*/"
+    r"|//[^\n]*",
+    re.S,
+)
 
 
 def strip_comments_and_strings(source: str) -> str:
-    """Remove block comments, line comments and string literals.
+    """Remove block comments, line comments, and string and char literals.
 
     Without this the check trips on prose: every one of these files
     *discusses* RGB8, because explaining why there is no RGB8 intermediate is
@@ -58,10 +80,15 @@ def strip_comments_and_strings(source: str) -> str:
     this test looks.
     """
 
-    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.S)
-    source = re.sub(r"//[^\n]*", " ", source)
-    source = re.sub(r'"(?:[^"\\]|\\.)*"', '""', source)
-    return source
+    def replace(match: "re.Match[str]") -> str:
+        text = match.group(0)
+        if text.startswith('"'):
+            return '""'
+        if text.startswith("'"):
+            return "''"
+        return " "
+
+    return _LEXICAL.sub(replace, source)
 
 
 class TestNoRgb8Intermediate(unittest.TestCase):
@@ -112,14 +139,54 @@ class TestNoRgb8Intermediate(unittest.TestCase):
 
     def test_the_check_can_actually_fail(self: "TestNoRgb8Intermediate") -> None:
         # A structural test that cannot fail is worth nothing, and this one is
-        # all regexes over text. Feed it the shape it is meant to catch.
-        planted = "void f() { u8 scratch[3]; CRGB mid; }"
-        self.assertIsNotNone(U8_BUFFER.search(planted))
-        self.assertRegex(strip_comments_and_strings(planted), r"\bCRGB\b")
-        # And the comment stripping really does hide prose, which is the
-        # other half of the trade.
-        prose = "// CRGB is deliberately absent here\nvoid f() {}"
-        self.assertNotRegex(strip_comments_and_strings(prose), r"\bCRGB\b")
+        # all regexes over text. Feed it the shapes it is meant to catch.
+        self.assertIsNotNone(U8_BUFFER.search("void f() { u8 scratch[3]; }"))
+        self.assertRegex(
+            strip_comments_and_strings("void f() { CRGB mid; }"), r"\bCRGB\b"
+        )
+
+        # The second declarator, which an earlier `u8 \w+ \[` pattern missed
+        # entirely: `code` is a legitimate scalar and `intermediate` is the
+        # buffer B3 forbids, in one statement.
+        self.assertIsNotNone(U8_BUFFER.search("u8 code, intermediate[3];"))
+
+    def test_the_check_does_not_fire_on_legitimate_code(
+        self: "TestNoRgb8Intermediate",
+    ) -> None:
+        # The other half. A guard that flags ordinary code gets disabled, so
+        # these are the forms it must leave alone.
+        for allowed in (
+            "u8 code = 0;",  # a scalar
+            "u8 value = table[index];",  # a subscript, not a buffer
+            "void f(u8 r, u8 g, u8 b) {}",  # parameters
+            "const u16 table[256] = {};",  # 16-bit is the working type
+        ):
+            with self.subTest(source=allowed):
+                self.assertIsNone(U8_BUFFER.search(allowed))
+
+    def test_prose_and_literals_are_stripped_correctly(
+        self: "TestNoRgb8Intermediate",
+    ) -> None:
+        # Comments discussing RGB8 are exactly what these files are full of,
+        # so the stripping has to hide them.
+        self.assertNotRegex(
+            strip_comments_and_strings(
+                "// CRGB is deliberately absent here\nvoid f() {}"
+            ),
+            r"\bCRGB\b",
+        )
+
+        # And the precedence has to be decided by which form starts first.
+        # Stripping comments before strings ate the rest of a line after a
+        # URL literal, which would have hidden real code from the check.
+        survived = strip_comments_and_strings(
+            'const char* url = "http://example.com"; CRGB mid;'
+        )
+        self.assertRegex(survived, r"\bCRGB\b")
+
+        # The mirror case: a quote inside a comment must not open a string.
+        survived = strip_comments_and_strings("// it's fine\nCRGB mid;")
+        self.assertRegex(survived, r"\bCRGB\b")
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_no_rgb8_intermediate.py
+++ b/ci/tests/test_no_rgb8_intermediate.py
@@ -1,0 +1,126 @@
+"""B3: the streaming path must not round-trip through RGB8.
+
+P6 (#4040) asks for decode to be one semantic conversion -- an RGB8 code
+straight to linear light -- with no intermediate RGB8 linear buffer and no
+RGB8 to RGB8 correction anywhere on the per-pixel path. That is a structural
+property, not something a numeric test can see: a pipeline that quantized to
+8 bits somewhere in the middle would still produce plausible colours, just
+worse ones, and the error would look like rounding rather than like a
+missing requirement.
+
+So this asserts the shape instead. Companion to
+test_no_iterative_solver_per_pixel.py, which guards A3/B11 the same way.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+GFX = PROJECT_ROOT / "src" / "fl" / "gfx"
+
+# The composition, and the stages it runs per pixel. `pipeline.cpp.hpp` is
+# the one that would grow an intermediate buffer if anyone added one.
+PER_PIXEL_STAGES = (
+    "pipeline.cpp.hpp",
+    "transfer.cpp.hpp",
+    "source_xyz.cpp.hpp",
+    "chromatic_adaptation.cpp.hpp",
+    "device_solve.cpp.hpp",
+    "gamut_map.cpp.hpp",
+    "white_allocation.cpp.hpp",
+    "flux_scalar.cpp.hpp",
+)
+
+# A declaration of one of these on the per-pixel path is the RGB8 round trip
+# B3 forbids. `CRGB` and `CRGBW` are the 8-bit pixel types; a bare `u8`
+# array is the hand-rolled version of the same thing.
+FORBIDDEN_TYPES = ("CRGB", "CRGBW")
+
+# `u8 name[` -- an 8-bit buffer. Single `u8` scalars are fine and common
+# (a code coming in, a channel count), which is why this looks for the
+# array form specifically rather than for the type.
+U8_BUFFER = re.compile(r"\bu8\s+\w+\s*\[")
+
+
+def strip_comments_and_strings(source: str) -> str:
+    """Remove block comments, line comments and string literals.
+
+    Without this the check trips on prose: every one of these files
+    *discusses* RGB8, because explaining why there is no RGB8 intermediate is
+    exactly what their comments are for. The same reasoning as the sibling
+    test's -- a regex over C++ is a deliberate trade, and the cost of getting
+    it wrong here is a false alarm rather than a silently weakened guard,
+    because a stripped-out declaration would still have to appear somewhere
+    this test looks.
+    """
+
+    source = re.sub(r"/\*.*?\*/", " ", source, flags=re.S)
+    source = re.sub(r"//[^\n]*", " ", source)
+    source = re.sub(r'"(?:[^"\\]|\\.)*"', '""', source)
+    return source
+
+
+class TestNoRgb8Intermediate(unittest.TestCase):
+    def test_the_stage_files_all_exist(self: "TestNoRgb8Intermediate") -> None:
+        # Without this the checks below pass vacuously the moment a file is
+        # renamed, which is exactly when the guard is most needed.
+        for name in PER_PIXEL_STAGES:
+            self.assertTrue((GFX / name).is_file(), msg=f"missing stage {name}")
+
+    def test_no_rgb8_pixel_type_on_the_per_pixel_path(
+        self: "TestNoRgb8Intermediate",
+    ) -> None:
+        for name in PER_PIXEL_STAGES:
+            with self.subTest(stage=name):
+                code = strip_comments_and_strings(
+                    (GFX / name).read_text(encoding="utf-8")
+                )
+                for forbidden in FORBIDDEN_TYPES:
+                    self.assertNotRegex(
+                        code,
+                        rf"\b{forbidden}\b",
+                        msg=(
+                            f"{name} references {forbidden} outside a comment. "
+                            "The streaming path decodes RGB8 to linear light in "
+                            "one step (B3); an 8-bit pixel type in the middle "
+                            "of it is the round trip #4040 rules out."
+                        ),
+                    )
+
+    def test_no_u8_buffer_on_the_per_pixel_path(
+        self: "TestNoRgb8Intermediate",
+    ) -> None:
+        for name in PER_PIXEL_STAGES:
+            with self.subTest(stage=name):
+                code = strip_comments_and_strings(
+                    (GFX / name).read_text(encoding="utf-8")
+                )
+                match = U8_BUFFER.search(code)
+                self.assertIsNone(
+                    match,
+                    msg=(
+                        f"{name} declares an 8-bit buffer "
+                        f"({match.group(0) if match else ''}). B3 allows a u8 "
+                        "code in and a u8 code out, but nothing 8-bit in "
+                        "between."
+                    ),
+                )
+
+    def test_the_check_can_actually_fail(self: "TestNoRgb8Intermediate") -> None:
+        # A structural test that cannot fail is worth nothing, and this one is
+        # all regexes over text. Feed it the shape it is meant to catch.
+        planted = "void f() { u8 scratch[3]; CRGB mid; }"
+        self.assertIsNotNone(U8_BUFFER.search(planted))
+        self.assertRegex(strip_comments_and_strings(planted), r"\bCRGB\b")
+        # And the comment stripping really does hide prose, which is the
+        # other half of the trade.
+        prose = "// CRGB is deliberately absent here\nvoid f() {}"
+        self.assertNotRegex(strip_comments_and_strings(prose), r"\bCRGB\b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_no_rgb8_intermediate.py
+++ b/ci/tests/test_no_rgb8_intermediate.py
@@ -60,7 +60,13 @@ U8_BUFFER = re.compile(r"\bu8\s+[^;{}()=]*\[")
 # line; stripping strings before comments would treat a quote inside a
 # comment as opening one.
 _LEXICAL = re.compile(
-    r'"(?:[^"\\\n]|\\.)*"'
+    # Raw strings first, and not merely for tidiness: `R"(a " b // c)"` holds
+    # both a quote and a line-comment marker, so whichever of the two forms
+    # below matched it would run off the end and take real code with it. The
+    # delimiter is captured and back-referenced, which is what makes the
+    # terminator unambiguous -- that is the whole point of the form.
+    r'R"([^()\\\s]{0,16})\(.*?\)\1"'
+    r'|"(?:[^"\\\n]|\\.)*"'
     r"|'(?:[^'\\\n]|\\.)*'"
     r"|/\*.*?\*/"
     r"|//[^\n]*",
@@ -82,7 +88,7 @@ def strip_comments_and_strings(source: str) -> str:
 
     def replace(match: "re.Match[str]") -> str:
         text = match.group(0)
-        if text.startswith('"'):
+        if text.startswith('"') or text.startswith('R"'):
             return '""'
         if text.startswith("'"):
             return "''"
@@ -186,6 +192,20 @@ class TestNoRgb8Intermediate(unittest.TestCase):
 
         # The mirror case: a quote inside a comment must not open a string.
         survived = strip_comments_and_strings("// it's fine\nCRGB mid;")
+        self.assertRegex(survived, r"\bCRGB\b")
+
+        # Raw strings are the form that defeats a naive lexer, because one
+        # can hold both a quote and a line-comment marker. Either of the
+        # plain forms would run off the end here and swallow the
+        # declaration that follows.
+        survived = strip_comments_and_strings(
+            'const char* s = R"(quote " // not a comment)"; CRGB mid;'
+        )
+        self.assertRegex(survived, r"\bCRGB\b")
+
+        # And with a custom delimiter, which is what makes the terminator
+        # unambiguous -- the closing `)"` inside the body is not the end.
+        survived = strip_comments_and_strings('auto s = R"xy(a)" b)xy"; CRGB mid;')
         self.assertRegex(survived, r"\bCRGB\b")
 
 

--- a/src/fl/gfx/_build.cpp.hpp
+++ b/src/fl/gfx/_build.cpp.hpp
@@ -22,6 +22,7 @@
 #include "fl/gfx/hsv16.cpp.hpp"
 #include "fl/gfx/leds.cpp.hpp"
 #include "fl/gfx/oklab_q16.cpp.hpp"
+#include "fl/gfx/pipeline.cpp.hpp"
 #include "fl/gfx/raster_sparse.cpp.hpp"
 #include "fl/gfx/rectangular_draw_buffer.cpp.hpp"
 #include "fl/gfx/rgbw.cpp.hpp"

--- a/src/fl/gfx/pipeline.cpp.hpp
+++ b/src/fl/gfx/pipeline.cpp.hpp
@@ -1,0 +1,85 @@
+// ok no header - implementation for fl/gfx/pipeline.h
+
+#include "fl/gfx/pipeline.h"
+
+#include "fl/gfx/chromatic_adaptation.h"
+#include "fl/gfx/transfer.h"
+
+namespace fl {
+
+namespace {
+
+/// The working domain's rendering white.
+///
+/// Named for this file because .cpp.hpp files share a translation unit under
+/// the unity build, so an anonymous namespace does not isolate it.
+constexpr Chromaticity kPipelineD65 = Chromaticity(0.3127f, 0.3290f);
+
+}  // namespace
+
+bool buildStreamingPipelineQ16(const SourceProfile& source,
+                               const EmitterProfile& device,
+                               StreamingPipelineQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    if (!buildSourceMatrixQ16(source.primaries, &out->source)) {
+        return false;
+    }
+
+    // Fold the source white's adaptation to D65 into the matrix above, so
+    // the per-pixel path never pays for it. Skipped when the source already
+    // renders to D65, where the transform is the identity and folding it
+    // would only add a round trip's worth of quantization.
+    const Chromaticity source_white = source.primaries.white;
+    const bool already_d65 =
+        source_white.x > kPipelineD65.x - 1e-4f &&
+        source_white.x < kPipelineD65.x + 1e-4f &&
+        source_white.y > kPipelineD65.y - 1e-4f &&
+        source_white.y < kPipelineD65.y + 1e-4f;
+    if (!already_d65) {
+        AdaptationMatrixQ16 adaptation;
+        if (!buildBradfordMatrixQ16(source_white, kPipelineD65, &adaptation)) {
+            return false;
+        }
+        foldAdaptationIntoSourceMatrix(adaptation, &out->source);
+    }
+
+    if (!buildGamutMapQ16(device, &out->gamut)) {
+        return false;
+    }
+    out->transfer = source.transfer;
+    out->flux = FluxScalar::unity();
+    return true;
+}
+
+void setPipelineFluxQ16(StreamingPipelineQ16* pipeline,
+                        FluxScalar flux) FL_NO_EXCEPT {
+    if (pipeline == nullptr) {
+        return;
+    }
+    pipeline->flux = flux;
+}
+
+void processPixelQ16(const StreamingPipelineQ16& pipeline, u8 r, u8 g, u8 b,
+                     i32 (&drives)[3]) FL_NO_EXCEPT {
+    // One semantic conversion per channel: code straight to linear light.
+    // Nothing here writes an RGB8 intermediate, which is what B3 asks and
+    // what ci/tests/test_no_rgb8_intermediate.py enforces structurally.
+    const u16 linear_r = decodeTransferU16(pipeline.transfer, r);
+    const u16 linear_g = decodeTransferU16(pipeline.transfer, g);
+    const u16 linear_b = decodeTransferU16(pipeline.transfer, b);
+
+    i32 xyz[3];
+    linearRgbToXyzQ16(pipeline.source, linear_r, linear_g, linear_b, xyz);
+
+    // The mapper owns clamping, so the stages above hand it the honest
+    // target even when that is outside the hull.
+    mapAndSolveDrivesQ16(pipeline.gamut, xyz, drives);
+
+    // C4's single amplitude stage, last so nothing downstream can rescale a
+    // channel on its own.
+    applyFluxScalar(pipeline.flux, span<i32>(drives, 3));
+}
+
+}  // namespace fl

--- a/src/fl/gfx/pipeline.h
+++ b/src/fl/gfx/pipeline.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// The streaming pipeline core (P6, #4040).
+//
+// P6's stages have existed as separate modules for a while -- decode,
+// primaries->XYZ, chromatic adaptation, the device solve, the gamut mapper,
+// the flux scalar -- with nothing composing them. This is the composition:
+// one bind-time build, and one per-pixel call that runs the whole chain.
+//
+// The chain, and why it is in this order:
+//
+//   1. `decodeTransferU16` turns each RGB8 code into u16 linear light. One
+//      semantic conversion, per B3: there is no intermediate RGB8 linear
+//      buffer and no RGB8->RGB8 correction anywhere in it.
+//   2. `linearRgbToXyzQ16` takes those to s16.16 XYZ. Chromatic adaptation
+//      is folded into that matrix at bind time, so it costs nothing here.
+//   3. The gamut mapper maps the target onto the device hull and solves for
+//      drives -- clamping belongs to it, not to the stages before.
+//   4. `applyFluxScalar` scales the drives. C4's single insertion point:
+//      brightness and the power limiter compose into one scalar before they
+//      get here, and scaling all drives together preserves chromaticity by
+//      construction. Nothing downstream rescales channels independently.
+//
+// Streaming, per C2: the per-pixel call carries no state and allocates
+// nothing, so it runs inside `PixelController` iteration without an RGB16
+// framebuffer.
+
+#include "fl/gfx/color_profile.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/gfx/flux_scalar.h"
+#include "fl/gfx/gamut_map.h"
+#include "fl/gfx/source_xyz.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// Everything the per-pixel path needs, derived once when a profile binds.
+///
+/// Deliberately a plain aggregate of the stages' own bind-time state rather
+/// than a rebuilt copy of it: the matrices here are the ones those modules
+/// produce, so there is no second place for them to drift.
+struct StreamingPipelineQ16 {
+    /// The source's transfer function, applied per code.
+    TransferFunction transfer;
+
+    /// Source primaries to XYZ, with adaptation to D65 already folded in.
+    SourceMatrixQ16 source;
+
+    /// The device hull, its solve, and the lightness bound.
+    GamutMapQ16 gamut;
+
+    /// Brightness times power limiting, as one scalar (C4).
+    ///
+    /// Initialized here because `FluxScalar` has no default constructor --
+    /// there is no sensible "unset" amplitude, and unity is what a pipeline
+    /// that has never been told a brightness should do.
+    FluxScalar flux = FluxScalar::unity();
+};
+
+/// Bind a source declaration and a device profile into a pipeline.
+///
+/// False when either half is degenerate -- collinear primaries, a white with
+/// no cone response, a device that cannot make a neutral. The individual
+/// stages decide that; this reports it.
+///
+/// The flux scalar starts at unity. `setPipelineFluxQ16` is how brightness
+/// and the power limiter reach it, because they change between frames while
+/// everything else here does not.
+bool buildStreamingPipelineQ16(const SourceProfile& source,
+                               const EmitterProfile& device,
+                               StreamingPipelineQ16* out) FL_NO_EXCEPT;
+
+/// Set the composed brightness-and-power scalar for the frames that follow.
+void setPipelineFluxQ16(StreamingPipelineQ16* pipeline, FluxScalar flux) FL_NO_EXCEPT;
+
+/// One pixel: an RGB8 code triple to three emitter drives in s16.16.
+///
+/// Drives always come back inside [0, 1]. No allocation, no state carried
+/// between calls, no RGB8 intermediate.
+void processPixelQ16(const StreamingPipelineQ16& pipeline, u8 r, u8 g, u8 b,
+                     i32 (&drives)[3]) FL_NO_EXCEPT;
+
+}  // namespace fl

--- a/src/fl/gfx/source_xyz.cpp.hpp
+++ b/src/fl/gfx/source_xyz.cpp.hpp
@@ -23,6 +23,28 @@ bool isUsableSourceChromaticity(Chromaticity c) FL_NO_EXCEPT {
            c.y > 1e-6f && c.y < 1.0f;
 }
 
+/// True when the three primaries enclose an actual area of chromaticity.
+///
+/// `invert3x3`'s determinant guard cannot catch a degenerate set. It rejects
+/// below 1e-20, and for chromaticities of order 1 the float32 cancellation
+/// floor is around 1e-7: primaries with red and green *identical* compute a
+/// determinant of -1.09e-7 and sail straight through, yielding an inverse
+/// scaled by 1/det -- about 9e6 -- of pure rounding noise. Measured, not
+/// assumed.
+///
+/// So the degeneracy is caught here instead, geometrically, where the
+/// quantity has meaning: twice the area of the primary triangle. A real
+/// gamut is nowhere near the threshold -- sRGB's is 0.224, three and a half
+/// thousand times larger.
+bool sourcePrimariesEncloseArea(const RgbPrimaries& primaries) FL_NO_EXCEPT {
+    const float ux = primaries.green.x - primaries.red.x;
+    const float uy = primaries.green.y - primaries.red.y;
+    const float vx = primaries.blue.x - primaries.red.x;
+    const float vy = primaries.blue.y - primaries.red.y;
+    const float twice_area = ux * vy - uy * vx;
+    return twice_area > 1e-4f || twice_area < -1e-4f;
+}
+
 /// Round-to-nearest quantization of a float into s16.16.
 i32 quantizeQ16(float v) FL_NO_EXCEPT {
     const float scaled = v * 65536.0f;
@@ -52,6 +74,9 @@ bool buildSourceMatrixQ16(const RgbPrimaries& primaries,
         !isUsableSourceChromaticity(primaries.green) ||
         !isUsableSourceChromaticity(primaries.blue) ||
         !isUsableSourceChromaticity(primaries.white)) {
+        return false;
+    }
+    if (!sourcePrimariesEncloseArea(primaries)) {
         return false;
     }
     const float xy_r[2] = {primaries.red.x, primaries.red.y};

--- a/tests/fl/gfx/pipeline.cpp
+++ b/tests/fl/gfx/pipeline.cpp
@@ -1,0 +1,291 @@
+// Streaming pipeline conformance for color pipeline P6 (#4040).
+
+#include "fl/gfx/pipeline.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/math/math.h"
+#include "fl/stl/int.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+/// The corpus's `rgb` device: sRGB primaries, unit luminance each.
+EmitterProfile rgbDevice() {
+    EmitterProfile p = {};
+    p.xy_r[0] = 0.6400f; p.xy_r[1] = 0.3300f;
+    p.xy_g[0] = 0.3000f; p.xy_g[1] = 0.6000f;
+    p.xy_b[0] = 0.1500f; p.xy_b[1] = 0.0600f;
+    p.lum_r = 1.0f; p.lum_g = 1.0f; p.lum_b = 1.0f;
+    p.native_code_depth = 8;
+    return p;
+}
+
+enum class Src { Srgb, DisplayP3, Bt2020 };
+
+SourceProfile sourceFor(Src which) {
+    switch (which) {
+    case Src::DisplayP3: return SourceProfile::displayP3();
+    case Src::Bt2020:    return SourceProfile::bt2020();
+    case Src::Srgb:      break;
+    }
+    return SourceProfile::srgbBt709();
+}
+
+float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
+
+/// One reference vector: the RGB8 the reference was given, and the emitter
+/// drives it produced. Taken from ci/golden/color-reference-v1.json, which
+/// is the P5 reference this phase is scored against.
+struct Vector {
+    Src source;
+    int code[3];
+    i32 drives[3];
+};
+
+const Vector kVectors[] = {
+    {Src::Bt2020, {  1,  1,  1}, {    12,    41,     4}},
+    {Src::Bt2020, {  1,  0,  0}, {    16,     0,     0}},
+    {Src::Bt2020, {  0,  1,  0}, {     0,    35,     1}},
+    {Src::Bt2020, {  0,  0,  1}, {     0,     3,     1}},
+    {Src::Bt2020, {  2,  4,  8}, {     5,   172,    35}},
+    {Src::Bt2020, {  8, 32, 96}, {     0,  1628,   450}},
+    {Src::Bt2020, {128,128,128}, {  3644, 12255,  1237}},
+    {Src::Bt2020, { 16, 16, 16}, {   194,   654,    66}},
+    {Src::Bt2020, {240,240,240}, { 12332, 41476,  4187}},
+    {Src::Bt2020, {255,  0,  0}, { 18045,     0,   181}},
+    {Src::Bt2020, {  0,255,  0}, {     0, 39791,   993}},
+    {Src::Bt2020, {  0,  0,255}, {     0,  3942,  1088}},
+    {Src::Bt2020, {255,255,  0}, { 14505, 47060,     0}},
+    {Src::Bt2020, {  0,255,255}, {     0, 41320,  3819}},
+    {Src::Bt2020, {255,  0,255}, { 18116,     0,  4364}},
+    {Src::Bt2020, {255, 64,  0}, { 20484,   633,     0}},
+    {Src::DisplayP3, {  1,  1,  1}, {     4,    14,     1}},
+    {Src::DisplayP3, {  1,  0,  0}, {     5,     0,     0}},
+    {Src::DisplayP3, {  0,  1,  0}, {     0,    13,     0}},
+    {Src::DisplayP3, {  0,  0,  1}, {     0,     0,     2}},
+    {Src::DisplayP3, {  2,  4,  8}, {     7,    58,    12}},
+    {Src::DisplayP3, {  8, 32, 96}, {     0,   720,   585}},
+    {Src::DisplayP3, {128,128,128}, {  3008, 10117,  1021}},
+    {Src::DisplayP3, { 16, 16, 16}, {    72,   243,    25}},
+    {Src::DisplayP3, {240,240,240}, { 12143, 40840,  4123}},
+    {Src::DisplayP3, {255,  0,  0}, { 15345,     0,     8}},
+    {Src::DisplayP3, {  0,255,  0}, {     0, 43563,   366}},
+    {Src::DisplayP3, {  0,  0,255}, {     0,     0,  5196}},
+    {Src::DisplayP3, {255,255,  0}, { 13657, 46586,     0}},
+    {Src::DisplayP3, {  0,255,255}, {     0, 45114,  4425}},
+    {Src::DisplayP3, {255,  0,255}, { 15916,     0,  4746}},
+    {Src::DisplayP3, {255, 64,  0}, { 15321,  2334,     0}},
+    {Src::Srgb, {  1,  1,  1}, {     4,    14,     1}},
+    {Src::Srgb, {  1,  0,  0}, {     4,     0,     0}},
+    {Src::Srgb, {  0,  1,  0}, {     0,    14,     0}},
+    {Src::Srgb, {  0,  0,  1}, {     0,     0,     1}},
+    {Src::Srgb, {  2,  4,  8}, {     8,    57,    11}},
+    {Src::Srgb, {  8, 32, 96}, {    34,   677,   553}},
+    {Src::Srgb, {128,128,128}, {  3008, 10117,  1021}},
+    {Src::Srgb, { 16, 16, 16}, {    72,   243,    25}},
+    {Src::Srgb, {240,240,240}, { 12143, 40840,  4123}},
+    {Src::Srgb, {255,  0,  0}, { 13936,     0,     0}},
+    {Src::Srgb, {  0,255,  0}, {     0, 46869,     0}},
+    {Src::Srgb, {  0,  0,255}, {     0,     0,  4731}},
+    {Src::Srgb, {255,255,  0}, { 13936, 46869,     0}},
+    {Src::Srgb, {  0,255,255}, {     0, 46869,  4731}},
+    {Src::Srgb, {255,  0,255}, { 13936,     0,  4731}},
+    {Src::Srgb, {255, 64,  0}, { 13936,  2403,     0}},};
+
+}  // namespace
+
+FL_TEST_CASE("Streaming pipeline reproduces the P5 reference") {
+    // P6's own acceptance criterion: the embedded implementation must stay
+    // inside the documented budget against the reference. These 48 vectors
+    // are the reference's own, across all three source profiles it covers,
+    // and they exercise the whole chain -- decode, primaries to XYZ, the
+    // gamut map, the solve -- rather than any stage alone.
+    //
+    // Worst drive error measured: 0.001312, about 86 raw units of s16.16.
+    // A1's luminance budget is 0.5%; this is 0.13%.
+    float worst = 0.0f;
+    for (const auto& vector : kVectors) {
+        StreamingPipelineQ16 pipeline;
+        FL_REQUIRE(buildStreamingPipelineQ16(sourceFor(vector.source),
+                                             rgbDevice(), &pipeline));
+        i32 drives[3];
+        processPixelQ16(pipeline, static_cast<u8>(vector.code[0]),
+                        static_cast<u8>(vector.code[1]),
+                        static_cast<u8>(vector.code[2]), drives);
+        for (int i = 0; i < 3; ++i) {
+            const float error = fl::fabsf(toFloat(drives[i] - vector.drives[i]));
+            if (error > worst) {
+                worst = error;
+            }
+        }
+    }
+    // The meaningful threshold: under one code at 8-bit output, so no
+    // reference vector can differ by something a device could show.
+    FL_CHECK_LT(worst, 1.0f / 255.0f);
+    // And the measured one, so a regression that stays under a code still
+    // fails rather than sliding by.
+    FL_CHECK_LT(worst, 0.002f);
+}
+
+FL_TEST_CASE("Brightness scales the drives without moving the colour") {
+    // C4: brightness is a linear flux scalar applied at one stage, and
+    // scaling every drive together preserves chromaticity by construction.
+    // The test is that the ratios between drives survive, since that is what
+    // "chromaticity preserved" means at this point in the chain.
+    StreamingPipelineQ16 pipeline;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                         rgbDevice(), &pipeline));
+
+    i32 full[3];
+    processPixelQ16(pipeline, 200, 120, 60, full);
+    for (int i = 0; i < 3; ++i) {
+        FL_REQUIRE_GT(full[i], 0);
+    }
+
+    const u8 kBrightnesses[] = {255, 128, 64, 8};
+    for (u8 brightness : kBrightnesses) {
+        setPipelineFluxQ16(&pipeline, FluxScalar::fromBrightness(brightness));
+        i32 dimmed[3];
+        processPixelQ16(pipeline, 200, 120, 60, dimmed);
+
+        const float expected = static_cast<float>(brightness) / 255.0f;
+        for (int i = 0; i < 3; ++i) {
+            const float got = toFloat(dimmed[i]) / toFloat(full[i]);
+            // Two raw units on the smallest drive is the resolution here, so
+            // the tolerance loosens as the target dims -- which is also why
+            // A1 allows 1.0 dE2000 at 1/32 brightness against 0.5 at unity.
+            FL_CHECK_LT(fl::fabsf(got - expected), 0.01f);
+        }
+    }
+}
+
+FL_TEST_CASE("Full brightness is exactly a pass-through") {
+    // fromBrightness(255) is unity, so the dimmed path must return bit-identical
+    // drives rather than merely close ones. A rounding bug in the scalar
+    // would show here and nowhere else.
+    StreamingPipelineQ16 pipeline;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                         rgbDevice(), &pipeline));
+    for (int code = 0; code <= 255; code += 17) {
+        i32 unity_drives[3];
+        processPixelQ16(pipeline, static_cast<u8>(code),
+                        static_cast<u8>(255 - code), 128, unity_drives);
+        setPipelineFluxQ16(&pipeline, FluxScalar::fromBrightness(255));
+        i32 full_drives[3];
+        processPixelQ16(pipeline, static_cast<u8>(code),
+                        static_cast<u8>(255 - code), 128, full_drives);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_EQ(unity_drives[i], full_drives[i]);
+        }
+        setPipelineFluxQ16(&pipeline, FluxScalar::unity());
+    }
+}
+
+FL_TEST_CASE("Streaming pipeline always returns drives inside [0, 1]") {
+    // Every RGB8 code the pipeline can be handed, across all three source
+    // profiles -- the widest of which reaches well outside the device's
+    // gamut, so the mapper is doing real work on a lot of these.
+    const Src kSources[] = {Src::Srgb, Src::DisplayP3, Src::Bt2020};
+    for (Src which : kSources) {
+        StreamingPipelineQ16 pipeline;
+        FL_REQUIRE(buildStreamingPipelineQ16(sourceFor(which), rgbDevice(),
+                                             &pipeline));
+        for (int r = 0; r <= 255; r += 15) {
+            for (int g = 0; g <= 255; g += 15) {
+                for (int b = 0; b <= 255; b += 15) {
+                    i32 drives[3];
+                    processPixelQ16(pipeline, static_cast<u8>(r),
+                                    static_cast<u8>(g), static_cast<u8>(b),
+                                    drives);
+                    for (int i = 0; i < 3; ++i) {
+                        FL_CHECK_GE(drives[i], 0);
+                        FL_CHECK_LE(drives[i], 65536);
+                    }
+                }
+            }
+        }
+    }
+}
+
+FL_TEST_CASE("Black stays black and the profile round-trips its own white") {
+    StreamingPipelineQ16 pipeline;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                         rgbDevice(), &pipeline));
+
+    i32 black[3];
+    processPixelQ16(pipeline, 0, 0, 0, black);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_EQ(black[i], 0);
+    }
+
+    // Full white must land on the device's D65 neutral. Not on full drive
+    // everywhere -- this profile's emitters are normalized to unit
+    // *luminance* each, so reaching D65 needs roughly 0.21 : 0.72 : 0.07,
+    // and expecting three full drives was simply wrong about the profile.
+    //
+    // Checked as a chromaticity rather than against those three numbers,
+    // since the numbers are what the solve produces and comparing them to
+    // themselves would prove nothing.
+    i32 white[3];
+    processPixelQ16(pipeline, 255, 255, 255, white);
+    float made[3] = {0.0f, 0.0f, 0.0f};
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    for (int e = 0; e < 3; ++e) {
+        float column[3];
+        colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                          column);
+        for (int i = 0; i < 3; ++i) {
+            made[i] += toFloat(white[e]) * column[i];
+        }
+    }
+    const float sum = made[0] + made[1] + made[2];
+    FL_REQUIRE_GT(sum, 1e-3f);
+    FL_CHECK_LT(fl::fabsf(made[0] / sum - 0.3127f), 0.002f);
+    FL_CHECK_LT(fl::fabsf(made[1] / sum - 0.3290f), 0.002f);
+    // And it must be at full luminance, not merely the right colour.
+    FL_CHECK_GT(made[1], 0.99f);
+    FL_CHECK_LT(made[1], 1.01f);
+}
+
+FL_TEST_CASE("Streaming pipeline rejects what its stages reject") {
+    StreamingPipelineQ16 pipeline;
+    FL_CHECK_FALSE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                             rgbDevice(), nullptr));
+
+    EmitterProfile collinear = rgbDevice();
+    collinear.xy_g[0] = 0.6400f;
+    collinear.xy_g[1] = 0.3300f;
+    FL_CHECK_FALSE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                             collinear, &pipeline));
+
+    // Red and green identical: no source gamut at all.
+    const SourceProfile degenerate = SourceProfile::custom(
+        RgbPrimaries(Chromaticity(0.64f, 0.33f), Chromaticity(0.64f, 0.33f),
+                     Chromaticity(0.15f, 0.06f), Chromaticity(0.3127f, 0.3290f)),
+        TransferFunction::Srgb);
+    FL_CHECK_FALSE(
+        buildStreamingPipelineQ16(degenerate, rgbDevice(), &pipeline));
+
+    // Nearly identical, which is the case the threshold is actually for.
+    // `invert3x3`'s own guard rejects below 1e-20, and these primaries
+    // compute a determinant around 1e-7 -- thirteen orders of magnitude
+    // above it -- so without the area check they are accepted and the
+    // inverse is 1/det times pure rounding noise. See #4194.
+    const SourceProfile nearly = SourceProfile::custom(
+        RgbPrimaries(Chromaticity(0.6400f, 0.33000f),
+                     Chromaticity(0.6401f, 0.33005f),
+                     Chromaticity(0.15f, 0.06f), Chromaticity(0.3127f, 0.3290f)),
+        TransferFunction::Srgb);
+    FL_CHECK_FALSE(buildStreamingPipelineQ16(nearly, rgbDevice(), &pipeline));
+
+    // And a real gamut is nowhere near the threshold, so this cannot be
+    // rejecting everything.
+    FL_CHECK(buildStreamingPipelineQ16(SourceProfile::bt2020(), rgbDevice(),
+                                       &pipeline));
+}
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
P6's stages have existed as separate modules for a while — decode, primaries→XYZ, chromatic adaptation, the device solve, the gamut mapper, the flux scalar — with **nothing composing them**. `linearRgbToXyzQ16` was referenced only by its own module. This is the composition.

One bind-time build, one per-pixel call, no state carried between calls and no allocation — so it runs inside `PixelController` iteration without an RGB16 framebuffer (C2).

## Order, and why

1. `decodeTransferU16` — RGB8 code straight to u16 linear light. One semantic conversion (B3).
2. `linearRgbToXyzQ16` — with chromatic adaptation **folded into the same matrix at bind time**, so it costs nothing per pixel.
3. The gamut mapper, which owns clamping — the stages before it hand over the honest target even when it's outside the hull.
4. `applyFluxScalar` last: C4's single amplitude stage, where scaling all drives together preserves chromaticity by construction.

## Conformance

Scored against the P5 reference on its own 48 `rgb` vectors, across all three source profiles:

**Worst drive error 0.001312** — about 86 raw units of s16.16. A1's luminance budget is 0.5%; this is **0.13%**.

The test pins both the meaningful threshold (under one code at 8-bit output, so no vector differs by something a device could show) *and* the measured value, so a regression that stays under a code still fails rather than sliding by.

## The B3 structural test

`ci/tests/test_no_rgb8_intermediate.py`, companion to the existing A3/B11 one. B3 is a shape, not a number: a pipeline that quantized to 8 bits mid-chain would still produce plausible colours, just worse ones, and the error would read as rounding rather than as a missing requirement. It includes a test that the check can actually fail, since it's all regexes over text.

## Two things the tests caught, both mine

**Full white doesn't come back as three full drives.** This profile's emitters are normalized to unit *luminance*, so reaching D65 needs roughly 0.21 : 0.72 : 0.07. The test now verifies the chromaticity the drives produce, rather than three numbers the solve would be comparing against itself.

**`buildSourceMatrixQ16` accepted primaries with red and green identical** — against its own documented contract (*"False if the primaries are collinear"*). Root cause is in `invert3x3`, whose singularity guard is `fabs(det) < 1e-20`. For chromaticity matrices with entries of order 1, float32's cancellation floor is ~1e-7: that exactly-singular set computes **−1.094e-7** and sails through, yielding an inverse scaled by `1/det ≈ −9.1e6` of pure rounding noise.

Guarded here geometrically instead — twice the primary triangle's area, a quantity with meaning at this scale (sRGB's is 0.224, against a 1e-4 threshold). The test covers both exact degeneracy *and* a near-degenerate set, since the exact case gives an area of precisely zero and so wouldn't exercise the threshold; the near case is the one that discriminates, confirmed by mutation.

The shared helper is **#4194**. This PR doesn't touch it — a relative determinant test changes behaviour for every caller and wants a maintainer's call.

Part of #4034 / #4040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Q16 streaming graphics pipeline that converts RGB8 pixels directly into emitter drive values.
  - Added support for configuring pipelines from source and device color profiles, adjusting brightness, and processing pixels without intermediate RGB8 buffers.
  - Added validation to reject profiles with degenerate color primaries.

- **Tests**
  - Added conformance coverage for color accuracy, brightness scaling, output bounds, edge cases, and invalid profiles.
  - Added safeguards against unintended RGB8 intermediate processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->