### PR TITLE
fix(autoresearch): derive the UART decode timing — UART loopback now passes on RP

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -14,6 +14,10 @@
 
 #include "AutoResearchTest.h"
 
+// uartWireTiming(): the decoder must classify against the quantised wire
+// timing the encoder produced, not the chipset's nominal values.
+#include "fl/channels/uart_wave_encoder.h"
+
 #include "platforms/arm/rp/is_rp.h"
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 // kRpPioRxEdgeCapacity bounds the static DMA/edge pool the RP PIO RX device
@@ -700,19 +704,32 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     if (is_uart_driver) {
         AR_FL_WARN("[CAPTURE] UART (inverted TX): using standard WS2812 decoder with UART timing...");
         // UART timing at 4 Mbps: T0H=250ns, T1H-T0H=500ns, T0L=1000ns
-        fl::ChipsetTiming uart_timing{
-            250,   // T1 = T0H (1 UART bit = 250ns)
-            500,   // T2 = T1H - T0H (3 bits - 1 bit = 2 bits = 500ns)
-            500,   // T3 = T1L (2 UART bits = 500ns, stop + next start)
-            50,    // reset_us (WS2812 minimum)
-            "UART_4Mbps"
-        };
+        // Derive the wire timing instead of hardcoding one chipset's. The
+        // encoder quantises T0H/T1H onto a period/P grid, so the decoder has
+        // to classify against what was actually sent. The old constants
+        // described WS2812 at a nominal 1250 ns; at 400 kHz they misclassify
+        // every symbol (40/40 LEDs wrong, measured on RP2350W).
+        //
+        // kMaxUartBaudRate rather than the backend's own ceiling: the latter
+        // is not reachable portably from here, and the geometry only depends
+        // on the ceiling through a feasibility gate. Where UART transmits at
+        // all, both geometries clear the backend ceiling too, so the choice
+        // matches. A backend whose ceiling excluded P=5 while the default
+        // admitted it would disagree -- worth revisiting if such a case
+        // appears.
+        fl::ChipsetTiming uart_timing =
+            fl::uartWireTiming(timing, fl::kMaxUartBaudRate);
+        if (uart_timing.T1 == 0 && uart_timing.T2 == 0) {
+            AR_FL_WARN("[CAPTURE] UART: no feasible wave geometry for this "
+                       "chipset; cannot derive decode timing");
+            return 0;
+        }
         // Use wider tolerance (250ns) for UART because the UART clock and RMT
         // sample clock are asynchronous, and GPIO matrix adds ~10-20ns jitter
         auto rx_timing = fl::make4PhaseTiming(uart_timing, 250);
         rx_timing.gap_tolerance_ns = 100000; // 100µs for UART inter-frame gaps
 
-        AR_FL_WARN("[CAPTURE] UART RX timing: T0H=" << uart_timing.T1
+        AR_FL_WARN("[CAPTURE] UART RX timing (derived): T0H=" << uart_timing.T1
                 << " T1H=" << (uart_timing.T1 + uart_timing.T2)
                 << " T0L=" << (uart_timing.T2 + uart_timing.T3)
                 << " T1L=" << uart_timing.T3);


### PR DESCRIPTION
Stacked on #4227, which adds the `uartWireTiming()` helper this uses.

### Result

```
before   TEST UART0 lanes=1 leds=40 FAIL 533ms   40/40 LEDs wrong
after    TEST UART0 lanes=1 leds=40 PASS 527ms
```

Three consecutive passes on RP2350W `2DCB876B587EA334`. PIO loopback unaffected (`PASS 685ms`).

This closes the UART clockless leg of #3899, which had been recorded as unreachable.

### The change

The decoder hardcoded one chipset's quantised wire timing:

```cpp
fl::ChipsetTiming uart_timing{250, 500, 500, 50, "UART_4Mbps"};
```

Those describe WS2812 at a nominal 1250 ns. At 400 kHz — the only rate an RP PL011 can clock (#4224) — they misclassify every symbol. It now derives them via `uartWireTiming()`.

### A defect I chased that did not exist

I had been reporting a residual "missing final byte": deriving the timing **by hand** for P=5 left 1/40 LEDs wrong and one byte short, and I attributed the remainder to a capture defect, then spent an iteration looking for it.

There was no such defect. My hand derivation omitted the minimum-symbol-separation bump that `fitUartWave()` applies (`kMinSymbolSeparationNs = 400`), so my decode windows were subtly wrong and clipped one LED. Calling the helper — which reproduces the encoder's rules exactly, bump included — decodes the frame completely.

The lesson is the one this change embodies: reimplementing the encoder's rounding at the decode site produces exactly the silent drift the encoder's comment warns about. I reproduced that bug by hand while investigating it.

### On the baud ceiling

`kMaxUartBaudRate` is used rather than the backend's own ceiling, which is not portably reachable from the harness. The geometry depends on the ceiling only through a feasibility gate, so the two agree wherever UART transmits at all — a backend whose ceiling excluded P=5 while the default admitted it would disagree, and the comment records that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51