### PR TITLE
feat(autoresearch): add --bitbang driver flag

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -18,6 +18,7 @@ class Args:
     rmt: bool
     spi: bool
     uart: bool
+    bitbang: bool
     lcd: bool
     lcd_spi: bool
     lcd_rgb: bool
@@ -294,6 +295,16 @@ See Also:
             "--uart",
             action="store_true",
             help="Test only UART driver (LPC845: UART DMA clockless RX-DMA loopback)",
+        )
+        driver_group.add_argument(
+            "--bitbang",
+            action="store_true",
+            help=(
+                "Test only the portable GPIO bit-bang driver (Bus::BIT_BANG). "
+                "This is AUTO's last-resort fallback on every platform, so it "
+                "is the one driver that must keep working when the hardware "
+                "engines are all claimed."
+            ),
         )
         driver_group.add_argument(
             "--rp-uart-index",
@@ -888,6 +899,7 @@ See Also:
             rmt=parsed.rmt,
             spi=parsed.spi,
             uart=parsed.uart,
+            bitbang=parsed.bitbang,
             lcd=parsed.lcd,
             lcd_spi=parsed.lcd_spi,
             lcd_rgb=parsed.lcd_rgb,

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -573,6 +573,11 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     rp_uart_index=args.rp_uart_index,
                 )
             )
+        if args.bitbang:
+            # Portable GPIO fallback. Name matches
+            # BitBangChannelDriver::getName(), which the firmware resolves
+            # against the manager's registered drivers at runtime.
+            drivers.append("BIT_BANG")
         if args.lcd:
             drivers.append("LCD_CLOCKLESS")
         if args.lcd_spi:

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -541,6 +541,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         )
         return 1
 
+    # `--all` replaces the selection wholesale, so an explicit --bitbang
+    # alongside it used to be silently dropped. Append rather than fold
+    # BIT_BANG into the --all sets themselves: those lists are curated to the
+    # platform's real transmit engines (see
+    # test_all_drivers_teensy4_only_real_teensy_drivers), and BIT_BANG is the
+    # universal software fallback rather than a platform driver. Folding it in
+    # would also make every --all run fail on RP while #4203 is open.
     if args.all and is_teensy4:
         drivers = [
             "OBJECT_FLED",
@@ -596,6 +603,12 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                         "FLEX_IO", final_environment, args.rp_pio_index
                     )
                 )
+
+    # An explicit --bitbang must survive --all, which replaces the selection
+    # wholesale. Appended here rather than folded into the --all sets: see the
+    # note above those lists.
+    if args.bitbang and "BIT_BANG" not in drivers:
+        drivers.append("BIT_BANG")
 
     parallel_mode = args.parallel
     if args.legacy and parallel_mode:

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -157,6 +157,7 @@ def _make_args(**overrides) -> Args:
         rp_spi_index=0,
         rp_spi_public_api=False,
         rp_spi_chipset="apa102",
+        bitbang=False,
         rp_uart_index=0,
         rp_pio_index=1,
         rp_pio_both=False,
@@ -3010,3 +3011,29 @@ class TestRunTestsOrSpecialMode:
             mock_rpc_cls.assert_not_called()
         assert rc == 0
         mock_discovery.close.assert_called_once()
+
+    def test_all_plus_bitbang_keeps_the_explicit_driver(
+        self, fake_project_dir: Path
+    ) -> None:
+        """`--all --bitbang` must not silently drop the explicit request.
+
+        The args.all branch replaces the driver selection wholesale, so an
+        explicitly requested BIT_BANG used to vanish. It is appended rather
+        than folded into the curated --all sets, which name each platform's
+        real transmit engines.
+        """
+        args = _make_args(
+            all=True,
+            bitbang=True,
+            parlio=False,
+            environment_positional="teensy40",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)
+        assert result.drivers == ["OBJECT_FLED", "FLEX_IO", "BIT_BANG"]


### PR DESCRIPTION
Adds `bash autoresearch <board> --bitbang`, selecting `Bus::BIT_BANG`.

## Why

`BIT_BANG` is AUTO's last-resort fallback (priority 0), but no autoresearch flag
selected it, so the portable bit-bang path had **no hardware-in-the-loop coverage
on any platform**. FastLED#3899's checklist item "AUTO and BIT_BANG fallback
behavior" could not be run as written because of this gap.

The driver name `BIT_BANG` matches `BitBangChannelDriver::getName()`, which the
firmware resolves against the manager's registered drivers at runtime — same
mechanism the existing driver flags use.

## Result

The flag immediately earned its keep: bit-bang fails to drive WS2812 on both
bench boards, 100% byte corruption, filed as a separate issue with wire captures
and a root-cause analysis. This PR is just the measurement tool; it makes no
behavioral change to the library.

## Verification

- `bash test --cpp` — 383/383 (299 unit + 84 examples)
- `bash lint` — clean
- Flag parsing verified not to leak into other driver flags
- Exercised end-to-end on RP2350W and ESP32-C6 hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--bitbang` option for selecting a portable GPIO fallback driver.
  - The selected fallback driver is included in targeted test runs.
  - The fallback driver is preserved when `--bitbang` is combined with `--all`, ensuring the explicit selection is honored alongside the standard driver set.

- **Bug Fixes**
  - Improved serial interface handling during loopback and public API test execution to support reliable handoff to test processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->