### PR TITLE
fix(autoresearch): time the RP HTTP server on stall, not total elapsed

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -766,6 +766,13 @@ void pollNetServer() {}
 
 namespace {
 
+// A stalled peer is one that has sent nothing for this long. Kept at the
+// old flat budget so a truly dead connection is reaped just as quickly.
+constexpr uint32_t kRpPeerStallMs = 2000;
+// Absolute ceiling for one request, so a peer that dribbles a byte at a time
+// cannot occupy the single-client server forever.
+constexpr uint32_t kRpPeerMaxRequestMs = 10000;
+
 struct RpPeerState {
     fl::unique_ptr<WiFiServer> server;
     fl::unique_ptr<WiFiClient> client;
@@ -777,6 +784,10 @@ struct RpPeerState {
     bool headers_complete = false;
     bool response_complete = false;
     uint32_t request_started_ms = 0;
+    // Progress watermark. The request deadline must measure a *stall*, not
+    // total elapsed time: a 4096-byte POST body arrives across several TCP
+    // segments and legitimately outruns a fixed budget on CYW43 SoftAP.
+    uint32_t last_progress_ms = 0;
 };
 
 RpPeerState& rpPeerState() {
@@ -790,6 +801,7 @@ void resetRpPeerRequest(RpPeerState& state) {
     state.headers_complete = false;
     state.response_complete = false;
     state.request_started_ms = 0;
+    state.last_progress_ms = 0;
     state.request[0] = '\0';
     state.body[0] = '\0';
 }
@@ -1220,6 +1232,7 @@ void pollNetServer() {
         state.client = fl::make_unique<WiFiClient>(state.server->accept());
         resetRpPeerRequest(state);
         state.request_started_ms = millis();
+        state.last_progress_ms = state.request_started_ms;
     }
     if (!state.client) {
         return;
@@ -1229,7 +1242,22 @@ void pollNetServer() {
         resetRpPeerRequest(state);
         return;
     }
-    if (static_cast<int32_t>(millis() - state.request_started_ms) >= 2000) {
+    // Drop only a genuinely stalled peer, and cap the whole exchange so a
+    // slow-loris cannot hold the single-client server open indefinitely.
+    // Previously this was a flat 2 s from accept, which silently killed
+    // in-progress 4 KiB POST bodies mid-transfer and left the client with
+    // status_code=-1 and zero bytes -- the server-side twin of #4173/#4196.
+    // Answering 408 instead of closing mutely means a real timeout is
+    // reported as one rather than as a transport error.
+    const uint32_t now_ms = millis();
+    const bool stalled =
+        static_cast<int32_t>(now_ms - state.last_progress_ms) >= kRpPeerStallMs;
+    const bool over_budget =
+        static_cast<int32_t>(now_ms - state.request_started_ms) >= kRpPeerMaxRequestMs;
+    if (stalled || over_budget) {
+        if (!state.response_complete) {
+            writeHttpErrorResponse(*state.client, "408 Request Timeout", "");
+        }
         state.client->stop();
         state.client.reset();
         resetRpPeerRequest(state);
@@ -1247,6 +1275,7 @@ void pollNetServer() {
         }
         state.request[state.request_length++] = static_cast<char>(ch);
         state.request[state.request_length] = '\0';
+        state.last_progress_ms = millis();
         if (state.request_length >= 4 &&
             fl::strncmp(state.request + state.request_length - 4, "\r\n\r\n", 4) == 0) {
             state.headers_complete = true;
@@ -1304,8 +1333,12 @@ void pollNetServer() {
             break;
         }
         state.body[state.body_length++] = static_cast<char>(ch);
+        state.last_progress_ms = millis();
     }
     if (is_post && state.body_length < state.expected_body_length) {
+        // Partial body: come back on a later poll. The stall timer above is
+        // what bounds this, and it has just been refreshed by the bytes we
+        // did consume, so a steadily-arriving 4 KiB body is never dropped.
         return;
     }
     state.body[state.body_length] = '\0';


### PR DESCRIPTION
### The bug

`AutoResearchNet.cpp` dropped any request still in flight 2 s after accept, closing the socket **without writing a response**:

```cpp
if (static_cast<int32_t>(millis() - state.request_started_ms) >= 2000) {
    state.client->stop();     // no response written
    state.client.reset();
    resetRpPeerRequest(state);
    return;
}
```

That is a *total elapsed* budget measured from accept. A 4096-byte `POST /echo` body arrives across several TCP segments over CYW43 SoftAP and can legitimately outrun it, so the server reaped the connection mid-transfer.

### Captured signature

From the ESP32-C6 side of a `--net-peer` run:

```
POST /echo 4096-byte FNV-1a   passed=False
  expected_hash=4277923066    received_hash=2166136261
  received_bytes=0            status_code=-1
```

`received_hash` is `0x811C9DC5` — the FNV-1a **offset basis**, i.e. the hash of zero bytes. Combined with `received_bytes=0` and `status_code=-1`, the client got no response at all rather than a corrupted one.

The body-accumulation loop is not at fault; it correctly returns to await more data on a partial body. It was the deadline above that killed the connection out from under it.

This is the server-side twin of #4173 / #4196, which fixed the same "to a deadline, not to completion" mistake in the RP HTTP *client*.

### The fix

- Refresh a progress watermark on every header and body byte consumed.
- Drop only after **2 s of no progress** (a genuinely stalled peer is still reaped as fast as before).
- Keep a **10 s absolute ceiling** so a slow-loris cannot occupy the single-client server indefinitely.
- Answer **408 Request Timeout** instead of closing mutely, so a real timeout is reported as one rather than surfacing as a transport error.

### Honest limit on verification

This is diagnosed from the captured signature plus the code path — **not demonstrated end-to-end.**

The peer link on this bench is currently flaky for reasons unrelated to this change. Across four runs today the failure moved between three different points (4 KiB echo returning zero bytes; `GET /ping` and `GET /rpc/ping` returning an empty status line with the RP as client; WiFi association failing outright), and critically an **unmodified baseline run fails too** — at association. So no configuration reaches a clean 10/10 right now, and I cannot honestly claim this change fixes the observed symptom.

What it does stand on: the signature above is unambiguous about *what* happened, and the deadline it names is unambiguously capable of causing it. The same code shape was already accepted as a bug on the client side in #4196.

Worth re-running when the bench link is stable. I did not want to either sit on the diagnosis or overstate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request timeout handling for single-client servers.
  - Slow requests now remain active while data continues to arrive, subject to an overall time limit.
  - Timed-out requests now receive a clear `408 Request Timeout` response before the connection closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->