### PR TITLE
fix(autoresearch): three RP SPI harness bugs that reported host failures as device faults

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -103,9 +103,16 @@ def _driver_name_for_environment(
     final_environment: str | None,
     rp_pio_index: int = 1,
     rp_uart_index: int = 0,
+    rp_spi_index: int = 0,
 ) -> str:
     if driver == "SPI" and _is_teensy4_environment(final_environment):
         return "SPI_UNIFIED"
+    if driver == "SPI" and _active_rp2xxx_environment(final_environment) is not None:
+        # RP registers its two fixed PL022 blocks as concrete "SPI0"/"SPI1"
+        # engines; the portable "SPI" bus name is not a runtime driver here, so
+        # sending it fails with `UnknownDriver: Driver 'SPI' not available`.
+        # Same shape as the FLEX_IO and UART cases below.
+        return f"SPI{rp_spi_index}"
     if (
         driver == "FLEX_IO"
         and _active_rp2xxx_environment(final_environment) is not None
@@ -564,7 +571,13 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         if args.rmt:
             drivers.append("RMT")
         if args.spi:
-            drivers.append(_driver_name_for_environment("SPI", final_environment))
+            drivers.append(
+                _driver_name_for_environment(
+                    "SPI",
+                    final_environment,
+                    rp_spi_index=args.rp_spi_index,
+                )
+            )
         if args.uart:
             drivers.append(
                 _driver_name_for_environment(

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -98,6 +98,19 @@ def _is_teensy4_environment(final_environment: str | None) -> bool:
     )
 
 
+def _is_spi_family_driver(driver: str) -> bool:
+    """Whether a driver name denotes an SPI transmitter on any platform.
+
+    Platforms spell this differently: the portable "SPI", Teensy's
+    "SPI_UNIFIED", and RP's concrete per-block "SPI0"/"SPI1". Anything
+    keying off the bare literal silently skips the RP names, which is how
+    the two-frame SPI default stopped applying there.
+    """
+    if driver in ("SPI", "SPI_UNIFIED"):
+        return True
+    return driver.startswith("SPI") and driver[3:].isdigit()
+
+
 def _driver_name_for_environment(
     driver: str,
     final_environment: str | None,
@@ -165,6 +178,9 @@ def _normalize_deferred_driver_names(ctx: RunContext) -> None:
     args = ctx.args
     if _active_rp2xxx_environment(environment) is not None:
         _replace_driver_selection(ctx, "UART", [f"UART{args.rp_uart_index}"])
+        # --all appends the portable "SPI", which is not a runtime driver on
+        # RP; without this it reaches the device as UnknownDriver.
+        _replace_driver_selection(ctx, "SPI", [f"SPI{args.rp_spi_index}"])
         pio_names = (
             ["PIO0", "PIO1"]
             if args.rp_pio_both and args.flex_io
@@ -1061,7 +1077,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
                     # others -> 1. User can override with --frames N.
                     if args.frames is not None:
                         frame_count = args.frames
-                    elif driver == "SPI":
+                    elif _is_spi_family_driver(driver):
                         frame_count = 2
                     else:
                         frame_count = 1

--- a/ci/autoresearch/test_rp_spi_loopback.py
+++ b/ci/autoresearch/test_rp_spi_loopback.py
@@ -109,14 +109,36 @@ def main() -> int:
     try:
         with RpcBench(args.port) as bench:
             schema = bench.call_flat("rpc.discover", args=[])
-            methods = schema.get("schema", []) if isinstance(schema, dict) else []
+            # `call_flat` collapses a timeout or transport error to None, so a
+            # failed discover is not evidence about the firmware. Reporting it
+            # as a missing method sends the reader hunting for a build-config
+            # problem that does not exist.
+            if not isinstance(schema, dict):
+                print(
+                    "FAIL — rpc.discover did not return a schema object "
+                    f"(got {type(schema).__name__}); cannot tell whether "
+                    "rpSpiLoopback is present. This is a host/transport "
+                    "failure, not a firmware gap."
+                )
+                return 1
+            methods = schema.get("schema", [])
             method_names = {
                 entry[0]
                 for entry in methods
                 if isinstance(entry, list) and entry and isinstance(entry[0], str)
             }
+            if not method_names:
+                print(
+                    "FAIL — rpc.discover returned a schema with no parseable "
+                    f"method names (keys: {sorted(schema)}); the response shape "
+                    "may have changed."
+                )
+                return 1
             if "rpSpiLoopback" not in method_names:
-                print("FAIL — deployed firmware schema does not contain rpSpiLoopback")
+                print(
+                    "FAIL — deployed firmware schema does not contain "
+                    f"rpSpiLoopback ({len(method_names)} methods discovered)"
+                )
                 return 1
             passed = all(
                 run_case(bench, args.spi_index, mosi_pin, miso_pin, sck_pin, clock_hz)

--- a/ci/autoresearch/test_rp_spi_loopback.py
+++ b/ci/autoresearch/test_rp_spi_loopback.py
@@ -108,7 +108,15 @@ def main() -> int:
     print(f"  SCK: GPIO{sck_pin} (output only)")
     try:
         with RpcBench(args.port) as bench:
-            schema = bench.call_flat("rpc.discover", args=[])
+            # rpc.discover is a built-in, not one of the positional-C++-param
+            # methods call_flat() exists for, so call() is the right API here.
+            # Note this is NOT what makes the discover succeed: when this
+            # script runs under `bash autoresearch`, the harness already holds
+            # an RpcBench on the same port and the second connection's
+            # responses do not come back, so discover returns None either way.
+            # Run standalone (`uv run python -m ci.autoresearch.
+            # test_rp_spi_loopback --port ...`) until that is addressed.
+            schema = bench.call("rpc.discover", timeout=30.0)
             # `call_flat` collapses a timeout or transport error to None, so a
             # failed discover is not evidence about the firmware. Reporting it
             # as a missing method sends the reader hunting for a build-config

--- a/ci/autoresearch/test_rp_spi_loopback.py
+++ b/ci/autoresearch/test_rp_spi_loopback.py
@@ -117,16 +117,27 @@ def main() -> int:
             # Run standalone (`uv run python -m ci.autoresearch.
             # test_rp_spi_loopback --port ...`) until that is addressed.
             schema = bench.call("rpc.discover", timeout=30.0)
-            # `call_flat` collapses a timeout or transport error to None, so a
-            # failed discover is not evidence about the firmware. Reporting it
-            # as a missing method sends the reader hunting for a build-config
-            # problem that does not exist.
+            # RpcBench.call() has three distinct outcomes and they mean very
+            # different things. Collapsing them sends the reader hunting for
+            # the wrong problem, which is what this diagnostic exists to stop.
+            if schema is METHOD_NOT_FOUND:
+                print(
+                    "FAIL — the firmware does not bind rpc.discover. This is a "
+                    "build/firmware gap, not a wiring or transport problem."
+                )
+                return 1
+            if schema is None:
+                print(
+                    "FAIL — rpc.discover timed out or the transport failed. "
+                    "This says nothing about whether rpSpiLoopback is present; "
+                    "it is a host/transport failure, not a firmware gap."
+                )
+                return 1
             if not isinstance(schema, dict):
                 print(
-                    "FAIL — rpc.discover did not return a schema object "
-                    f"(got {type(schema).__name__}); cannot tell whether "
-                    "rpSpiLoopback is present. This is a host/transport "
-                    "failure, not a firmware gap."
+                    "FAIL — rpc.discover returned a malformed schema "
+                    f"(got {type(schema).__name__}, expected an object); "
+                    "cannot tell whether rpSpiLoopback is present."
                 )
                 return 1
             methods = schema.get("schema", [])

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -3013,22 +3013,6 @@ class TestRunTestsOrSpecialMode:
         assert rc == 0
         mock_discovery.close.assert_called_once()
 
-
-def test_spi_family_predicate_covers_every_platform_spelling() -> None:
-    """The two-frame SPI default must not skip RP's concrete block names.
-
-    RP registers "SPI0"/"SPI1" rather than the portable "SPI", so keying the
-    frame default off the bare literal silently gave RP SPI one frame and
-    dropped the #2254/#2288 second-frame degradation check.
-    """
-    from ci.autoresearch.phases import _is_spi_family_driver
-
-    for name in ("SPI", "SPI_UNIFIED", "SPI0", "SPI1"):
-        assert _is_spi_family_driver(name), name
-
-    for name in ("PARLIO", "RMT", "UART", "UART0", "LCD_SPI", "I2S_SPI", "SPIX", ""):
-        assert not _is_spi_family_driver(name), name
-
     def test_legacy_rejects_chipsets_without_a_legacy_template(
         self, fake_project_dir: Path
     ) -> None:
@@ -3080,3 +3064,19 @@ def test_spi_family_predicate_covers_every_platform_spelling() -> None:
         ):
             result = _parse_args_and_build_commands(args)
         assert isinstance(result, RunContext)
+
+
+def test_spi_family_predicate_covers_every_platform_spelling() -> None:
+    """The two-frame SPI default must not skip RP's concrete block names.
+
+    RP registers "SPI0"/"SPI1" rather than the portable "SPI", so keying the
+    frame default off the bare literal silently gave RP SPI one frame and
+    dropped the #2254/#2288 second-frame degradation check.
+    """
+    from ci.autoresearch.phases import _is_spi_family_driver
+
+    for name in ("SPI", "SPI_UNIFIED", "SPI0", "SPI1"):
+        assert _is_spi_family_driver(name), name
+
+    for name in ("PARLIO", "RMT", "UART", "UART0", "LCD_SPI", "I2S_SPI", "SPIX", ""):
+        assert not _is_spi_family_driver(name), name

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -3010,3 +3010,19 @@ class TestRunTestsOrSpecialMode:
             mock_rpc_cls.assert_not_called()
         assert rc == 0
         mock_discovery.close.assert_called_once()
+
+
+def test_spi_family_predicate_covers_every_platform_spelling() -> None:
+    """The two-frame SPI default must not skip RP's concrete block names.
+
+    RP registers "SPI0"/"SPI1" rather than the portable "SPI", so keying the
+    frame default off the bare literal silently gave RP SPI one frame and
+    dropped the #2254/#2288 second-frame degradation check.
+    """
+    from ci.autoresearch.phases import _is_spi_family_driver
+
+    for name in ("SPI", "SPI_UNIFIED", "SPI0", "SPI1"):
+        assert _is_spi_family_driver(name), name
+
+    for name in ("PARLIO", "RMT", "UART", "UART0", "LCD_SPI", "I2S_SPI", "SPIX", ""):
+        assert not _is_spi_family_driver(name), name


### PR DESCRIPTION
Three independent harness bugs found while running the PIO/SPI/UART driver
matrix for #3832 on an attached RP2350W. All three share a failure shape:
**a host-side problem presented as a device or firmware fault.**

## 1. `--spi` never reached the RP SPI engine

```
Error: UnknownDriver
Message: Driver 'SPI' not available
```

RP registers its two fixed PL022 blocks as `SPI0`/`SPI1`; the portable `SPI`
bus name is not a runtime driver there. `_driver_name_for_environment()`
already mapped `FLEX_IO -> PIO{n}` and `UART -> UART{n}` for RP — SPI was
simply missing and fell through to the portable name. `--rp-spi-index`
existed but was only consumed by the loopback / public-api paths.

Verified on hardware: the harness now emits `"driver":"SPI0"` and the engine
resolves it. ESP32 and Teensy mappings unchanged.

**Scope note:** this makes `--spi` *reach* the engine, not pass with it.
`ChannelEngineRpSpi::canHandle()` requires an `SpiChipsetConfig` (clocked
APA102/SK9822) and its pin table restricts SPI0 MOSI to `{3,7,19,23}` / SCK
`{2,6,18,22}`. Driving it with the default WS2812 clockless timing cannot
succeed by design.

## 2. A failed `rpc.discover` was reported as missing firmware

```
FAIL — deployed firmware schema does not contain rpSpiLoopback
```

on a board that **does** expose it — querying the device directly returns
both `rpSpiLoopback` and `rpSpiPublicApiLoopback`. `RpcBench.call_flat()`
collapses `RpcTimeoutError` and `RpcError` to `None`, and the caller read any
non-dict as "no methods discovered".

That message asserts a build-configuration gap and sends the reader hunting
for a missing `FASTLED_AUTORESEARCH_LOW_MEMORY` branch or an unbuilt source
file. I went down that path myself before checking the device.

Now distinguishes three cases: discover returned no object at all (stated as
a host/transport failure), returned an object with no parseable method names
(shape changed, keys printed), or the method genuinely absent (with the
discovered method count).

## 3. `rpc.discover` called through the wrong API

`call_flat()` is for methods bound with positional C++ parameters; the
built-in `rpc.discover` should use `call()`.

## The bug behind #2 that this PR does *not* fix

Verified cause of the `NoneType`: under `bash autoresearch`, the harness
already holds an `RpcBench` on the same port — its own fetch logs `✅ Fetched
schema: 71 methods` in the same run — and the script's second connection
never sees its responses. **Run standalone and the identical code path
succeeds**, reaches the device and executes the loopback:

```
uv run python -m ci.autoresearch.test_rp_spi_loopback --port /dev/ttyACM0 --spi-index 0
  rpSpiLoopback(SPI0, 1,000,000 Hz)
    FAIL — RP SPI loopback failed.
      expected: [0, 255, 85, 170, 18, 52, ...]
      received: [0, 0, 0, 0, 0, 0, ...]   wireIdle: True
```

That remaining failure is **physical**: all-zero MISO with the wire idle is
an unfitted GPIO3 (MOSI) -> GPIO0 (MISO) jumper. This bench has GPIO0<->GPIO1
(what pin discovery selects for the clockless tests), not GPIO3->GPIO0. Not a
driver defect.

I have left the two-connection issue unfixed rather than guess at it again —
see below.

## Method note

I proposed three wrong causes for the `NoneType` before testing standalone: a
short discover timeout, then the `call_flat` frame shape, then payload size.
Each was refuted by the next run. The root cause was only visible by
comparing the harness run against a standalone run — and the fix in #2 is
what made the failure falsifiable at all, since it replaced the false
firmware claim with `got NoneType`.

## Verification

- PIO0 / PIO1 / PIO2 all `PASS 683ms` on the same board (the matrix this work
  was serving)
- UART0 correctly refuses with `RP UART: chipset timing needs a baud above
  the UART backend maximum` rather than emitting garbage
- `bash lint` clean
- Both bench boards enumerated and answered serial RPC throughout; neither
  wedged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPI requests on active RP2040 and RP2350 environments now use the correct platform-specific driver names, including automatic handling when targeting all drivers.
  * SPI operations retain the correct default frame count across supported SPI driver variants.
  * SPI loopback validation now more reliably detects discovery and transport failures, including malformed responses and unavailable firmware methods.
  * Test harnesses now close serial connections before launching related processes, preventing communication conflicts.
  * Legacy mode rejects unsupported chipsets instead of applying incorrect timing defaults.
  * The `ws2811-400` chipset now uses the correct 400 kHz configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->