### PR TITLE
diag(rp): explain peer-server timeouts, and retry a failed association

### DIFF
--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -446,10 +446,15 @@ kListenRetryDelayS = 30.0
 kListenReserveSeconds = 15.0
 
 # CYW43 association is not instant, and a re-join after stopNet has been
-# observed to take longer than the original 10 s budget allowed. Poll for up
-# to ~30 s before calling it a failure; a healthy join still returns on the
-# first or second poll, so this costs nothing when things are working.
-kJoinPollAttempts = 60
+# observed to take longer than the original 10 s budget allowed.
+#
+# `connectSta()` does not retry, so a transient association failure is
+# terminal until the join is re-issued -- no amount of extra polling recovers
+# a radio whose status() is stuck at FAILED. So poll ~15 s per attempt and
+# re-issue the join a few times, which subsumes the single 60-poll sweep this
+# replaces.
+kJoinAttempts = 4
+kJoinPollsPerAttempt = 30
 # Reserve enough of the run deadline for the post-failure wifiStatus report and
 # the teardown pings. Polling to the very last second loses the diagnostics
 # this change exists to produce.
@@ -647,45 +652,49 @@ async def run_net_peer_autoresearch(
             if not connect.get("success"):
                 raise RpcError(f"RP2350W wifiConnect failed: {connect}")
 
+            # connectSta() issues a single WiFi.beginNoBlock() and never
+            # retries (src/platforms/arm/rp/wifi_rp.cpp.hpp), so one transient
+            # CYW43 association failure leaves status()=FAILED for good. Re-issue
+            # the join rather than failing the cycle on a single attempt.
             rp_ip: str | None = None
             wifi_status: dict[str, Any] = {}
             join_started = time.monotonic()
-            polls = 0
-            for _ in range(kJoinPollAttempts):
-                # Stop polling once the whole-run deadline is close enough that
-                # continuing would starve the remaining cycles -- and, more
-                # importantly, would consume the budget the failure
-                # diagnostics below need in order to report at all.
-                if deadline - time.monotonic() < kJoinReserveSeconds:
+            attempts = 0
+            for attempt in range(kJoinAttempts):
+                attempts = attempt + 1
+                if attempt > 0:
+                    print(
+                        f"  RP2350W association reported "
+                        f"{wifi_status.get('status')!r}; re-issuing join "
+                        f"({attempts}/{kJoinAttempts})"
+                    )
+                    reconnect = await rpc_data(
+                        primary, "wifiConnect", {"ssid": ssid, "password": password}
+                    )
+                    if not reconnect.get("success"):
+                        raise RpcError(f"RP2350W wifiConnect failed: {reconnect}")
+                for _ in range(kJoinPollsPerAttempt):
+                    wifi_status = await rpc_data(primary, "wifiStatus")
+                    candidate_ip = wifi_status.get("ip")
+                    if wifi_status.get("connected") and isinstance(candidate_ip, str):
+                        rp_ip = candidate_ip
+                        break
+                    if str(wifi_status.get("status")) == "FAILED":
+                        break  # terminal for this attempt; re-issue the join
+                    await asyncio.sleep(min(0.5, rpc_timeout()))
+                if rp_ip:
                     break
-                polls += 1
-                wifi_status = await rpc_data(primary, "wifiStatus")
-                candidate_ip = wifi_status.get("ip")
-                if wifi_status.get("connected") and isinstance(candidate_ip, str):
-                    rp_ip = candidate_ip
-                    break
-                await asyncio.sleep(min(0.5, rpc_timeout()))
             join_elapsed = time.monotonic() - join_started
             if not rp_ip:
-                # Report what the radio actually said. Without this the failure
-                # is indistinguishable between "still associating", "auth
-                # rejected" and "associated but no DHCP lease", which are three
-                # different problems with three different fixes.
-                # Report the polls actually made. Quoting the configured
-                # maximum would overstate the evidence whenever the deadline
-                # reserve cut the loop short, which is exactly the case a
-                # reader needs to distinguish from a full unsuccessful sweep.
-                cut_short = (
-                    " (stopped early to reserve deadline for this report)"
-                    if polls < kJoinPollAttempts
-                    else ""
-                )
                 raise RpcTimeoutError(
                     "RP2350W did not join the ESP32-C6 AP after "
-                    f"{join_elapsed:.1f}s across {polls} wifiStatus "
-                    f"poll(s){cut_short}; last wifiStatus={wifi_status!r}"
+                    f"{join_elapsed:.1f}s across {attempts} attempt(s); "
+                    f"last wifiStatus={wifi_status!r}"
                 )
-            print(f"  RP2350W joined in {join_elapsed:.1f}s -> {rp_ip}")
+            print(
+                f"  RP2350W joined in {join_elapsed:.1f}s "
+                f"(attempt {attempts}) -> {rp_ip}"
+            )
 
             rp_server = await rpc_data(primary, "startNetServer")
             rp_port = rp_server.get("port")
@@ -750,7 +759,18 @@ async def run_net_peer_autoresearch(
                 max_wait=30.0,
             )
             if not c6_to_rp.get("success"):
-                raise RpcError(f"ESP32-C6 -> RP2350W HTTP failed: {c6_to_rp}")
+                # The RP is the server for this direction, so ask it why it
+                # gave up. A 408 alone does not say which budget expired or
+                # how much of the request had arrived.
+                server_stats: Any = None
+                try:
+                    server_stats = await rpc_data(primary, "netServerStats")
+                except (RpcError, RpcTimeoutError) as exc:  # noqa: BLE001
+                    server_stats = f"<unavailable: {exc}>"
+                raise RpcError(
+                    f"ESP32-C6 -> RP2350W HTTP failed: {c6_to_rp}; "
+                    f"RP server stats: {server_stats!r}"
+                )
             _summarize_client_tests("ESP32-C6 -> RP2350W", c6_to_rp)
 
             stop_result = await rpc_data(primary, "stopNet")

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -765,6 +765,9 @@ async def run_net_peer_autoresearch(
                 server_stats: Any = None
                 try:
                     server_stats = await rpc_data(primary, "netServerStats")
+                except KeyboardInterrupt as ki:
+                    handle_keyboard_interrupt(ki)
+                    raise
                 except (RpcError, RpcTimeoutError) as exc:  # noqa: BLE001
                     server_stats = f"<unavailable: {exc}>"
                 raise RpcError(

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -660,6 +660,8 @@ async def run_net_peer_autoresearch(
             wifi_status: dict[str, Any] = {}
             join_started = time.monotonic()
             attempts = 0
+            polls = 0
+            cut_short = False
             for attempt in range(kJoinAttempts):
                 attempts = attempt + 1
                 if attempt > 0:
@@ -674,7 +676,25 @@ async def run_net_peer_autoresearch(
                     if not reconnect.get("success"):
                         raise RpcError(f"RP2350W wifiConnect failed: {reconnect}")
                 for _ in range(kJoinPollsPerAttempt):
-                    wifi_status = await rpc_data(primary, "wifiStatus")
+                    # Stop polling once the whole-run deadline is close enough
+                    # that continuing would starve the remaining cycles -- and,
+                    # more importantly, would consume the budget the failure
+                    # diagnostics below need in order to report at all.
+                    poll_budget = (
+                        deadline - time.monotonic() - kJoinReserveSeconds
+                    )
+                    if poll_budget <= 0:
+                        cut_short = True
+                        break
+                    polls += 1
+                    # Clamp the poll itself to the budget, not just the check
+                    # before it. Checking first and then letting the RPC wait
+                    # its own 15 s can land the next check inside the reserve
+                    # -- and if that RPC times out, the run dies before the
+                    # join-failure report this reserve exists to protect.
+                    wifi_status = await rpc_data(
+                        primary, "wifiStatus", max_wait=min(15.0, poll_budget)
+                    )
                     candidate_ip = wifi_status.get("ip")
                     if wifi_status.get("connected") and isinstance(candidate_ip, str):
                         rp_ip = candidate_ip
@@ -686,9 +706,20 @@ async def run_net_peer_autoresearch(
                     break
             join_elapsed = time.monotonic() - join_started
             if not rp_ip:
+                # Report the polls actually made, not the configured maximum:
+                # quoting the maximum would overstate the evidence whenever
+                # the deadline reserve cut the sweep short, which is exactly
+                # the case a reader needs to tell apart from a full
+                # unsuccessful one.
+                stopped_early = (
+                    " (stopped early to reserve deadline for this report)"
+                    if cut_short
+                    else ""
+                )
                 raise RpcTimeoutError(
                     "RP2350W did not join the ESP32-C6 AP after "
-                    f"{join_elapsed:.1f}s across {attempts} attempt(s); "
+                    f"{join_elapsed:.1f}s across {attempts} attempt(s) and "
+                    f"{polls} wifiStatus poll(s){stopped_early}; "
                     f"last wifiStatus={wifi_status!r}"
                 )
             print(

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -680,9 +680,7 @@ async def run_net_peer_autoresearch(
                     # that continuing would starve the remaining cycles -- and,
                     # more importantly, would consume the budget the failure
                     # diagnostics below need in order to report at all.
-                    poll_budget = (
-                        deadline - time.monotonic() - kJoinReserveSeconds
-                    )
+                    poll_budget = deadline - time.monotonic() - kJoinReserveSeconds
                     if poll_budget <= 0:
                         cut_short = True
                         break

--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -639,6 +639,13 @@ fl::json runNetClientTest(const char* host_ip, uint16_t port) {
     return response;
 }
 
+fl::json netServerStats() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "netServerStats is RP-only");
+    return response;
+}
+
 fl::json runNetLoopback() {
     fl::json response = fl::json::object();
     int tests_passed = 0;
@@ -784,6 +791,17 @@ struct RpPeerState {
     bool headers_complete = false;
     bool response_complete = false;
     uint32_t request_started_ms = 0;
+    // Why the last request was abandoned, for netServerStats. A 408 tells the
+    // peer that time ran out but not which budget ran out, nor how much of
+    // the request had arrived -- which is the difference between a slow peer,
+    // a request the server never completes, and a starved poll loop.
+    uint32_t timeout_count = 0;
+    bool last_timeout_was_stall = false;
+    size_t last_timeout_body_length = 0;
+    size_t last_timeout_expected_body = 0;
+    uint32_t last_timeout_elapsed_ms = 0;
+    bool last_timeout_headers_complete = false;
+    char last_timeout_request[64] = {};
     // Progress watermark. The request deadline must measure a *stall*, not
     // total elapsed time: a 4096-byte POST body arrives across several TCP
     // segments and legitimately outruns a fixed budget on CYW43 SoftAP.
@@ -1302,6 +1320,23 @@ fl::json runNetClientTest(const char* host_ip, uint16_t port) {
     return response;
 }
 
+fl::json netServerStats() {
+    RpPeerState& state = rpPeerState();
+    fl::json response = fl::json::object();
+    response.set("success", true);
+    response.set("timeoutCount", static_cast<int64_t>(state.timeout_count));
+    response.set("lastTimeoutWasStall", state.last_timeout_was_stall);
+    response.set("lastTimeoutBodyLength",
+                 static_cast<int64_t>(state.last_timeout_body_length));
+    response.set("lastTimeoutExpectedBody",
+                 static_cast<int64_t>(state.last_timeout_expected_body));
+    response.set("lastTimeoutElapsedMs",
+                 static_cast<int64_t>(state.last_timeout_elapsed_ms));
+    response.set("lastTimeoutHeadersComplete", state.last_timeout_headers_complete);
+    response.set("lastTimeoutRequest", state.last_timeout_request);
+    return response;
+}
+
 fl::json runNetLoopback() {
     fl::json response = fl::json::object();
     response.set("success", false);
@@ -1361,6 +1396,18 @@ void pollNetServer() {
         static_cast<int32_t>(now_ms - state.request_started_ms) >= kRpPeerMaxRequestMs;
     if (stalled || over_budget) {
         if (!state.response_complete) {
+            ++state.timeout_count;
+            state.last_timeout_was_stall = stalled;
+            state.last_timeout_body_length = state.body_length;
+            state.last_timeout_expected_body = state.expected_body_length;
+            state.last_timeout_elapsed_ms = now_ms - state.request_started_ms;
+            state.last_timeout_headers_complete = state.headers_complete;
+            fl::size copy_len = state.request_length;
+            if (copy_len >= sizeof(state.last_timeout_request)) {
+                copy_len = sizeof(state.last_timeout_request) - 1;
+            }
+            fl::memcpy(state.last_timeout_request, state.request, copy_len);
+            state.last_timeout_request[copy_len] = '\0';
             writeHttpErrorResponse(*state.client, "408 Request Timeout", "");
         }
         state.client->stop();
@@ -1505,6 +1552,13 @@ void pollNetServer() {
 }
 
 #else  // !FL_IS_ESP32 && !FL_IS_RP2350
+
+fl::json netServerStats() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "netServerStats is RP-only");
+    return response;
+}
 
 // ============================================================================
 // Stub Implementation for Non-ESP32 Platforms

--- a/examples/AutoResearch/AutoResearchNet.h
+++ b/examples/AutoResearch/AutoResearchNet.h
@@ -59,6 +59,11 @@ fl::json stopNet();
 /// ESP32 uses its native HTTP server task; Arduino-Pico uses this poll hook.
 void pollNetServer();
 
+/// Why the RP peer server last abandoned a request (FastLED#3899 diagnostics).
+/// A 408 tells the peer that time ran out but not which budget expired, nor
+/// how much of the request had arrived.
+fl::json netServerStats();
+
 /// @brief Get current network autoresearch state.
 /// @return Reference to the global net state
 AutoResearchNetState& getNetState();

--- a/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
@@ -241,6 +241,11 @@ void AutoResearchRemoteControl::bindNetworkMethods(fl::Remote& remote) {
 
     // Register "runNetLoopback" - Self-contained loopback test (no WiFi needed)
     // Starts HTTP server on localhost, client GETs 127.0.0.1 endpoints
+    remote.bind("netServerStats", [](const fl::json& args) -> fl::json {
+        (void)args;
+        return netServerStats();
+    });
+
     remote.bind("runNetLoopback", [](const fl::json& args) -> fl::json {
         return runNetLoopback();
     });


### PR DESCRIPTION
Two changes to the RP peer-network path: one diagnostic, one robustness.

### `netServerStats`

A 408 tells the peer that time ran out, but not *which* budget expired, how much of the request had arrived, or whether headers were even complete. Those are three different problems — a slow peer, a request the server never completes, and a starved poll loop.

The server now records the reason on timeout and exposes it via a new RPC, and `net.py` quotes it when a C6→RP request fails:

```
ESP32-C6 -> RP2350W HTTP failed: {...}; RP server stats:
  {'timeoutCount': 1, 'lastTimeoutWasStall': True,
   'lastTimeoutBodyLength': 0, 'lastTimeoutExpectedBody': 4096,
   'lastTimeoutElapsedMs': 2001, 'lastTimeoutHeadersComplete': True,
   'lastTimeoutRequest': 'POST /echo HTTP/1.1'}
```

RP-only; the ESP32 and fallback branches return a "not supported" stub.

### Association retry

`connectSta()` issues a single `WiFi.beginNoBlock()` and never retries (`src/platforms/arm/rp/wifi_rp.cpp.hpp:67-87`). The comment there is explicit that `beginNoBlock`'s return cannot distinguish "still associating" from "failed", so the failure surfaces later through `status()` — and nothing ever re-issues the join. One transient CYW43 association failure is therefore terminal for the cycle.

The harness now re-issues up to 4 times and breaks out of the poll early on a terminal `FAILED` instead of waiting out the full budget.

**The retry did not fire once across 11 cycles in two runs**, so it is justified by the code fact rather than demonstrated to help. It costs nothing when association succeeds first try.

### Bench observations, recorded not fixed

Run-to-run variance on this fixture is large, and the failure point moves:

| run | cycles reached | failure |
|---|---|---|
| A | 1 | association `status=FAILED` |
| B | 3 | RP→C6 `GET` returned nothing |
| C | 8 | `startNetServer`: "TCP server failed to listen" |

Earlier runs also failed at the 4 KiB echo and at a 408 on a small `POST /rpc unknown`. Eight consecutive clean cycles in run C, with zero association retries needed, is the furthest this has got.

The cycle-8 `TCP server failed to listen` is new and worth its own look: `startNetServer` has a bounded `begin()` retry, so after eight start/stop cycles the previous listener is plausibly not fully released. Not chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RP2350W network-server diagnostics, including timeout causes, request progress, elapsed time, and recent request details.
  - Exposed server statistics through the remote network interface.
  - Added clear platform-specific responses when diagnostics are unavailable.

- **Bug Fixes**
  - Improved RP2350W Wi-Fi connection reliability by retrying failed joins.
  - Prevented lengthy status requests from consuming diagnostic time.

- **Diagnostics**
  - Connection and HTTP test failures now include timing, attempt, status, server statistics, and client test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->