### PR TITLE
fix(autoresearch): stop under-sizing the RP PIO RX capture request

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -824,6 +824,21 @@ def _parse_args_and_build_commands(args: Args) -> RunContext | int:
         print(f"\u274c Error: {flag} requires --legacy")
         return 1
 
+    # The legacy path resolves timing from a LegacyClocklessChipset template
+    # and ignores timing_name entirely (AutoResearchRemoteRunSingleTest.cpp),
+    # so a chipset with no legacy template silently runs as WS2812B rather
+    # than failing. Reject the combination instead of reporting a pass for
+    # timing that was never applied.
+    legacy_capable_chipsets = {"ws2812", "ws2814", "ws2818"}
+    if args.legacy and args.chipset not in legacy_capable_chipsets:
+        print(
+            f"\u274c Error: --chipset {args.chipset} has no legacy template, so "
+            "--legacy would silently fall back to WS2812B timing. Use "
+            f"--chipset {args.chipset} without --legacy, or pick one of: "
+            + ", ".join(sorted(legacy_capable_chipsets))
+        )
+        return 1
+
     explicit_legacy_chipsets = {
         "ws2814": "WS2814",
         "ws2818": "WS2818",

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -9,6 +9,8 @@ Tests the refactored phase decomposition:
 """
 
 import asyncio
+import contextlib
+import io
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3026,9 +3028,22 @@ class TestRunTestsOrSpecialMode:
                 chipset=chipset,
                 flex_io=True,
                 parlio=False,
+                environment_positional="teensy40",
                 project_dir=fake_project_dir,
+                use_root_platformio_ini=False,
             )
-            assert _parse_args_and_build_commands(args) == 1, chipset
+            with patch(
+                "ci.autoresearch.staging.synthesise_autoresearch_project",
+                return_value=fake_project_dir,
+            ):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    result = _parse_args_and_build_commands(args)
+            assert result == 1, chipset
+            # Assert on the reason, not just the code. Without this the test
+            # passed on the unrelated --use-root-platformio-ini rejection and
+            # never reached the guard it was written for.
+            assert "has no legacy template" in buffer.getvalue(), chipset
 
     def test_non_legacy_still_accepts_those_chipsets(
         self, fake_project_dir: Path

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -3010,3 +3010,42 @@ class TestRunTestsOrSpecialMode:
             mock_rpc_cls.assert_not_called()
         assert rc == 0
         mock_discovery.close.assert_called_once()
+
+    def test_legacy_rejects_chipsets_without_a_legacy_template(
+        self, fake_project_dir: Path
+    ) -> None:
+        """--legacy silently ignores timing_name, so guard the combination.
+
+        The legacy path resolves timing from a LegacyClocklessChipset template.
+        A chipset with no template (ucs7604, ws2811-400) would run as WS2812B
+        and report a pass for timing that was never applied.
+        """
+        for chipset in ("ucs7604", "ws2811-400"):
+            args = _make_args(
+                legacy=True,
+                chipset=chipset,
+                flex_io=True,
+                parlio=False,
+                project_dir=fake_project_dir,
+            )
+            assert _parse_args_and_build_commands(args) == 1, chipset
+
+    def test_non_legacy_still_accepts_those_chipsets(
+        self, fake_project_dir: Path
+    ) -> None:
+        """The guard must not block them outside legacy mode."""
+        args = _make_args(
+            legacy=False,
+            chipset="ws2811-400",
+            flex_io=True,
+            parlio=False,
+            environment_positional="teensy40",
+            project_dir=fake_project_dir,
+            use_root_platformio_ini=False,
+        )
+        with patch(
+            "ci.autoresearch.staging.synthesise_autoresearch_project",
+            return_value=fake_project_dir,
+        ):
+            result = _parse_args_and_build_commands(args)
+        assert isinstance(result, RunContext)

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -485,8 +485,15 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         // high and low phase, so using that whole buffer here would request
         // several MiB on a Pico and leave DMA with an invalid destination.
         constexpr size_t kPioPhasesPerDataByte = 16;
+        // The guard must cover the headroom multiplier too: checking only
+        // against kPioPhasesPerDataByte would let an oversized byte count
+        // wrap during the *2 below and produce a small `requested` that
+        // sails past the clamp into RpPioRxDevice::begin().
+        constexpr size_t kPioPhaseHeadroomNumerator = 2;
+        constexpr size_t kPioPhasesPerDataByteWithHeadroom =
+            kPioPhasesPerDataByte * kPioPhaseHeadroomNumerator;
         if (expected_data_bytes >
-            (static_cast<size_t>(-1) - 1u) / kPioPhasesPerDataByte) {
+            (static_cast<size_t>(-1) - 1u) / kPioPhasesPerDataByteWithHeadroom) {
             FL_ERROR("[CAPTURE] PIO edge-capacity overflow");
             return 0;
         }
@@ -496,9 +503,8 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         // land in one entry. Ask for headroom, then clamp to the static pool
         // so the request can never exceed the FixedVector backing it:
         // over-requesting authorises appendDuration() to write past the end.
-        constexpr size_t kPioPhaseHeadroomNumerator = 2;
         size_t requested =
-            expected_data_bytes * kPioPhasesPerDataByte * kPioPhaseHeadroomNumerator + 1u;
+            expected_data_bytes * kPioPhasesPerDataByteWithHeadroom + 1u;
         if (requested > fl::kRpPioRxEdgeCapacity) {
             requested = fl::kRpPioRxEdgeCapacity;
         }

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -13,6 +13,13 @@
 #if !(defined(FASTLED_AUTORESEARCH_LOW_MEMORY) && FASTLED_AUTORESEARCH_LOW_MEMORY)
 
 #include "AutoResearchTest.h"
+
+#include "platforms/arm/rp/is_rp.h"
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+// kRpPioRxEdgeCapacity bounds the static DMA/edge pool the RP PIO RX device
+// writes into; the capture request must never exceed it.
+#include "platforms/arm/rp/rpcommon/rx_pio_channel.h"  // IWYU pragma: keep
+#endif
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 #include "fl/stl/atomic.h"
 #include "fl/stl/isr.h"
@@ -483,7 +490,19 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
             FL_ERROR("[CAPTURE] PIO edge-capacity overflow");
             return 0;
         }
-        rx_config.edge_capacity = expected_data_bytes * kPioPhasesPerDataByte + 1u;
+        // 16 phases per byte is a *clean* frame: 8 bits x (high + low). Slower
+        // chipsets exceed it -- a 400 kHz capture overflows and is discarded
+        // (RxWaitResult::BUFFER_OVERFLOW), because long runs do not always
+        // land in one entry. Ask for headroom, then clamp to the static pool
+        // so the request can never exceed the FixedVector backing it:
+        // over-requesting authorises appendDuration() to write past the end.
+        constexpr size_t kPioPhaseHeadroomNumerator = 2;
+        size_t requested =
+            expected_data_bytes * kPioPhasesPerDataByte * kPioPhaseHeadroomNumerator + 1u;
+        if (requested > fl::kRpPioRxEdgeCapacity) {
+            requested = fl::kRpPioRxEdgeCapacity;
+        }
+        rx_config.edge_capacity = requested;
     }
 #endif
 


### PR DESCRIPTION
Stacked on #4224 (which adds the 400 kHz chipset that made this observable).

### Root cause

The RP capture request assumes a clean frame:

```cpp
constexpr size_t kPioPhasesPerDataByte = 16;   // 8 bits x (high + low)
rx_config.edge_capacity = expected_data_bytes * kPioPhasesPerDataByte + 1u;
```

Exact for 800 kHz, too small for slower chipsets — their captures produce more entries than one per phase. The capture then hits `RxWaitResult::BUFFER_OVERFLOW` and the buffer is discarded, surfacing as `decode_mismatch` with zero decoded bytes.

That overflow is what the cryptic `RX wait/raw: 2/256` was reporting all along: `RxWaitResult` is `SUCCESS = 0, TIMEOUT = 1, BUFFER_OVERFLOW = 2`. The `256` is unrelated — it is the diagnostic dump window.

### Fix

Request 2× the phases, then **clamp to `kRpPioRxEdgeCapacity`**.

The clamp is load-bearing, not defensive tidiness. That constant sizes `RpPioRxEdgeStorage = FixedVector<EdgeTime, kRpPioRxEdgeCapacity>`, the static container the device appends into — so requesting more than it holds authorises `appendDuration()` to write past the end. I confirmed that by doing it: an unclamped request fails in 17 ms with nothing captured, versus 684 ms for a healthy run.

### Measured on RP2350W `2DCB876B587EA334`

| case | before | after |
|---|---|---|
| 800 kHz, 100 LEDs | PASS 684 ms | **PASS 683 ms** — no regression |
| 400 kHz, 40 LEDs | FAIL `decode_mismatch` | **PASS 518 ms** — new capability |
| 400 kHz, 100 LEDs | FAIL | FAIL — clamped at the pool |

### What this deliberately does not do

The 100-LED 400 kHz case stays blocked, because `kRpPioRxEdgeCapacity` is `100 * 3 * 16 + 1` — exactly one clean 800 kHz frame, with a single spare slot that `finishTailIfIdle()` consumes with its own tail append. There is no headroom by construction.

Doubling that pool **does** fix it — verified, 400 kHz/100 LEDs passes at 1222 ms with 800 kHz unaffected. But it costs:

```
pool entries   4801 -> 9601
words array    18.8 KB -> 37.5 KB
edges array    18.8 KB -> 37.5 KB
delta          +37.5 KB static RAM, unconditional
               = 14.2% of an RP2040's 264 KB
```

`gPioRxCaptureBuffers` is a static global, allocated whether or not any RX capture is used, so that cost lands on every RP build. That is a real trade-off and I am not taking it unilaterally in a fix aimed at a test harness — flagging it with the measurement instead.

### Note on the include

`AutoResearchTest.cpp` now includes `rx_pio_channel.h`, which is marked `IWYU pragma: private`, inside the existing RP-only guard. It is needed for the clamp bound. If that is unwelcome, the alternative is exposing the capacity through the RX channel interface rather than duplicating the constant — I did not want to duplicate a magic number that must track the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy mode now reports an error when used with chipsets that do not support legacy timing templates, instead of silently falling back to WS2812B timing.
  - RP-based signal capture now validates sizing and allocates buffer capacity more reliably, reducing the risk of insufficient capture space or invalid sizing.

- **Tests**
  - Added coverage for supported and unsupported chipset combinations in legacy and non-legacy modes.
  - Added validation for RP-based capture capacity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->