### PR TITLE
fix(rp): return released pins to hi-Z instead of leaving them muxed

### DIFF
--- a/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_spi_peripheral.cpp.hpp
@@ -163,9 +163,16 @@ void RpSpiPeripheral::deinitialize() FL_NO_EXCEPT {
     if (mTxDmaChannel >= 0) resources.releaseDmaChannel(mTxDmaChannel);
     if (mRxDmaChannel >= 0) resources.releaseDmaChannel(mRxDmaChannel);
     if (mOwnsPins) {
-        resources.releasePins(static_cast<u8>(mMosiPin), 1);
-        resources.releasePins(static_cast<u8>(mMisoPin), 1);
-        resources.releasePins(static_cast<u8>(mSckPin), 1);
+        // initialize() muxed these to GPIO_FUNC_SPI. Releasing them in the
+        // ledger alone leaves the pads driven by the PL022, so a later driver
+        // on the same net meets an output it cannot see in the ledger.
+        for (const u8 pin : {static_cast<u8>(mMosiPin),
+                             static_cast<u8>(mMisoPin),
+                             static_cast<u8>(mSckPin)}) {
+            gpio_set_function(static_cast<uint>(pin), GPIO_FUNC_SIO);
+            gpio_set_dir(static_cast<uint>(pin), GPIO_IN);
+            resources.releasePins(pin, 1);
+        }
     }
     if (mOwnsSpi) resources.releaseSpi(static_cast<u8>(mSpiIndex));
     mTxDmaChannel = -1;

--- a/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rp_uart_peripheral.cpp.hpp
@@ -164,6 +164,10 @@ void RpUartPeripheral::deinitialize() FL_NO_EXCEPT {
     }
     if (mOwnsPin) {
         gpio_set_outover(static_cast<uint>(mTxPin), GPIO_OVERRIDE_NORMAL);
+        // The override was undone above but the pin was still muxed to the
+        // UART by initialize(); return it to hi-Z so the release is real.
+        gpio_set_function(static_cast<uint>(mTxPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mTxPin), GPIO_IN);
         resources.releasePins(static_cast<u8>(mTxPin), 1);
     }
     if (mOwnsUart) {

--- a/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_2_rp.cpp.hpp
@@ -535,6 +535,15 @@ void SPIDualRP2040::cleanup() {
             RpPioDmaResourceManager::instance().releaseDmaChannel(mDMAChannel);
             mDMAChannel = -1;
         }
+        // pio_gpio_init() muxed these to the PIO; return them to hi-Z so
+        // the ledger release matches the hardware state.
+        for (u8 offset = 0; offset < 2; ++offset) {
+            const uint pin = static_cast<uint>(mData0Pin) + offset;
+            gpio_set_function(pin, GPIO_FUNC_SIO);
+            gpio_set_dir(pin, GPIO_IN);
+        }
+        gpio_set_function(static_cast<uint>(mClockPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mClockPin), GPIO_IN);
         RpPioDmaResourceManager::instance().releasePins(mData0Pin, 2);
         RpPioDmaResourceManager::instance().releasePins(mClockPin, 1);
 

--- a/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/spi_hw_8_rp.cpp.hpp
@@ -553,6 +553,15 @@ void SpiHw8RP2040::cleanup() {
             RpPioDmaResourceManager::instance().releaseDmaChannel(mDMAChannel);
             mDMAChannel = -1;
         }
+        // pio_gpio_init() muxed these to the PIO; return them to hi-Z so
+        // the ledger release matches the hardware state.
+        for (u8 offset = 0; offset < 8; ++offset) {
+            const uint pin = static_cast<uint>(mDataPins[0]) + offset;
+            gpio_set_function(pin, GPIO_FUNC_SIO);
+            gpio_set_dir(pin, GPIO_IN);
+        }
+        gpio_set_function(static_cast<uint>(mClockPin), GPIO_FUNC_SIO);
+        gpio_set_dir(static_cast<uint>(mClockPin), GPIO_IN);
         RpPioDmaResourceManager::instance().releasePins(mDataPins[0], 8);
         RpPioDmaResourceManager::instance().releasePins(mClockPin, 1);
 


### PR DESCRIPTION
Four RP teardown paths release their pins in the resource ledger but never undo the muxing `initialize()` applied. The pad keeps being driven by a peripheral the ledger reports as free.

| File | Claimed with | Restored? |
|---|---|---|
| `rp_spi_peripheral` | `gpio_set_function(GPIO_FUNC_SPI)` | no |
| `rp_uart_peripheral` | `gpio_set_function(UART_FUNCSEL_NUM)` | undoes `gpio_set_outover` only — pin stays muxed |
| `spi_hw_8_rp` | `pio_gpio_init` × 8 data + clock | no |
| `spi_hw_2_rp` | `pio_gpio_init` × 2 data + clock | no |

### Why this is worth fixing

A released-but-still-driven pin is an output-vs-output short as soon as another driver takes that net. That is reachable on the current bench rather than theoretical: the RP2350W fixture has a soldered GPIO0 ↔ GPIO1 bridge, and adding the `GPIO3 → GPIO0` jumper that SPI0 loopback requires would put the PL022 and a PIO driver on one wire for the duration of a mixed driver sweep.

### The idiom already exists in this codebase

Two RP paths get this right today and were used as the model — no new convention invented:

- `rp_pio_tx_peripheral.cpp.hpp:190-192`
- `rp_pio_spi_peripheral.cpp.hpp:177-186`

Both do `gpio_set_function(pin, GPIO_FUNC_SIO)` then `gpio_set_dir(pin, GPIO_IN)` before `releasePins`. This PR applies that same sequence to the four that omitted it, so a ledger release now means the hardware is genuinely released.

### Verification

- `bash test --cpp` → **385/385** (with #4213 applied; without it the run hits the unrelated #4212 stale-artifact failures)
- Zero compile errors introduced
- On RP2350W `2DCB876B587EA334`: `RESULT: RPC smoke PASS (discovery, help, ping, payload, status, drivers, testNoSerial, RP concurrency, error handling)`

The SPI loopback legs themselves cannot be functionally exercised on this fixture — they need the `GPIO3 → GPIO0` and `GPIO11 → GPIO8` jumpers documented on #3899 — so this is verified as compile-correct and non-regressing rather than as a behavioural SPI test.

### Provenance

Found while writing up the unreachable-path wiring constraints for #3899. I had asserted the jumpers were safe to leave fitted, then checked, and they were not. Same defect class as #4214, which fixes the matching omission in `~ClocklessController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SPI and UART peripherals now restore pins to a safe, high-impedance input state during cleanup.
  * SPI pins correctly return to their default GPIO configuration after use, preventing them from remaining assigned to peripheral hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->