### PR TITLE
fix(autoresearch): report the real platform from getPins

### DIFF
--- a/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemotePinMethods.cpp
@@ -22,6 +22,7 @@
 #include "Common.h"
 #include "AutoResearchTest.h"
 #include "AutoResearchHelpers.h"
+#include "AutoResearchPlatform.h"
 #include "fl/stl/sstream.h"
 #include "fl/stl/unique_ptr.h"
 #include "fl/stl/optional.h"
@@ -226,17 +227,15 @@ void AutoResearchRemoteControl::bindPinMethods(fl::Remote& remote) {
         defaults.set("rxPin", static_cast<int64_t>(mState->default_pin_rx));
         response.set("defaults", defaults);
 
-        #if defined(FL_IS_ESP_32S3)
-            response.set("platform", "ESP32-S3");
-        #elif defined(FL_IS_ESP_32S2)
-            response.set("platform", "ESP32-S2");
-        #elif defined(FL_IS_ESP_32C6)
-            response.set("platform", "ESP32-C6");
-        #elif defined(FL_IS_ESP_32C3)
-            response.set("platform", "ESP32-C3");
-        #else
-            response.set("platform", "unknown");
-        #endif
+        // Use the shared chipName() so this agrees with `status`. The
+        // hand-rolled chain here only knew four ESP32 variants and reported
+        // "unknown" for every other target, so an RP2350W answered
+        //   getPins -> platform "unknown"
+        //   status  -> platform "Raspberry Pi Pico 2 W (RP2350)"
+        // on the same firmware (FastLED#3899, whose closeout requires exact
+        // recorded identities). chipName() covers stub, the ESP32 family,
+        // Teensy 4.x and both RP2350 variants.
+        response.set("platform", autoresearch::chipName());
 
         return response;
     });


### PR DESCRIPTION
`getPins` hand-rolled an ESP32-only preprocessor chain and fell through to
`"unknown"` for every other target, so the same firmware disagreed with itself
on an RP2350W:

```
getPins -> {'platform': 'unknown', ...}
status  -> {'platform': 'Raspberry Pi Pico 2 W (RP2350)', ...}
```

`status` already uses the shared `autoresearch::chipName()`, which covers stub,
the ESP32 family, Teensy 4.x and both RP2350 variants. This uses it in
`getPins` too and drops the duplicated chain — so Teensy and LPC, which were
equally reporting `"unknown"`, are fixed as a side effect.

## Verified on hardware

```
getPins -> {'txPin': 1, 'rxPin': 0, 'success': True,
            'defaults': {'txPin': 1, 'rxPin': 0},
            'platform': 'Raspberry Pi Pico 2 W (RP2350)'}
```

Matches `status` on the same firmware. Full `--rpc-smoke` still passes:
`RESULT: RPC smoke PASS (discovery, help, ping, payload, status, drivers,
testNoSerial, RP concurrency, error handling)`.

## Why it matters beyond tidiness

Found while evidencing the pin-discovery / `testGpioConnection` criterion on
#3899, whose closeout explicitly requires recording *"the exact commands,
commits, wiring, ports, VID:PIDs/serials"*. Two RPCs on one board reporting
different platform identities is exactly the kind of discrepancy that gets
mis-transcribed into a closeout record, and `"unknown"` is the more plausible
one to copy since it looks like a deliberate value rather than a gap.

`bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform information reported by the pin configuration now matches the platform shown in firmware status.
  * Added support for recognizing platforms beyond the previously limited set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->