### PR TITLE
fix(channels): give RP's two SPI blocks real device info

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -90,6 +90,13 @@ ParlioRawTestState& parlioRawTestState() {
 fl::json autoResearchDeviceJson(const fl::string& name) {
     if (name == "RMT") return fl::deviceJson<fl::Bus::RMT>();
     if (name == "SPI" || name == "SPI_UNIFIED") return fl::deviceJson<fl::Bus::SPI>();
+    // RP registers its two fixed PL022 blocks under the concrete names
+    // "SPI0"/"SPI1". Without these they fell through to the generic tail
+    // below, which hardcodes which=0 and echoes the driver name into
+    // bus_name/vendor_name/device_name -- so `drivers` reported SPI1 with
+    // which=0 and no real bus metadata, unlike UART0/UART1 and PIO0/1/2.
+    if (name == "SPI0") return fl::deviceJson<fl::Bus::SPI, 0>();
+    if (name == "SPI1") return fl::deviceJson<fl::Bus::SPI, 1>();
     if (name == "UART" || name == "LPUART" || name == "UART0") {
         return fl::deviceJson<fl::Bus::UART, 0>();
     }

--- a/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteSystemMethods.cpp
@@ -95,8 +95,17 @@ fl::json autoResearchDeviceJson(const fl::string& name) {
     // below, which hardcodes which=0 and echoes the driver name into
     // bus_name/vendor_name/device_name -- so `drivers` reported SPI1 with
     // which=0 and no real bus metadata, unlike UART0/UART1 and PIO0/1/2.
+    // RP-only. SAMD21 (spi_hw_manager_samd21.cpp.hpp:38-39) and nRF52
+    // (init_channel_driver_nrf52.cpp.hpp:49) also register drivers called
+    // "SPI0"/"SPI1", but DeviceInfoResolver<Bus::SPI, 0|1> is specialized
+    // only in the RP branch of bus_info.h. Routing those platforms here
+    // would hand them the unspecialized no-op resolver and report
+    // is_noop=true / available=false -- the very regression this mapping
+    // was added to fix, just moved to a different chip.
+#if defined(FL_IS_RP)
     if (name == "SPI0") return fl::deviceJson<fl::Bus::SPI, 0>();
     if (name == "SPI1") return fl::deviceJson<fl::Bus::SPI, 1>();
+#endif
     if (name == "UART" || name == "LPUART" || name == "UART0") {
         return fl::deviceJson<fl::Bus::UART, 0>();
     }

--- a/src/fl/channels/bus_info.h
+++ b/src/fl/channels/bus_info.h
@@ -182,6 +182,22 @@ template<> struct DeviceInfoResolver<Bus::UART, 1> {
     }
 };
 
+// RP's two fixed SPI blocks are PL022 controllers, registered as concrete
+// Bus::SPI instances 0 and 1 by rp_spi_bus_traits.h. Without these the
+// generic resolver reports them as unavailable no-ops, which is wrong: they
+// are real engines that resolve and run.
+template<> struct DeviceInfoResolver<Bus::SPI, 0> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::SPI, 0, "PL022", "RP SPI0");
+    }
+};
+
+template<> struct DeviceInfoResolver<Bus::SPI, 1> {
+    static inline DeviceInfo get() FL_NO_EXCEPT {
+        return makeInfo(Bus::SPI, 1, "PL022", "RP SPI1");
+    }
+};
+
 #if defined(FL_IS_RP2350)
 template<> struct DeviceInfoResolver<Bus::FLEX_IO, 2> {
     static inline DeviceInfo get() FL_NO_EXCEPT {


### PR DESCRIPTION
The `drivers` RPC misreported RP's SPI engines on two counts:

```
SPI0  which=0  bus_name=SPI0  vendor=SPI0  device=SPI0
SPI1  which=0  bus_name=SPI1  vendor=SPI1  device=SPI1   <- which should be 1
```

Compare UART and PIO on the same board, which are correct:

```
UART0 which=0  bus_name=UART  vendor=PL011 device=RP UART0
UART1 which=1  bus_name=UART  vendor=PL011 device=RP UART1
```

## Two causes, and a trap between them

The name→device lookup maps `UART0`/`UART1` and `PIO0/1/2` explicitly but had
no entry for the concrete `SPI0`/`SPI1` names RP registers, so both fell
through to a generic tail that hardcodes `which=0` and echoes the driver name
into `bus_name`/`vendor_name`/`device_name`.

**Adding those two entries alone made it worse.** `DeviceInfoResolver` had no
RP specialization for `Bus::SPI`, so the drivers then reported:

```
SPI0  is_noop=True  available=False  error='unavailable'
SPI1  is_noop=True  available=False  error='unavailable'
```

That is actively false — these engines resolve and run — and worse than a
wrong index, because a consumer can reasonably skip a driver marked
unavailable. Caught it on hardware before pushing. This PR therefore also adds
the missing `DeviceInfoResolver<Bus::SPI, 0/1>` specializations alongside the
existing RP FLEX_IO/UART ones.

## Verified on an RP2350W

```
PIO0   which=0 is_noop=False bus=FLEX_IO vendor=PIO   dev=RP PIO0      avail=True
PIO1   which=1 is_noop=False bus=FLEX_IO vendor=PIO   dev=RP PIO1      avail=True
PIO2   which=2 is_noop=False bus=FLEX_IO vendor=PIO   dev=RP2350 PIO2  avail=True
SPI0   which=0 is_noop=False bus=SPI     vendor=PL022 dev=RP SPI0      avail=True
SPI1   which=1 is_noop=False bus=SPI     vendor=PL022 dev=RP SPI1      avail=True
UART0  which=0 is_noop=False bus=UART    vendor=PL011 dev=RP UART0     avail=True
UART1  which=1 is_noop=False bus=UART    vendor=PL011 dev=RP UART1     avail=True
```

Consistent across all seven drivers, and `--rpc-smoke` still passes.

Found while auditing `drivers` output for #3899, whose closeout requires exact
recorded identities.

## Host tests — please rely on CI

`bash test --cpp` could not be run to completion on this bench:

```
❌ Stale test artifact: .build/meson-quick/tests/cled_controller.so
   DLL mtime (1788816732.21) predates this build's start (1788837138.54).
```

(FastLED#3011.) `zccache stop` and `bash test --clean` did not clear it — after
the clean the same failure just moved from unit tests to examples, with the
DLL mtime unchanged across runs. **Confirmed identical failures with this
change stashed**, so the two are unrelated, but I could not produce a green
local test run and would rather say so than imply one. `bash lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected device reporting for SPI buses on RP2040 and RP2350 platforms.
  * SPI0 and SPI1 now display accurate bus indices and metadata, including their proper device names and vendor information.
  * Improved handling of SPI device identification across supported platforms to provide more consistent reporting for connected hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->