### PR TITLE
feat(channels): run the colour pipeline in show() (P6, #4040)

### DIFF
--- a/src/fl/channels/_build.cpp.hpp
+++ b/src/fl/channels/_build.cpp.hpp
@@ -8,6 +8,7 @@
 #include "fl/channels/capabilities.cpp.hpp"
 #include "fl/channels/channel.cpp.hpp"
 #include "fl/channels/channel_events.cpp.hpp"
+#include "fl/channels/color_managed_source.cpp.hpp"
 #include "fl/channels/color_profile.cpp.hpp"
 #include "fl/channels/config.cpp.hpp"
 #include "fl/channels/data.cpp.hpp"

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -382,9 +382,12 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         // Through the hook, not by name. Calling `buildPipelineForBinding`
         // directly from here is what kept the entire pipeline alive in every
         // build; the pointer is null until `setColorProfile` installs it.
+        // Built on the stack first, so a binding that does not describe a
+        // usable pipeline costs no allocation -- that is the failing half of
+        // an ordinary unbound channel, not an exceptional path.
         StreamingPipelineQ16 pipeline;
         if (hooks.build(mSettings.mColorProfile, &pipeline)) {
-            mPipeline = pipeline;
+            mPipeline = fl::make_unique<StreamingPipelineQ16>(pipeline);
         }
     }
 
@@ -629,11 +632,11 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // this working when FASTLED_HD_COLOR_MIXING is off, where that field
     // does not exist.
     const ColorPipelineHooks& flux_hooks = colorPipelineHooks();
-    if (mPipeline && flux_hooks.setFlux != nullptr) {
-        flux_hooks.setFlux(&mPipeline.value(),
+    const StreamingPipelineQ16* pipeline = mPipeline.get();
+    if (pipeline != nullptr && flux_hooks.setFlux != nullptr) {
+        flux_hooks.setFlux(mPipeline.get(),
                            pixels.mColorAdjustment.premixed.r);
     }
-    const StreamingPipelineQ16* pipeline = mPipeline ? &mPipeline.value() : nullptr;
 #else
     const StreamingPipelineQ16* pipeline = nullptr;
 #endif

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -633,10 +633,10 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // it -- and reading it rather than `ColorAdjustment::brightness` keeps
     // this working when FASTLED_HD_COLOR_MIXING is off, where that field
     // does not exist.
-    if (mPipeline) {
-        setPipelineFluxQ16(&mPipeline.value(),
-                           FluxScalar::fromBrightness(
-                               pixels.mColorAdjustment.premixed.r));
+    const ColorPipelineHooks& flux_hooks = colorPipelineHooks();
+    if (mPipeline && flux_hooks.setFlux != nullptr) {
+        flux_hooks.setFlux(&mPipeline.value(),
+                           pixels.mColorAdjustment.premixed.r);
     }
     const StreamingPipelineQ16* pipeline = mPipeline ? &mPipeline.value() : nullptr;
 #else

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -369,11 +369,6 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         mSettings.mColorProfile.mSource = detail::defaultSourceProfile();
     }
 
-    // Derive the pipeline once, here, rather than per frame: it inverts
-    // matrices and bisects a lightness bound. A binding that does not
-    // describe a usable pipeline leaves the channel on the legacy path
-    // rather than failing -- an unbound channel is the ordinary case, not an
-    // error.
     const bool rejectedNow = mColorProfileFallback && !mProfileBindingAccepted;
 
     // Derive the pipeline once, here, rather than per frame: it inverts

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -11,7 +11,6 @@
 #include "fl/stl/atomic.h"
 #include "fl/log/log.h"
 #include "fl/channels/options.h"
-#include "fl/channels/color_managed_source.h"
 #include "fl/channels/pipeline_binding.h"
 #include "fl/gfx/pixel_iterator_any.h"
 #include "pixel_controller.h"
@@ -61,8 +60,16 @@ class ReorderingPixelIteratorAny {
     // Present only when a colour profile is bound. The managed source keeps
     // a reference to the controller it wraps, so it has to outlive the
     // iterator built over it -- both live here, for the frame.
-    fl::optional<ColorManagedPixelSource> mManagedSource;
-    fl::Optional<PixelIterator> mManagedIterator;
+    //
+    // Raw storage rather than the types themselves, because naming them here
+    // is what made the whole colour pipeline reachable from `show()` and cost
+    // every sketch ~3.5 KB of flash. `colorPipelineHooks()` builds into this,
+    // and only `setColorProfile` installs those hooks -- so a program that
+    // never binds a profile never references the pipeline and the linker
+    // drops it.
+    FL_ALIGNAS(8) unsigned char mManagedSourceStorage[kColorPipelineSourceStorage];
+    FL_ALIGNAS(8) unsigned char mManagedIteratorStorage[kColorPipelineIteratorStorage];
+    PixelIterator* mManagedIterator = nullptr;
 #endif
 
   public:
@@ -120,16 +127,32 @@ class ReorderingPixelIteratorAny {
         }
 
 #if FL_COLOR_PROFILE_RUNTIME
-        if (pipeline != nullptr) {
+        const ColorPipelineHooks& hooks = colorPipelineHooks();
+        if (pipeline != nullptr && hooks.makeIterator != nullptr) {
             // Colour-managed: build the iterator over a streaming source
             // instead of over the order-variant controller. The source
             // applies the colour order itself, so it wraps the RGB-ordered
             // controller -- whichever of the two that is after addressing.
             PixelController<RGB, 1, 0xFFFFFFFF>& base =
                 mAddressedController ? mAddressedController.value() : pixels;
-            mManagedSource.emplace(base, rgbOrder, *pipeline);
-            mManagedIterator.emplace(
-                PixelIterator(&mManagedSource.value(), rgbw, rgbww));
+            mManagedIterator = hooks.makeIterator(
+                mManagedSourceStorage, mManagedIteratorStorage, base, rgbOrder,
+                *pipeline, rgbw, rgbww);
+        }
+#endif
+    }
+
+    ~ReorderingPixelIteratorAny() FL_NO_EXCEPT {
+#if FL_COLOR_PROFILE_RUNTIME
+        // Placement-new'd into our own storage, so the teardown goes back
+        // through the hooks too -- this file must not name the types.
+        if (mManagedIterator != nullptr) {
+            const ColorPipelineHooks& hooks = colorPipelineHooks();
+            if (hooks.destroyIterator != nullptr) {
+                hooks.destroyIterator(mManagedSourceStorage,
+                                      mManagedIteratorStorage);
+            }
+            mManagedIterator = nullptr;
         }
 #endif
     }
@@ -141,8 +164,8 @@ class ReorderingPixelIteratorAny {
     /// is why the encoders need no branch of their own.
     PixelIterator& get() FL_NO_EXCEPT {
 #if FL_COLOR_PROFILE_RUNTIME
-        if (mManagedIterator.has_value()) {
-            return mManagedIterator.value();
+        if (mManagedIterator != nullptr) {
+            return *mManagedIterator;
         }
 #endif
         return mPixelIterator.get();
@@ -359,9 +382,13 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
     // rather than failing -- an unbound channel is the ordinary case, not an
     // error.
     mPipeline.reset();
-    if (!rejectedNow) {
+    const ColorPipelineHooks& hooks = colorPipelineHooks();
+    if (!rejectedNow && hooks.build != nullptr) {
+        // Through the hook, not by name. Calling `buildPipelineForBinding`
+        // directly from here is what kept the entire pipeline alive in every
+        // build; the pointer is null until `setColorProfile` installs it.
         StreamingPipelineQ16 pipeline;
-        if (buildPipelineForBinding(mSettings.mColorProfile, &pipeline)) {
+        if (hooks.build(mSettings.mColorProfile, &pipeline)) {
             mPipeline = pipeline;
         }
     }

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -11,6 +11,8 @@
 #include "fl/stl/atomic.h"
 #include "fl/log/log.h"
 #include "fl/channels/options.h"
+#include "fl/channels/color_managed_source.h"
+#include "fl/channels/pipeline_binding.h"
 #include "fl/gfx/pixel_iterator_any.h"
 #include "pixel_controller.h"
 #include "fl/system/trace.h"
@@ -55,6 +57,13 @@ class ReorderingPixelIteratorAny {
     }
     fl::optional<PixelController<RGB, 1, 0xFFFFFFFF>> mAddressedController;
     PixelIteratorAny mPixelIterator;
+#if FL_COLOR_PROFILE_RUNTIME
+    // Present only when a colour profile is bound. The managed source keeps
+    // a reference to the controller it wraps, so it has to outlive the
+    // iterator built over it -- both live here, for the frame.
+    fl::optional<ColorManagedPixelSource> mManagedSource;
+    fl::Optional<PixelIterator> mManagedIterator;
+#endif
 
   public:
     /// @brief Construct pixel iterator with optional addressing transformation
@@ -69,8 +78,10 @@ class ReorderingPixelIteratorAny {
         EOrder rgbOrder,
         Rgbw rgbw,
         Rgbww rgbww,
-        const fl::string& channelName)
+        const fl::string& channelName,
+        const StreamingPipelineQ16* pipeline) FL_NO_EXCEPT
         : mPixelIterator(pixels, rgbOrder, rgbw, rgbww) {
+        FL_UNUSED(pipeline);
         FL_UNUSED(channelName);  // only consumed by FL_ERROR_F, a no-op on small platforms
 
         // Apply addressing transformation if configured
@@ -107,11 +118,38 @@ class ReorderingPixelIteratorAny {
                 pixels.mColorAdjustment, DISABLE_DITHER);
             mPixelIterator = PixelIteratorAny(mAddressedController.value(), rgbOrder, rgbw, rgbww);
         }
+
+#if FL_COLOR_PROFILE_RUNTIME
+        if (pipeline != nullptr) {
+            // Colour-managed: build the iterator over a streaming source
+            // instead of over the order-variant controller. The source
+            // applies the colour order itself, so it wraps the RGB-ordered
+            // controller -- whichever of the two that is after addressing.
+            PixelController<RGB, 1, 0xFFFFFFFF>& base =
+                mAddressedController ? mAddressedController.value() : pixels;
+            mManagedSource.emplace(base, rgbOrder, *pipeline);
+            mManagedIterator.emplace(
+                PixelIterator(&mManagedSource.value(), rgbw, rgbww));
+        }
+#endif
     }
 
     /// @brief Get the constructed pixel iterator
-    PixelIterator& get() { return mPixelIterator.get(); }
-    const PixelIterator& get() const { return mPixelIterator.get(); }
+    ///
+    /// The colour-managed one when a profile is bound, the legacy one
+    /// otherwise. Everything downstream sees the same type either way, which
+    /// is why the encoders need no branch of their own.
+    PixelIterator& get() FL_NO_EXCEPT {
+#if FL_COLOR_PROFILE_RUNTIME
+        if (mManagedIterator.has_value()) {
+            return mManagedIterator.value();
+        }
+#endif
+        return mPixelIterator.get();
+    }
+    const PixelIterator& get() const FL_NO_EXCEPT {
+        return const_cast<ReorderingPixelIteratorAny*>(this)->get();
+    }
 };
 
 /// @brief Out-of-line cold-path emitter for the #2517 silent-drop
@@ -308,7 +346,26 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         mSettings.mColorProfile.mSource = detail::defaultSourceProfile();
     }
 
+    // Derive the pipeline once, here, rather than per frame: it inverts
+    // matrices and bisects a lightness bound. A binding that does not
+    // describe a usable pipeline leaves the channel on the legacy path
+    // rather than failing -- an unbound channel is the ordinary case, not an
+    // error.
     const bool rejectedNow = mColorProfileFallback && !mProfileBindingAccepted;
+
+    // Derive the pipeline once, here, rather than per frame: it inverts
+    // matrices and bisects a lightness bound. A binding that does not
+    // describe a usable pipeline leaves the channel on the legacy path
+    // rather than failing -- an unbound channel is the ordinary case, not an
+    // error.
+    mPipeline.reset();
+    if (!rejectedNow) {
+        StreamingPipelineQ16 pipeline;
+        if (buildPipelineForBinding(mSettings.mColorProfile, &pipeline)) {
+            mPipeline = pipeline;
+        }
+    }
+
     if (rejectedNow) {
         setEnabled(false);
     } else if (wasRejectedByUs) {
@@ -542,9 +599,25 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
     // (#2558) Pass both Rgbw and Rgbww from the channel options; the iterator
     // carries both, and the encoder dispatch below picks the right path based
     // on which variant alternative ChannelOptions::mWhiteCfg holds.
+#if FL_COLOR_PROFILE_RUNTIME
+    // Brightness reaches the pipeline as C4's flux scalar and nowhere else.
+    // `premixed` is the brightness on this path: binding a profile sets
+    // correction and temperature to identity, so nothing else is folded into
+    // it -- and reading it rather than `ColorAdjustment::brightness` keeps
+    // this working when FASTLED_HD_COLOR_MIXING is off, where that field
+    // does not exist.
+    if (mPipeline) {
+        setPipelineFluxQ16(&mPipeline.value(),
+                           FluxScalar::fromBrightness(
+                               pixels.mColorAdjustment.premixed.r));
+    }
+    const StreamingPipelineQ16* pipeline = mPipeline ? &mPipeline.value() : nullptr;
+#else
+    const StreamingPipelineQ16* pipeline = nullptr;
+#endif
     ReorderingPixelIteratorAny iterator(pixels, mScreenMap.getXYMap(), mRgbOrder,
                                         mSettings.rgbw(), mSettings.rgbww(),
-                                        mName);
+                                        mName, pipeline);
     PixelIterator& pixelIterator = iterator.get();
 
     // Encode pixels based on chipset type

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -66,6 +66,7 @@ public:
         ChannelConfig rebound(config);
 #if FL_COLOR_PROFILE_RUNTIME
         rebound.options.clearColorProfile();
+        installColorPipelineHooks();
         rebound.options.mColorProfile.mStaticProfile = &Profile;
         rebound.options.mColorProfile.mRequested = true;
 #else

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -19,6 +19,7 @@
 #include "fl/channels/ichannel.h"
 #include "fl/channels/options.h"
 #include "fl/gfx/pipeline.h"
+#include "fl/stl/unique_ptr.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/string.h"
 #include "fl/stl/weak_ptr.h"
@@ -143,6 +144,17 @@ public:
 
     /// @brief Get the number of LEDs in this channel
     int size() const override;
+
+#if FL_COLOR_PROFILE_RUNTIME
+    /// How a channel stores the colour pipeline its binding describes.
+    ///
+    /// Named because it is a decision, not an implementation detail: holding
+    /// a `StreamingPipelineQ16` inline charges every channel 88 bytes for a
+    /// pipeline most of them never bind. A static assertion in the tests
+    /// holds this to pointer size so the inline form cannot come back
+    /// unnoticed.
+    using ColorPipelineStorage = fl::unique_ptr<StreamingPipelineQ16>;
+#endif
 
     /// @brief Show the LEDs with optional brightness scaling
     void showLeds(u8 brightness = 255) OVERRIDE_IF_NOT_AVR;
@@ -317,10 +329,21 @@ private:
     ChipsetVariant mChipset;         // Chipset configuration (clockless or SPI)
     EOrder mRgbOrder;
 #if FL_COLOR_PROFILE_RUNTIME
-    /// The colour pipeline this channel's binding describes, or empty when
+    /// The colour pipeline this channel's binding describes, or null when
     /// nothing is bound. Derived in `reconcileColorProfile`, since building
     /// it inverts matrices and bisects a lightness bound -- not per frame.
-    fl::optional<StreamingPipelineQ16> mPipeline;
+    ///
+    /// Held behind a pointer rather than inline. `StreamingPipelineQ16` is
+    /// 88 bytes and an `fl::optional` of it carries that whether or not a
+    /// profile is bound: every channel on the sketch paid it, and an unbound
+    /// channel is the ordinary case. Inline storage took `sizeof(Channel)`
+    /// from 488 to 576 bytes, which is 1.4 KB across a sixteen-channel
+    /// parallel output for a feature none of those channels had asked for.
+    ///
+    /// Nothing pays for the indirection per pixel: `showPixels` already
+    /// handed the iterator a `const StreamingPipelineQ16*`, so the change is
+    /// one dereference per frame at the point the pointer is taken.
+    ColorPipelineStorage mPipeline;
 #endif
     fl::weak_ptr<IChannelDriver> mDriver;  // Weak reference to driver (prevents dangling pointers)
     bool mDriverPreBound = false;    // True if setDriver() was called (legacy addLeds<> path).

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -18,6 +18,7 @@
 #include "fl/channels/bus.h"
 #include "fl/channels/ichannel.h"
 #include "fl/channels/options.h"
+#include "fl/gfx/pipeline.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/string.h"
 #include "fl/stl/weak_ptr.h"
@@ -314,6 +315,12 @@ private:
 
     ChipsetVariant mChipset;         // Chipset configuration (clockless or SPI)
     EOrder mRgbOrder;
+#if FL_COLOR_PROFILE_RUNTIME
+    /// The colour pipeline this channel's binding describes, or empty when
+    /// nothing is bound. Derived in `reconcileColorProfile`, since building
+    /// it inverts matrices and bisects a lightness bound -- not per frame.
+    fl::optional<StreamingPipelineQ16> mPipeline;
+#endif
     fl::weak_ptr<IChannelDriver> mDriver;  // Weak reference to driver (prevents dangling pointers)
     bool mDriverPreBound = false;    // True if setDriver() was called (legacy addLeds<> path).
                                      // When true, showPixels() uses mDriver directly and skips

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -177,6 +177,9 @@ public:
     void bindStaticEmitterProfile(const EmitterProfile* profile) FL_NO_EXCEPT {
 #if FL_COLOR_PROFILE_RUNTIME
         mSettings.clearColorProfile();
+        if (profile != nullptr) {
+            installColorPipelineHooks();
+        }
         mSettings.mColorProfile.mStaticProfile = profile;
         mSettings.mColorProfile.mRequested = profile != nullptr;
 #else

--- a/src/fl/channels/color_managed_source.cpp.hpp
+++ b/src/fl/channels/color_managed_source.cpp.hpp
@@ -1,0 +1,49 @@
+// ok no header - implementation for fl/channels/color_managed_source.h
+
+#include "fl/channels/color_managed_source.h"
+
+namespace fl {
+
+void ColorManagedPixelSource::loadAndScaleRGB(u8* b0_out, u8* b1_out,
+                                             u8* b2_out) FL_NO_EXCEPT {
+        const u8* raw = mController.mData;
+        i32 drives[3];
+        processPixelQ16(mPipeline, raw[0], raw[1], raw[2], drives);
+        u8 channels[3];
+        for (int i = 0; i < 3; ++i) {
+            channels[i] = quantize(drives[i]);
+        }
+        *b0_out = channels[mSlot0];
+        *b1_out = channels[mSlot1];
+        *b2_out = channels[mSlot2];
+    }
+
+void ColorManagedPixelSource::loadAndScaleRGBW(const Rgbw& rgbw, u8* b0_out,
+                                              u8* b1_out, u8* b2_out,
+                                              u8* b3_out) FL_NO_EXCEPT {
+        mController.loadAndScaleRGBW(rgbw, b0_out, b1_out, b2_out, b3_out);
+    }
+
+void ColorManagedPixelSource::loadAndScaleRGBWW(Rgbww rgbww, u8* b0_out,
+                                               u8* b1_out, u8* b2_out,
+                                               u8* b3_out,
+                                               u8* b4_out) FL_NO_EXCEPT {
+        mController.loadAndScaleRGBWW(rgbww, b0_out, b1_out, b2_out, b3_out,
+                                      b4_out);
+    }
+
+void ColorManagedPixelSource::loadRGBScaleAndBrightness(
+    u8* c0, u8* c1, u8* c2, u8* brightness) FL_NO_EXCEPT {
+        mController.loadRGBScaleAndBrightness(c0, c1, c2, brightness);
+    }
+
+u8 ColorManagedPixelSource::quantize(i32 drive) FL_NO_EXCEPT {
+        if (drive <= 0) {
+            return 0;
+        }
+        if (drive >= 65536) {
+            return 255;
+        }
+        return static_cast<u8>((static_cast<i32>(drive) * 255 + 32768) >> 16);
+    }
+}  // namespace fl

--- a/src/fl/channels/color_managed_source.cpp.hpp
+++ b/src/fl/channels/color_managed_source.cpp.hpp
@@ -16,13 +16,13 @@ void ColorManagedPixelSource::loadAndScaleRGB(u8* b0_out, u8* b1_out,
         *b0_out = channels[mSlot0];
         *b1_out = channels[mSlot1];
         *b2_out = channels[mSlot2];
-    }
+}
 
 void ColorManagedPixelSource::loadAndScaleRGBW(const Rgbw& rgbw, u8* b0_out,
                                               u8* b1_out, u8* b2_out,
                                               u8* b3_out) FL_NO_EXCEPT {
         mController.loadAndScaleRGBW(rgbw, b0_out, b1_out, b2_out, b3_out);
-    }
+}
 
 void ColorManagedPixelSource::loadAndScaleRGBWW(Rgbww rgbww, u8* b0_out,
                                                u8* b1_out, u8* b2_out,
@@ -30,12 +30,17 @@ void ColorManagedPixelSource::loadAndScaleRGBWW(Rgbww rgbww, u8* b0_out,
                                                u8* b4_out) FL_NO_EXCEPT {
         mController.loadAndScaleRGBWW(rgbww, b0_out, b1_out, b2_out, b3_out,
                                       b4_out);
-    }
+}
 
+#if FASTLED_HD_COLOR_MIXING
+// Guarded to match the declaration. Without this the definition survives on a
+// build with HD mixing off -- AVR, among others -- where the member does not
+// exist, and the compile fails there and nowhere else.
 void ColorManagedPixelSource::loadRGBScaleAndBrightness(
     u8* c0, u8* c1, u8* c2, u8* brightness) FL_NO_EXCEPT {
-        mController.loadRGBScaleAndBrightness(c0, c1, c2, brightness);
-    }
+    mController.loadRGBScaleAndBrightness(c0, c1, c2, brightness);
+}
+#endif
 
 u8 ColorManagedPixelSource::quantize(i32 drive) FL_NO_EXCEPT {
         if (drive <= 0) {
@@ -45,5 +50,5 @@ u8 ColorManagedPixelSource::quantize(i32 drive) FL_NO_EXCEPT {
             return 255;
         }
         return static_cast<u8>((static_cast<i32>(drive) * 255 + 32768) >> 16);
-    }
+}
 }  // namespace fl

--- a/src/fl/channels/color_managed_source.h
+++ b/src/fl/channels/color_managed_source.h
@@ -52,35 +52,19 @@ class ColorManagedPixelSource {
     /// going through them would apply it twice. Legacy correction and
     /// temperature are not a concern here: binding a profile clears them,
     /// which is what the `LegacyClearedByProfile` warning is for.
-    void loadAndScaleRGB(u8* b0_out, u8* b1_out, u8* b2_out) FL_NO_EXCEPT {
-        const u8* raw = mController.mData;
-        i32 drives[3];
-        processPixelQ16(mPipeline, raw[0], raw[1], raw[2], drives);
-        u8 channels[3];
-        for (int i = 0; i < 3; ++i) {
-            channels[i] = quantize(drives[i]);
-        }
-        *b0_out = channels[mSlot0];
-        *b1_out = channels[mSlot1];
-        *b2_out = channels[mSlot2];
-    }
+    void loadAndScaleRGB(u8* b0_out, u8* b1_out, u8* b2_out) FL_NO_EXCEPT;
 
     /// Legacy. An RGBW device's white emitter has no home in
     /// `EmitterProfile`, which carries three primaries and nothing else, so
     /// there is no profile for `allocateEmitterDrivesQ16` to be given. That
     /// is a schema question (P1/P3), not something to invent here.
     void loadAndScaleRGBW(const Rgbw& rgbw, u8* b0_out, u8* b1_out, u8* b2_out,
-                          u8* b3_out) FL_NO_EXCEPT {
-        mController.loadAndScaleRGBW(rgbw, b0_out, b1_out, b2_out, b3_out);
-    }
+                          u8* b3_out) FL_NO_EXCEPT;
 
     /// Legacy, for the same reason, with two whites instead of one -- and
     /// the two-white allocation is itself unimplemented (#4198).
     void loadAndScaleRGBWW(Rgbww rgbww, u8* b0_out, u8* b1_out, u8* b2_out,
-                           u8* b3_out, u8* b4_out) FL_NO_EXCEPT {
-        mController.loadAndScaleRGBWW(rgbww, b0_out, b1_out, b2_out, b3_out,
-                                      b4_out);
-    }
+                           u8* b3_out, u8* b4_out) FL_NO_EXCEPT;
 
 #if FASTLED_HD_COLOR_MIXING
     /// Legacy. This hands the encoder a colour triple *and* a separate 5-bit
@@ -89,9 +73,7 @@ class ColorManagedPixelSource {
     /// quantization and 5-bit semantics -- and answering it by whatever
     /// makes this compile would be the wrong way round.
     void loadRGBScaleAndBrightness(u8* c0, u8* c1, u8* c2,
-                                   u8* brightness) FL_NO_EXCEPT {
-        mController.loadRGBScaleAndBrightness(c0, c1, c2, brightness);
-    }
+                                   u8* brightness) FL_NO_EXCEPT;
 #endif
 
     /// Dithering stays with the controller; P8 owns it.
@@ -106,15 +88,7 @@ class ColorManagedPixelSource {
     ///
     /// This is the single final quantization B3 asks for: nothing upstream
     /// of it is 8-bit, and nothing downstream re-quantizes.
-    static u8 quantize(i32 drive) FL_NO_EXCEPT {
-        if (drive <= 0) {
-            return 0;
-        }
-        if (drive >= 65536) {
-            return 255;
-        }
-        return static_cast<u8>((static_cast<i32>(drive) * 255 + 32768) >> 16);
-    }
+    static u8 quantize(i32 drive) FL_NO_EXCEPT;
 
     PixelController<RGB>& mController;
     const StreamingPipelineQ16& mPipeline;

--- a/src/fl/channels/color_managed_source.h
+++ b/src/fl/channels/color_managed_source.h
@@ -1,0 +1,126 @@
+#pragma once
+
+// Streaming colour-managed pixel source (P6, #4040).
+//
+// The last stage of the wiring: something a `PixelIterator` can be built
+// over that runs the pipeline per pixel instead of the legacy scale.
+//
+// It is a source, not a buffer, and that is the point. C2 asks for the
+// per-pixel work to happen inside the existing iteration with no RGB16
+// framebuffer, and B3 forbids an intermediate RGB8 one. `showPixels`
+// already has a place that rewrites pixels -- the XYMap path materializes a
+// thread-local `CRGB` vector -- and putting the pipeline there would break
+// both rules at once. This reads one pixel, transforms it, and yields the
+// bytes; nothing is held between pixels.
+//
+// `PixelIterator`'s constructor is templated over its source, so this only
+// has to provide the same members `PixelController` does. It is not itself
+// templated on colour order: the order is applied to the three outputs at
+// the end, which avoids six near-identical instantiations for something
+// decided at bind time.
+
+#include "fl/gfx/pipeline.h"
+#include "fl/stl/int.h"
+#include "fl/stl/noexcept.h"
+#include "fl/gfx/eorder.h"
+#include "fl/gfx/rgbw.h"
+#include "fl/gfx/rgbww.h"
+#include "pixel_controller.h"
+
+namespace fl {
+
+/// Runs `processPixelQ16` over a `PixelController`'s pixels as they are read.
+///
+/// Only the plain RGB path is colour-managed. `loadAndScaleRGBW`,
+/// `loadAndScaleRGBWW` and the HD entry points delegate to the wrapped
+/// controller, which is the legacy behaviour, and they say why at each site.
+/// Those are not oversights: each is blocked on something this phase does
+/// not own.
+class ColorManagedPixelSource {
+  public:
+    ColorManagedPixelSource(PixelController<RGB>& controller, EOrder order,
+                            const StreamingPipelineQ16& pipeline) FL_NO_EXCEPT
+        : mController(controller), mPipeline(pipeline),
+          mSlot0(RGB_BYTE0(order)), mSlot1(RGB_BYTE1(order)),
+          mSlot2(RGB_BYTE2(order)) {}
+
+    /// The colour-managed path.
+    ///
+    /// Reads the *raw* pixel rather than `loadAndScale0/1/2`, deliberately.
+    /// Those fold in `mColorAdjustment`, whose `premixed` carries brightness
+    /// -- and the pipeline carries brightness too, as C4's flux scalar, so
+    /// going through them would apply it twice. Legacy correction and
+    /// temperature are not a concern here: binding a profile clears them,
+    /// which is what the `LegacyClearedByProfile` warning is for.
+    void loadAndScaleRGB(u8* b0_out, u8* b1_out, u8* b2_out) FL_NO_EXCEPT {
+        const u8* raw = mController.mData;
+        i32 drives[3];
+        processPixelQ16(mPipeline, raw[0], raw[1], raw[2], drives);
+        u8 channels[3];
+        for (int i = 0; i < 3; ++i) {
+            channels[i] = quantize(drives[i]);
+        }
+        *b0_out = channels[mSlot0];
+        *b1_out = channels[mSlot1];
+        *b2_out = channels[mSlot2];
+    }
+
+    /// Legacy. An RGBW device's white emitter has no home in
+    /// `EmitterProfile`, which carries three primaries and nothing else, so
+    /// there is no profile for `allocateEmitterDrivesQ16` to be given. That
+    /// is a schema question (P1/P3), not something to invent here.
+    void loadAndScaleRGBW(const Rgbw& rgbw, u8* b0_out, u8* b1_out, u8* b2_out,
+                          u8* b3_out) FL_NO_EXCEPT {
+        mController.loadAndScaleRGBW(rgbw, b0_out, b1_out, b2_out, b3_out);
+    }
+
+    /// Legacy, for the same reason, with two whites instead of one -- and
+    /// the two-white allocation is itself unimplemented (#4198).
+    void loadAndScaleRGBWW(Rgbww rgbww, u8* b0_out, u8* b1_out, u8* b2_out,
+                           u8* b3_out, u8* b4_out) FL_NO_EXCEPT {
+        mController.loadAndScaleRGBWW(rgbww, b0_out, b1_out, b2_out, b3_out,
+                                      b4_out);
+    }
+
+#if FASTLED_HD_COLOR_MIXING
+    /// Legacy. This hands the encoder a colour triple *and* a separate 5-bit
+    /// brightness for APA102-HD. What that should mean once the pipeline
+    /// owns the amplitude stage is P8's question -- chipset-aware
+    /// quantization and 5-bit semantics -- and answering it by whatever
+    /// makes this compile would be the wrong way round.
+    void loadRGBScaleAndBrightness(u8* c0, u8* c1, u8* c2,
+                                   u8* brightness) FL_NO_EXCEPT {
+        mController.loadRGBScaleAndBrightness(c0, c1, c2, brightness);
+    }
+#endif
+
+    /// Dithering stays with the controller; P8 owns it.
+    void stepDithering() FL_NO_EXCEPT { mController.stepDithering(); }
+
+    void advanceData() FL_NO_EXCEPT { mController.advanceData(); }
+    int size() const FL_NO_EXCEPT { return mController.size(); }
+    bool has(int n) FL_NO_EXCEPT { return mController.has(n); }
+
+  private:
+    /// s16.16 drive to an 8-bit code, rounding to nearest.
+    ///
+    /// This is the single final quantization B3 asks for: nothing upstream
+    /// of it is 8-bit, and nothing downstream re-quantizes.
+    static u8 quantize(i32 drive) FL_NO_EXCEPT {
+        if (drive <= 0) {
+            return 0;
+        }
+        if (drive >= 65536) {
+            return 255;
+        }
+        return static_cast<u8>((static_cast<i32>(drive) * 255 + 32768) >> 16);
+    }
+
+    PixelController<RGB>& mController;
+    const StreamingPipelineQ16& mPipeline;
+    int mSlot0;
+    int mSlot1;
+    int mSlot2;
+};
+
+}  // namespace fl

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -15,6 +15,15 @@
 
 namespace fl {
 
+// Declared rather than included. `pipeline_binding.h` pulls the whole gfx
+// pipeline in behind it, and reaching those headers from here puts them
+// ahead of whatever brings `EmitterProfile` into scope unqualified --
+// `device_solve.h`, `gamut_map.h` and `white_allocation.h` all stop
+// compiling. One declaration is all this file needs, and keeping it to one
+// also keeps `options.h` cheap for every translation unit that includes it.
+void installColorPipelineHooks() FL_NO_EXCEPT;
+
+
 #ifndef FL_COLOR_PROFILE_RUNTIME
 #define FL_COLOR_PROFILE_RUNTIME (!FL_PLATFORM_HAS_TINY_MEMORY)
 #endif
@@ -117,6 +126,12 @@ struct ChannelOptions {
                 ColorProfileEvent{-1, {}, ColorProfileWarning::LegacyClearedByProfile});
             mWarnedLegacyCleared = true;
         }
+        // The one call that makes the colour pipeline reachable. Everything
+        // downstream goes through function pointers these install, so a
+        // program that never gets here never references the pipeline and the
+        // linker drops it -- about 3.5 KB of flash for sketches that do not
+        // ask for colour management.
+        installColorPipelineHooks();
         mColorProfile.mStorage = fl::make_shared<ColorProfileStorage>(profile);
         mColorProfile.mSource = source;
         mColorProfile.mGamut = gamut;

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -15,6 +15,14 @@
 
 namespace fl {
 
+// Declared rather than included. Every path that binds a profile has to
+// install these -- there are four, and three of them do not go through
+// setColorProfile: Channel::create<Profile>,
+// ChannelOptions::withColorProfile<Profile> and
+// CLEDController::bindStaticEmitterProfile all set mStaticProfile directly.
+// Missing one leaves that channel silently on the legacy path, which is the
+// exact bug this whole change exists to fix.
+//
 // Declared rather than included. `pipeline_binding.h` pulls the whole gfx
 // pipeline in behind it, and reaching those headers from here puts them
 // ahead of whatever brings `EmitterProfile` into scope unqualified --
@@ -211,6 +219,7 @@ struct ChannelOptions {
     static ChannelOptions withColorProfile() FL_NO_EXCEPT {
         ChannelOptions options;
 #if FL_COLOR_PROFILE_RUNTIME
+        installColorPipelineHooks();
         options.mColorProfile.mStaticProfile = &Profile;
         options.mColorProfile.mRequested = true;
 #endif

--- a/src/fl/channels/pipeline_binding.cpp.hpp
+++ b/src/fl/channels/pipeline_binding.cpp.hpp
@@ -38,6 +38,11 @@ PixelIterator* makeColorPipelineIterator(
     return new (iterator_storage) PixelIterator(source, rgbw, rgbww);
 }
 
+void setColorPipelineFlux(StreamingPipelineQ16* pipeline,
+                          u8 brightness) FL_NO_EXCEPT {
+    setPipelineFluxQ16(pipeline, FluxScalar::fromBrightness(brightness));
+}
+
 void destroyColorPipelineIterator(void* source_storage,
                                   void* iterator_storage) FL_NO_EXCEPT {
     static_cast<PixelIterator*>(iterator_storage)->~PixelIterator();
@@ -51,7 +56,7 @@ ColorPipelineHooks& colorPipelineHooks() FL_NO_EXCEPT {
     // Not a function-local static with a non-trivial constructor: this is a
     // zero-initialized aggregate, so there is no guard variable and no
     // Teensy 3.x `__cxa_guard` conflict.
-    static ColorPipelineHooks hooks = {nullptr, nullptr, nullptr};
+    static ColorPipelineHooks hooks = {nullptr, nullptr, nullptr, nullptr};
     return hooks;
 }
 
@@ -60,6 +65,7 @@ void installColorPipelineHooks() FL_NO_EXCEPT {
     hooks.build = &buildPipelineForBinding;
     hooks.makeIterator = &makeColorPipelineIterator;
     hooks.destroyIterator = &destroyColorPipelineIterator;
+    hooks.setFlux = &setColorPipelineFlux;
 }
 
 }  // namespace fl

--- a/src/fl/channels/pipeline_binding.cpp.hpp
+++ b/src/fl/channels/pipeline_binding.cpp.hpp
@@ -2,6 +2,9 @@
 
 #include "fl/channels/pipeline_binding.h"
 
+#include "fl/channels/color_managed_source.h"
+#include "fl/stl/new.h"
+
 namespace fl {
 
 bool buildPipelineForBinding(const ColorProfileBinding& binding,
@@ -17,6 +20,46 @@ bool buildPipelineForBinding(const ColorProfileBinding& binding,
     }
     return buildStreamingPipelineQ16(binding.mSource, *profile, binding.mGamut,
                                      out);
+}
+
+namespace {
+
+/// Builds the managed iterator in the caller's storage.
+///
+/// Named for this file because .cpp.hpp files share a translation unit under
+/// the unity build, so an anonymous namespace does not isolate it.
+PixelIterator* makeColorPipelineIterator(
+    void* source_storage, void* iterator_storage,
+    PixelController<RGB, 1, 0xFFFFFFFF>& controller, EOrder order,
+    const StreamingPipelineQ16& pipeline, const Rgbw& rgbw,
+    Rgbww rgbww) FL_NO_EXCEPT {
+    ColorManagedPixelSource* source =
+        new (source_storage) ColorManagedPixelSource(controller, order, pipeline);
+    return new (iterator_storage) PixelIterator(source, rgbw, rgbww);
+}
+
+void destroyColorPipelineIterator(void* source_storage,
+                                  void* iterator_storage) FL_NO_EXCEPT {
+    static_cast<PixelIterator*>(iterator_storage)->~PixelIterator();
+    static_cast<ColorManagedPixelSource*>(source_storage)
+        ->~ColorManagedPixelSource();
+}
+
+}  // namespace
+
+ColorPipelineHooks& colorPipelineHooks() FL_NO_EXCEPT {
+    // Not a function-local static with a non-trivial constructor: this is a
+    // zero-initialized aggregate, so there is no guard variable and no
+    // Teensy 3.x `__cxa_guard` conflict.
+    static ColorPipelineHooks hooks = {nullptr, nullptr, nullptr};
+    return hooks;
+}
+
+void installColorPipelineHooks() FL_NO_EXCEPT {
+    ColorPipelineHooks& hooks = colorPipelineHooks();
+    hooks.build = &buildPipelineForBinding;
+    hooks.makeIterator = &makeColorPipelineIterator;
+    hooks.destroyIterator = &destroyColorPipelineIterator;
 }
 
 }  // namespace fl

--- a/src/fl/channels/pipeline_binding.h
+++ b/src/fl/channels/pipeline_binding.h
@@ -11,8 +11,14 @@
 // round -- channels already include gfx headers, and gfx must not learn
 // about channels.
 
+#include "fl/channels/color_managed_source.h"
 #include "fl/channels/color_profile.h"
+#include "fl/chipsets/encoders/pixel_iterator.h"
+#include "fl/gfx/eorder.h"
 #include "fl/gfx/pipeline.h"
+#include "fl/gfx/rgbw.h"
+#include "fl/gfx/rgbww.h"
+#include "pixel_controller.h"
 #include "fl/stl/noexcept.h"
 
 namespace fl {
@@ -25,5 +31,59 @@ namespace fl {
 /// rather than to fail the frame.
 bool buildPipelineForBinding(const ColorProfileBinding& binding,
                              StreamingPipelineQ16* out) FL_NO_EXCEPT;
+
+/// The two things `Channel` needs from the colour pipeline, reached through
+/// pointers rather than by name.
+///
+/// This is a pay-for-what-you-use seam, not indirection for its own sake.
+/// Naming `buildPipelineForBinding` and `ColorManagedPixelSource` directly
+/// from `Channel` made the whole pipeline reachable from `show()` --
+/// decode, the transfer LUTs, primaries to XYZ, adaptation, the gamut map,
+/// OKLab, the cube root, the device solve -- so `--gc-sections` could not
+/// drop any of it and every sketch paid about 3.5 KB of flash whether or not
+/// it ever called `setColorProfile`.
+///
+/// Behind these pointers, the only thing that references the pipeline is the
+/// installer, and the only thing that calls the installer is
+/// `setColorProfile`. A program that never binds a profile never mentions
+/// it, and the linker takes the lot.
+/// Bytes `Channel` must reserve for the managed source and its iterator.
+///
+/// Taken with `sizeof` rather than guessed, so the two cannot drift. Naming
+/// the types for their size does not defeat the elision: a header declares,
+/// and it is *references* to the definitions that keep code alive.
+constexpr fl::size kColorPipelineSourceStorage = sizeof(ColorManagedPixelSource);
+constexpr fl::size kColorPipelineIteratorStorage = sizeof(PixelIterator);
+
+struct ColorPipelineHooks {
+    /// Derives a pipeline from a binding. Null until installed.
+    bool (*build)(const ColorProfileBinding&, StreamingPipelineQ16*);
+
+    /// Constructs a colour-managed `PixelIterator` in caller-provided
+    /// storage. Null until installed.
+    ///
+    /// The storage is `Channel`'s, sized by `kColorPipelineIteratorStorage`,
+    /// because the factory cannot return an object whose type the caller is
+    /// forbidden to name -- that is the whole point of the seam.
+    PixelIterator* (*makeIterator)(void* source_storage,
+                                   void* iterator_storage,
+                                   PixelController<RGB, 1, 0xFFFFFFFF>& controller,
+                                   EOrder order,
+                                   const StreamingPipelineQ16& pipeline,
+                                   const Rgbw& rgbw, Rgbww rgbww);
+
+    /// Destroys what `makeIterator` built. Null until installed.
+    void (*destroyIterator)(void* source_storage, void* iterator_storage);
+};
+
+/// The installed hooks. Both pointers are null in a program that never binds
+/// a colour profile.
+ColorPipelineHooks& colorPipelineHooks() FL_NO_EXCEPT;
+
+/// Point the hooks at the real implementations.
+///
+/// Called from `ChannelOptions::setColorProfile`, which is the only place
+/// that can know the pipeline is wanted. Idempotent.
+void installColorPipelineHooks() FL_NO_EXCEPT;
 
 }  // namespace fl

--- a/src/fl/channels/pipeline_binding.h
+++ b/src/fl/channels/pipeline_binding.h
@@ -74,6 +74,14 @@ struct ColorPipelineHooks {
 
     /// Destroys what `makeIterator` built. Null until installed.
     void (*destroyIterator)(void* source_storage, void* iterator_storage);
+
+    /// Sets the frame's amplitude on a pipeline. Null until installed.
+    ///
+    /// Here rather than called directly for the same reason as the rest:
+    /// `setPipelineFluxQ16` and `FluxScalar::fromBrightness` are pipeline
+    /// functions, and naming either from `Channel` keeps their translation
+    /// units -- and what they pull in -- alive in every build.
+    void (*setFlux)(StreamingPipelineQ16*, u8 brightness);
 };
 
 /// The installed hooks. Both pointers are null in a program that never binds

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,14 +1,23 @@
-# 2026-09-10, PR #4283 (issue #4041): +1 B, 342177 -> 342178.
+# 2026-09-10, PR #4200 (issue #4040, colour pipeline P6): +305 B,
+# 342178 -> 342483.
 #
-# The continuity fix adds highestReachableLightness to the gamut mappers,
-# which walk down to the highest reachable lightness instead of dropping to
-# the neutral cap. None of that code links into the NEOPIXEL Blink sketch
-# this gate builds: no gamut or colour-pipeline symbol appears anywhere in
-# the run's top-25 symbol table (largest entries are fl::ClocklessIdf5<...>
-# at 45,342 B, the libc printf family, and fl::Channel::showPixels at
-# 3,296 B). The byte is layout drift, not a feature cost.
+# This is the cost of being able to reach the colour pipeline at runtime.
+# The pipeline math itself is NOT in here: not one gamut, OKLab, transfer,
+# white-allocation or device-solve symbol appears anywhere in the run's
+# top-25 table, so --gc-sections still takes the ~3.5 KB of it out of a
+# Blink build that binds no profile. What is left is the dispatch code in
+# fl::Channel -- the reconcileColorProfile build block, the showPixels flux
+# call, and the iterator's branches. It cannot be elided, because it is the
+# code that decides whether to elide.
 #
-# Attribution was checked rather than assumed: master's last three runs and
-# the concurrent PR #4282 all measure 342,177 B, so the byte arrived with
-# this branch.
-342178
+# The cost was 429 B when this PR was last measured. Holding the pipeline
+# behind a pointer instead of inline in every Channel took it to 305 B, and
+# took the per-channel RAM from 88 B to 16 B at the same time.
+#
+# Why this is accepted rather than refused: FL_COLOR_PROFILE_RUNTIME is
+# !FL_PLATFORM_HAS_TINY_MEMORY, and every use of the pipeline sits inside
+# that guard -- the member, the whole of reconcileColorProfile, and the
+# showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
+# only ever spent where flash is not the binding constraint. On a target
+# that does compile it in, 305 B is 0.089% of the image.
+342483

--- a/tests/fl/channels/color_managed_source.cpp
+++ b/tests/fl/channels/color_managed_source.cpp
@@ -11,11 +11,31 @@
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/gfx/colorimetric_response.h"
 #include "fl/stl/scope_exit.h"
+#include "fl/stl/static_assert.h"
 #include "fl/stl/span.h"
 #include "fl/stl/int.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
+
+#if FL_COLOR_PROFILE_RUNTIME
+// The pipeline is reached through a pointer, not carried inside every channel.
+//
+// `StreamingPipelineQ16` is 88 bytes. Held inline as an `fl::optional`, every
+// channel on the sketch paid that whether or not it bound a profile, and an
+// unbound channel is the ordinary case -- `sizeof(fl::Channel)` measured 576
+// against 488 without this feature, so 1.4 KB across a sixteen-channel
+// parallel output for something none of those channels asked for. Behind a
+// pointer it measures 504.
+//
+// Asserted on the storage type rather than on `sizeof(fl::Channel)`, which is
+// a different number on every target and would pin the whole class's layout
+// to whatever this host compiles.
+FL_STATIC_ASSERT(sizeof(fl::Channel::ColorPipelineStorage) <= 2 * sizeof(void*),
+                 "Channel must reach its colour pipeline through a pointer: "
+                 "storing StreamingPipelineQ16 inline charges every channel "
+                 "for a pipeline most of them never bind.");
+#endif
 
 using namespace fl;
 

--- a/tests/fl/channels/color_managed_source.cpp
+++ b/tests/fl/channels/color_managed_source.cpp
@@ -1,0 +1,292 @@
+// Streaming colour-managed pixel source for color pipeline P6 (#4040).
+
+#include "fl/channels/color_managed_source.h"
+#include "FastLED.h"
+#include "fl/channels/all_drivers.h"
+#include "fl/channels/channel.h"
+#include "fl/channels/data.h"
+#include "fl/channels/driver.h"
+#include "fl/channels/manager.h"
+#include "fl/chipsets/chipset_timing_config.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/stl/scope_exit.h"
+#include "fl/stl/span.h"
+#include "fl/stl/int.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+EmitterProfile rgbDevice() {
+    EmitterProfile p = {};
+    p.xy_r[0] = 0.6400f; p.xy_r[1] = 0.3300f;
+    p.xy_g[0] = 0.3000f; p.xy_g[1] = 0.6000f;
+    p.xy_b[0] = 0.1500f; p.xy_b[1] = 0.0600f;
+    p.lum_r = 1.0f; p.lum_g = 1.0f; p.lum_b = 1.0f;
+    p.native_code_depth = 8;
+    return p;
+}
+
+StreamingPipelineQ16 makePipeline() {
+    StreamingPipelineQ16 pipeline;
+    const bool ok = buildStreamingPipelineQ16(SourceProfile::srgbBt709(),
+                                              rgbDevice(),
+                                              GamutPolicy::ChromaCompress,
+                                              &pipeline);
+    FL_REQUIRE(ok);
+    return pipeline;
+}
+
+/// Captures the bytes a channel hands to its driver.
+class ByteCapturingMockEngine : public IChannelDriver {
+  public:
+    explicit ByteCapturingMockEngine(const char* name = "PIPELINE_CAPTURE")
+        : mName(name) {}
+
+    fl::vector<ChannelDataPtr> mCapturedChannels;
+
+    bool canHandle(const ChannelDataPtr& data) const override {
+        (void)data;
+        return true;
+    }
+    void enqueue(ChannelDataPtr channelData) override {
+        if (channelData) {
+            mCapturedChannels.push_back(channelData);
+        }
+    }
+    void show() override {}
+    DriverState poll() override { return DriverState::READY; }
+    fl::string getName() const override { return mName; }
+    Capabilities getCapabilities() const override {
+        return Capabilities(true, true);
+    }
+
+  private:
+    fl::string mName;
+};
+
+}  // namespace
+
+FL_TEST_CASE("The managed source emits one byte triple per pixel, in order") {
+    // Colour order is applied to the outputs rather than by instantiating a
+    // controller per order, so it needs checking directly: the same pixel
+    // through GRB must be the RGB answer with the first two swapped.
+    CRGB leds[2] = {CRGB(200, 120, 60), CRGB(10, 240, 90)};
+    const StreamingPipelineQ16 pipeline = makePipeline();
+
+    u8 rgb[2][3];
+    u8 grb[2][3];
+    {
+        PixelController<RGB> controller(leds, 2, ColorAdjustment(), DISABLE_DITHER);
+        ColorManagedPixelSource source(controller, RGB, pipeline);
+        for (int i = 0; i < 2; ++i) {
+            FL_REQUIRE(source.has(1));
+            source.loadAndScaleRGB(&rgb[i][0], &rgb[i][1], &rgb[i][2]);
+            source.advanceData();
+        }
+    }
+    {
+        PixelController<RGB> controller(leds, 2, ColorAdjustment(), DISABLE_DITHER);
+        ColorManagedPixelSource source(controller, GRB, pipeline);
+        for (int i = 0; i < 2; ++i) {
+            source.loadAndScaleRGB(&grb[i][0], &grb[i][1], &grb[i][2]);
+            source.advanceData();
+        }
+    }
+    for (int i = 0; i < 2; ++i) {
+        FL_CHECK_EQ(grb[i][0], rgb[i][1]);
+        FL_CHECK_EQ(grb[i][1], rgb[i][0]);
+        FL_CHECK_EQ(grb[i][2], rgb[i][2]);
+    }
+}
+
+FL_TEST_CASE("Brightness is applied once, by the pipeline") {
+    // The trap this class exists to avoid. `loadAndScale0/1/2` fold in
+    // `mColorAdjustment`, whose premixed value carries brightness, and the
+    // pipeline carries brightness too as C4's flux scalar. Reading through
+    // the scaled accessors would apply it twice, which would show up as a
+    // frame roughly a quarter as bright at half brightness.
+    //
+    // So: a controller told brightness 128 must produce the *same* bytes as
+    // one told 255, because the source reads raw and the pipeline here is at
+    // unity. Halving is then done by the flux scalar, and only there.
+    CRGB leds[1] = {CRGB(200, 120, 60)};
+    const StreamingPipelineQ16 unity = makePipeline();
+
+    ColorAdjustment dim;
+    dim.premixed = CRGB(128, 128, 128);
+    dim.color = CRGB(0xff, 0xff, 0xff);
+    dim.brightness = 128;
+
+    u8 bright_bytes[3];
+    u8 dim_bytes[3];
+    {
+        PixelController<RGB> controller(leds, 1, ColorAdjustment(), DISABLE_DITHER);
+        ColorManagedPixelSource source(controller, RGB, unity);
+        source.loadAndScaleRGB(&bright_bytes[0], &bright_bytes[1], &bright_bytes[2]);
+    }
+    {
+        PixelController<RGB> controller(leds, 1, dim, DISABLE_DITHER);
+        ColorManagedPixelSource source(controller, RGB, unity);
+        source.loadAndScaleRGB(&dim_bytes[0], &dim_bytes[1], &dim_bytes[2]);
+    }
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_EQ(bright_bytes[i], dim_bytes[i]);
+    }
+
+    // And the flux scalar is what actually dims. Half brightness must land
+    // near half the drive -- not a quarter, which is what double application
+    // would give.
+    StreamingPipelineQ16 halved = makePipeline();
+    setPipelineFluxQ16(&halved, FluxScalar::fromBrightness(128));
+    u8 halved_bytes[3];
+    {
+        PixelController<RGB> controller(leds, 1, ColorAdjustment(), DISABLE_DITHER);
+        ColorManagedPixelSource source(controller, RGB, halved);
+        source.loadAndScaleRGB(&halved_bytes[0], &halved_bytes[1], &halved_bytes[2]);
+    }
+    for (int i = 0; i < 3; ++i) {
+        if (bright_bytes[i] < 8) {
+            continue;  // too small for the ratio to mean anything
+        }
+        const float ratio = static_cast<float>(halved_bytes[i]) /
+                            static_cast<float>(bright_bytes[i]);
+        FL_CHECK_GT(ratio, 0.44f);
+        FL_CHECK_LT(ratio, 0.56f);
+    }
+}
+
+FL_TEST_CASE("Black and white land on the ends of the byte range") {
+    CRGB leds[2] = {CRGB(0, 0, 0), CRGB(255, 255, 255)};
+    const StreamingPipelineQ16 pipeline = makePipeline();
+    PixelController<RGB> controller(leds, 2, ColorAdjustment(), DISABLE_DITHER);
+    ColorManagedPixelSource source(controller, RGB, pipeline);
+
+    u8 black[3];
+    source.loadAndScaleRGB(&black[0], &black[1], &black[2]);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_EQ(black[i], 0);
+    }
+    source.advanceData();
+
+    // Full white on this device is the D65 neutral, which needs unequal
+    // drives -- the emitters are normalized to unit luminance each. So this
+    // is not three 255s, and asserting that it were would have been wrong
+    // about the profile rather than about the code.
+    u8 white[3];
+    source.loadAndScaleRGB(&white[0], &white[1], &white[2]);
+    int lit = 0;
+    for (int i = 0; i < 3; ++i) {
+        if (white[i] > 0) {
+            ++lit;
+        }
+    }
+    FL_CHECK_EQ(lit, 3);
+    FL_CHECK_GT(white[1], white[0]);  // green carries most of D65's luminance
+    FL_CHECK_GT(white[0], white[2]);
+}
+
+FL_TEST_CASE("The source reports the controller's extent") {
+    CRGB leds[4] = {};
+    const StreamingPipelineQ16 pipeline = makePipeline();
+    PixelController<RGB> controller(leds, 4, ColorAdjustment(), DISABLE_DITHER);
+    ColorManagedPixelSource source(controller, RGB, pipeline);
+    FL_CHECK_EQ(source.size(), 4);
+    FL_CHECK(source.has(4));
+    FL_CHECK_FALSE(source.has(5));
+}
+
+#if FL_COLOR_PROFILE_RUNTIME
+FL_TEST_CASE("A bound colour profile reaches the encoded bytes") {
+    // The wiring. `setColorProfile` has been settable and inert: the binding
+    // was validated and its fallback tracked, and no pixel ever went through
+    // it. This says it now does.
+    //
+    // The assertion is on the *exact* bytes the pipeline produces, not on
+    // the two channels merely differing. A first version compared them and
+    // passed with the pipeline forced off -- binding a profile also disables
+    // dithering and clears legacy correction, so the bytes move for reasons
+    // that have nothing to do with this change.
+    const int NUM_LEDS = 2;
+    CRGB plain_leds[NUM_LEDS] = {CRGB(200, 40, 10), CRGB(10, 180, 90)};
+    CRGB managed_leds[NUM_LEDS] = {CRGB(200, 40, 10), CRGB(10, 180, 90)};
+    const EmitterProfile device = rgbDevice();
+
+    auto mockEngine = fl::make_shared<ByteCapturingMockEngine>();
+    ChannelManager& manager = ChannelManager::instance();
+    manager.addDriver(2010, mockEngine);
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+
+    ChannelOptions plain_options;
+    ChannelConfig plain_config(1, timing, fl::span<CRGB>(plain_leds, NUM_LEDS),
+                               RGB, plain_options);
+    auto plain = Channel::create(plain_config);
+    FL_REQUIRE(plain != nullptr);
+
+    ChannelOptions managed_options;
+    // A source wider than the device, so the mapper has real work to do.
+    FL_REQUIRE(managed_options.setColorProfile(device, SourceProfile::bt2020(),
+                                               GamutPolicy::ChromaCompress));
+    ChannelConfig managed_config(2, timing,
+                                 fl::span<CRGB>(managed_leds, NUM_LEDS), RGB,
+                                 managed_options);
+    auto managed = Channel::create(managed_config);
+    FL_REQUIRE(managed != nullptr);
+
+    auto cleanup = fl::make_scope_exit([&]() {
+        plain->removeFromDrawList();
+        managed->removeFromDrawList();
+        manager.removeDriver(mockEngine);
+    });
+
+    FastLED.add(plain);
+    FastLED.add(managed);
+    mockEngine->mCapturedChannels.clear();
+    FastLED.show();
+
+    FL_REQUIRE(mockEngine->mCapturedChannels.size() >= 2);
+    const auto& first = mockEngine->mCapturedChannels[0]->getData();
+    const auto& second = mockEngine->mCapturedChannels[1]->getData();
+    FL_REQUIRE(first.size() >= static_cast<fl::size>(NUM_LEDS * 3));
+    FL_REQUIRE(second.size() >= static_cast<fl::size>(NUM_LEDS * 3));
+
+    // The unbound channel is the pass-through, byte for byte.
+    FL_CHECK_EQ(first[0], 200);
+    FL_CHECK_EQ(first[1], 40);
+    FL_CHECK_EQ(first[2], 10);
+
+    // The bound one carries exactly what the pipeline produces.
+    StreamingPipelineQ16 expected;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::bt2020(), device,
+                                         GamutPolicy::ChromaCompress, &expected));
+    setPipelineFluxQ16(&expected, FluxScalar::fromBrightness(255));
+    for (int led = 0; led < NUM_LEDS; ++led) {
+        const CRGB& source_pixel = managed_leds[led];
+        i32 drives[3];
+        processPixelQ16(expected, source_pixel.r, source_pixel.g,
+                        source_pixel.b, drives);
+        for (int channel_index = 0; channel_index < 3; ++channel_index) {
+            const i32 drive = drives[channel_index];
+            const int want =
+                drive <= 0 ? 0
+                           : (drive >= 65536
+                                  ? 255
+                                  : static_cast<int>((drive * 255 + 32768) >> 16));
+            FL_CHECK_EQ(static_cast<int>(second[led * 3 + channel_index]), want);
+        }
+    }
+
+    // And it really transformed, so this cannot be passing on an identity.
+    int difference = 0;
+    for (int i = 0; i < NUM_LEDS * 3; ++i) {
+        const int delta = static_cast<int>(first[i]) - static_cast<int>(second[i]);
+        difference += delta < 0 ? -delta : delta;
+    }
+    FL_CHECK_GT(difference, 16);
+}
+#endif
+
+}  // FL_TEST_FILE

--- a/tests/fl/channels/color_managed_source.cpp
+++ b/tests/fl/channels/color_managed_source.cpp
@@ -116,10 +116,15 @@ FL_TEST_CASE("Brightness is applied once, by the pipeline") {
     CRGB leds[1] = {CRGB(200, 120, 60)};
     const StreamingPipelineQ16 unity = makePipeline();
 
+    // `color` and `brightness` only exist under FASTLED_HD_COLOR_MIXING;
+    // `premixed` is the one field that is always there, and it is the one
+    // this test is about -- it is what the legacy scale would have folded in.
     ColorAdjustment dim;
     dim.premixed = CRGB(128, 128, 128);
+#if FASTLED_HD_COLOR_MIXING
     dim.color = CRGB(0xff, 0xff, 0xff);
     dim.brightness = 128;
+#endif
 
     u8 bright_bytes[3];
     u8 dim_bytes[3];

--- a/tests/fl/channels/color_managed_source.cpp
+++ b/tests/fl/channels/color_managed_source.cpp
@@ -7,6 +7,7 @@
 #include "fl/channels/data.h"
 #include "fl/channels/driver.h"
 #include "fl/channels/manager.h"
+#include "fl/channels/pipeline_binding.h"
 #include "fl/chipsets/chipset_timing_config.h"
 #include "fl/gfx/colorimetric_response.h"
 #include "fl/stl/scope_exit.h"
@@ -29,6 +30,10 @@ EmitterProfile rgbDevice() {
     p.native_code_depth = 8;
     return p;
 }
+
+// At namespace scope, not inside the test: a function-local static has no
+// linkage, and C++11 will not take one as a template reference argument.
+const EmitterProfile kStaticProfile = rgbDevice();
 
 StreamingPipelineQ16 makePipeline() {
     StreamingPipelineQ16 pipeline;
@@ -66,6 +71,16 @@ class ByteCapturingMockEngine : public IChannelDriver {
 
   private:
     fl::string mName;
+};
+
+/// The smallest concrete `CLEDController`, so `bindStaticEmitterProfile`
+/// can be called on a real one.
+class StubController : public CLEDController {
+  public:
+    StubController(CRGB* leds, int count) { setLeds(leds, count); }
+    void showColor(const CRGB&, int, fl::u8) FL_NO_EXCEPT override {}
+    void show(const CRGB*, int, fl::u8) FL_NO_EXCEPT override {}
+    void init() FL_NO_EXCEPT override {}
 };
 
 }  // namespace
@@ -291,6 +306,79 @@ FL_TEST_CASE("A bound colour profile reaches the encoded bytes") {
         difference += delta < 0 ? -delta : delta;
     }
     FL_CHECK_GT(difference, 16);
+}
+#endif
+
+#if FL_COLOR_PROFILE_RUNTIME
+FL_TEST_CASE("Every static binding path installs the pipeline seam") {
+    // Regression. Four call sites bind a colour profile and only one of them
+    // is `setColorProfile`: `Channel::create<Profile>`,
+    // `ChannelOptions::withColorProfile<Profile>` and
+    // `CLEDController::bindStaticEmitterProfile` set `mStaticProfile`
+    // directly. The seam that keeps the pipeline linker-elidable installs
+    // its hooks from the binding call, so a path that forgets to install
+    // leaves that channel silently on the legacy path -- the exact
+    // "settable but inert" bug this change exists to fix, reintroduced by
+    // the fix.
+    //
+    // The hooks are one process-wide struct, so a sibling test that binds a
+    // profile would install them and make a naive assertion here vacuous.
+    // Each leg therefore clears them first; that is what makes this a test
+    // of the binding path rather than of the test order.
+    const ColorPipelineHooks kCleared = {nullptr, nullptr, nullptr, nullptr};
+    auto restore = fl::make_scope_exit([]() { installColorPipelineHooks(); });
+
+    {
+        colorPipelineHooks() = kCleared;
+        ChannelOptions options =
+            ChannelOptions::withColorProfile<kStaticProfile>();
+        FL_REQUIRE(options.hasColorProfile());
+        // `REQUIRE`, not `CHECK`: the pipeline build below dereferences it.
+        FL_REQUIRE(colorPipelineHooks().build != nullptr);
+        FL_CHECK(colorPipelineHooks().makeIterator != nullptr);
+        FL_CHECK(colorPipelineHooks().destroyIterator != nullptr);
+        FL_CHECK(colorPipelineHooks().setFlux != nullptr);
+
+        // And the binding really yields a pipeline, so the hooks being
+        // installed is not the whole of the claim.
+        StreamingPipelineQ16 pipeline;
+        FL_CHECK(colorPipelineHooks().build(options.mColorProfile, &pipeline));
+    }
+
+    {
+        colorPipelineHooks() = kCleared;
+        auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+        CRGB leds[2] = {};
+        ChannelOptions options;
+        ChannelConfig config(2101, timing, fl::span<CRGB>(leds, 2), RGB,
+                             options);
+        auto channel = Channel::create<kStaticProfile>(config);
+        FL_REQUIRE(channel != nullptr);
+        auto cleanup =
+            fl::make_scope_exit([&]() { channel->removeFromDrawList(); });
+        FL_CHECK(colorPipelineHooks().build != nullptr);
+        FL_CHECK(colorPipelineHooks().makeIterator != nullptr);
+    }
+
+    {
+        colorPipelineHooks() = kCleared;
+        CRGB leds[2] = {};
+        StubController controller(leds, 2);
+        controller.bindStaticEmitterProfile(&kStaticProfile);
+        FL_REQUIRE(controller.emitterProfile() == &kStaticProfile);
+        FL_CHECK(colorPipelineHooks().build != nullptr);
+        FL_CHECK(colorPipelineHooks().makeIterator != nullptr);
+    }
+
+    // Unbinding must not install: a null profile means the legacy path, and
+    // paying for the pipeline there is the regression the seam prevents.
+    {
+        colorPipelineHooks() = kCleared;
+        CRGB leds[2] = {};
+        StubController controller(leds, 2);
+        controller.bindStaticEmitterProfile(nullptr);
+        FL_CHECK(colorPipelineHooks().build == nullptr);
+    }
 }
 #endif
 


### PR DESCRIPTION
`setColorProfile` has been settable and **inert**. The binding was validated, its acceptance and fallback tracked, `GamutPolicy` stored — and no pixel ever went through any of it. This is the wiring, and P6's last deliverable.

## Why a source and not a buffer

`showPixels` already has a place that rewrites pixels: the XYMap path materializes a thread-local `fl::vector<CRGB>`. Putting the pipeline there would break **C2** (per-pixel inside the existing iteration, no framebuffer) and **B3** (no intermediate RGB8) at once — and `ci/tests/test_no_rgb8_intermediate.py` already guards the gfx stages against exactly that shape.

`PixelIterator` is a hand-built vtable over a duck-typed source with a templated constructor, so `ColorManagedPixelSource` slots in with no buffer at all: read one pixel, transform, yield the bytes.

## Brightness was the trap

`loadAndScale0/1/2` fold in `mColorAdjustment`, whose `premixed` carries brightness — and the pipeline carries brightness too, as C4's flux scalar. Reading through them would **apply it twice**, showing up as roughly a quarter brightness at half.

So the source reads raw `mData` and the frame's brightness goes into the flux scalar instead. It's read from `premixed` rather than `ColorAdjustment::brightness` because that field only exists under `FASTLED_HD_COLOR_MIXING` — and on this path `premixed` *is* the brightness, since binding a profile sets correction and temperature to identity.

The pipeline is derived in `reconcileColorProfile`, not per frame; it inverts matrices and bisects a lightness bound.

## Three paths deliberately left on legacy

Each says why at the site, rather than being silently unhandled:

- **RGBW / RGBWW** — `EmitterProfile` carries three primaries and no white emitter, so there's no profile to allocate against. That's a schema question (P1/P3), and the two-white allocation is unimplemented anyway (#4198).
- **HD** — `loadRGBScaleAndBrightness` hands the encoder a colour triple *and* a separate 5-bit brightness. What that means once the pipeline owns the amplitude stage is P8's (5-bit semantics), not something to settle by whatever makes this compile.

## The test asserts the bytes, not a difference

The end-to-end test pins the **exact** bytes the pipeline produces. A first version just compared the managed channel against an unbound one — and **passed with the pipeline forced off**, because binding a profile also disables dithering and clears legacy correction, so the bytes move for unrelated reasons. Both it and the brightness test are verified by mutation.

Part of #4034 / #4040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added colour-managed rendering for LED output when a colour profile is configured.
  * Applied configured colour profiles during pixel streaming for more accurate colour output.
  * Added support for colour-managed RGB channel ordering while preserving existing RGBW and RGBWW formats.

* **Bug Fixes**
  * Prevented brightness from being applied more than once during colour-managed rendering.
  * Improved consistency between configured colour profiles and emitted pixel colours.
  * Preserved legacy rendering behavior when no colour profile is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->