### PR TITLE
feat(channels): make the colour-profile binding drive a pipeline (P6, #4040)

### DIFF
--- a/src/fl/channels/_build.cpp.hpp
+++ b/src/fl/channels/_build.cpp.hpp
@@ -14,6 +14,7 @@
 #include "fl/channels/driver.cpp.hpp"
 #include "fl/channels/id_tracker.cpp.hpp"
 #include "fl/channels/manager.cpp.hpp"
+#include "fl/channels/pipeline_binding.cpp.hpp"
 #include "fl/channels/rx.cpp.hpp"
 #include "fl/channels/uart_wave_encoder.cpp.hpp"
 #include "fl/channels/validation.cpp.hpp"

--- a/src/fl/channels/pipeline_binding.cpp.hpp
+++ b/src/fl/channels/pipeline_binding.cpp.hpp
@@ -1,0 +1,22 @@
+// ok no header - implementation for fl/channels/pipeline_binding.h
+
+#include "fl/channels/pipeline_binding.h"
+
+namespace fl {
+
+bool buildPipelineForBinding(const ColorProfileBinding& binding,
+                             StreamingPipelineQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    const EmitterProfile* profile = binding.profile();
+    if (profile == nullptr) {
+        // Not an error: a channel with no profile bound stays on the legacy
+        // path, which is what `active()` being false means.
+        return false;
+    }
+    return buildStreamingPipelineQ16(binding.mSource, *profile, binding.mGamut,
+                                     out);
+}
+
+}  // namespace fl

--- a/src/fl/channels/pipeline_binding.h
+++ b/src/fl/channels/pipeline_binding.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// From a channel's colour-profile binding to a running pipeline (P6, #4040).
+//
+// `ColorProfileBinding` has carried a source profile, an emitter profile and
+// a gamut policy for a while, and nothing read them: the binding's
+// acceptance was tracked, but no pixel ever went through it. This is the
+// adapter that turns one into a `StreamingPipelineQ16`.
+//
+// It lives here rather than in fl/gfx because the dependency runs that way
+// round -- channels already include gfx headers, and gfx must not learn
+// about channels.
+
+#include "fl/channels/color_profile.h"
+#include "fl/gfx/pipeline.h"
+#include "fl/stl/noexcept.h"
+
+namespace fl {
+
+/// Build the streaming pipeline a binding describes.
+///
+/// False when the binding has no profile bound, or when the profiles it
+/// names are degenerate -- the stages decide that, this reports it. A false
+/// return is the caller's signal to leave the channel on its legacy path
+/// rather than to fail the frame.
+bool buildPipelineForBinding(const ColorProfileBinding& binding,
+                             StreamingPipelineQ16* out) FL_NO_EXCEPT;
+
+}  // namespace fl

--- a/src/fl/gfx/pipeline.cpp.hpp
+++ b/src/fl/gfx/pipeline.cpp.hpp
@@ -19,10 +19,12 @@ constexpr Chromaticity kPipelineD65 = Chromaticity(0.3127f, 0.3290f);
 
 bool buildStreamingPipelineQ16(const SourceProfile& source,
                                const EmitterProfile& device,
+                               GamutPolicy policy,
                                StreamingPipelineQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
         return false;
     }
+    out->gamut_policy = policy;
     if (!buildSourceMatrixQ16(source.primaries, &out->source)) {
         return false;
     }
@@ -73,9 +75,24 @@ void processPixelQ16(const StreamingPipelineQ16& pipeline, u8 r, u8 g, u8 b,
     i32 xyz[3];
     linearRgbToXyzQ16(pipeline.source, linear_r, linear_g, linear_b, xyz);
 
-    // The mapper owns clamping, so the stages above hand it the honest
-    // target even when that is outside the hull.
-    mapAndSolveDrivesQ16(pipeline.gamut, xyz, drives);
+    if (pipeline.gamut_policy == GamutPolicy::Clamp) {
+        // The caller asked for the cheap answer. Solve and clip, which is
+        // `map_clip` from the P7 study -- about 20 dE2000 from the reference
+        // where the mapper is at 0.15, and offered only because the binding
+        // offers it.
+        solveRgbDrivesQ16(pipeline.gamut.solve, xyz, drives);
+        for (int i = 0; i < 3; ++i) {
+            if (drives[i] < 0) {
+                drives[i] = 0;
+            } else if (drives[i] > 65536) {
+                drives[i] = 65536;
+            }
+        }
+    } else {
+        // The mapper owns clamping, so the stages above hand it the honest
+        // target even when that is outside the hull.
+        mapAndSolveDrivesQ16(pipeline.gamut, xyz, drives);
+    }
 
     // C4's single amplitude stage, last so nothing downstream can rescale a
     // channel on its own.

--- a/src/fl/gfx/pipeline.h
+++ b/src/fl/gfx/pipeline.h
@@ -37,9 +37,18 @@ namespace fl {
 
 /// Everything the per-pixel path needs, derived once when a profile binds.
 ///
-/// Deliberately a plain aggregate of the stages' own bind-time state rather
+/// Deliberately a plain carrier of the stages' own bind-time state rather
 /// than a rebuilt copy of it: the matrices here are the ones those modules
 /// produce, so there is no second place for them to drift.
+///
+/// Not aggregate-initializable, and not by accident. `FluxScalar` has no
+/// default constructor -- there is no sensible "unset" amplitude -- so the
+/// member below carries an initializer, and in C++11, which this project
+/// builds as, a class with one is not an aggregate. `StreamingPipelineQ16 p
+/// = {transfer, source, gamut, flux};` does not compile and never has.
+/// Members are therefore free to be grouped by meaning rather than pinned by
+/// position, and `buildStreamingPipelineQ16` is the only thing that should
+/// be filling one in.
 struct StreamingPipelineQ16 {
     /// The source's transfer function, applied per code.
     TransferFunction transfer;

--- a/src/fl/gfx/pipeline.h
+++ b/src/fl/gfx/pipeline.h
@@ -50,6 +50,16 @@ struct StreamingPipelineQ16 {
     /// The device hull, its solve, and the lightness bound.
     GamutMapQ16 gamut;
 
+    /// What to do with a target the device cannot reproduce.
+    ///
+    /// `ChromaCompress` is the default and the one the P7 study selected;
+    /// `Clamp` is the caller saying they would rather have the cheap answer.
+    /// The study measured what that costs: clipping drives into range lands
+    /// about 20 dE2000 from the reference against a budget of 0.5, because
+    /// no amount of clamping substitutes for the objective. It is offered
+    /// because `ColorProfileBinding` offers it, not because it is close.
+    GamutPolicy gamut_policy = GamutPolicy::ChromaCompress;
+
     /// Brightness times power limiting, as one scalar (C4).
     ///
     /// Initialized here because `FluxScalar` has no default constructor --
@@ -69,6 +79,7 @@ struct StreamingPipelineQ16 {
 /// everything else here does not.
 bool buildStreamingPipelineQ16(const SourceProfile& source,
                                const EmitterProfile& device,
+                               GamutPolicy policy,
                                StreamingPipelineQ16* out) FL_NO_EXCEPT;
 
 /// Set the composed brightness-and-power scalar for the frames that follow.

--- a/tests/fl/channels/pipeline_binding.cpp
+++ b/tests/fl/channels/pipeline_binding.cpp
@@ -1,0 +1,174 @@
+// Binding-to-pipeline adapter for color pipeline P6 (#4040).
+
+#include "fl/channels/pipeline_binding.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/math/math.h"
+#include "fl/stl/int.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+/// The corpus's `rgb` device: sRGB primaries, unit luminance each.
+EmitterProfile rgbDevice() {
+    EmitterProfile p = {};
+    p.xy_r[0] = 0.6400f; p.xy_r[1] = 0.3300f;
+    p.xy_g[0] = 0.3000f; p.xy_g[1] = 0.6000f;
+    p.xy_b[0] = 0.1500f; p.xy_b[1] = 0.0600f;
+    p.lum_r = 1.0f; p.lum_g = 1.0f; p.lum_b = 1.0f;
+    p.native_code_depth = 8;
+    return p;
+}
+
+const EmitterProfile& staticRgbDevice() {
+    static const EmitterProfile kProfile = rgbDevice();
+    return kProfile;
+}
+
+float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
+
+}  // namespace
+
+FL_TEST_CASE("An unbound binding builds no pipeline") {
+    // Not an error: a channel with nothing bound stays on the legacy path,
+    // and a false return is what tells the caller that.
+    ColorProfileBinding binding;
+    StreamingPipelineQ16 pipeline;
+    FL_CHECK_FALSE(binding.active());
+    FL_CHECK_FALSE(buildPipelineForBinding(binding, &pipeline));
+    FL_CHECK_FALSE(buildPipelineForBinding(binding, nullptr));
+}
+
+FL_TEST_CASE("A bound binding carries its source, device and policy through") {
+    ColorProfileBinding binding;
+    binding.mStaticProfile = &staticRgbDevice();
+    binding.mSource = SourceProfile::srgbBt709();
+    binding.mGamut = GamutPolicy::ChromaCompress;
+
+    StreamingPipelineQ16 pipeline;
+    FL_REQUIRE(buildPipelineForBinding(binding, &pipeline));
+    FL_CHECK(pipeline.transfer == TransferFunction::Srgb);
+    FL_CHECK(pipeline.gamut_policy == GamutPolicy::ChromaCompress);
+
+    // And it produces the same drives as building the pipeline directly, so
+    // the adapter is not quietly substituting defaults.
+    StreamingPipelineQ16 direct;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(), rgbDevice(),
+                                         GamutPolicy::ChromaCompress, &direct));
+    for (int code = 0; code <= 255; code += 51) {
+        i32 through_binding[3];
+        i32 through_direct[3];
+        processPixelQ16(pipeline, static_cast<u8>(code), 200,
+                        static_cast<u8>(255 - code), through_binding);
+        processPixelQ16(direct, static_cast<u8>(code), 200,
+                        static_cast<u8>(255 - code), through_direct);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_EQ(through_binding[i], through_direct[i]);
+        }
+    }
+}
+
+FL_TEST_CASE("The gamut policy reaches the pixels") {
+    // `GamutPolicy` has been stored on the binding and read by nothing. It
+    // now decides what happens to a target the device cannot reproduce, so
+    // the two settings have to differ where that matters -- and agree where
+    // it does not.
+    ColorProfileBinding compress;
+    compress.mStaticProfile = &staticRgbDevice();
+    compress.mSource = SourceProfile::bt2020();
+    compress.mGamut = GamutPolicy::ChromaCompress;
+
+    ColorProfileBinding clamp = compress;
+    clamp.mGamut = GamutPolicy::Clamp;
+
+    StreamingPipelineQ16 compressing;
+    StreamingPipelineQ16 clamping;
+    FL_REQUIRE(buildPipelineForBinding(compress, &compressing));
+    FL_REQUIRE(buildPipelineForBinding(clamp, &clamping));
+
+    // BT.2020 primaries reach well outside this device's gamut, so saturated
+    // codes are exactly where the policies part company.
+    int differed = 0;
+    const int kSaturated[][3] = {
+        {255, 0, 0}, {0, 255, 0}, {0, 0, 255},
+        {255, 255, 0}, {0, 255, 255}, {255, 0, 255},
+    };
+    for (const auto& code : kSaturated) {
+        i32 with_compress[3];
+        i32 with_clamp[3];
+        processPixelQ16(compressing, static_cast<u8>(code[0]),
+                        static_cast<u8>(code[1]), static_cast<u8>(code[2]),
+                        with_compress);
+        processPixelQ16(clamping, static_cast<u8>(code[0]),
+                        static_cast<u8>(code[1]), static_cast<u8>(code[2]),
+                        with_clamp);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_GE(with_clamp[i], 0);
+            FL_CHECK_LE(with_clamp[i], 65536);
+        }
+        for (int i = 0; i < 3; ++i) {
+            if (with_compress[i] != with_clamp[i]) {
+                ++differed;
+                break;
+            }
+        }
+    }
+    // Guard against the policies never diverging, which would let a
+    // regression that ignores the setting pass.
+    FL_CHECK_GT(differed, 3);
+
+    // Grey is inside the gamut, so both policies must leave it identical --
+    // clamping is only supposed to matter where the mapper would engage.
+    i32 grey_compress[3];
+    i32 grey_clamp[3];
+    processPixelQ16(compressing, 128, 128, 128, grey_compress);
+    processPixelQ16(clamping, 128, 128, 128, grey_clamp);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_EQ(grey_compress[i], grey_clamp[i]);
+    }
+}
+
+FL_TEST_CASE("Clamping is the worse answer, which is why it is not default") {
+    // The P7 study measured clipping at about 20 dE2000 from the reference
+    // where chroma compression is at 0.15. That gap should be visible here
+    // rather than taken on faith: for a deeply out-of-gamut target the two
+    // must land far apart, and the clamped one must sit on the hull's
+    // boundary with a channel pinned.
+    ColorProfileBinding binding;
+    binding.mStaticProfile = &staticRgbDevice();
+    binding.mSource = SourceProfile::bt2020();
+    binding.mGamut = GamutPolicy::Clamp;
+
+    StreamingPipelineQ16 clamping;
+    FL_REQUIRE(buildPipelineForBinding(binding, &clamping));
+
+    i32 drives[3];
+    processPixelQ16(clamping, 0, 255, 0, drives);
+    // A BT.2020 primary green is outside this device entirely, so clipping
+    // has to pin at least one channel at a limit.
+    bool pinned = false;
+    for (int i = 0; i < 3; ++i) {
+        if (drives[i] == 0 || drives[i] == 65536) {
+            pinned = true;
+        }
+    }
+    FL_CHECK(pinned);
+
+    binding.mGamut = GamutPolicy::ChromaCompress;
+    StreamingPipelineQ16 compressing;
+    FL_REQUIRE(buildPipelineForBinding(binding, &compressing));
+    i32 mapped[3];
+    processPixelQ16(compressing, 0, 255, 0, mapped);
+
+    float distance = 0.0f;
+    for (int i = 0; i < 3; ++i) {
+        distance += fl::fabsf(toFloat(mapped[i] - drives[i]));
+    }
+    // Far apart, not a rounding difference.
+    FL_CHECK_GT(distance, 0.02f);
+}
+
+}  // FL_TEST_FILE

--- a/tests/fl/gfx/pipeline.cpp
+++ b/tests/fl/gfx/pipeline.cpp
@@ -109,8 +109,8 @@ FL_TEST_CASE("Streaming pipeline reproduces the P5 reference") {
     float worst = 0.0f;
     for (const auto& vector : kVectors) {
         StreamingPipelineQ16 pipeline;
-        FL_REQUIRE(buildStreamingPipelineQ16(sourceFor(vector.source),
-                                             rgbDevice(), &pipeline));
+        FL_REQUIRE(buildStreamingPipelineQ16(sourceFor(vector.source), rgbDevice(),
+                                             GamutPolicy::ChromaCompress, &pipeline));
         i32 drives[3];
         processPixelQ16(pipeline, static_cast<u8>(vector.code[0]),
                         static_cast<u8>(vector.code[1]),
@@ -137,7 +137,8 @@ FL_TEST_CASE("Brightness scales the drives without moving the colour") {
     // "chromaticity preserved" means at this point in the chain.
     StreamingPipelineQ16 pipeline;
     FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
-                                         rgbDevice(), &pipeline));
+                                         rgbDevice(),
+                                         GamutPolicy::ChromaCompress, &pipeline));
 
     i32 full[3];
     processPixelQ16(pipeline, 200, 120, 60, full);
@@ -168,7 +169,8 @@ FL_TEST_CASE("Full brightness is exactly a pass-through") {
     // would show here and nowhere else.
     StreamingPipelineQ16 pipeline;
     FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
-                                         rgbDevice(), &pipeline));
+                                         rgbDevice(),
+                                         GamutPolicy::ChromaCompress, &pipeline));
     for (int code = 0; code <= 255; code += 17) {
         i32 unity_drives[3];
         processPixelQ16(pipeline, static_cast<u8>(code),
@@ -192,6 +194,7 @@ FL_TEST_CASE("Streaming pipeline always returns drives inside [0, 1]") {
     for (Src which : kSources) {
         StreamingPipelineQ16 pipeline;
         FL_REQUIRE(buildStreamingPipelineQ16(sourceFor(which), rgbDevice(),
+                                             GamutPolicy::ChromaCompress,
                                              &pipeline));
         for (int r = 0; r <= 255; r += 15) {
             for (int g = 0; g <= 255; g += 15) {
@@ -213,7 +216,8 @@ FL_TEST_CASE("Streaming pipeline always returns drives inside [0, 1]") {
 FL_TEST_CASE("Black stays black and the profile round-trips its own white") {
     StreamingPipelineQ16 pipeline;
     FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
-                                         rgbDevice(), &pipeline));
+                                         rgbDevice(),
+                                         GamutPolicy::ChromaCompress, &pipeline));
 
     i32 black[3];
     processPixelQ16(pipeline, 0, 0, 0, black);
@@ -253,14 +257,15 @@ FL_TEST_CASE("Black stays black and the profile round-trips its own white") {
 
 FL_TEST_CASE("Streaming pipeline rejects what its stages reject") {
     StreamingPipelineQ16 pipeline;
-    FL_CHECK_FALSE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
-                                             rgbDevice(), nullptr));
+    FL_CHECK_FALSE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(), rgbDevice(),
+                                             GamutPolicy::ChromaCompress, nullptr));
 
     EmitterProfile collinear = rgbDevice();
     collinear.xy_g[0] = 0.6400f;
     collinear.xy_g[1] = 0.3300f;
     FL_CHECK_FALSE(buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
-                                             collinear, &pipeline));
+                                             collinear,
+                                             GamutPolicy::ChromaCompress, &pipeline));
 
     // Red and green identical: no source gamut at all.
     const SourceProfile degenerate = SourceProfile::custom(
@@ -268,7 +273,8 @@ FL_TEST_CASE("Streaming pipeline rejects what its stages reject") {
                      Chromaticity(0.15f, 0.06f), Chromaticity(0.3127f, 0.3290f)),
         TransferFunction::Srgb);
     FL_CHECK_FALSE(
-        buildStreamingPipelineQ16(degenerate, rgbDevice(), &pipeline));
+        buildStreamingPipelineQ16(degenerate, rgbDevice(),
+                                              GamutPolicy::ChromaCompress, &pipeline));
 
     // Nearly identical, which is the case the threshold is actually for.
     // `invert3x3`'s own guard rejects below 1e-20, and these primaries
@@ -280,12 +286,13 @@ FL_TEST_CASE("Streaming pipeline rejects what its stages reject") {
                      Chromaticity(0.6401f, 0.33005f),
                      Chromaticity(0.15f, 0.06f), Chromaticity(0.3127f, 0.3290f)),
         TransferFunction::Srgb);
-    FL_CHECK_FALSE(buildStreamingPipelineQ16(nearly, rgbDevice(), &pipeline));
+    FL_CHECK_FALSE(buildStreamingPipelineQ16(nearly, rgbDevice(),
+                                              GamutPolicy::ChromaCompress, &pipeline));
 
     // And a real gamut is nowhere near the threshold, so this cannot be
     // rejecting everything.
     FL_CHECK(buildStreamingPipelineQ16(SourceProfile::bt2020(), rgbDevice(),
-                                       &pipeline));
+                                       GamutPolicy::ChromaCompress, &pipeline));
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
`ColorProfileBinding` has carried a source profile, an emitter profile and a gamut policy for a while, and **nothing read them**. The binding's acceptance and fallback status were tracked carefully; no pixel ever went through it, and `GamutPolicy` was stored and consumed by nobody.

`buildPipelineForBinding` is the adapter. It lives in `fl/channels` rather than `fl/gfx` because the dependency runs that way round — channels already include gfx headers, and gfx must not learn about channels.

## `GamutPolicy` now means something

- `ChromaCompress` runs the P7 mapper.
- `Clamp` solves and clips — `map_clip` from the study, about **20 ΔE2000** from the reference where the mapper is at 0.15.

It's offered because the binding offers it, not because it's close, and the header says so rather than leaving a reader to assume the two are comparable.

An unbound binding returns `false` rather than failing: that's the signal to leave the channel on its legacy path, not an error. `active()` being false is the normal state for a channel nobody has bound a profile to.

## Tests

Pinning what could regress silently:

- The adapter doesn't substitute defaults — drives are identical to building the pipeline directly.
- The two policies **differ** on out-of-gamut targets (BT.2020 primaries against this device) and **agree** on in-gamut grey, with a guard against them never diverging.
- Clipping really does pin a channel at a limit where the mapper doesn't, and the two land far apart rather than a rounding distance.

Both halves verified by mutation: ignoring the policy in the pipeline, and dropping it in the adapter, each fail the suite.

## Scope

This does **not** call into `show()`. It's the piece that wiring needs, landed on its own so the wiring PR is about wiring.

Part of #4034 / #4040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting gamut handling when building color pipelines, including chroma compression and clamping.
  - Added binding-based pipeline construction that preserves source profile, emitter profile, and gamut policy settings.
  - Invalid or incomplete bindings safely fall back without producing a pipeline.

- **Bug Fixes**
  - Improved handling of out-of-gamut colors with policy-specific pixel processing.

- **Tests**
  - Added coverage for binding validation, gamut policy behavior, and invalid profile configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->