### PR TITLE
feat(autoresearch): add a 400 kHz chipset so UART is reachable on RP

### DIFF
--- a/ci/autoresearch/args.py
+++ b/ci/autoresearch/args.py
@@ -778,14 +778,16 @@ See Also:
         # Chipset selection
         parser.add_argument(
             "--chipset",
-            choices=["ws2812", "ws2814", "ws2818", "ucs7604"],
+            choices=["ws2812", "ws2814", "ws2818", "ucs7604", "ws2811-400"],
             default="ws2812",
             help=(
                 "Chipset to use for autoresearch (default: ws2812). "
                 "ws2814 requires --legacy and exercises automatic RGBW output; "
                 "ws2818 requires --legacy and exercises its RGB backup-input "
                 "chipset timing; "
-                "ucs7604 uses UCS7604-800KHZ timing with 16-bit encoding."
+                "ucs7604 uses UCS7604-800KHZ timing with 16-bit encoding; "
+                "ws2811-400 uses 400 kHz (2500 ns) timing, which is the only "
+                "geometry the RP PL011 can reach over UART."
             ),
         )
 

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -987,6 +987,7 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         "ws2814": "WS2814",
         "ws2818": "WS2818",
         "ucs7604": "UCS7604-800KHZ",
+        "ws2811-400": "WS2811-400KHZ",
     }
     timing_name = chipset_timing_map.get(args.chipset, "WS2812B-V5")
 

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -823,6 +823,15 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     } else if (timing_name == "UCS7604-800KHZ") {
         resolved_timing = fl::makeTimingConfig<fl::TIMING_UCS7604_800KHZ>();
         resolved_encoder = fl::encoder_for<fl::TIMING_UCS7604_800KHZ>();
+    } else if (timing_name == "WS2811-400KHZ") {
+        // 2500 ns period. The RP PL011 tops out at clk_peri/16 = 3.0 Mbaud,
+        // below the >=3.2 Mbaud that WS2812's 1250 ns needs at the coarsest
+        // (4 pulses/bit) UART geometry -- so 800 kHz parts cannot be driven
+        // over UART there at all. At 2500 ns the requirement drops to
+        // 1.6 Mbaud, which fits, and exercises the backend on RP for the
+        // first time. See FastLED#3899.
+        resolved_timing = fl::makeTimingConfig<fl::TIMING_WS2811_400KHZ>();
+        resolved_encoder = fl::encoder_for<fl::TIMING_WS2811_400KHZ>();
     } else if (timing_name == "SK6812") {
         // SK6812 exercises the UART wave8-frame geometry (its T0H/T1H
         // are exact multiples of period/4 — FastLED#3572 follow-up).


### PR DESCRIPTION
### The UART backend on RP was never actually exercised

`bash autoresearch rp2350w --uart` fails with:

```
TEST UART0 lanes=1 leds=100 FAIL 2017ms class=zero_capture
RP UART: attempted=False started=False encodedBytes=0 actualBaud=0
lastError='RP UART: chipset timing needs a baud above the UART backend maximum'
```

`attempted=False` — it declined before transmitting. Not wiring (pin discovery correctly applies `txPin: 0`, and GPIO0 is a valid UART0 TX pin), and not a regression (A/B'd against #4218, which rewrote this teardown: identical failure with it reverted).

The cause is arithmetic. `canRepresentTimingForMaxBaud` accepts a chipset if 5 or 4 pulses per LED bit fits, where `baud = pulses × 1e9 / period_ns`:

| period | 5 pulses | 4 pulses |
|---|---|---|
| WS2812 @ 1250 ns | 4.00 MBaud | 3.20 MBaud |
| WS2811-400 @ 2500 ns | 2.00 MBaud | 1.60 MBaud |

`RpUartPeripheral::maxBaudRate()` is `min(clk_peri/16, 6.25 MBaud)`, and `clk_peri/16` binds at **3.0 MBaud** on this silicon (the constant's own comment records "achieved 3000000"). So every 800 kHz part is rejected — and **every `--chipset` choice was 800 kHz** (`ws2812`, `ws2814`, `ws2818`, and `ucs7604`, which is UCS7604-**800KHZ**).

The backend was not broken. It was never handed a chipset it could clock.

### This PR

Adds `--chipset ws2811-400`, mapped to the existing `TIMING_WS2811_400KHZ`. First UART transmission on RP:

```
before   attempted=False started=False encodedBytes=0    actualBaud=0
after    attempted=True  started=True  encodedBytes=1200 actualBaud=2000000
```

1200 bytes is 100 LEDs × 3 × 4, and 2.0 MBaud is exactly 5 pulses/bit at 2500 ns.

### Loopback still fails — and now we can see why

```
TEST UART0 lanes=1 leds=100 FAIL 827ms class=decode_mismatch
Raw sample: H1000 L1500  H1000 L1500  H500 L2000  H500 L2000 ...
```

Period is 2500 ns as intended, and the two symbols are **500 ns** and **1000 ns**. But WS2811-400 specifies T0H = 500 ns and **T1H = 1200 ns ±150 ns** (1050–1350). The encoded `1` lands at 1000 ns — **50 ns below the low edge of tolerance**.

That is quantization, and it is avoidable:

| geometry | pulse width | encoded T0H | encoded T1H | T1H in 1050–1350? |
|---|---|---|---|---|
| 5 pulses/bit | 500 ns | 500 ns | **1000 ns** | ✗ |
| 4 pulses/bit | 625 ns | 625 ns | **1250 ns** | ✓ |

`canRepresentTimingForMaxBaud` evaluates `fitUartWave(timing, 5, ...) || fitUartWave(timing, 4, ...)` — it takes the **first** geometry that fits rather than the one that reproduces the datasheet timing most closely. For this chipset the coarser geometry is strictly better on both symbols.

I have not changed that selection here. It affects every platform using the UART backend, ESP32 included, and I can only test RP — so it belongs in its own change with someone able to check the ESP32 side. Filing this PR with the measurement so that decision has evidence behind it.

### Scope note

`--chipset ws2811-400` is additive; the default stays `ws2812`, and no existing invocation changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the WS2811 400 kHz chipset option in the autoresearch test runner.
  * Enabled 400 kHz WS2811 timing for compatible RP platforms using UART.
  * Added timing details to the chipset option’s help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->