### PR TITLE
fix(build): restore the exec bit on the single-test path too (#4205, #4168)

### DIFF
--- a/ci/meson/mtime_stabilizer.py
+++ b/ci/meson/mtime_stabilizer.py
@@ -193,7 +193,11 @@ def restore_executable_bits(build_dir: Path, verbose: bool = False) -> int:
         Number of files made executable (0 if all were already correct).
     """
     restored = 0
-    for directory in ("tests", "examples"):
+    # `tests/profile` is listed because `_resolve_test_command` spawns
+    # profile binaries straight out of it, and the scan does not recurse:
+    # a directory is not a file, so without naming it here every profile
+    # executable is walked straight past.
+    for directory in ("tests", "tests/profile", "examples"):
         target_dir = build_dir / directory
         # Path.is_dir() reports False for a directory it cannot stat, which
         # would silently skip every binary inside it. Distinguish "absent"

--- a/ci/meson/sequential_runner.py
+++ b/ci/meson/sequential_runner.py
@@ -20,6 +20,7 @@ from running_process import RunningProcess
 from ci.meson.build_timer import BuildTimer
 from ci.meson.cache_utils import save_test_result_state
 from ci.meson.compile import CompileResult, _is_compilation_error, compile_meson
+from ci.meson.mtime_stabilizer import restore_executable_bits
 from ci.meson.output import print_banner, print_error, print_success
 from ci.meson.phase_tracker import PhaseTracker
 from ci.meson.runner_helpers import _apply_phase_timing, _write_failure_log
@@ -464,6 +465,14 @@ def run_direct_test(ctx: DirectTestContext) -> MesonTestResult:
             num_tests_passed=0,
             num_tests_failed=0,
         )
+
+    # After resolution, not before: `_resolve_test_command` may relink the
+    # runner, and a link zccache serves from its cache comes back without the
+    # executable bit (FastLED#4205). `test_execution.py` restores it on the
+    # `meson test` path; this is the other way a test binary gets spawned, and
+    # it had no such call -- so a single named test died on
+    # `Permission denied (os error 13)` with nothing pointing at the mode.
+    restore_executable_bits(ctx.build_dir)
 
     print_banner("Test", "▶️", verbose=ctx.verbose)
     print(f"Running: {ctx.meson_test_name}")

--- a/ci/tests/test_direct_test_exec_bit.py
+++ b/ci/tests/test_direct_test_exec_bit.py
@@ -27,6 +27,26 @@ from ci.meson.sequential_runner import DirectTestContext, run_direct_test
 
 
 @typechecked
+def _stub_profile_tree(root: Path) -> Path:
+    """A profile test: its own executable under `tests/profile`, no runner.
+
+    `_resolve_test_command` prefers this shape and spawns the binary
+    directly, and the restore does not recurse into subdirectories -- so a
+    scan that names only `tests` walks straight past it.
+    """
+    real_exe = shutil.which("sh")
+    if real_exe is None:
+        pytest.skip("no system shell to stand in for the test runner")
+
+    profile = root / "tests" / "profile"
+    profile.mkdir(parents=True)
+    executable = profile / "stub_case"
+    shutil.copyfile(real_exe, executable)
+    executable.chmod(0o644)
+    return executable
+
+
+@typechecked
 def _stub_build_tree(root: Path) -> Path:
     """A build directory shaped like the one `run_direct_test` looks at.
 
@@ -96,3 +116,16 @@ def test_an_already_executable_runner_is_left_alone(tmp_path: Path) -> None:
 
     assert result.success
     assert stat.S_IMODE(runner.stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+@typechecked
+def test_a_profile_test_executable_is_restored_too(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    executable = _stub_profile_tree(build_dir)
+    assert not executable.stat().st_mode & stat.S_IXUSR
+
+    result = run_direct_test(_context(tmp_path, build_dir))
+
+    assert result.success, "run_direct_test could not spawn a profile executable"
+    assert executable.stat().st_mode & stat.S_IXUSR

--- a/ci/tests/test_direct_test_exec_bit.py
+++ b/ci/tests/test_direct_test_exec_bit.py
@@ -1,0 +1,98 @@
+"""The single-test path must restore the runner's executable bit (FastLED#4205).
+
+`restore_executable_bits` was added for the `meson test` path, and the fix
+stopped there. `bash test <name>` takes a different route -- `run_direct_test`
+spawns the runner itself -- and that route had no such call. A runner zccache
+had served from its link cache therefore stayed non-executable, and every
+single-test invocation died with `failed to spawn process: Permission denied
+(os error 13)`, which names neither the file nor the mode (FastLED#4168).
+
+This drives the real `run_direct_test` against a real executable rather than
+asserting that a particular function gets called, so it fails if the restore
+moves, is reordered after the spawn, or is dropped.
+"""
+
+import os
+import shutil
+import stat
+import time
+from pathlib import Path
+
+import pytest
+from typeguard import typechecked
+
+from ci.meson.build_timer import BuildTimer
+from ci.meson.phase_tracker import PhaseTracker
+from ci.meson.sequential_runner import DirectTestContext, run_direct_test
+
+
+@typechecked
+def _stub_build_tree(root: Path) -> Path:
+    """A build directory shaped like the one `run_direct_test` looks at.
+
+    The runner is a copy of a real system executable: `restore_executable_bits`
+    only touches files carrying a native-executable magic number, so a stub
+    written as text would be skipped for the right reason and prove nothing.
+    `sh` rather than `true`, because a multi-call coreutils binary dispatches
+    on argv[0] and refuses to run under the name `runner`.
+    """
+    real_exe = shutil.which("sh")
+    if real_exe is None:
+        pytest.skip("no system shell to stand in for the test runner")
+
+    tests = root / "tests"
+    tests.mkdir(parents=True)
+    runner = tests / "runner"
+    shutil.copyfile(real_exe, runner)
+    # The state zccache leaves behind: readable, not executable.
+    runner.chmod(0o644)
+    # `run_direct_test` spawns `runner <artifact>`, so the artifact is this
+    # shell's script and exits 0. A real runner would dlopen a real .so; what
+    # matters here is that something got spawned at all.
+    (tests / "stub_case.so").write_text("exit 0\n")
+    return runner
+
+
+@typechecked
+def _context(source_dir: Path, build_dir: Path) -> DirectTestContext:
+    timer = BuildTimer()
+    timer.start()
+    return DirectTestContext(
+        source_dir=source_dir,
+        build_dir=build_dir,
+        meson_test_name="stub_case",
+        build_mode="quick",
+        verbose=False,
+        log_failures=None,
+        start_time=time.time(),
+        build_timer=timer,
+        phase_tracker=PhaseTracker(build_dir, "quick"),
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+@typechecked
+def test_direct_test_run_restores_a_non_executable_runner(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    runner = _stub_build_tree(build_dir)
+    assert not runner.stat().st_mode & stat.S_IXUSR
+
+    result = run_direct_test(_context(tmp_path, build_dir))
+
+    # Spawned rather than refused, which is the whole claim.
+    assert result.success, "run_direct_test could not spawn a cache-restored runner"
+    assert runner.stat().st_mode & stat.S_IXUSR
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+@typechecked
+def test_an_already_executable_runner_is_left_alone(tmp_path: Path) -> None:
+    """The restore must not widen permissions it did not need to touch."""
+    build_dir = tmp_path / "build"
+    runner = _stub_build_tree(build_dir)
+    runner.chmod(0o700)
+
+    result = run_direct_test(_context(tmp_path, build_dir))
+
+    assert result.success
+    assert stat.S_IMODE(runner.stat().st_mode) == 0o700


### PR DESCRIPTION
Closes #4205. Closes #4168.

## The half that was missed

#4213 added `restore_executable_bits` and wired it into two places: the
streaming compile path and `test_execution.py`, immediately before `meson test`
spawns the runner. That covers `bash test --cpp`.

It does not cover `bash test <name>`. That takes a third route —
`run_direct_test` in `ci/meson/sequential_runner.py` locates the runner and
spawns it directly — and that module never imported the function. A runner
zccache had served from its link cache stayed at `0644`, and the run died with

```
[MESON] Test execution failed with exception: failed to spawn process: Permission denied (os error 13)
```

which names neither the file nor the mode. That is #4168's complaint verbatim,
and it is still reproducible on `master` with #4213 merged:

```console
$ chmod -x .build/meson-quick/tests/runner
$ bash test cled_controller --cpp
3.88 [MESON] Test execution failed with exception: failed to spawn process: Permission denied (os error 13)
$ ls -l .build/meson-quick/tests/runner
-rw-r--r--  ...   # untouched
```

With this change, the same two commands:

```console
8.64 [BUILD] ⚡ Restored 1 executable bit(s) (zccache link-cache fix)
8.66 ✅ All tests passed (1/1 in 0.01s, build: 7.9s)
-rwxr-xr-x  ...
```

## Placement

The call goes *after* `_resolve_test_command`, not before it. That function
relinks the runner when it is missing, and a relink is exactly the moment the
bit goes away — restoring first would race the thing it is repairing.

## The test

`ci/tests/test_direct_test_exec_bit.py` drives the real `run_direct_test`
against a real executable, rather than asserting that a particular function
gets called. Two mutations were run against it:

| mutation | result |
|---|---|
| drop the `restore_executable_bits` call | fails with the original `os error 13` |
| move it after the spawn | fails with the original `os error 13` |

A second case pins that an already-executable runner keeps its exact mode, so
the restore cannot quietly widen permissions.

The stand-in runner is a copy of `sh`, not `true`: `restore_executable_bits`
only touches files with a native-executable magic number (so a text stub would
be skipped for the right reason and prove nothing), and a multi-call coreutils
binary dispatches on `argv[0]` and refuses to run under the name `runner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where running a single test could fail with a “Permission denied” error when the test executable lacked executable permissions.
  - Test runners now launch successfully after permissions are restored, while existing executable permissions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->