### PR TITLE
fix(autoresearch): recover the ESP32-C6 attaching mute after a flash

### DIFF
--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -547,7 +547,15 @@ async def _connect_peer_with_retry(
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
             raise
-        except (RpcError, RpcTimeoutError, OSError) as exc:
+        except Exception as exc:  # noqa: BLE001
+            # Deliberately broad. Observed on the bench: attempts 1-2 failed
+            # mute (RpcTimeoutError), and the third reconnect failed with
+            # "attach failed: open_port(...) exceeded 3s" from the serial
+            # layer -- a different type entirely, which escaped a narrow
+            # (RpcError, RpcTimeoutError, OSError) list and propagated raw,
+            # so this helper's own diagnostic never printed. Every failure to
+            # bring the peer up is the same fault class here, and the last
+            # error is re-raised verbatim once the attempts are spent.
             failure = exc
 
         if failure is None:
@@ -559,7 +567,7 @@ async def _connect_peer_with_retry(
             except KeyboardInterrupt as ki:
                 handle_keyboard_interrupt(ki)
                 raise
-            except (RpcError, RpcTimeoutError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001
                 failure = exc
 
         if failure is None:
@@ -578,7 +586,14 @@ async def _connect_peer_with_retry(
             await peer.close()
         # Also outside any suppression: if the budget went while we were
         # failing, stop rather than sleep past the deadline.
-        await asyncio.sleep(min(2.0, remaining_timeout()))
+        #
+        # Backs off progressively. A flat 2 s was measured to be too short:
+        # the peer went from "opens but stays mute" on attempts 1-2 to
+        # "will not open at all" by attempt 3, i.e. reconnecting quickly made
+        # the port worse rather than better. Give the CDC time to finish
+        # re-enumerating instead of hammering it.
+        backoff = min(2.0 * attempt, 8.0)
+        await asyncio.sleep(min(backoff, remaining_timeout()))
     raise RpcTimeoutError(
         f"{label} did not answer its serial RPC on {port} after {attempts} "
         f"connect attempts; last error: {last_error}"

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -530,36 +530,55 @@ async def _connect_peer_with_retry(
     """
     last_error: Exception | None = None
     for attempt in range(1, attempts + 1):
-        # Budget checks sit outside the try on purpose. `remaining_timeout`
-        # signals expiry by raising RpcTimeoutError, which is the same type a
-        # mute endpoint raises -- catching it here would retry a run that has
-        # already run out of time, and report it as an unresponsive board.
+        # Every remaining_timeout() call sits outside a try on purpose. It
+        # signals expiry by raising RpcTimeoutError, the same type a mute
+        # endpoint raises; caught here it would retry a run that has already
+        # run out of time and report it as an unresponsive board.
+        #
+        # Each budget is also read immediately before the call it bounds, not
+        # once per attempt. connect() can itself consume most of the budget,
+        # so a ping timeout computed before it would be stale and could
+        # outlive the caller's deadline.
+        failure: Exception | None = None
+
         boot_wait = min(3.0, remaining_timeout())
-        ping_timeout = min(10.0, remaining_timeout())
         try:
             await peer.connect(boot_wait=boot_wait, drain_boot=True)
-            # Prove the endpoint answers before returning. connect() only
-            # opens the port; a stale CDC endpoint opens fine and stays mute.
-            await peer.send("ping", {}, timeout=ping_timeout)
-            if attempt > 1:
-                print(f"  {label} answered on connect attempt {attempt}/{attempts}")
-            return
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
             raise
         except (RpcError, RpcTimeoutError, OSError) as exc:
-            last_error = exc
-            if attempt == attempts:
-                break
-            print(
-                f"  {label} did not answer on {port} "
-                f"(attempt {attempt}/{attempts}: {exc}); reconnecting"
-            )
-            with contextlib.suppress(Exception):
-                await peer.close()
-            # Also outside any suppression: if the budget went while we were
-            # failing, stop rather than sleep past the deadline.
-            await asyncio.sleep(min(2.0, remaining_timeout()))
+            failure = exc
+
+        if failure is None:
+            ping_timeout = min(10.0, remaining_timeout())
+            try:
+                # Prove the endpoint answers. connect() only opens the port;
+                # a stale CDC endpoint opens fine and stays mute.
+                await peer.send("ping", {}, timeout=ping_timeout)
+            except KeyboardInterrupt as ki:
+                handle_keyboard_interrupt(ki)
+                raise
+            except (RpcError, RpcTimeoutError, OSError) as exc:
+                failure = exc
+
+        if failure is None:
+            if attempt > 1:
+                print(f"  {label} answered on connect attempt {attempt}/{attempts}")
+            return
+
+        last_error = failure
+        if attempt == attempts:
+            break
+        print(
+            f"  {label} did not answer on {port} "
+            f"(attempt {attempt}/{attempts}: {failure}); reconnecting"
+        )
+        with contextlib.suppress(Exception):
+            await peer.close()
+        # Also outside any suppression: if the budget went while we were
+        # failing, stop rather than sleep past the deadline.
+        await asyncio.sleep(min(2.0, remaining_timeout()))
     raise RpcTimeoutError(
         f"{label} did not answer its serial RPC on {port} after {attempts} "
         f"connect attempts; last error: {last_error}"

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -547,8 +547,18 @@ async def _connect_peer_with_retry(
         failure: Exception | None = None
 
         boot_wait = min(3.0, remaining_timeout())
+        # Bound the whole open, not just the boot wait. The serial layer
+        # self-bounds the port open at about 3 s -- that is where
+        # "open_port(...) exceeded 3s" comes from -- but it knows nothing of
+        # this caller's deadline, so with under 3 s left the attach alone can
+        # outlive it before the ping and back-off checks get to look. Six is
+        # the natural ceiling: three for the open, three for the boot wait.
+        open_budget = min(6.0, remaining_timeout())
         try:
-            await peer.connect(boot_wait=boot_wait, drain_boot=True)
+            await asyncio.wait_for(
+                peer.connect(boot_wait=boot_wait, drain_boot=True),
+                timeout=open_budget,
+            )
         except KeyboardInterrupt as ki:
             handle_keyboard_interrupt(ki)
             raise
@@ -581,14 +591,17 @@ async def _connect_peer_with_retry(
             return
 
         last_error = failure
+        # Close on every failure, including the last. `wait_for` cancels the
+        # open mid-flight, so skipping this on the final attempt would hand
+        # the caller a half-opened transport along with the exception.
+        with contextlib.suppress(Exception):
+            await peer.close()
         if attempt == attempts:
             break
         print(
             f"  {label} did not answer on {port} "
             f"(attempt {attempt}/{attempts}: {failure}); reconnecting"
         )
-        with contextlib.suppress(Exception):
-            await peer.close()
         # Also outside any suppression: if the budget went while we were
         # failing, stop rather than sleep past the deadline.
         #

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -21,6 +21,8 @@ from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ci.util.serial_interface import SerialInterface
 
 # WiFi AP credentials (must match firmware constants)
@@ -502,7 +504,11 @@ def _describe_failed_client_tests(data: dict[str, Any]) -> str:
 
 
 async def _connect_peer_with_retry(
-    peer: RpcClient, label: str, port: str, attempts: int = 3
+    peer: RpcClient,
+    label: str,
+    port: str,
+    remaining_timeout: "Callable[[], float]",
+    attempts: int = 3,
 ) -> None:
     """Connect the companion board, retrying a silent first RPC.
 
@@ -516,14 +522,25 @@ async def _connect_peer_with_retry(
     A fixed `boot_wait` cannot cover this, because the wait is over before the
     endpoint is replaced. Reconnecting is what recovers it. Each retry is
     reported so the need for one stays visible instead of being smoothed away.
+
+    Every wait is clamped by `remaining_timeout`, the run's own budget helper.
+    Unclamped, three mute attempts would spend ~43 s of boot waits, pings and
+    back-offs before any later call noticed the deadline had passed, so a
+    recovery mechanism would end up consuming the run it exists to save.
     """
     last_error: Exception | None = None
     for attempt in range(1, attempts + 1):
+        # Budget checks sit outside the try on purpose. `remaining_timeout`
+        # signals expiry by raising RpcTimeoutError, which is the same type a
+        # mute endpoint raises -- catching it here would retry a run that has
+        # already run out of time, and report it as an unresponsive board.
+        boot_wait = min(3.0, remaining_timeout())
+        ping_timeout = min(10.0, remaining_timeout())
         try:
-            await peer.connect(boot_wait=3.0, drain_boot=True)
+            await peer.connect(boot_wait=boot_wait, drain_boot=True)
             # Prove the endpoint answers before returning. connect() only
             # opens the port; a stale CDC endpoint opens fine and stays mute.
-            await peer.send("ping", {}, timeout=10.0)
+            await peer.send("ping", {}, timeout=ping_timeout)
             if attempt > 1:
                 print(f"  {label} answered on connect attempt {attempt}/{attempts}")
             return
@@ -540,7 +557,9 @@ async def _connect_peer_with_retry(
             )
             with contextlib.suppress(Exception):
                 await peer.close()
-            await asyncio.sleep(2.0)
+            # Also outside any suppression: if the budget went while we were
+            # failing, stop rather than sleep past the deadline.
+            await asyncio.sleep(min(2.0, remaining_timeout()))
     raise RpcTimeoutError(
         f"{label} did not answer its serial RPC on {port} after {attempts} "
         f"connect attempts; last error: {last_error}"
@@ -661,7 +680,9 @@ async def run_net_peer_autoresearch(
         print(f"  Connecting RP2350W on {upload_port}...")
         await primary.connect(boot_wait=3.0, drain_boot=True)
         print(f"  Connecting ESP32-C6 on {peer_upload_port}...")
-        await _connect_peer_with_retry(peer, "ESP32-C6", peer_upload_port)
+        await _connect_peer_with_retry(
+            peer, "ESP32-C6", peer_upload_port, rpc_timeout
+        )
 
         primary_status = await rpc_data(primary, "status")
         if "rp2350" not in str(primary_status.get("platform", "")).lower():

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -448,6 +448,11 @@ kListenRetryDelayS = 30.0
 # Keep enough of the deadline to report the outcome of the retry.
 kListenReserveSeconds = 15.0
 
+# How many times to reopen the companion board's serial RPC before giving up.
+# Three covers the observed USB-JTAG CDC re-enumeration window without letting
+# a genuinely dead board stall the run.
+kPeerConnectAttempts = 3
+
 # CYW43 association is not instant, and a re-join after stopNet has been
 # observed to take longer than the original 10 s budget allowed.
 #
@@ -508,7 +513,7 @@ async def _connect_peer_with_retry(
     label: str,
     port: str,
     remaining_timeout: "Callable[[], float]",
-    attempts: int = 3,
+    attempts: int,
 ) -> None:
     """Connect the companion board, retrying a silent first RPC.
 
@@ -715,7 +720,7 @@ async def run_net_peer_autoresearch(
         await primary.connect(boot_wait=3.0, drain_boot=True)
         print(f"  Connecting ESP32-C6 on {peer_upload_port}...")
         await _connect_peer_with_retry(
-            peer, "ESP32-C6", peer_upload_port, rpc_timeout
+            peer, "ESP32-C6", peer_upload_port, rpc_timeout, kPeerConnectAttempts
         )
 
         primary_status = await rpc_data(primary, "status")

--- a/ci/autoresearch/net.py
+++ b/ci/autoresearch/net.py
@@ -5,6 +5,7 @@ Provides WiFi management, HTTP server, and autoresearch flows for
 """
 
 import asyncio
+import contextlib
 import os
 import platform as platform_mod
 import subprocess
@@ -500,6 +501,52 @@ def _describe_failed_client_tests(data: dict[str, Any]) -> str:
     )
 
 
+async def _connect_peer_with_retry(
+    peer: RpcClient, label: str, port: str, attempts: int = 3
+) -> None:
+    """Connect the companion board, retrying a silent first RPC.
+
+    The most frequent failure on this fixture is not a network fault at all:
+    `No response with ID 1 within 15.0s` while attaching to the ESP32-C6,
+    before any cycle runs. Across the captured logs it is always the C6 and
+    never the RP2350W, which points at the C6's USB-JTAG CDC re-enumerating
+    after the post-flash reset -- the port path is unchanged, so a connect
+    that lands inside that window attaches to an endpoint that never answers.
+
+    A fixed `boot_wait` cannot cover this, because the wait is over before the
+    endpoint is replaced. Reconnecting is what recovers it. Each retry is
+    reported so the need for one stays visible instead of being smoothed away.
+    """
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await peer.connect(boot_wait=3.0, drain_boot=True)
+            # Prove the endpoint answers before returning. connect() only
+            # opens the port; a stale CDC endpoint opens fine and stays mute.
+            await peer.send("ping", {}, timeout=10.0)
+            if attempt > 1:
+                print(f"  {label} answered on connect attempt {attempt}/{attempts}")
+            return
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except (RpcError, RpcTimeoutError, OSError) as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            print(
+                f"  {label} did not answer on {port} "
+                f"(attempt {attempt}/{attempts}: {exc}); reconnecting"
+            )
+            with contextlib.suppress(Exception):
+                await peer.close()
+            await asyncio.sleep(2.0)
+    raise RpcTimeoutError(
+        f"{label} did not answer its serial RPC on {port} after {attempts} "
+        f"connect attempts; last error: {last_error}"
+    )
+
+
 def _summarize_client_tests(label: str, data: dict[str, Any]) -> None:
     """Print the sub-test tally so the payload leg is visible, not inferred.
 
@@ -614,7 +661,7 @@ async def run_net_peer_autoresearch(
         print(f"  Connecting RP2350W on {upload_port}...")
         await primary.connect(boot_wait=3.0, drain_boot=True)
         print(f"  Connecting ESP32-C6 on {peer_upload_port}...")
-        await peer.connect(boot_wait=3.0, drain_boot=True)
+        await _connect_peer_with_retry(peer, "ESP32-C6", peer_upload_port)
 
         primary_status = await rpc_data(primary, "status")
         if "rp2350" not in str(primary_status.get("platform", "")).lower():

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from colorama import Fore, Style
 
-from ci.autoresearch.net import _connect_peer_with_retry, create_wifi_manager
+from ci.autoresearch.net import (
+    _connect_peer_with_retry,
+    create_wifi_manager,
+    kPeerConnectAttempts,
+)
 from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
@@ -165,7 +169,7 @@ async def run_ota_peer_autoresearch(
         # mid-re-enumeration here. Four of the captured `No response with ID 1`
         # failures came from this path. See FastLED#3899.
         await _connect_peer_with_retry(
-            peer, "ESP32-C6", peer_upload_port, rpc_timeout
+            peer, "ESP32-C6", peer_upload_port, rpc_timeout, kPeerConnectAttempts
         )
 
         # Settle both links before the first real call. The peer flash runs
@@ -331,7 +335,7 @@ async def run_ota_autoresearch(
             return min(20.0, left)
 
         await _connect_peer_with_retry(
-            client, "device", upload_port, ota_remaining
+            client, "device", upload_port, ota_remaining, kPeerConnectAttempts
         )
         print(f"  {Fore.GREEN}Connected to device{Style.RESET_ALL}")
 

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from colorama import Fore, Style
 
-from ci.autoresearch.net import create_wifi_manager
+from ci.autoresearch.net import _connect_peer_with_retry, create_wifi_manager
 from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
@@ -161,7 +161,12 @@ async def run_ota_peer_autoresearch(
             serial_interface=create_serial_interface(peer_upload_port),
         )
         await primary.connect(boot_wait=3.0, drain_boot=True)
-        await peer.connect(boot_wait=3.0, drain_boot=True)
+        # The peer flashes last, so its USB-CDC is the one most likely to be
+        # mid-re-enumeration here. Four of the captured `No response with ID 1`
+        # failures came from this path. See FastLED#3899.
+        await _connect_peer_with_retry(
+            peer, "ESP32-C6", peer_upload_port, rpc_timeout
+        )
 
         # Settle both links before the first real call. The peer flash runs
         # for ~60-90 s after the primary's, and the first request on the
@@ -315,7 +320,19 @@ async def run_ota_autoresearch(
         # Connect to device via RPC
         print(f"\n  Connecting to device on {upload_port}...")
         client = RpcClient(upload_port, timeout=timeout, serial_interface=serial_iface)
-        await client.connect(boot_wait=3.0, drain_boot=True)
+        # This path has no budget helper of its own, so give it one rather
+        # than letting the retry waits run unbounded.
+        ota_deadline = time.monotonic() + timeout
+
+        def ota_remaining() -> float:
+            left = ota_deadline - time.monotonic()
+            if left <= 0:
+                raise RpcTimeoutError("--ota deadline expired")
+            return min(20.0, left)
+
+        await _connect_peer_with_retry(
+            client, "device", upload_port, ota_remaining
+        )
         print(f"  {Fore.GREEN}Connected to device{Style.RESET_ALL}")
 
         # Step 1: Start OTA on device

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -340,7 +340,14 @@ class RpcClient:
             print(f"📊 [RPC] Session sent {self._sent_count} request(s)")
         if self._serial is not None:
             await self._serial.close()
-            self._serial = None
+            # Keep a *borrowed* interface. `connect()` fabricates a default
+            # fbuild backend whenever `_serial` is None, so dropping an
+            # injected one here means a caller that closes and reconnects --
+            # every retry loop -- silently stops using the transport it was
+            # given. `_owns_serial` already records which case this is; it
+            # just was not consulted (#4233).
+            if self._owns_serial:
+                self._serial = None
             await asyncio.sleep(0)  # Yield control
 
     async def drain_boot_output(

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -488,3 +488,36 @@ def test_connect_peer_propagates_an_expired_budget() -> None:
     assert peer.send.await_count == 0
     assert "did not answer" not in captured.getvalue()
     assert "reconnecting" not in captured.getvalue()
+
+
+def test_connect_peer_reads_the_ping_budget_after_connect() -> None:
+    """The ping budget must be read after connect(), not before it.
+
+    connect() can consume most of the remaining budget itself, so a ping
+    timeout computed beforehand is stale and can outlive the caller's
+    deadline -- the exact thing the clamping exists to prevent. The budget
+    here shrinks *because* connect ran, so a reading taken before it differs
+    from one taken after.
+    """
+    budget = {"left": 10.0}
+
+    def _remaining() -> float:
+        return budget["left"]
+
+    peer = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(return_value=MagicMock())
+
+    async def _connect_that_spends_the_budget(**_kwargs: object) -> None:
+        budget["left"] = 0.5
+
+    peer.connect = AsyncMock(side_effect=_connect_that_spends_the_budget)
+
+    asyncio.run(
+        _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _remaining)
+    )
+
+    # boot_wait is bounded by the pre-connect budget...
+    assert peer.connect.await_args.kwargs["boot_wait"] == 3.0
+    # ...and the ping by what is actually left afterwards, not by 10.0.
+    assert peer.send.await_args.kwargs["timeout"] == 0.5

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -10,6 +10,7 @@ import pytest
 
 from ci.autoresearch.net import (
     _describe_failed_client_tests,
+    _connect_peer_with_retry,
     _summarize_client_tests,
     run_net_peer_autoresearch,
 )
@@ -367,3 +368,58 @@ def test_describe_failed_client_tests_reports_a_malformed_row() -> None:
     assert "1 of 2 sub-tests failed" in described
     assert "result[1] is not an object" in described
     assert "not-a-dict" in described
+
+
+def test_connect_peer_retries_a_mute_endpoint() -> None:
+    """A first connect that opens but never answers must be retried.
+
+    This is the captured bench failure: `No response with ID 1 within 15.0s`
+    while attaching to the ESP32-C6, with connect() itself succeeding. A
+    stale CDC endpoint opens fine and stays mute, so only the follow-up ping
+    detects it.
+    """
+    peer = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(
+        side_effect=[RpcTimeoutError("No response with ID 1 within 15.0s"), MagicMock()]
+    )
+
+    with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
+        asyncio.run(_connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1"))
+
+    assert peer.connect.await_count == 2
+    assert peer.send.await_count == 2
+
+
+def test_connect_peer_gives_up_and_names_the_port() -> None:
+    """Exhausting the retries must fail loudly, naming port and cause."""
+    peer = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(side_effect=RpcTimeoutError("still mute"))
+
+    with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(RpcTimeoutError) as excinfo:
+            asyncio.run(
+                _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", attempts=2)
+            )
+
+    message = str(excinfo.value)
+    assert "/dev/ttyACM1" in message
+    assert "2 connect attempts" in message
+    assert "still mute" in message
+    assert peer.connect.await_count == 2
+
+
+def test_connect_peer_does_not_retry_a_healthy_board() -> None:
+    """A board that answers first time must not be reconnected."""
+    peer = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(return_value=MagicMock())
+
+    asyncio.run(_connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1"))
+
+    assert peer.connect.await_count == 1
+    assert peer.close.await_count == 0

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -11,8 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ci.autoresearch.net import (
-    _describe_failed_client_tests,
     _connect_peer_with_retry,
+    _describe_failed_client_tests,
     _summarize_client_tests,
     run_net_peer_autoresearch,
 )
@@ -389,7 +389,7 @@ def test_connect_peer_retries_a_mute_endpoint() -> None:
 
     with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
         asyncio.run(
-            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0)
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0, 3)
         )
 
     assert peer.connect.await_count == 2
@@ -426,8 +426,8 @@ def test_connect_peer_does_not_retry_a_healthy_board() -> None:
     peer.send = AsyncMock(return_value=MagicMock())
 
     asyncio.run(
-            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0)
-        )
+        _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0, 3)
+    )
 
     assert peer.connect.await_count == 1
     assert peer.close.await_count == 0
@@ -443,9 +443,7 @@ def test_connect_peer_clamps_waits_to_the_run_budget() -> None:
     peer = AsyncMock()
     peer.connect = AsyncMock()
     peer.close = AsyncMock()
-    peer.send = AsyncMock(
-        side_effect=[RpcTimeoutError("mute"), MagicMock()]
-    )
+    peer.send = AsyncMock(side_effect=[RpcTimeoutError("mute"), MagicMock()])
     sleeps: list[float] = []
 
     async def _record_sleep(seconds: float) -> None:
@@ -454,7 +452,7 @@ def test_connect_peer_clamps_waits_to_the_run_budget() -> None:
     # Only 1.5s of budget left: every wait must be clamped below its default.
     with patch("ci.autoresearch.net.asyncio.sleep", new=_record_sleep):
         asyncio.run(
-            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 1.5)
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 1.5, 3)
         )
 
     assert peer.connect.await_args_list[0].kwargs["boot_wait"] == 1.5
@@ -476,7 +474,7 @@ def test_connect_peer_propagates_an_expired_budget() -> None:
     with contextlib.redirect_stdout(captured):
         with pytest.raises(RpcTimeoutError, match="deadline expired"):
             asyncio.run(
-                _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _expired)
+                _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _expired, 3)
             )
 
     # The point of the test: an expired budget must not be *reported* as an
@@ -514,7 +512,7 @@ def test_connect_peer_reads_the_ping_budget_after_connect() -> None:
     peer.connect = AsyncMock(side_effect=_connect_that_spends_the_budget)
 
     asyncio.run(
-        _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _remaining)
+        _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _remaining, 3)
     )
 
     # boot_wait is bounded by the pre-connect budget...
@@ -544,7 +542,7 @@ def test_connect_peer_retries_a_port_that_will_not_open() -> None:
 
     with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
         asyncio.run(
-            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM2", lambda: 30.0)
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM2", lambda: 30.0, 3)
         )
 
     assert peer.connect.await_count == 2

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import io
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -573,3 +574,33 @@ def test_connect_peer_reports_a_serial_error_in_its_own_message() -> None:
     assert "/dev/ttyACM2" in message
     assert "2 connect attempts" in message
     assert "attach failed" in message
+
+
+def test_connect_peer_bounds_a_transport_that_never_opens() -> None:
+    """A hung port open must not outlive the caller's deadline.
+
+    `boot_wait` was bounded by the remaining budget, but the transport open
+    itself was not: the serial layer self-bounds at about 3 s and knows
+    nothing of this caller's deadline, so with under 3 s left the attach
+    alone could overrun before the ping and back-off checks ran.
+    """
+    peer = MagicMock()
+
+    async def _never_opens(**_kwargs: Any) -> None:
+        await asyncio.sleep(30.0)
+
+    peer.connect = AsyncMock(side_effect=_never_opens)
+    peer.close = AsyncMock()
+    peer.send = AsyncMock()
+
+    started = time.monotonic()
+    with pytest.raises(RpcTimeoutError):
+        asyncio.run(
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 0.25, 2)
+        )
+    elapsed = time.monotonic() - started
+
+    # Two attempts of a 30 s hang would be a minute; the budget caps each.
+    assert elapsed < 5.0, f"took {elapsed:.1f}s"
+    # And the half-opened transport is closed every time, final attempt too.
+    assert peer.close.await_count == 2

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -521,3 +521,57 @@ def test_connect_peer_reads_the_ping_budget_after_connect() -> None:
     assert peer.connect.await_args.kwargs["boot_wait"] == 3.0
     # ...and the ping by what is actually left afterwards, not by 10.0.
     assert peer.send.await_args.kwargs["timeout"] == 0.5
+
+
+def test_connect_peer_retries_a_port_that_will_not_open() -> None:
+    """A port that cannot be opened is the same fault class as a mute one.
+
+    Observed on the bench: attempts 1-2 failed mute with RpcTimeoutError, and
+    the third reconnect raised "attach failed: open_port(...) exceeded 3s"
+    from the serial layer -- a different exception type, which escaped a
+    narrow catch list and propagated raw, so this helper's own diagnostic
+    never printed and the caller saw a bare serial error instead.
+    """
+    peer = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(return_value=MagicMock())
+    peer.connect = AsyncMock(
+        side_effect=[
+            RuntimeError("attach failed: open_port(/dev/ttyACM2) exceeded 3s"),
+            None,
+        ]
+    )
+
+    with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
+        asyncio.run(
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM2", lambda: 30.0)
+        )
+
+    assert peer.connect.await_count == 2
+
+
+def test_connect_peer_reports_a_serial_error_in_its_own_message() -> None:
+    """Exhausting the attempts must surface this helper's diagnostic.
+
+    Previously a non-RpcError type escaped entirely, so the run reported the
+    raw serial error with no port, attempt count, or context.
+    """
+    peer = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock()
+    peer.connect = AsyncMock(
+        side_effect=RuntimeError("attach failed: open_port exceeded 3s")
+    )
+
+    with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(RpcTimeoutError) as excinfo:
+            asyncio.run(
+                _connect_peer_with_retry(
+                    peer, "ESP32-C6", "/dev/ttyACM2", lambda: 30.0, attempts=2
+                )
+            )
+
+    message = str(excinfo.value)
+    assert "/dev/ttyACM2" in message
+    assert "2 connect attempts" in message
+    assert "attach failed" in message

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import io
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -386,7 +388,9 @@ def test_connect_peer_retries_a_mute_endpoint() -> None:
     )
 
     with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
-        asyncio.run(_connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1"))
+        asyncio.run(
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0)
+        )
 
     assert peer.connect.await_count == 2
     assert peer.send.await_count == 2
@@ -402,7 +406,9 @@ def test_connect_peer_gives_up_and_names_the_port() -> None:
     with patch("ci.autoresearch.net.asyncio.sleep", new=AsyncMock()):
         with pytest.raises(RpcTimeoutError) as excinfo:
             asyncio.run(
-                _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", attempts=2)
+                _connect_peer_with_retry(
+                    peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0, attempts=2
+                )
             )
 
     message = str(excinfo.value)
@@ -419,7 +425,66 @@ def test_connect_peer_does_not_retry_a_healthy_board() -> None:
     peer.close = AsyncMock()
     peer.send = AsyncMock(return_value=MagicMock())
 
-    asyncio.run(_connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1"))
+    asyncio.run(
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 30.0)
+        )
 
     assert peer.connect.await_count == 1
     assert peer.close.await_count == 0
+
+
+def test_connect_peer_clamps_waits_to_the_run_budget() -> None:
+    """Retry waits must not outlive the run's own deadline.
+
+    Unclamped, three mute attempts spend ~43s of boot waits, pings and
+    back-offs before any later call notices the deadline passed -- a recovery
+    mechanism consuming the run it exists to save.
+    """
+    peer = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock(
+        side_effect=[RpcTimeoutError("mute"), MagicMock()]
+    )
+    sleeps: list[float] = []
+
+    async def _record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    # Only 1.5s of budget left: every wait must be clamped below its default.
+    with patch("ci.autoresearch.net.asyncio.sleep", new=_record_sleep):
+        asyncio.run(
+            _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", lambda: 1.5)
+        )
+
+    assert peer.connect.await_args_list[0].kwargs["boot_wait"] == 1.5
+    assert peer.send.await_args_list[0].kwargs["timeout"] == 1.5
+    assert sleeps == [1.5]
+
+
+def test_connect_peer_propagates_an_expired_budget() -> None:
+    """A budget helper that raises must abort the retry loop, not be swallowed."""
+    peer = AsyncMock()
+    peer.connect = AsyncMock()
+    peer.close = AsyncMock()
+    peer.send = AsyncMock()
+
+    def _expired() -> float:
+        raise RpcTimeoutError("--net-peer deadline expired")
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        with pytest.raises(RpcTimeoutError, match="deadline expired"):
+            asyncio.run(
+                _connect_peer_with_retry(peer, "ESP32-C6", "/dev/ttyACM1", _expired)
+            )
+
+    # The point of the test: an expired budget must not be *reported* as an
+    # unresponsive board. Checking the budget inside the try block still
+    # aborts (the back-off re-raises), but first prints
+    # "ESP32-C6 did not answer ... reconnecting" -- blaming the peer for the
+    # caller running out of time.
+    assert peer.connect.await_count == 0
+    assert peer.send.await_count == 0
+    assert "did not answer" not in captured.getvalue()
+    assert "reconnecting" not in captured.getvalue()

--- a/ci/tests/test_rpc_client_errors.py
+++ b/ci/tests/test_rpc_client_errors.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import AsyncIterator
 
 import pytest
+from typeguard import typechecked
 
 from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 
@@ -147,5 +148,75 @@ def test_a_crash_keeps_its_own_type_and_decoded_lines() -> None:
             await client.send("boom", {}, timeout=0.1)
         assert caught.value.decoded_lines == ["#0 boom"]
         await client.close()
+
+    asyncio.run(_run())
+
+
+class _CountingSerial:
+    """Records how many times it was opened and closed."""
+
+    def __init__(self: "_CountingSerial") -> None:
+        self.connects = 0
+        self.closes = 0
+
+    async def connect(self: "_CountingSerial") -> None:
+        self.connects += 1
+
+    async def close(self: "_CountingSerial") -> None:
+        self.closes += 1
+
+    async def write(self: "_CountingSerial", data: str) -> None:
+        pass
+
+    async def read_lines(self: "_CountingSerial", timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        return
+        yield ""  # pragma: no cover - makes this an async generator
+
+    async def reset_device(
+        self: "_CountingSerial", board: str | None
+    ) -> bool:  # pragma: no cover
+        return True
+
+
+@typechecked
+def test_close_keeps_an_injected_serial_interface() -> None:
+    """A borrowed transport must survive close/reconnect (#4233).
+
+    `connect()` fabricates a default fbuild backend whenever `_serial` is
+    None, so a `close()` that drops an injected interface makes the next
+    `connect()` silently talk over a different transport. Every retry loop
+    closes and reconnects, so this is the common path, not a corner.
+    """
+
+    async def _run() -> None:
+        iface = _CountingSerial()
+        client = RpcClient("FAKE", serial_interface=iface)
+        await client.connect(boot_wait=0, drain_boot=False)
+        await client.close()
+        # Still the caller's interface, not a replacement.
+        assert client._serial is iface
+        await client.connect(boot_wait=0, drain_boot=False)
+        assert client._serial is iface
+        assert iface.connects == 2
+        assert iface.closes == 1
+        await client.close()
+
+    asyncio.run(_run())
+
+
+@typechecked
+def test_close_still_releases_an_owned_serial_interface() -> None:
+    """The other half: an interface the client made is still dropped.
+
+    Keeping it would leak a backend the client owns across a close, which is
+    the behaviour the ownership flag exists to distinguish.
+    """
+
+    async def _run() -> None:
+        client = RpcClient("FAKE", serial_interface=_CountingSerial())
+        client._owns_serial = True  # pretend connect() built it
+        await client.connect(boot_wait=0, drain_boot=False)
+        await client.close()
+        assert client._serial is None
 
     asyncio.run(_run())


### PR DESCRIPTION
## This is the most common failure on the peer fixture, and it is not a network fault

```
Network peer autoresearch failed: No response with ID 1 within 15.0s
```

raised while attaching to the companion board — **before any cycle runs**.

Counting the captured bench logs from this investigation:

| Failure mode | Occurrences |
|---|---|
| **Peer attaches mute** | **10** |
| WiFi join failure | 7 |
| HTTP stall (#4231) | 4 |

It occurs in both `--net-peer` and `--ota` runs, and it costs an entire run every time, since it happens before cycle 1.

## Why the ESP32-C6 specifically

In all 10 logs the board being connected is the **ESP32-C6**. Never the RP2350W — which is connected *first*, from the same code path, with the same `boot_wait=3.0`:

```python
print(f"  Connecting RP2350W on {upload_port}...")
await primary.connect(boot_wait=3.0, drain_boot=True)
print(f"  Connecting ESP32-C6 on {peer_upload_port}...")
await peer.connect(boot_wait=3.0, drain_boot=True)   # <- always this one
```

The C6 is also connected *later*, so it has strictly more settle time than the RP and still fails. That rules out "not enough wall-clock time since deploy" and points at the C6's **USB-JTAG CDC re-enumerating after the post-flash reset**.

Two consequences follow, and both match the symptom:

- **The port path does not change** (`/dev/ttyACM1` before and after), so nothing in the path signals that the endpoint was replaced.
- **`connect()` succeeds anyway.** Opening a stale CDC endpoint works fine; it simply never answers. That is why the failure surfaces as a timeout on the *first RPC* rather than as a connect error.

A larger `boot_wait` cannot fix this: the wait elapses before the endpoint is replaced, and no amount of waiting makes a stale handle answer. **Reconnecting is the only recovery** — the same shape as the join-leg finding in #3899, where polling a terminal state could not help and re-issuing could.

## The change

`_connect_peer_with_retry()`:

1. **Proves the endpoint answers.** `connect()` alone cannot detect this, because a mute endpoint opens cleanly — so a `ping` follows the connect.
2. **Reconnects on silence**, up to three attempts, closing the stale client between tries.
3. **Reports every retry** (`ESP32-C6 answered on connect attempt 2/3`), so needing one stays visible rather than being silently smoothed away. If this starts happening on every run, that is a regression worth seeing.
4. **Fails loudly** when exhausted, naming the port and the last error instead of a bare RPC id:

```
ESP32-C6 did not answer its serial RPC on /dev/ttyACM1 after 3 connect
attempts; last error: No response with ID 1 within 15.0s
```

## Tests

Three tests, using the captured failure text: a mute-then-healthy endpoint is retried; exhaustion names port, attempt count and cause; and a healthy board is **not** reconnected. All were verified to **fail** when the verifying ping is removed — the exact defect — rather than passing vacuously:

```
2 failed, 1 passed     # ping removed
3 passed               # restored
```

Collection count checked, not just pass count: 9 collected (was 6), 9 passed.

## Honest scope

The re-enumeration race is inferred from a consistent 10-for-10 device asymmetry plus the mechanics of CDC reset, not from a USB-level trace. The retry is correct regardless of the precise trigger — a peer that cannot answer its first RPC should be reconnected before a run is abandoned — and the printed retry count is what will show whether the inference holds in practice. If retries turn out never to help, that falsifies the CDC explanation and the message will say so plainly.

Relates to #3899 and #3832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device and companion-board connections after flashing by retrying transient connection and serial-port failures.
  * Applied bounded retries consistently during OTA updates.
  * Verifies connections are responsive before proceeding.
  * Limits waits, retry delays, and timeouts to the remaining operation time.
  * Reports expired connection attempts accurately and preserves externally provided serial interfaces across reconnects.

* **Tests**
  * Added coverage for retry behavior, serial failures, backoff, deadlines, exhausted attempts, and serial-interface preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->