### PR TITLE
feat(color): closed-form two-white (RGBWW) allocation (P7, #4198)

### DIFF
--- a/ci/color_rgbw_study.py
+++ b/ci/color_rgbw_study.py
@@ -11,10 +11,11 @@ three free emitters and pinning the rest to 0 or 1, solved and filtered.
 That is bounded but not small, and A3/B11 forbid anything resembling a
 search on the per-pixel path.
 
-This harness asks whether the enumeration is necessary. For one white
-emitter it is not -- see `allocate_one_white`. For two it is; the reduction
-that looks like it should work is measured failing here rather than left for
-someone to try.
+This harness asks whether the enumeration is necessary. It is not, for one
+white emitter (`allocate_one_white`) or for two (`allocate_two_white`). The
+reduction that looks like it should work for two -- run the one-white form
+per white and keep the better answer -- is measured failing here rather than
+left for someone to try.
 """
 
 from __future__ import annotations
@@ -58,6 +59,12 @@ class TwoWhiteLevels:
 # Slack on the drive bounds. The allocation is compared against a float64
 # reference, so this only has to absorb float64 rounding.
 DRIVE_TOLERANCE = 1e-9
+
+# The slack `most_white_two` allows on each of its constraints, exported so
+# the comparison against it can tell a real disagreement from a target that
+# sits on the device hull's boundary and is accepted by one method's
+# tolerance and refused by the other's.
+ENUMERATION_TOLERANCE = 1e-7
 
 
 def emitter_column(x: float, y: float) -> Xyz:
@@ -169,7 +176,9 @@ def most_white_two(
     )
 
     def inside(w1: float, w2: float) -> bool:
-        return all(a * w1 + b * w2 <= c + 1e-7 for a, b, c in constraints)
+        return all(
+            a * w1 + b * w2 <= c + ENUMERATION_TOLERANCE for a, b, c in constraints
+        )
 
     best: TwoWhiteLevels | None = None
     for (a1, b1, c1), (a2, b2, c2) in itertools.combinations(constraints, 2):
@@ -203,3 +212,123 @@ def best_single_white(
         if best is None or span.highest > best:
             best = span.highest
     return best
+
+
+def _split_bounds(
+    inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
+) -> tuple[list[tuple[float, float]], list[tuple[float, float]]] | None:
+    """Bounds on `w1` as functions of the total, as `(constant, slope)` pairs.
+
+    Substituting `w2 = s - w1` leaves the RGB drives as
+    `(d0 - s*from_second) - w1*(from_first - from_second)`, which is the
+    one-white shape with a shifted target. So each of the six drive bounds,
+    and each of the four bounds from `w1` and `w2` being drives themselves,
+    is one bound on `w1` that is affine in `s`.
+
+    None when a drive that the split cannot move is already out of range.
+    """
+
+    at_zero = _matvec(inverse, target)
+    from_first = _matvec(inverse, first)
+    from_second = _matvec(inverse, second)
+    lowers: list[tuple[float, float]] = [(0.0, 0.0), (-1.0, 1.0)]
+    uppers: list[tuple[float, float]] = [(1.0, 0.0), (0.0, 1.0)]
+    for index in range(3):
+        difference = from_first[index] - from_second[index]
+        if abs(difference) <= DRIVE_TOLERANCE:
+            # The split cannot move this drive; the bound falls on the total,
+            # which the caller sees as a degenerate pair.
+            constant = at_zero[index]
+            slope = -from_second[index]
+            if abs(slope) <= DRIVE_TOLERANCE:
+                if not -DRIVE_TOLERANCE <= constant <= 1.0 + DRIVE_TOLERANCE:
+                    return None
+                continue
+            # Expressed as a pair of coincident w1 bounds, so the pairwise
+            # sweep below picks the same totals up without a special case.
+            at_dark = (constant / slope, 0.0)
+            at_full = ((constant - 1.0) / slope, 0.0)
+            if slope > 0:
+                uppers.append((at_dark[0], 0.0))
+                lowers.append((at_full[0], 0.0))
+            else:
+                uppers.append((at_full[0], 0.0))
+                lowers.append((at_dark[0], 0.0))
+            continue
+        at_dark = (at_zero[index] / difference, -from_second[index] / difference)
+        at_full = (
+            (at_zero[index] - 1.0) / difference,
+            -from_second[index] / difference,
+        )
+        if difference > 0:
+            uppers.append(at_dark)
+            lowers.append(at_full)
+        else:
+            uppers.append(at_full)
+            lowers.append(at_dark)
+    return lowers, uppers
+
+
+def allocate_two_white(
+    inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
+) -> TwoWhiteLevels | None:
+    """Largest total white for two white emitters, in closed form.
+
+    The same answer `most_white_two` reaches by enumerating vertices, without
+    the enumeration -- which is what makes it legal on the per-pixel path
+    under A3/B11.
+
+    Some `w1` exists at a total exactly when every lower bound sits under
+    every upper bound there. Each of those bounds is affine in the total, so
+    each pair is one linear inequality in it, and intersecting them gives the
+    feasible totals directly.
+
+    The interval has to be *found*, not assumed to start at zero: a bright
+    target is unreachable with the primaries alone, so its feasible totals
+    begin above zero and anything searching upward from zero calls it
+    unreachable (#4198).
+    """
+
+    bounds = _split_bounds(inverse, target, first, second)
+    if bounds is None:
+        return None
+    lowers, uppers = bounds
+
+    low_total = 0.0
+    high_total = 2.0
+    for constant_low, slope_low in lowers:
+        for constant_high, slope_high in uppers:
+            slope = slope_low - slope_high
+            constant = constant_high - constant_low
+            if abs(slope) <= DRIVE_TOLERANCE:
+                if constant < -DRIVE_TOLERANCE:
+                    return None
+                continue
+            bound = constant / slope
+            if slope > 0:
+                high_total = min(high_total, bound)
+            else:
+                low_total = max(low_total, bound)
+    if low_total > high_total + DRIVE_TOLERANCE:
+        return None
+
+    total = high_total
+    split_low = max(constant + slope * total for constant, slope in lowers)
+    split_high = min(constant + slope * total for constant, slope in uppers)
+    if split_low > split_high + DRIVE_TOLERANCE:
+        return None
+
+    # The low end, and there is nothing to choose. The reference settles the
+    # split by minimizing the sum of squares of the RGB drives, and an
+    # earlier revision did that here -- affine in w1, so a quadratic with a
+    # closed-form minimum. Measurement removed it: at the extreme total the
+    # feasible split is a single point, so no rule has any freedom to
+    # exercise. `split_high - split_low` measured 0.0 over 4000 random
+    # targets on the corpus's cool/warm device and over 951 on a device built
+    # to make one drive's constraint parallel to `w1 + w2`, which is the
+    # shape that could have produced an optimal edge.
+    #
+    # Where the split really is free -- two whites of the same colour, so no
+    # RGB drive moves with it -- the reference's tie-break falls through to
+    # the lexicographically smallest drives, which is this end.
+    return TwoWhiteLevels(split_low, total - split_low)

--- a/ci/color_rgbw_study.py
+++ b/ci/color_rgbw_study.py
@@ -214,10 +214,25 @@ def best_single_white(
     return best
 
 
+@dataclass(frozen=True, slots=True)
+class _SplitBounds:
+    """The constraints on a two-white allocation, in terms of the total.
+
+    `lowers` and `uppers` bound `w1` as `(constant, slope)` pairs meaning
+    `constant + slope*s`. `low_total` and `high_total` bound the total
+    directly, which is where the drives the split cannot move end up.
+    """
+
+    lowers: list[tuple[float, float]]  # noqa: DCT002
+    uppers: list[tuple[float, float]]  # noqa: DCT002
+    low_total: float
+    high_total: float
+
+
 def _split_bounds(
     inverse: Matrix3, target: Xyz, first: Xyz, second: Xyz
-) -> tuple[list[tuple[float, float]], list[tuple[float, float]]] | None:
-    """Bounds on `w1` as functions of the total, as `(constant, slope)` pairs.
+) -> _SplitBounds | None:
+    """Bounds on `w1` as functions of the total, plus bounds on the total.
 
     Substituting `w2 = s - w1` leaves the RGB drives as
     `(d0 - s*from_second) - w1*(from_first - from_second)`, which is the
@@ -225,7 +240,17 @@ def _split_bounds(
     and each of the four bounds from `w1` and `w2` being drives themselves,
     is one bound on `w1` that is affine in `s`.
 
-    None when a drive that the split cannot move is already out of range.
+    A drive whose difference column is zero is the exception: the split
+    cannot move it at all, so its constraint is on the total alone and comes
+    back in `low_total` / `high_total`. An earlier revision encoded those as
+    constant `w1` bounds instead, which is dimensionally wrong -- the value
+    is a total, not a split -- and made this disagree with `most_white_two`
+    on 2206 of 3000 targets for a device whose two whites are the same
+    colour. The shipped C++ never had that bug; this is the model catching
+    up with it.
+
+    None when a drive that neither the split nor the total can rescue is
+    already out of range.
     """
 
     at_zero = _matvec(inverse, target)
@@ -233,27 +258,29 @@ def _split_bounds(
     from_second = _matvec(inverse, second)
     lowers: list[tuple[float, float]] = [(0.0, 0.0), (-1.0, 1.0)]
     uppers: list[tuple[float, float]] = [(1.0, 0.0), (0.0, 1.0)]
+    low_total = 0.0
+    high_total = 2.0
     for index in range(3):
         difference = from_first[index] - from_second[index]
         if abs(difference) <= DRIVE_TOLERANCE:
-            # The split cannot move this drive; the bound falls on the total,
-            # which the caller sees as a degenerate pair.
+            # The split cannot move this drive at all, so the constraint is
+            # on the total: `at_zero - s*from_second` must stay in [0, 1].
             constant = at_zero[index]
             slope = -from_second[index]
             if abs(slope) <= DRIVE_TOLERANCE:
                 if not -DRIVE_TOLERANCE <= constant <= 1.0 + DRIVE_TOLERANCE:
                     return None
                 continue
-            # Expressed as a pair of coincident w1 bounds, so the pairwise
-            # sweep below picks the same totals up without a special case.
-            at_dark = (constant / slope, 0.0)
-            at_full = ((constant - 1.0) / slope, 0.0)
+            # `constant + slope*s` in [0, 1]; dividing by a negative slope
+            # swaps which end is which.
+            first_bound = -constant / slope
+            second_bound = (1.0 - constant) / slope
             if slope > 0:
-                uppers.append((at_dark[0], 0.0))
-                lowers.append((at_full[0], 0.0))
+                low_total = max(low_total, first_bound)
+                high_total = min(high_total, second_bound)
             else:
-                uppers.append((at_full[0], 0.0))
-                lowers.append((at_dark[0], 0.0))
+                low_total = max(low_total, second_bound)
+                high_total = min(high_total, first_bound)
             continue
         at_dark = (at_zero[index] / difference, -from_second[index] / difference)
         at_full = (
@@ -266,7 +293,7 @@ def _split_bounds(
         else:
             uppers.append(at_full)
             lowers.append(at_dark)
-    return lowers, uppers
+    return _SplitBounds(lowers, uppers, low_total, high_total)
 
 
 def allocate_two_white(
@@ -292,10 +319,11 @@ def allocate_two_white(
     bounds = _split_bounds(inverse, target, first, second)
     if bounds is None:
         return None
-    lowers, uppers = bounds
+    lowers = bounds.lowers
+    uppers = bounds.uppers
 
-    low_total = 0.0
-    high_total = 2.0
+    low_total = bounds.low_total
+    high_total = bounds.high_total
     for constant_low, slope_low in lowers:
         for constant_high, slope_high in uppers:
             slope = slope_low - slope_high

--- a/ci/color_rgbw_study.py
+++ b/ci/color_rgbw_study.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 import itertools
 from dataclasses import dataclass
 
+from typeguard import typechecked
+
 from ci.color_reference import Matrix3, Xyz, _matvec
 
 
+@typechecked
 @dataclass(frozen=True, slots=True)
 class WhiteLevelRange:
     """The white drives that keep every RGB drive inside [0, 1]."""
@@ -34,6 +37,7 @@ class WhiteLevelRange:
     highest: float
 
 
+@typechecked
 @dataclass(frozen=True, slots=True)
 class WhitePreferredDrives:
     """One device's drives under the C3 white-preferred policy."""
@@ -44,6 +48,7 @@ class WhitePreferredDrives:
     white: float
 
 
+@typechecked
 @dataclass(frozen=True, slots=True)
 class TwoWhiteLevels:
     """Drives for a pair of white emitters."""
@@ -214,6 +219,7 @@ def best_single_white(
     return best
 
 
+@typechecked
 @dataclass(frozen=True, slots=True)
 class _SplitBounds:
     """The constraints on a two-white allocation, in terms of the total.

--- a/ci/tests/test_color_rgbw_study.py
+++ b/ci/tests/test_color_rgbw_study.py
@@ -343,6 +343,48 @@ class TestTwoWhitesAreAlsoClosedForm(unittest.TestCase):
         self.assertEqual(tally.solved, 4000)
         self.assertLess(tally.worst_total_delta, 1e-9)
 
+    def test_it_agrees_when_the_two_whites_are_the_same_colour(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+    ) -> None:
+        """The branch where the split moves no RGB drive at all.
+
+        Two strings of the same white LED is an ordinary device, and it is
+        the only shape that reaches the zero-difference branch: the split
+        cannot move any drive, so those constraints fall on the *total*
+        instead. An earlier revision encoded them as constant `w1` bounds --
+        dimensionally wrong, a total is not a split -- and disagreed with the
+        enumeration on 2206 of 3000 targets, by as much as 1.87 in total
+        white. Every other device in this file has a non-zero difference in
+        all three channels, so nothing else here goes near it.
+        """
+
+        random.seed(4198)
+        columns = [*RGB_COLUMNS, D65_WHITE_COLUMN, D65_WHITE_COLUMN]
+        solved = disagreed = 0
+        worst = 0.0
+        for _ in range(3000):
+            drives = [random.random() for _ in range(5)]
+            target = tuple(
+                sum(columns[e][i] * drives[e] for e in range(5)) for i in range(3)
+            )
+            closed = allocate_two_white(
+                self.inverse, target, D65_WHITE_COLUMN, D65_WHITE_COLUMN
+            )
+            exact = most_white_two(
+                self.inverse, target, D65_WHITE_COLUMN, D65_WHITE_COLUMN
+            )
+            if (closed is None) != (exact is None):
+                disagreed += 1
+                continue
+            if closed is None:
+                continue
+            assert exact is not None
+            solved += 1
+            worst = max(worst, abs(closed.total - exact.total))
+        self.assertEqual(disagreed, 0)
+        self.assertEqual(solved, 3000)
+        self.assertLess(worst, 1e-9)
+
     def test_it_agrees_about_targets_outside_the_hull(
         self: "TestTwoWhitesAreAlsoClosedForm",
     ) -> None:

--- a/ci/tests/test_color_rgbw_study.py
+++ b/ci/tests/test_color_rgbw_study.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 from ci.color_reference import Xyz, _invert_3x3, _matvec
 from ci.color_rgbw_study import (
+    ENUMERATION_TOLERANCE,
     allocate_one_white,
+    allocate_two_white,
     best_single_white,
     emitter_column,
     most_white_two,
@@ -212,6 +214,168 @@ class TestTwoWhitesNeedMoreThanOne(unittest.TestCase):
         self.assertGreater(mixing_wins, checked // 2)
         # And the shortfall reaches a full emitter's worth of light.
         self.assertGreater(worst_gap, 0.9)
+
+
+@dataclass(frozen=True, slots=True)
+class SweepTally:
+    """What one comparison sweep found."""
+
+    solved: int
+    disagreed: int
+    boundary: int
+    rejected_by_both: int
+    worst_total_delta: float
+
+
+class TestTwoWhitesAreAlsoClosedForm(unittest.TestCase):
+    """The closed form must match the enumeration it replaces (#4198).
+
+    Nothing is skipped here. The first attempt at this allocation reported
+    "0 disagreements over 10,285 targets" while its harness had quietly
+    dropped roughly 30,000 of 40,000 -- and the dropped ones were precisely
+    the bright targets it could not handle. So every sample is classified by
+    both methods and any disagreement about *feasibility* is counted as
+    loudly as a disagreement about the answer.
+    """
+
+    def setUp(self: "TestTwoWhitesAreAlsoClosedForm") -> None:
+        self.inverse = _invert_3x3(rgb_matrix(RGB_COLUMNS))
+        self.columns = [*RGB_COLUMNS, D65_WHITE_COLUMN, D50_WHITE_COLUMN]
+
+    def _target(self: "TestTwoWhitesAreAlsoClosedForm", drives: list[float]) -> Xyz:
+        return tuple(
+            sum(self.columns[e][i] * drives[e] for e in range(5)) for i in range(3)
+        )
+
+    def _worst_violation(
+        self: "TestTwoWhitesAreAlsoClosedForm", target: Xyz, levels: "object"
+    ) -> float:
+        """How far outside [0, 1] the drives implied by `levels` reach."""
+
+        at_zero = _matvec(self.inverse, target)
+        from_first = _matvec(self.inverse, D65_WHITE_COLUMN)
+        from_second = _matvec(self.inverse, D50_WHITE_COLUMN)
+        first = levels.first  # type: ignore[attr-defined]
+        second = levels.second  # type: ignore[attr-defined]
+        worst = 0.0
+        for value in (
+            first,
+            second,
+            *(
+                at_zero[i] - first * from_first[i] - second * from_second[i]
+                for i in range(3)
+            ),
+        ):
+            worst = max(worst, -value, value - 1.0)
+        return worst
+
+    def _sweep(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+        make_drives: "object",
+        count: int,
+    ) -> SweepTally:
+        """Compare both methods over `count` targets, returning the tallies.
+
+        A "boundary" is a target the two classify differently *and* whose
+        answer sits within the enumeration's own constraint tolerance of the
+        hull. Those are not agreement, and they are not swept under the rug
+        either: they are counted and asserted to stay rare, because the two
+        methods draw the hull's edge with different arithmetic and a target
+        landing exactly on it can fall either side. Anything further out is a
+        real disagreement.
+        """
+
+        random.seed(4198)
+        solved = disagreed = boundary = rejected_by_both = 0
+        worst = 0.0
+        for _ in range(count):
+            target = self._target(make_drives())  # type: ignore[operator]
+            closed = allocate_two_white(
+                self.inverse, target, D65_WHITE_COLUMN, D50_WHITE_COLUMN
+            )
+            exact = most_white_two(
+                self.inverse, target, D65_WHITE_COLUMN, D50_WHITE_COLUMN
+            )
+            if closed is None and exact is None:
+                rejected_by_both += 1
+                continue
+            if (closed is None) != (exact is None):
+                answered = closed if closed is not None else exact
+                if self._worst_violation(target, answered) <= ENUMERATION_TOLERANCE:
+                    boundary += 1
+                else:
+                    disagreed += 1
+                continue
+            assert closed is not None and exact is not None
+            solved += 1
+            worst = max(worst, abs(closed.total - exact.total))
+        return SweepTally(solved, disagreed, boundary, rejected_by_both, worst)
+
+    def test_it_matches_the_enumeration_on_reachable_targets(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+    ) -> None:
+        tally = self._sweep(lambda: [random.random() for _ in range(5)], 8000)
+        self.assertEqual(tally.disagreed, 0)
+        self.assertEqual(tally.boundary, 0)
+        # Sampling drives rather than XYZ makes every target reachable by
+        # construction, so a rejection from either side is a defect and this
+        # count is the whole sample.
+        self.assertEqual(tally.solved, 8000)
+        self.assertLess(tally.worst_total_delta, 1e-9)
+
+    def test_it_matches_on_targets_needing_both_whites(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+    ) -> None:
+        # The half the first attempt failed: totals whose feasible interval
+        # does not start at zero.
+        tally = self._sweep(
+            lambda: [
+                random.random() * 0.2,
+                random.random() * 0.2,
+                random.random() * 0.2,
+                0.8 + random.random() * 0.2,
+                0.8 + random.random() * 0.2,
+            ],
+            4000,
+        )
+        self.assertEqual(tally.disagreed, 0)
+        self.assertEqual(tally.boundary, 0)
+        self.assertEqual(tally.solved, 4000)
+        self.assertLess(tally.worst_total_delta, 1e-9)
+
+    def test_it_agrees_about_targets_outside_the_hull(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+    ) -> None:
+        # Half again as much light as every emitter at full drive can make.
+        # Some of these land inside the hull and some do not; both methods
+        # must say the same thing about each.
+        tally = self._sweep(lambda: [random.random() * 1.35 for _ in range(5)], 4000)
+        self.assertEqual(tally.disagreed, 0)
+        self.assertGreater(tally.rejected_by_both, 0)
+        self.assertGreater(tally.solved, 0)
+        self.assertLess(tally.worst_total_delta, 1e-9)
+        # Measured at 1 in 4000, and recorded rather than tolerated silently:
+        # these are targets lying on the hull to within 1e-7, which the
+        # enumeration's per-constraint slack admits and the closed form's
+        # exact interval does not.
+        self.assertLessEqual(tally.boundary, 4)
+
+    def test_it_reproduces_the_reference_where_the_corpus_reaches(
+        self: "TestTwoWhitesAreAlsoClosedForm",
+    ) -> None:
+        # The corpus is the P5 reference's own output, so this is the
+        # strongest available check -- and the reason the sweeps above exist
+        # is that the corpus does not reach the cases they cover.
+        vectors = corpus_vectors("rgbww")
+        self.assertGreater(len(vectors), 0)
+        for vector in vectors:
+            closed = allocate_two_white(
+                self.inverse, vector.target, D65_WHITE_COLUMN, D50_WHITE_COLUMN
+            )
+            self.assertIsNotNone(closed)
+            assert closed is not None
+            reference_total = vector.emitter_light[3] + vector.emitter_light[4]
+            self.assertLess(abs(closed.total - reference_total), 1e-9)
 
 
 if __name__ == "__main__":

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -363,6 +363,61 @@ polygon; `most_white_two` solves it by exact vertex enumeration, and the
 regression test keeps the cheap reduction pinned as *failing* so nobody
 simplifies to it later.
 
+### Two whites also have a closed form
+
+Not the reduction above, and not a search. Write the total `s = w₁ + w₂` and
+substitute `w₂ = s − w₁`: the RGB drives become
+
+```
+(d₀ − s·dW₂) − w₁·(dW₁ − dW₂)
+```
+
+which is the one-white shape with a shifted target and a difference column.
+At any fixed total the feasible `w₁` is again an interval, bounded by five
+lower and five upper bounds — three from the RGB drives, and two more because
+`w₁` and `w₂ = s − w₁` are drives in their own right. Every one of those
+bounds is **affine in `s`**, so "some `w₁` exists at this total" is exactly
+the conjunction of the pairwise inequalities `lowerₖ(s) ≤ upperⱼ(s)`, each
+linear in `s`. Intersecting the 25 of them gives the feasible totals directly.
+
+The interval has to be *found*, not assumed to start at zero, and that is
+where the first attempt went wrong (#4198). A bright target is unreachable
+with the primaries alone, so its feasible totals begin above zero and a
+bisection seeded at zero reports it out of gamut. That attempt's validation
+hid the failure: the harness skipped every target its method could not answer
+and reported "0 disagreements over 10 285" while silently dropping roughly
+30 000 of 40 000 — including precisely the bright ones.
+
+Measured against `most_white_two`, nothing skipped:
+
+| targets | how drawn | solved by both | disagreements |
+|---|---|---:|---:|
+| 8 000 | uniform drives | 8 000 | 0 |
+| 4 000 | both whites near full | 4 000 | 0 |
+| 4 000 | drives to 1.35, so many are out of hull | 2 862 | 0 |
+
+Worst difference in total white, 2.2 × 10⁻¹⁵. One target in 4 000 lands on
+the hull to within 10⁻⁷ and is admitted by the enumeration's per-constraint
+slack while the closed form's exact interval refuses it; that is counted
+separately rather than folded into agreement.
+
+**At the extreme total the split is not free.** The reference settles a free
+split by minimizing the sum of squares of the RGB drives, and an earlier
+revision of the embedded path did the same — one division, since the drives
+are affine in `w₁`. Measurement removed it: the feasible split at the extreme
+total is a single point. Width measured 0.0 over 4 000 targets on the
+cool/warm device, and over 951 on a device constructed so one drive's
+constraint is parallel to `w₁ + w₂`, which is the shape that could have
+produced an optimal edge. Two whites of the *same* colour are the exception,
+and there the reference's own tie-break — lexicographically smallest drives —
+is the end the closed form takes anyway.
+
+`allocateTwoWhiteDrivesQ16` is the s16.16 implementation. It costs up to 25
+divisions per pixel against the one-white path's six, which is recorded
+rather than optimized away: cross-multiplying the pairwise comparisons would
+leave one division and a great many i64 multiplies, and nobody has measured
+which wins on an 8-bit target.
+
 ### The mapper has to target the real hull
 
 A white emitter enlarges the reachable set, so testing a target against the
@@ -406,19 +461,23 @@ D65, exactly the one unit that emitter contributes.
 
 ### What this leaves
 
-`rgbw` and `non_d65_white` are settled and ready to implement. `rgbww` needs
-either the 2D enumeration above — or a closed form nobody has found yet. It
-also needs corpus vectors bright enough to tell the two apart before any of it
-can be trusted.
+`rgbw`, `non_d65_white` and `rgbww` are all settled and implemented.
 
-The enumeration is bounded but not cheap. `most_white_two` builds ten
-constraints — six from the RGB drive bounds, four from the box on the two
+The enumeration stays where it belongs, as the oracle. `most_white_two` builds
+ten constraints — six from the RGB drive bounds, four from the box on the two
 white drives — and intersects every unordered pair: 45 of them, of which five
 are structurally parallel, leaving **40** candidate intersections to test for
 feasibility. That is a constant known at compile time, so it is not an
 iterative solver in the A3/B11 sense, but it is roughly forty times the work
-of the one-white case and would want its own cost measurement before going
+of the one-white case, and the closed form above makes it unnecessary
 per-pixel.
+
+What is still missing is corpus coverage. All 48 `rgbww` vectors are reachable
+with one white or none, so the golden corpus cannot distinguish a correct
+two-white allocation from the reduction it replaces; the sweeps above stand in
+for that, measured against the reference's own enumeration rather than against
+its recorded output. Corpus vectors bright enough to need both whites would
+close the gap.
 
 ## Not covered
 

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -368,9 +368,7 @@ simplifies to it later.
 Not the reduction above, and not a search. Write the total `s = w₁ + w₂` and
 substitute `w₂ = s − w₁`: the RGB drives become
 
-```
-(d₀ − s·dW₂) − w₁·(dW₁ − dW₂)
-```
+    (d₀ − s·dW₂) − w₁·(dW₁ − dW₂)
 
 which is the one-white shape with a shifted target and a difference column.
 At any fixed total the feasible `w₁` is again an interval, bounded by five

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -156,4 +156,343 @@ bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
     return true;
 }
 
+namespace {
+
+/// The largest magnitude a per-white column or a solved drive may reach
+/// before the pairwise bounds stop fitting.
+///
+/// Chosen from the arithmetic rather than picked: a bound is
+/// `(n + m*s) / q` with every part in s16.16, and the pairwise comparison
+/// forms `q * n` and then shifts the difference left by 16 to divide in
+/// s16.16. With each part under 2^19 raw (8.0 in drive space) the products
+/// stay under 2^38, the shifted difference under 2^55, and i64 has room. A
+/// white emitter the primaries would need eight units of any one channel to
+/// express is not a white emitter.
+constexpr i32 kTwoWhiteMaxColumn = 8 * 65536;
+
+/// How far past full drive the bounds let an RGB drive reach.
+///
+/// Deliberately *half* the tolerance the final range check applies, and that
+/// gap is the point. Relaxing a bound and then re-checking the same drive
+/// against the same number puts the boundary case exactly on the threshold,
+/// where the two independent roundings decide it: measured rejecting a drive
+/// at 65601 against a limit of 65600, one raw unit, on the RGB-preferred end
+/// of a target needing both whites. With the bounds admitting less than the
+/// check tolerates there is room for that rounding, so no total the interval
+/// accepts is then refused for arithmetic reasons.
+constexpr i32 kTwoWhiteBoundSlack = kWhiteSlack / 2;
+
+/// A bound on the split, as `(numerator + slope * s) / denominator` with a
+/// positive denominator.
+///
+/// Kept unevaluated because it has to be compared against other bounds *as
+/// a function of s*, which is the whole method: dividing here would throw
+/// away the s-dependence that the pairwise inequalities are solved for.
+struct SplitBound {
+    i32 numerator;
+    i32 slope;
+    i32 denominator;  // > 0 always; the sign is folded into the other two.
+};
+
+/// `value` at total `s`, in s16.16.
+i64 splitBoundAt(const SplitBound& bound, i64 total) FL_NO_EXCEPT {
+    const i64 scaled =
+        (static_cast<i64>(bound.numerator) << 16) + static_cast<i64>(bound.slope) * total;
+    return scaled / static_cast<i64>(bound.denominator);
+}
+
+/// Whether every part of a bound stays inside the range the accumulators
+/// were sized for.
+bool splitBoundInRange(const SplitBound& bound) FL_NO_EXCEPT {
+    return bound.numerator >= -kTwoWhiteMaxColumn &&
+           bound.numerator <= kTwoWhiteMaxColumn &&
+           bound.slope >= -kTwoWhiteMaxColumn && bound.slope <= kTwoWhiteMaxColumn &&
+           bound.denominator > 0 && bound.denominator <= kTwoWhiteMaxColumn;
+}
+
+/// Fold a negative denominator into the numerator and slope, so every bound
+/// compares the same way round.
+SplitBound normalizedSplitBound(i32 numerator, i32 slope,
+                                i32 denominator) FL_NO_EXCEPT {
+    SplitBound bound;
+    if (denominator < 0) {
+        bound.numerator = -numerator;
+        bound.slope = -slope;
+        bound.denominator = -denominator;
+    } else {
+        bound.numerator = numerator;
+        bound.slope = slope;
+        bound.denominator = denominator;
+    }
+    return bound;
+}
+
+/// The totals at which `lower <= upper` holds, narrowed into
+/// `[*low, *high]`.
+///
+/// Returns false when the pair excludes every total, which is the one case
+/// the caller cannot express as a narrowed interval.
+///
+/// Cross-multiplied rather than divided first: with positive denominators
+/// the inequality
+///
+///     (nL + mL*s) / qL  <=  (nU + mU*s) / qU
+///
+/// is `s * (qU*mL - qL*mU) <= qL*nU - qU*nL`, one linear inequality in s
+/// whose coefficients are exact in i64.
+bool narrowTotalForPair(const SplitBound& lower, const SplitBound& upper, i64* low,
+                        i64* high) FL_NO_EXCEPT {
+    const i64 slope = static_cast<i64>(upper.denominator) * lower.slope -
+                      static_cast<i64>(lower.denominator) * upper.slope;
+    const i64 constant = static_cast<i64>(lower.denominator) * upper.numerator -
+                         static_cast<i64>(upper.denominator) * lower.numerator;
+    if (slope == 0) {
+        // No s makes this pair better or worse; it either always holds or
+        // never does.
+        return constant >= 0;
+    }
+    const i64 bound = (constant << 16) / slope;
+    if (slope > 0) {
+        if (bound < *high) {
+            *high = bound;
+        }
+    } else if (bound > *low) {
+        *low = bound;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool buildTwoWhiteAllocationQ16(const EmitterProfile& profile,
+                                const i32 (&white1_xyz)[3],
+                                const i32 (&white2_xyz)[3],
+                                WhiteAllocationPolicy policy,
+                                TwoWhiteAllocationQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    out->policy = policy;
+    if (!buildRgbSolveMatrixQ16(profile, &out->rgb_solve)) {
+        return false;
+    }
+    i32 per_white1[3];
+    solveRgbDrivesQ16(out->rgb_solve, white1_xyz, per_white1);
+    solveRgbDrivesQ16(out->rgb_solve, white2_xyz, out->per_white2);
+
+    for (int i = 0; i < 3; ++i) {
+        // The difference is what the split multiplies, so it is the one that
+        // has to fit; both columns are checked because it is derived from
+        // them and because each is a bound coefficient in its own right.
+        if (per_white1[i] > kTwoWhiteMaxColumn || per_white1[i] < -kTwoWhiteMaxColumn ||
+            out->per_white2[i] > kTwoWhiteMaxColumn ||
+            out->per_white2[i] < -kTwoWhiteMaxColumn) {
+            return false;
+        }
+        out->difference[i] = per_white1[i] - out->per_white2[i];
+    }
+    return true;
+}
+
+bool allocateTwoWhiteDrivesQ16(const TwoWhiteAllocationQ16& allocation,
+                               const i32 (&xyz)[3],
+                               i32 (&drives)[5]) FL_NO_EXCEPT {
+    i32 at_zero[3];
+    solveRgbDrivesQ16(allocation.rgb_solve, xyz, at_zero);
+    for (int i = 0; i < 3; ++i) {
+        // A target this far out is not a rounding case, it is outside the
+        // hull by a wide margin, and letting it through would be the only
+        // way the bounds below could overflow.
+        if (at_zero[i] > kTwoWhiteMaxColumn || at_zero[i] < -kTwoWhiteMaxColumn) {
+            return false;
+        }
+    }
+
+    // `w1 >= 0`, `w1 >= s - 1` (from `w2 <= 1`), `w1 <= 1`, `w1 <= s` (from
+    // `w2 >= 0`). Every part of a bound is s16.16, the denominator included,
+    // so a denominator of "one" is `kWhiteFullDrive` and not 1 -- writing a
+    // raw 1 there scales those four bounds by 65536 and silently rejects
+    // every target whose total runs past the primaries.
+    SplitBound lowers[5];
+    SplitBound uppers[5];
+    int lower_count = 0;
+    int upper_count = 0;
+    lowers[lower_count++] = normalizedSplitBound(0, 0, kWhiteFullDrive);
+    lowers[lower_count++] =
+        normalizedSplitBound(-kWhiteFullDrive, kWhiteFullDrive, kWhiteFullDrive);
+    uppers[upper_count++] = normalizedSplitBound(kWhiteFullDrive, 0, kWhiteFullDrive);
+    uppers[upper_count++] = normalizedSplitBound(0, kWhiteFullDrive, kWhiteFullDrive);
+
+    i64 low_total = 0;
+    i64 high_total = 2 * static_cast<i64>(kWhiteFullDrive);
+
+    for (int i = 0; i < 3; ++i) {
+        // drive_i(w1, s) = (at_zero_i - s*per_white2_i) - w1*difference_i,
+        // which must stay in [0, 1].
+        const i32 slope = allocation.difference[i];
+        if (slope == 0) {
+            // The split cannot move this drive: the constraint is on the
+            // total alone. `at_zero_i - s*per_white2_i` in [0, 1].
+            const i32 per = allocation.per_white2[i];
+            if (per == 0) {
+                if (at_zero[i] < -kWhiteSlack ||
+                    at_zero[i] > kWhiteFullDrive + kWhiteSlack) {
+                    return false;
+                }
+                continue;
+            }
+            const i64 first = divideWhiteQ16(at_zero[i], per);
+            const i64 second =
+                divideWhiteQ16(at_zero[i] - kWhiteFullDrive - kTwoWhiteBoundSlack, per);
+            const i64 upper = per > 0 ? first : second;
+            const i64 lower = per > 0 ? second : first;
+            if (upper < high_total) {
+                high_total = upper;
+            }
+            if (lower > low_total) {
+                low_total = lower;
+            }
+            continue;
+        }
+        // Dividing by a negative slope swaps which bound is which; that is
+        // handled once, in normalizedSplitBound, by folding the sign.
+        // The slack sits on the `drive <= 1` side and nowhere else, which
+        // is the same asymmetry the one-white path argues for above. That
+        // side can only *narrow* the white the policy may take, so tolerating
+        // a drive 64 raw units past full -- exactly what the final range
+        // check tolerates -- costs nothing. Putting slack on the `drive >= 0`
+        // side would be different: the policy maximizes white, so it would
+        // spend the slack on every pixel.
+        //
+        // Without it the exact hull corner is refused. Five emitters at full
+        // drive solve, through a quantized matrix, to a target needing 57 raw
+        // units more than a total of 2.0 can supply, so the feasible interval
+        // comes out empty by less than a thousandth of a drive.
+        const SplitBound at_full =
+            normalizedSplitBound(at_zero[i] - kWhiteFullDrive - kTwoWhiteBoundSlack,
+                                 -allocation.per_white2[i], slope);
+        const SplitBound at_dark =
+            normalizedSplitBound(at_zero[i], -allocation.per_white2[i], slope);
+        if (!splitBoundInRange(at_full) || !splitBoundInRange(at_dark)) {
+            return false;
+        }
+        if (slope > 0) {
+            uppers[upper_count++] = at_dark;
+            lowers[lower_count++] = at_full;
+        } else {
+            uppers[upper_count++] = at_full;
+            lowers[lower_count++] = at_dark;
+        }
+    }
+
+    // Some total admits a split exactly when every lower bound sits under
+    // every upper bound there. Each pair is linear in the total, so this is
+    // the closed form the header describes.
+    for (int k = 0; k < lower_count; ++k) {
+        for (int j = 0; j < upper_count; ++j) {
+            if (!narrowTotalForPair(lowers[k], uppers[j], &low_total, &high_total)) {
+                return false;
+            }
+        }
+    }
+    if (high_total < 0) {
+        high_total = 0;
+    }
+    if (low_total > high_total) {
+        return false;
+    }
+
+    const i64 total = allocation.policy == WhiteAllocationPolicy::RgbPreferred
+                          ? low_total
+                          : high_total;
+
+    // At the chosen total the split is free, and the reference minimizes the
+    // sum of squares of the RGB drives -- a quadratic in w1, so its minimum
+    // is one division.
+    i64 split_low = 0;
+    i64 split_high = kWhiteFullDrive;
+    for (int k = 0; k < lower_count; ++k) {
+        const i64 value = splitBoundAt(lowers[k], total);
+        if (value > split_low) {
+            split_low = value;
+        }
+    }
+    for (int j = 0; j < upper_count; ++j) {
+        const i64 value = splitBoundAt(uppers[j], total);
+        if (value < split_high) {
+            split_high = value;
+        }
+    }
+    if (split_low > split_high) {
+        // Collapsed rather than empty. At either end of the total the split
+        // bounds meet exactly, and they were derived through a quantized
+        // matrix, so integer truncation can cross them by a few raw units --
+        // measured at 21 on the RGB-preferred end of a target needing both
+        // whites. Same answer as the one-white path gives its own boundary
+        // case: take the point they collapse to and let the drive check
+        // below decide whether the target is really reachable.
+        if (split_low - split_high > kWhiteSlack) {
+            return false;
+        }
+        const i64 middle = (split_low + split_high) / 2;
+        split_low = middle;
+        split_high = middle;
+    }
+
+    i64 at_total[3];
+    for (int i = 0; i < 3; ++i) {
+        at_total[i] = static_cast<i64>(at_zero[i]) -
+                      ((static_cast<i64>(allocation.per_white2[i]) * total + 32768) >> 16);
+    }
+
+    // The low end, and there is nothing to choose. The reference settles the
+    // split by minimizing the sum of squares of the RGB drives, and an
+    // earlier revision here did the same -- it is a quadratic in the split,
+    // so one division. Measurement removed it: at the *extreme* total the
+    // feasible split is a single point, so there is no freedom for any rule
+    // to exercise. Widest interval measured 0.0 over 4000 random targets on
+    // the corpus's cool/warm device and 951 on a device built specifically
+    // to make one drive's constraint parallel to `w1 + w2`, which is the
+    // shape that could have produced an optimal edge.
+    //
+    // Where the split really is free -- two whites of the same colour, so
+    // the difference column is zero and no RGB drive moves with the split --
+    // the reference's own tie-break falls through to the lexicographically
+    // smallest drives, which is this end. So the low end is not a
+    // simplification away from the reference; it is what the reference does.
+    //
+    // See `ci/tests/test_color_rgbw_study.py`, which gates the whole
+    // allocation against the reference and would fail if this stopped
+    // holding.
+    const i64 split = split_low;
+
+    i32 rgb[3];
+    for (int i = 0; i < 3; ++i) {
+        const i64 drive =
+            at_total[i] -
+            ((static_cast<i64>(allocation.difference[i]) * split + 32768) >> 16);
+        if (drive < -kWhiteSlack || drive > kWhiteFullDrive + kWhiteSlack) {
+            return false;
+        }
+        rgb[i] = drive < 0 ? 0
+                           : (drive > kWhiteFullDrive ? kWhiteFullDrive
+                                                      : static_cast<i32>(drive));
+    }
+    const i64 second = total - split;
+    if (second < -kWhiteSlack || second > kWhiteFullDrive + kWhiteSlack ||
+        split < -kWhiteSlack || split > kWhiteFullDrive + kWhiteSlack) {
+        return false;
+    }
+    drives[0] = rgb[0];
+    drives[1] = rgb[1];
+    drives[2] = rgb[2];
+    drives[3] = split < 0 ? 0
+                          : (split > kWhiteFullDrive ? kWhiteFullDrive
+                                                     : static_cast<i32>(split));
+    drives[4] = second < 0 ? 0
+                           : (second > kWhiteFullDrive ? kWhiteFullDrive
+                                                       : static_cast<i32>(second));
+    return true;
+}
+
 }  // namespace fl

--- a/src/fl/gfx/white_allocation.h
+++ b/src/fl/gfx/white_allocation.h
@@ -22,12 +22,12 @@
 // rounding. The derivation never assumed the white sat on the neutral axis,
 // which is what the second device checks.
 //
-// This covers exactly one white emitter. Two are a different problem:
-// maximizing w1 + w2 is a linear program over a polygon, and the obvious
-// reduction -- run this twice and keep the better answer -- agrees with the
-// reference on every corpus vector while being wrong on 85% of random
-// reachable targets, because a single emitter's drive is capped at 1. See
-// the same document.
+// Two whites are a different problem, solved by
+// `allocateTwoWhiteDrivesQ16` further down: maximizing w1 + w2 is a linear
+// program over a polygon, and the obvious reduction -- run this twice and
+// keep the better answer -- agrees with the reference on every corpus vector
+// while being wrong on 85% of random reachable targets, because a single
+// emitter's drive is capped at 1. See the same document.
 
 #include "fl/gfx/device_solve.h"
 #include "fl/stl/int.h"
@@ -103,5 +103,91 @@ bool buildWhiteAllocationQ16(const EmitterProfile& profile,
 bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
                               const i32 (&xyz)[3],
                               i32 (&drives)[4]) FL_NO_EXCEPT;
+
+/// Everything the two-white allocation needs, derived once when a profile
+/// binds (C3, #4198).
+struct TwoWhiteAllocationQ16 {
+    /// Inverse RGB emitter matrix.
+    EmitterSolveMatrixQ16 rgb_solve;
+
+    /// `M^-1 . w2`: the RGB drives one unit of the second white replaces.
+    i32 per_white2[3];
+
+    /// `M^-1 . w1 - M^-1 . w2`, the difference column.
+    ///
+    /// Held rather than recomputed because it is the coefficient of the
+    /// split variable in every bound, and the per-pixel path reads it eight
+    /// times. The first white's own column is not kept: it only ever
+    /// appears through this difference.
+    i32 difference[3];
+
+    /// Which end of the feasible total this profile takes.
+    WhiteAllocationPolicy policy;
+};
+
+/// Derive the allocation for three primaries plus two white emitters.
+///
+/// `white1_xyz` / `white2_xyz` are each white's XYZ at full drive, in
+/// s16.16, the same working domain the rest of the pipeline carries.
+///
+/// False on the profiles `buildRgbSolveMatrixQ16` rejects, and when either
+/// white lands so far outside what the primaries express that the per-pixel
+/// bounds would overflow their accumulators -- see `kTwoWhiteMaxColumn` in
+/// the implementation, which a real white emitter is nowhere near.
+bool buildTwoWhiteAllocationQ16(const EmitterProfile& profile,
+                                const i32 (&white1_xyz)[3],
+                                const i32 (&white2_xyz)[3],
+                                WhiteAllocationPolicy policy,
+                                TwoWhiteAllocationQ16* out) FL_NO_EXCEPT;
+
+/// One pixel: XYZ in s16.16 to five drives -- red, green, blue, white1,
+/// white2 -- at whichever end of the feasible total the profile's policy
+/// names.
+///
+/// The method, and why it is not a search. Writing the total `s = w1 + w2`
+/// and substituting `w2 = s - w1` leaves the RGB drives as
+///
+///     (d0 - s * per_white2) - w1 * difference
+///
+/// which is the one-white shape with a shifted target. So at any fixed total
+/// the feasible `w1` is again an interval, bounded by five lower and five
+/// upper bounds: three from the RGB drives, and two more because `w1` and
+/// `w2 = s - w1` are each a drive in their own right. Every one of those
+/// bounds is *affine in s*, so "some `w1` exists at this total" is exactly
+/// the conjunction of the pairwise inequalities `lower_k(s) <= upper_j(s)`,
+/// each linear in `s` and each solvable for one `s` bound. Intersecting them
+/// gives the feasible totals in closed form -- no bisection, no vertex
+/// enumeration, no per-pixel iteration (A3/B11).
+///
+/// That the interval has to be *found* rather than assumed is the whole
+/// point. Achievable totals form `[s_lo, s_hi]`, which need not start at
+/// zero: a bright target is unreachable with the primaries alone, so a
+/// bisection seeded at zero has no feasible starting point and reports such
+/// targets unreachable. The first attempt at this made exactly that
+/// assumption (#4198).
+///
+/// At the chosen total the split is *not* free, which is measurement rather
+/// than assumption. The reference settles a free split by minimizing the sum
+/// of squares of the RGB drives, and an earlier revision did the same here;
+/// the feasible splits at the extreme total turn out to be a single point,
+/// so there was nothing for the rule to choose. Width measured 0.0 over 4000
+/// random targets on the corpus's cool/warm device and 951 on a device built
+/// to make one drive's constraint parallel to `w1 + w2` -- the shape that
+/// could have produced an optimal edge. Two whites of the same colour are
+/// the exception, and there the reference's own tie-break is the end this
+/// takes.
+///
+/// False when no total keeps every drive in range, which means the target is
+/// outside the device hull -- the gamut mapper's job, not this one's.
+/// `drives` is not written in that case.
+///
+/// Cost note, recorded rather than optimized away on a guess: up to 25
+/// s16.16 divisions per pixel against the one-white path's six. Whether
+/// cross-multiplying the pairwise comparisons -- which would leave one
+/// division and a great many i64 multiplies -- wins on an 8-bit target is
+/// unmeasured, so the straightforward version is what ships.
+bool allocateTwoWhiteDrivesQ16(const TwoWhiteAllocationQ16& allocation,
+                               const i32 (&xyz)[3],
+                               i32 (&drives)[5]) FL_NO_EXCEPT;
 
 }  // namespace fl

--- a/tests/fl/gfx/white_allocation.cpp
+++ b/tests/fl/gfx/white_allocation.cpp
@@ -403,4 +403,575 @@ FL_TEST_CASE("White allocation rejects profiles it cannot work with") {
                                        &allocation));
 }
 
+
+// ---------------------------------------------------------------------------
+// Two whites (#4198)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// The corpus's two-white device: a cool white at D65 and a warm one at D50,
+/// each at unit luminance, in s16.16.
+const i32 (&kCoolWhite)[3] = kWhiteD65;
+const i32 (&kWarmWhite)[3] = kWhiteD50;
+
+/// A float model of the same device, built from the chromaticities rather
+/// than from anything the code under test computes.
+///
+/// This is the oracle, so it must not share a line of arithmetic with the
+/// implementation: it inverts in float, enumerates vertices, and knows
+/// nothing about s16.16.
+struct FloatDevice {
+    float inverse[3][3];  // M^-1, columns R G B
+    float per_white1[3];  // M^-1 . w1
+    float per_white2[3];  // M^-1 . w2
+    float column1[3];     // w1 XYZ
+    float column2[3];     // w2 XYZ
+    float primaries[3][3];
+};
+
+void primaryXyz(const float (&xy)[2], float lum, float (&out)[3]) {
+    colorimetric_response::xyY_to_XYZ(xy[0], xy[1], lum, out);
+}
+
+bool invertFloat3(const float (&m)[3][3], float (&out)[3][3]) {
+    const float det =
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1]) -
+        m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+        m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+    if (fl::fabsf(det) < 1e-9f) {
+        return false;
+    }
+    const float inv = 1.0f / det;
+    out[0][0] = (m[1][1] * m[2][2] - m[1][2] * m[2][1]) * inv;
+    out[0][1] = (m[0][2] * m[2][1] - m[0][1] * m[2][2]) * inv;
+    out[0][2] = (m[0][1] * m[1][2] - m[0][2] * m[1][1]) * inv;
+    out[1][0] = (m[1][2] * m[2][0] - m[1][0] * m[2][2]) * inv;
+    out[1][1] = (m[0][0] * m[2][2] - m[0][2] * m[2][0]) * inv;
+    out[1][2] = (m[0][2] * m[1][0] - m[0][0] * m[1][2]) * inv;
+    out[2][0] = (m[1][0] * m[2][1] - m[1][1] * m[2][0]) * inv;
+    out[2][1] = (m[0][1] * m[2][0] - m[0][0] * m[2][1]) * inv;
+    out[2][2] = (m[0][0] * m[1][1] - m[0][1] * m[1][0]) * inv;
+    return true;
+}
+
+void applyFloat3(const float (&m)[3][3], const float (&v)[3], float (&out)[3]) {
+    for (int r = 0; r < 3; ++r) {
+        out[r] = m[r][0] * v[0] + m[r][1] * v[1] + m[r][2] * v[2];
+    }
+}
+
+FloatDevice makeFloatDevice(const i32 (&white1)[3], const i32 (&white2)[3]) {
+    const EmitterProfile profile = rgbDevice();
+    FloatDevice device = {};
+    float r[3];
+    float g[3];
+    float b[3];
+    primaryXyz(profile.xy_r, profile.lum_r, r);
+    primaryXyz(profile.xy_g, profile.lum_g, g);
+    primaryXyz(profile.xy_b, profile.lum_b, b);
+    float matrix[3][3];
+    for (int i = 0; i < 3; ++i) {
+        matrix[i][0] = r[i];
+        matrix[i][1] = g[i];
+        matrix[i][2] = b[i];
+        device.primaries[i][0] = r[i];
+        device.primaries[i][1] = g[i];
+        device.primaries[i][2] = b[i];
+        device.column1[i] = toFloat(white1[i]);
+        device.column2[i] = toFloat(white2[i]);
+    }
+    FL_REQUIRE(invertFloat3(matrix, device.inverse));
+    applyFloat3(device.inverse, device.column1, device.per_white1);
+    applyFloat3(device.inverse, device.column2, device.per_white2);
+    return device;
+}
+
+/// The largest reachable `w1 + w2` for a target, by vertex enumeration.
+///
+/// The feasible set in (w1, w2) is a polygon cut by ten half-planes -- the
+/// two white drives and the three RGB drives, each bounded twice. A linear
+/// objective over a polygon is maximized at a vertex, so intersecting every
+/// pair of boundary lines and keeping the feasible intersections finds the
+/// optimum exactly. This is the enumeration A3/B11 forbids per pixel, which
+/// is precisely why it belongs in the test and not in the shipped path.
+struct Optimum {
+    bool feasible;
+    float total;
+};
+
+Optimum bruteForceMaxWhite(const FloatDevice& device, const float (&target)[3]) {
+    float at_zero[3];
+    applyFloat3(device.inverse, target, at_zero);
+
+    // Each row is `a*w1 + b*w2 <= c`.
+    float rows[10][3];
+    int count = 0;
+    rows[count][0] = -1.0f; rows[count][1] = 0.0f; rows[count][2] = 0.0f; ++count;
+    rows[count][0] = 1.0f;  rows[count][1] = 0.0f; rows[count][2] = 1.0f; ++count;
+    rows[count][0] = 0.0f;  rows[count][1] = -1.0f; rows[count][2] = 0.0f; ++count;
+    rows[count][0] = 0.0f;  rows[count][1] = 1.0f;  rows[count][2] = 1.0f; ++count;
+    for (int i = 0; i < 3; ++i) {
+        // d_i = at_zero_i - w1*p1_i - w2*p2_i, needing 0 <= d_i <= 1.
+        rows[count][0] = device.per_white1[i];
+        rows[count][1] = device.per_white2[i];
+        rows[count][2] = at_zero[i];
+        ++count;
+        rows[count][0] = -device.per_white1[i];
+        rows[count][1] = -device.per_white2[i];
+        rows[count][2] = 1.0f - at_zero[i];
+        ++count;
+    }
+
+    Optimum best = {false, 0.0f};
+    const float tolerance = 1e-4f;
+    for (int a = 0; a < count; ++a) {
+        for (int b = a + 1; b < count; ++b) {
+            const float det = rows[a][0] * rows[b][1] - rows[a][1] * rows[b][0];
+            if (fl::fabsf(det) < 1e-7f) {
+                continue;
+            }
+            const float w1 = (rows[a][2] * rows[b][1] - rows[a][1] * rows[b][2]) / det;
+            const float w2 = (rows[a][0] * rows[b][2] - rows[a][2] * rows[b][0]) / det;
+            bool inside = true;
+            for (int k = 0; k < count && inside; ++k) {
+                inside = rows[k][0] * w1 + rows[k][1] * w2 <= rows[k][2] + tolerance;
+            }
+            if (!inside) {
+                continue;
+            }
+            if (!best.feasible || w1 + w2 > best.total) {
+                best.feasible = true;
+                best.total = w1 + w2;
+            }
+        }
+    }
+    return best;
+}
+
+/// The XYZ five drives produce on the float model.
+void reproduce(const FloatDevice& device, const float (&drives)[5],
+               float (&out)[3]) {
+    for (int i = 0; i < 3; ++i) {
+        out[i] = device.primaries[i][0] * drives[0] +
+                 device.primaries[i][1] * drives[1] +
+                 device.primaries[i][2] * drives[2] +
+                 device.column1[i] * drives[3] + device.column2[i] * drives[4];
+    }
+}
+
+/// A target built from drives, so it is reachable by construction.
+void targetFromDrives(const FloatDevice& device, const float (&drives)[5],
+                      i32 (&out)[3]) {
+    float xyz[3];
+    reproduce(device, drives, xyz);
+    for (int i = 0; i < 3; ++i) {
+        out[i] = q16(xyz[i]);
+    }
+}
+
+TwoWhiteAllocationQ16 buildTwoWhite(WhiteAllocationPolicy policy) {
+    TwoWhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildTwoWhiteAllocationQ16(rgbDevice(), kCoolWhite, kWarmWhite,
+                                          policy, &allocation));
+    return allocation;
+}
+
+}  // namespace
+
+FL_TEST_CASE("Two-white allocation reproduces the target it was given") {
+    // The identity the whole method rests on: whichever total and split come
+    // back, the five drives must still make the requested colour.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 allocation =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    const float samples[][5] = {
+        {0.20f, 0.40f, 0.60f, 0.30f, 0.10f},
+        {0.90f, 0.10f, 0.05f, 0.00f, 0.00f},
+        {0.05f, 0.05f, 0.05f, 0.90f, 0.90f},
+        {0.00f, 0.00f, 0.00f, 1.00f, 1.00f},
+        {1.00f, 1.00f, 1.00f, 1.00f, 1.00f},
+        {0.33f, 0.66f, 0.99f, 0.50f, 0.50f},
+        {0.01f, 0.02f, 0.03f, 0.04f, 0.05f},
+    };
+    const int count = static_cast<int>(sizeof(samples) / sizeof(samples[0]));
+    for (int v = 0; v < count; ++v) {
+        i32 xyz[3];
+        targetFromDrives(device, samples[v], xyz);
+        i32 drives[5];
+        FL_REQUIRE(allocateTwoWhiteDrivesQ16(allocation, xyz, drives));
+        float as_float[5];
+        for (int i = 0; i < 5; ++i) {
+            as_float[i] = toFloat(drives[i]);
+        }
+        float reproduced[3];
+        reproduce(device, as_float, reproduced);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(xyz[i])), 0.01f);
+        }
+    }
+}
+
+FL_TEST_CASE("Two-white allocation takes the largest reachable total") {
+    // White-preferred over two whites is a linear program, and this asks
+    // whether the closed form finds its optimum -- against an independent
+    // vertex enumeration, not against a nudge.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 allocation =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    int exercised = 0;
+    for (int r = 0; r <= 4; ++r) {
+        for (int g = 0; g <= 4; ++g) {
+            for (int b = 0; b <= 4; ++b) {
+                for (int w = 0; w <= 4; ++w) {
+                    const float sample[5] = {
+                        static_cast<float>(r) / 4.0f, static_cast<float>(g) / 4.0f,
+                        static_cast<float>(b) / 4.0f, static_cast<float>(w) / 4.0f,
+                        static_cast<float>(4 - w) / 4.0f};
+                    i32 xyz[3];
+                    targetFromDrives(device, sample, xyz);
+                    float as_target[3];
+                    for (int i = 0; i < 3; ++i) {
+                        as_target[i] = toFloat(xyz[i]);
+                    }
+                    const Optimum best = bruteForceMaxWhite(device, as_target);
+                    i32 drives[5];
+                    const bool solved =
+                        allocateTwoWhiteDrivesQ16(allocation, xyz, drives);
+                    FL_REQUIRE(best.feasible);
+                    FL_REQUIRE(solved);
+                    const float total = toFloat(drives[3]) + toFloat(drives[4]);
+                    // One 8-bit code, the same tolerance the one-white
+                    // vectors carry: the oracle inverts in float, this
+                    // quantizes the matrix first.
+                    FL_CHECK_LT(fl::fabsf(total - best.total), 2.0f / 255.0f);
+                    ++exercised;
+                }
+            }
+        }
+    }
+    FL_CHECK_EQ(exercised, 625);
+}
+
+FL_TEST_CASE("Two-white allocation solves targets one white cannot reach") {
+    // The case the first attempt got wrong (#4198). The achievable totals
+    // form an interval that need not start at zero: these targets are
+    // unreachable with the primaries alone *and* unreachable with either
+    // white on its own, so anything that searches upward from zero, or that
+    // runs the one-white form twice and keeps the better answer, reports
+    // them as outside the gamut.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 allocation =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    int exercised = 0;
+    for (int step = 0; step <= 8; ++step) {
+        const float lean = static_cast<float>(step) / 8.0f;
+        // Green at full with both whites near full. Green is the channel
+        // this device's whites load most heavily, so the target needs more
+        // green than one white plus a full green primary can supply -- which
+        // is what makes it a two-white target rather than merely a bright
+        // one. The `lean` slides the split without moving the total, so the
+        // family also says the answer does not depend on which white is
+        // asked first.
+        const float sample[5] = {0.10f, 1.00f, 0.10f, 0.80f + 0.2f * lean,
+                                 1.00f - 0.2f * lean};
+        i32 xyz[3];
+        targetFromDrives(device, sample, xyz);
+
+        // Confirm the premise rather than asserting it: one white capped at
+        // full drive cannot reach this target.
+        WhiteAllocationQ16 single;
+        FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kCoolWhite,
+                                           WhiteAllocationPolicy::WhitePreferred,
+                                           &single));
+        i32 single_drives[4];
+        FL_CHECK_FALSE(allocateEmitterDrivesQ16(single, xyz, single_drives));
+
+        i32 drives[5];
+        FL_REQUIRE(allocateTwoWhiteDrivesQ16(allocation, xyz, drives));
+        FL_CHECK_GT(toFloat(drives[3]) + toFloat(drives[4]), 1.0f);
+        ++exercised;
+    }
+    FL_CHECK_EQ(exercised, 9);
+}
+
+FL_TEST_CASE("Two-white allocation rejects targets outside the hull") {
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 allocation =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    // Every emitter at full drive, then half as much again. No combination
+    // of drives in [0, 1] reaches it.
+    const float full[5] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    float xyz_f[3];
+    reproduce(device, full, xyz_f);
+    const i32 beyond[3] = {q16(xyz_f[0] * 1.5f), q16(xyz_f[1] * 1.5f),
+                           q16(xyz_f[2] * 1.5f)};
+    i32 drives[5];
+    FL_CHECK_FALSE(allocateTwoWhiteDrivesQ16(allocation, beyond, drives));
+}
+
+FL_TEST_CASE("Two-white RGB-preferred takes the other end of the total") {
+    // The per-profile override C3 asks for. Same targets, same feasible
+    // interval; this end is its minimum, and for a target the primaries can
+    // reach on their own that minimum is no white at all.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 white_first =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+    const TwoWhiteAllocationQ16 rgb_first =
+        buildTwoWhite(WhiteAllocationPolicy::RgbPreferred);
+
+    const float sample[5] = {0.30f, 0.20f, 0.10f, 0.00f, 0.00f};
+    i32 xyz[3];
+    targetFromDrives(device, sample, xyz);
+
+    i32 white_drives[5];
+    i32 rgb_drives[5];
+    FL_REQUIRE(allocateTwoWhiteDrivesQ16(white_first, xyz, white_drives));
+    FL_REQUIRE(allocateTwoWhiteDrivesQ16(rgb_first, xyz, rgb_drives));
+
+    const float white_total = toFloat(white_drives[3]) + toFloat(white_drives[4]);
+    const float rgb_total = toFloat(rgb_drives[3]) + toFloat(rgb_drives[4]);
+    FL_CHECK_LT(rgb_total, white_total);
+    FL_CHECK_LT(rgb_total, 1.0f / 255.0f);
+
+    // And it still reproduces the target, so this is a different point on
+    // the same feasible set rather than a different answer.
+    float as_float[5];
+    for (int i = 0; i < 5; ++i) {
+        as_float[i] = toFloat(rgb_drives[i]);
+    }
+    float reproduced[3];
+    reproduce(device, as_float, reproduced);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(xyz[i])), 0.01f);
+    }
+}
+
+
+FL_TEST_CASE("Two-white allocation leaves no freedom in the split") {
+    // Why the shipped path takes an end of the split interval rather than
+    // optimizing over it: at the extreme total there is nothing to optimize.
+    // Scanned exactly -- drives in [0, 1] with only enough room for the
+    // quantization of the target -- the feasible splits are a point.
+    //
+    // The implementation's slack widens that to about 0.05 here, because a
+    // drive may sit 64 raw units outside range and the difference column's
+    // smallest entry is 0.017; the second check is that the split it picks
+    // stays inside the widened set rather than wandering off it.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 allocation =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    const float samples[][5] = {
+        {0.20f, 0.40f, 0.60f, 0.30f, 0.10f},
+        {0.10f, 0.90f, 0.20f, 0.70f, 0.60f},
+        {0.05f, 0.05f, 0.05f, 0.90f, 0.90f},
+        {0.33f, 0.66f, 0.99f, 0.50f, 0.50f},
+        {0.40f, 0.30f, 0.20f, 0.10f, 0.80f},
+    };
+    const int count = static_cast<int>(sizeof(samples) / sizeof(samples[0]));
+    const float kSlack = 64.0f / 65536.0f;
+    for (int v = 0; v < count; ++v) {
+        i32 xyz[3];
+        targetFromDrives(device, samples[v], xyz);
+        i32 drives[5];
+        FL_REQUIRE(allocateTwoWhiteDrivesQ16(allocation, xyz, drives));
+
+        const float total = toFloat(drives[3]) + toFloat(drives[4]);
+        const float chosen = toFloat(drives[3]);
+        float target_f[3];
+        for (int i = 0; i < 3; ++i) {
+            target_f[i] = toFloat(xyz[i]);
+        }
+        float at_zero[3];
+        applyFloat3(device.inverse, target_f, at_zero);
+
+        float exact_low = 2.0f;
+        float exact_high = -1.0f;
+        float slack_low = 2.0f;
+        float slack_high = -1.0f;
+        const int kSteps = 8192;
+        for (int step = 0; step <= kSteps; ++step) {
+            const float split =
+                total * static_cast<float>(step) / static_cast<float>(kSteps);
+            if (split > 1.0f + kSlack || total - split > 1.0f + kSlack) {
+                continue;
+            }
+            float worst = 0.0f;
+            for (int i = 0; i < 3; ++i) {
+                const float drive = at_zero[i] - split * device.per_white1[i] -
+                                    (total - split) * device.per_white2[i];
+                const float outside = drive < 0.0f ? -drive : drive - 1.0f;
+                if (outside > worst) {
+                    worst = outside;
+                }
+            }
+            // 1e-4 is the target's own quantization, not a policy: the XYZ
+            // went through s16.16 before it got here.
+            if (worst <= 1e-4f) {
+                if (split < exact_low) { exact_low = split; }
+                if (split > exact_high) { exact_high = split; }
+            }
+            if (worst <= kSlack) {
+                if (split < slack_low) { slack_low = split; }
+                if (split > slack_high) { slack_high = split; }
+            }
+        }
+        FL_REQUIRE(exact_high >= 0.0f);
+        FL_CHECK_LT(exact_high - exact_low, 0.01f);
+        FL_CHECK_GE(chosen, slack_low - 0.01f);
+        FL_CHECK_LE(chosen, slack_high + 0.01f);
+    }
+}
+
+FL_TEST_CASE("Two-white allocation handles two whites of the same colour") {
+    // The degenerate device: both whites in the same place, so the
+    // difference column is zero and the split cannot move any RGB drive.
+    // Every bound then falls on the total alone, which is a branch nothing
+    // else in this file reaches.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kCoolWhite);
+    TwoWhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildTwoWhiteAllocationQ16(rgbDevice(), kCoolWhite, kCoolWhite,
+                                          WhiteAllocationPolicy::WhitePreferred,
+                                          &allocation));
+    for (int i = 0; i < 3; ++i) {
+        FL_REQUIRE(allocation.difference[i] == 0);
+    }
+
+    const float samples[][5] = {
+        {0.20f, 0.40f, 0.60f, 0.30f, 0.10f},
+        {0.05f, 0.05f, 0.05f, 0.90f, 0.90f},
+        {0.10f, 1.00f, 0.10f, 0.90f, 0.90f},
+        {0.60f, 0.20f, 0.10f, 0.00f, 0.00f},
+    };
+    const int count = static_cast<int>(sizeof(samples) / sizeof(samples[0]));
+    for (int v = 0; v < count; ++v) {
+        i32 xyz[3];
+        targetFromDrives(device, samples[v], xyz);
+        i32 drives[5];
+        FL_REQUIRE(allocateTwoWhiteDrivesQ16(allocation, xyz, drives));
+
+        float as_float[5];
+        for (int i = 0; i < 5; ++i) {
+            as_float[i] = toFloat(drives[i]);
+        }
+        float reproduced[3];
+        reproduce(device, as_float, reproduced);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(xyz[i])), 0.01f);
+        }
+
+        // And the total is still maximal, which is what the lower bound on
+        // the total exists to make possible for the bright ones.
+        float target_f[3];
+        for (int i = 0; i < 3; ++i) {
+            target_f[i] = toFloat(xyz[i]);
+        }
+        const Optimum best = bruteForceMaxWhite(device, target_f);
+        FL_REQUIRE(best.feasible);
+        const float total = toFloat(drives[3]) + toFloat(drives[4]);
+        FL_CHECK_LT(fl::fabsf(total - best.total), 2.0f / 255.0f);
+
+        // This is the one device where the split really is free -- no RGB
+        // drive moves with it -- so it is also the only place the choice of
+        // end is observable. The reference's tie-break falls through to the
+        // lexicographically smallest drives, which puts every unit it can on
+        // the second white.
+        const float lowest_split = total > 1.0f ? total - 1.0f : 0.0f;
+        FL_CHECK_LT(fl::fabsf(toFloat(drives[3]) - lowest_split), 2.0f / 255.0f);
+    }
+}
+
+FL_TEST_CASE("Two-white RGB-preferred still lights the whites when it must") {
+    // RGB-preferred takes the *minimum* feasible total, and that minimum is
+    // not always zero: for a target the primaries cannot reach alone, the
+    // smallest total that makes it reachable is a positive number, and only
+    // the lower bound on the total finds it.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kWarmWhite);
+    const TwoWhiteAllocationQ16 rgb_first =
+        buildTwoWhite(WhiteAllocationPolicy::RgbPreferred);
+    const TwoWhiteAllocationQ16 white_first =
+        buildTwoWhite(WhiteAllocationPolicy::WhitePreferred);
+
+    const float sample[5] = {0.10f, 1.00f, 0.10f, 0.90f, 0.90f};
+    i32 xyz[3];
+    targetFromDrives(device, sample, xyz);
+
+    i32 rgb_drives[5];
+    i32 white_drives[5];
+    FL_REQUIRE(allocateTwoWhiteDrivesQ16(rgb_first, xyz, rgb_drives));
+    FL_REQUIRE(allocateTwoWhiteDrivesQ16(white_first, xyz, white_drives));
+
+    const float rgb_total = toFloat(rgb_drives[3]) + toFloat(rgb_drives[4]);
+    const float white_total = toFloat(white_drives[3]) + toFloat(white_drives[4]);
+    FL_CHECK_GT(rgb_total, 0.5f);
+    FL_CHECK_LT(rgb_total, white_total);
+
+    // Still the same colour: a different point on the same feasible set.
+    float as_float[5];
+    for (int i = 0; i < 5; ++i) {
+        as_float[i] = toFloat(rgb_drives[i]);
+    }
+    float reproduced[3];
+    reproduce(device, as_float, reproduced);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(xyz[i])), 0.01f);
+    }
+}
+
+
+FL_TEST_CASE("Two-white RGB-preferred finds the smallest total on equal whites") {
+    // Closes the other half of the degenerate device: with the difference
+    // column zero everywhere, every bound falls on the total alone, and
+    // RGB-preferred needs the *lower* one of those -- which for a target the
+    // primaries cannot reach is a positive number.
+    const FloatDevice device = makeFloatDevice(kCoolWhite, kCoolWhite);
+    TwoWhiteAllocationQ16 allocation;
+    FL_REQUIRE(buildTwoWhiteAllocationQ16(rgbDevice(), kCoolWhite, kCoolWhite,
+                                          WhiteAllocationPolicy::RgbPreferred,
+                                          &allocation));
+
+    const float sample[5] = {0.10f, 1.00f, 0.10f, 0.90f, 0.90f};
+    i32 xyz[3];
+    targetFromDrives(device, sample, xyz);
+    i32 drives[5];
+    FL_REQUIRE(allocateTwoWhiteDrivesQ16(allocation, xyz, drives));
+
+    // The primaries alone cannot reach it, so the smallest feasible total is
+    // well above zero.
+    const float total = toFloat(drives[3]) + toFloat(drives[4]);
+    FL_CHECK_GT(total, 0.5f);
+
+    // And it is the *smallest*: one code less would put a drive out of range.
+    float at_zero[3];
+    float target_f[3];
+    for (int i = 0; i < 3; ++i) {
+        target_f[i] = toFloat(xyz[i]);
+    }
+    applyFloat3(device.inverse, target_f, at_zero);
+    bool lower_total_is_infeasible = false;
+    const float probe = total - 4.0f / 255.0f;
+    for (int i = 0; i < 3; ++i) {
+        const float drive = at_zero[i] - probe * device.per_white1[i];
+        if (drive > 1.0f + 64.0f / 65536.0f) {
+            lower_total_is_infeasible = true;
+        }
+    }
+    FL_CHECK(lower_total_is_infeasible);
+
+    float as_float[5];
+    for (int i = 0; i < 5; ++i) {
+        as_float[i] = toFloat(drives[i]);
+    }
+    float reproduced[3];
+    reproduce(device, as_float, reproduced);
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_LT(fl::fabsf(reproduced[i] - toFloat(xyz[i])), 0.01f);
+    }
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
Closes #4198. Part of #4041 (P7), under #4034.

P7 asks for the C3 allocation policy on "RGBW/RGBWW". One white landed in #4188
and #4193. Two did not, and #4198 recorded a failed attempt at them.

## The closed form

Write the total `s = w₁ + w₂` and substitute `w₂ = s − w₁`. The RGB drives
become

```
(d₀ − s·dW₂) − w₁·(dW₁ − dW₂)
```

which is the one-white shape with a shifted target and a difference column. So
at any fixed total the feasible `w₁` is again an interval, bounded by five
lower and five upper bounds — three from the RGB drives, and two more because
`w₁` and `w₂ = s − w₁` are drives in their own right.

Every one of those bounds is **affine in `s`**. So "some split exists at this
total" is exactly the conjunction of the pairwise inequalities
`lowerₖ(s) ≤ upperⱼ(s)`, each linear in `s` and each solvable for one `s`
bound. Intersecting the 25 of them gives the feasible totals directly — no
bisection, no vertex enumeration, nothing iterative on the per-pixel path
(A3/B11).

**The interval has to be found, not assumed to start at zero.** That is where
the previous attempt broke: a bright target is unreachable with the primaries
alone, so its feasible totals begin above zero and a bisection seeded at zero
reports it out of gamut.

## Measured, with nothing skipped

The previous attempt reported "0 disagreements over 10,285 targets" while its
harness had silently dropped roughly 30,000 of 40,000 — including precisely
the bright targets it could not handle. So every sample here is classified by
both methods, and a disagreement about *feasibility* counts as loudly as a
disagreement about the answer:

| targets | how drawn | solved by both | disagreements |
|---|---|---:|---:|
| 8,000 | uniform drives | 8,000 | 0 |
| 4,000 | both whites near full | 4,000 | 0 |
| 4,000 | drives to 1.35×, many out of hull | 2,862 | 0 |

Worst difference in total white: 2.2 × 10⁻¹⁵. The corpus's 48 `rgbww` vectors
also reproduce to < 10⁻⁹.

One target in 4,000 sits on the hull to within 10⁻⁷ and is admitted by the
enumeration's per-constraint slack while the closed form's exact interval
refuses it. That is counted as its own category and asserted to stay rare —
not folded into agreement, and not skipped.

## Two things measurement decided

**The slack is one-sided.** The exact hull corner was refused: five emitters at
full drive solve, through a quantized matrix, to a target needing 57 raw units
more than a total of 2.0 can supply. The bounds therefore carry slack on the
`drive ≤ 1` side only — the `drive ≥ 0` side would be *spent* by a policy that
maximizes white, which is the same asymmetry `allocateEmitterDrivesQ16` already
argues for.

**And it is half the final check's.** Relaxing a bound and then re-checking the
same drive against the same number puts the boundary case exactly on the
threshold, where two independent roundings decide it — measured rejecting a
drive at 65601 against a limit of 65600, one raw unit, on the RGB-preferred end
of a target needing both whites.

## What was written and then deleted

The least-squares split rule #4198's plan called for. It is a quadratic in the
split, so one division, and it was implemented here. Measurement removed it:
**at the extreme total the feasible split is a single point**, so there is
nothing for any rule to choose. Width measured 0.0 over 4,000 targets on the
corpus's cool/warm device, and over 951 on a device built specifically so one
drive's constraint is parallel to `w₁ + w₂` — the shape that could have
produced an optimal edge.

Two whites of the *same* colour are the one case where the split really is
free, and there the reference's own tie-break — lexicographically smallest
drives — is the end this takes anyway.

Shipping an untestable division on a per-pixel embedded path to serve an
unreachable case is the wrong trade, so it is gone and the reason is recorded
in the header and in `docs/color-gamut-algorithm-selection.md`.

## Tests

`ci/tests/test_color_rgbw_study.py` gates the algorithm against the reference's
enumeration (the sweeps above). `tests/fl/gfx/white_allocation.cpp` gates the
s16.16 implementation against an independent float vertex enumeration written
in the test — reproduction, maximal total, targets one white cannot reach,
out-of-hull rejection, the RGB-preferred end, the degenerate equal-whites
device, and the claim that the split interval is a point.

Eight mutations of the implementation were run; all eight fail the tests:

| mutation | caught by |
|---|---|
| always take the lowest total | maximal-total, both-whites |
| drop the total's lower bound (fixed-drive branch) | equal-whites RGB-preferred |
| pairwise bound always narrows the top | maximal-total |
| ignore the sign of the difference column | maximal-total |
| `difference = per_white1` | reproduction, maximal-total |
| take the high end of the split | equal-whites split |
| drop `w₁ ≥ s − 1` | maximal-total |
| drop `w₁ ≤ s` | the Python gate (3 sweeps) |

`bash test --cpp --clean`: 383 passed, 0 failed (299 unit, 84 examples).
`bash lint` clean.

## Still open

The golden corpus has no `rgbww` vector that needs both whites — all 48 are
reachable with one white or none — so it cannot distinguish a correct two-white
allocation from the reduction it replaces. The sweeps stand in for that,
measured against the reference's own enumeration rather than its recorded
output. Corpus vectors bright enough to need both whites would close the gap;
that is noted in the document rather than claimed as done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for allocating color targets across two white emitters.
  * Supports white-preferred and RGB-preferred allocation policies.
  * Provides consistent allocation for targets requiring both white emitters, including identical emitters.
  * Added validation for unreachable targets, invalid inputs, overflow, and degenerate configurations.

* **Documentation**
  * Documented the closed-form two-white allocation approach and implementation behavior.

* **Tests**
  * Added comprehensive coverage for target reconstruction, boundary conditions, rejection cases, identical emitters, and quantized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->