### PR TITLE
docs(lessons): record five verification failures from the RP2350 session

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -218,3 +218,17 @@
   plausible number hid it. `pytest --collect-only -q` showed 178 vs 180, and
   grepping the collected names showed 0 vs 2. A pass count cannot distinguish
   "passing" from "not present"; a collection count can.
+- Do not reimplement production logic to investigate a bug caused by
+  reimplemented production logic. The AutoResearch UART decoder hardcoded one
+  chipset's quantised wire timing, so 400 kHz frames decoded every symbol
+  wrongly. To test the fix I derived the timing *by hand*, got 1 of 40 LEDs
+  still wrong, called the remainder a "missing final byte" capture defect, and
+  spent an iteration hunting it. There was no such defect: my derivation had
+  omitted the minimum-symbol-separation bump that `fitUartWave()` applies
+  (`kMinSymbolSeparationNs`), so the decode windows were subtly wrong and
+  clipped one LED. Calling the real function decoded the frame completely. The
+  encoder's own comment had named the hazard — *"Shared by buildWave10Lut()
+  and canRepresentTiming() so the LUT that gets built is always judged by the
+  same rules that admitted it"* — and I reproduced it by hand while
+  investigating it. Before positing a new defect to explain a residual,
+  suspect the approximation you introduced to look for it.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -169,7 +169,7 @@
   reading depends on shell configuration), and twice wrote "`bash test --cpp`
   is clean"/"still fails" from the previous run's behaviour rather than the run
   just executed — once in each direction. None changed a conclusion, because
-  the logs were read afterwards, but each put a false claim in a PR that then
+  the logs were read afterward, but each put a false claim in a PR that then
   needed a correction comment. Capture the result, read it, then write.
 - A test that asserts only an exit code can pass for a completely unrelated
   reason. My `--legacy` chipset-rejection test returned 1 from the
@@ -232,3 +232,14 @@
   same rules that admitted it"* — and I reproduced it by hand while
   investigating it. Before positing a new defect to explain a residual,
   suspect the approximation you introduced to look for it.
+- A long hardware campaign and a `git checkout` share one working tree. I
+  started a five-run `--net-peer` campaign on the branch carrying the
+  `netServerStats` probe, then checked out a different branch in the same
+  repository to resolve an unrelated PR conflict. The first run had already
+  died on the conflict markers still in `ci/autoresearch/net.py`; the
+  remaining runs would have built and deployed firmware from a branch that
+  does not contain the probe the campaign existed to exercise. Nothing was
+  wedged, but the evidence would have been silently worthless. Background
+  device work pins the tree: do concurrent branch work in a `git worktree`,
+  and have the loop assert its own branch before each run so a stray checkout
+  aborts the campaign instead of quietly changing what it measures.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -161,3 +161,36 @@
   left `dma_chan_waits[]` pointing at a destroyed `mWait` for the shared ISR.
   When testing resource arbitration, always include a control leg that claims
   and then releases; the starved leg alone cannot see a leak.
+- Read the command output before writing the sentence that summarises it. Three
+  times in one session I asserted a verification result I had not looked at: I
+  quoted `_EXIT=` values that were measuring `tail` rather than the command
+  (`cmd | tail; echo $?` reports the tail), and twice wrote "`bash test --cpp`
+  is clean"/"still fails" from the previous run's behaviour rather than the run
+  just executed — once in each direction. None changed a conclusion, because
+  the logs were read afterwards, but each put a false claim in a PR that then
+  needed a correction comment. Capture the result, read it, then write.
+- A test that asserts only an exit code can pass for a completely unrelated
+  reason. My `--legacy` chipset-rejection test returned 1 from the
+  Teensy/`--use-root-platformio-ini` check and never reached the guard it was
+  written for; my `--net-peer` summariser test checked call counts and would
+  have passed with the summariser deleted. Assert on the *evidence* — the
+  message text, the printed rows — and prove the assertion discriminates by
+  temporarily disabling the code under test.
+- An exhaustive check is only as good as its input space. `cycles_from_ns()`
+  was verified against a 64-bit oracle across 16 clock rates and still shipped
+  a bug for clocks that are not whole kHz, because all 16 rates were multiples
+  of 1000 and the truncation had nothing to truncate. The same PR's earlier
+  overflow bug survived a Python equivalence sweep because bignums never
+  overflow. When a check passes, ask what shape of input it structurally
+  cannot contain.
+- `git pull --rebase` is not a safe refresh for a branch that carries a merge.
+  Rebasing #4214 linearised it and silently dropped the #4215 merge commit
+  along with two files; only a `FileNotFoundError` on the next edit revealed
+  it. Reset to the remote to recover. For stacked or merge-carrying branches,
+  merge master in or leave the branch alone.
+- Eliminating the obvious candidate does not make the next one proven. I
+  reported "transient PCB exhaustion" because `SOF_REUSEADDR` ruled out
+  TIME_WAIT, and named `-Os` as the cause of a 12x slowdown because alignment
+  and `FL_IRAM` were refuted — both wrong, the second demonstrably so once the
+  disassembly was read. State what the evidence supports and name the
+  unexplained remainder.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -164,7 +164,9 @@
 - Read the command output before writing the sentence that summarises it. Three
   times in one session I asserted a verification result I had not looked at: I
   quoted `_EXIT=` values that were measuring `tail` rather than the command
-  (`cmd | tail; echo $?` reports the tail), and twice wrote "`bash test --cpp`
+  (without `pipefail`, `cmd | tail; echo $?` reports the tail's status, not the
+  command's; shells with `set -o pipefail` report the pipeline's, so the
+  reading depends on shell configuration), and twice wrote "`bash test --cpp`
   is clean"/"still fails" from the previous run's behaviour rather than the run
   just executed — once in each direction. None changed a conclusion, because
   the logs were read afterwards, but each put a false claim in a PR that then

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -194,3 +194,15 @@
   and `FL_IRAM` were refuted — both wrong, the second demonstrably so once the
   disassembly was read. State what the evidence supports and name the
   unexplained remainder.
+- On a fixture with time-varying flakiness, a cross-build comparison proves
+  almost nothing; isolate the change *within one build* instead. Four times on
+  the RP2350W peer link a small sample looked like causation: a `stopNet`
+  settle delay (1 join -> 4), a raised WiFi join budget (2 master failures vs
+  3 clean branch runs), and client-side HTTP deadlines (master 0/2 vs branch
+  3/3, with master failing on the exact symptom the fix addressed). Reverting
+  only the change in question, on the same branch, refuted all three — the
+  runs passed anyway. The same technique caught a genuine regression I had
+  introduced (a server-side service-gap credit produced 408s that master never
+  showed, across three formulations), so it discriminates in both directions.
+  This link's behaviour varies over hours; two or three runs per arm cannot
+  see through that.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -243,3 +243,15 @@
   device work pins the tree: do concurrent branch work in a `git worktree`,
   and have the loop assert its own branch before each run so a stray checkout
   aborts the campaign instead of quietly changing what it measures.
+- Parallel worktrees are not free, and the thing they kill is the unattended
+  run. Three `git worktree`s, each with its own `.build` tree and its own
+  `fbuild-daemon`, plus a device campaign and a platform compile, drove the
+  host out of memory; the harness killed the campaign mid-run. Nothing was
+  wedged and both boards re-enumerated healthy, but an hour of unattended
+  collection was lost, and the kill looked at first glance like a test
+  failure rather than an environmental one. Worktrees are the right answer to
+  the shared-tree hazard above, so the fix is not to stop using them: retire
+  each one as soon as its work is pushed, kill the daemon that belongs to it,
+  and have long unattended loops check free memory before each iteration and
+  stop cleanly rather than be killed part-way. Read the exit reason before
+  concluding anything about the code. See [[shared-tree-hazard]].

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -277,3 +277,24 @@
   large and that sudden is nearly always the measurement, not the thing
   measured; check how many cycles actually executed before interpreting a
   rate.
+- A dual-device campaign builds *two* firmware images, and pre-building only
+  one leaves the spike in place. Three unattended campaigns were killed for
+  host memory, every one during run 1 of a freshly created worktree. I had
+  pre-compiled the RP image each time and concluded the builds were cached;
+  `--net-peer` also builds the ESP32-C6 peer image, which took 2m18s from
+  cold and was the actual spike. Later runs in every campaign were fine
+  because run 1 had warmed the cache. Two consequences: pre-build every
+  target a run will touch, not just the one under test; and stop creating a
+  worktree per experiment, because each new one pays for two full toolchain
+  builds when only a few lines differ -- reuse one bench worktree and change
+  what is merged into it. Note a memory guard that samples before each run
+  cannot see a spike that happens inside a run; smaller batches limit the
+  loss instead. See [[worktree-memory-exhaustion]].
+- A board missing from the USB bus is not necessarily wedged. Immediately
+  after a killed campaign the RP2350W was absent entirely -- the wedge
+  signature -- and it was in BOOTSEL as `2e8a:000f RP2350 Boot`, the normal
+  transient while fbuild flashes it, returning as `2e8a:f00f` within about
+  four seconds. Checking only for the application VID/PID and stopping there
+  would have reported a wedged board and halted the loop for nothing. Scan
+  the whole vendor family and wait for re-enumeration before calling a board
+  lost.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -255,3 +255,25 @@
   and have long unattended loops check free memory before each iteration and
   stop cleanly rather than be killed part-way. Read the exit reason before
   concluding anything about the code. See [[shared-tree-hazard]].
+- A tty node path is not a device identity, and the failure it produces lies.
+  Four unattended runs died on `Could not open /dev/ttyACM2, the port is busy
+  or doesn't exist`, which reads like a wedged board. Nothing was wedged: the
+  ESP32-C6 had re-enumerated and the kernel gave it `/dev/ttyACM1` instead.
+  I had hardcoded both node paths because `--net-peer` requires them and
+  neither `bash autoresearch` nor `fbuild deploy` accepts a USB serial, and
+  they had been stable for 241 cycles before they were not. The benign
+  outcome is a failed deploy; the dangerous one is two boards swapping
+  numbers, which turns a hardcoded path into flashing the wrong board and
+  breaks the deploy-isolation property #3832 requires. Resolve the USB serial
+  to a node immediately before each use and abort cleanly when the serial is
+  absent, rather than deploying to whoever inherited the path. Identity comes
+  from something stable, never from enumeration order -- the same rule the
+  USB VID/PID registry exists to enforce. See [[worktree-memory-exhaustion]].
+- When a whole campaign inverts -- 1-in-6 runs failing became 5-in-6 -- suspect
+  the harness before the device. I had just raised an HTTP deadline and was
+  ready to read the result as "the peer got worse under the longer budget".
+  It was the renumbering above: run 1 was real, runs 3-6 never reached a
+  single network cycle because the deploy could not open a port. A result that
+  large and that sudden is nearly always the measurement, not the thing
+  measured; check how many cycles actually executed before interpreting a
+  rate.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -210,3 +210,11 @@
   showed, across three formulations), so it discriminates in both directions.
   This link's behaviour varies over hours; two or three runs per arm cannot
   see through that.
+- After resolving a conflict in a test file, check the **collection** count, not
+  the pass count. Resolving a merge in `test_autoresearch_phases.py` left two
+  tests nested inside another test function, where pytest never collects them.
+  The suite reported `180 passed` before and after the fix — the missing tests
+  were absent from the count rather than failing, so the green run and the
+  plausible number hid it. `pytest --collect-only -q` showed 178 vs 180, and
+  grepping the collected names showed 0 vs 2. A pass count cannot distinguish
+  "passing" from "not present"; a collection count can.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -202,8 +202,10 @@
   settle delay (1 join -> 4), a raised WiFi join budget (2 master failures vs
   3 clean branch runs), and client-side HTTP deadlines (master 0/2 vs branch
   3/3, with master failing on the exact symptom the fix addressed). Reverting
-  only the change in question, on the same branch, refuted all three — the
-  runs passed anyway. The same technique caught a genuine regression I had
+  only the change in question, on the same branch, produced evidence against
+  all three — the runs passed anyway. Two runs per arm is not proof of a
+  negative on a link this variable; it is enough to stop crediting the change,
+  not enough to rule it out. The same technique caught a genuine regression I had
   introduced (a server-side service-gap credit produced 408s that master never
   showed, across three formulations), so it discriminates in both directions.
   This link's behaviour varies over hours; two or three runs per arm cannot


### PR DESCRIPTION
Follow-up to #4209 (merged). Five more entries, all from mistakes made during the RP2350 HIL work that produced a wrong claim and needed a correction afterwards. Recorded as recurring habits rather than one-off slips, since three of them happened more than once.

| Lesson | What went wrong |
|---|---|
| Read the output before writing the summary | Asserted a verification result three times without looking at it — including `cmd \| tail; echo $?`, which reports the tail's status, not the command's |
| An exit-code assertion can pass for an unrelated reason | A `--legacy` rejection test returned 1 from the Teensy/`--use-root-platformio-ini` check and never reached the guard it tested; a summariser test would have passed with the summariser deleted |
| An exhaustive check is only as good as its input space | `cycles_from_ns()` was swept against a 64-bit oracle across 16 clock rates and still shipped a bug for non-whole-kHz clocks, because all 16 were multiples of 1000 |
| `git pull --rebase` is unsafe on a merge-carrying branch | Rebasing #4214 silently dropped the #4215 merge commit and two files; only a `FileNotFoundError` on the next edit revealed it |
| Eliminating the obvious candidate does not prove the next one | Named "PCB exhaustion" and later `-Os` as causes because other candidates were refuted; the second was demonstrably wrong once the disassembly was read |

The common shape is asserting something the available evidence did not actually establish — either because the check could not have caught it, or because the output was never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded lessons learned on accurately interpreting command output, exit codes, test results, and test collection counts.
  * Documented limitations of exhaustive checks, cross-build comparisons, and time-varying test fixtures.
  * Added guidance on preserving merge commits during rebases and avoiding premature conclusions when evaluating alternative explanations.
  * Clarified how reimplemented logic can introduce misleading diagnostic results, including timing-related false defects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->