### PR TITLE
fix(rpc): normalize serial transport failures into RpcError (#4191)

### DIFF
--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -79,24 +79,18 @@ async def _settle_link(
             # KBI002: this repo requires the handler notify the main thread.
             handle_keyboard_interrupt(ki)
             raise
-        except (RpcError, RpcTimeoutError, RuntimeError) as exc:
-            # RuntimeError is here because a failed *write* arrives as one:
-            # `PyserialMonitor.write` converts `serial.SerialException` into
-            # `RuntimeError("Serial write error: ...")`, and `RpcClient.send`
-            # only retries `RpcTimeoutError`, so it comes straight out. Left
-            # uncaught it defeats the point of this helper twice over -- no
+        except (RpcError, RpcTimeoutError) as exc:
+            # `RuntimeError` used to be in this tuple, because a failed
+            # *write* arrived as one: `PyserialMonitor.write` converts
+            # `serial.SerialException` into `RuntimeError("Serial write
+            # error: ...")` and `RpcClient.send` let it straight through.
+            # Uncaught it defeated the point of this helper twice over -- no
             # retry, and a bare transport error naming neither the board nor
             # the call, which is exactly the failure #3956 was about.
             #
-            # Normalizing that at the `RpcClient.send` boundary would be the
-            # better home for it, and is not this change's to make: 31
-            # modules use RpcClient, and some of them (ci/autoresearch/
-            # decode.py) rely on a bare `except RuntimeError` to report
-            # transport failures cleanly. Filed separately.
-            #
-            # The cost of the wider catch is that a genuine bug retries twice
-            # before surfacing. It still surfaces: the raised error carries
-            # the original text.
+            # `send` normalizes it into `RpcError` now (#4191), which is the
+            # right home for it, so the workaround is gone and this tuple is
+            # back to the contract `send` documents.
             last = exc
             print(f"  {label} did not answer ping (attempt {attempt}/3): {exc}")
             # No backoff after the final attempt -- it would just delay the

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -80,8 +80,26 @@ class RpcTimeoutError(TimeoutError):
     pass
 
 
-class RpcError(Exception):
-    """RPC operation failed."""
+class RpcError(RuntimeError):
+    """RPC operation failed.
+
+    Deliberately a `RuntimeError` rather than a bare `Exception`, so that
+    `send` can normalize transport failures into it without breaking the
+    callers that report those failures by catching `RuntimeError` (#4191).
+
+    `PyserialMonitor.write` raises `RuntimeError("Serial write error: ...")`,
+    and `send` used to let it straight through -- past its own documented
+    contract of `RpcTimeoutError` or `RpcError`, so every caller handling
+    `(RpcError, RpcTimeoutError)` missed a failed write. Normalizing it is
+    only safe because this widening keeps the existing `except RuntimeError`
+    handlers working; the four that RPC errors can actually reach
+    (`ci/autoresearch/gpio.py`, `ci/autoresearch/decode.py`) all report a
+    transport failure and return, which is exactly what an `RpcError`
+    arriving there should do -- today it escapes them as a traceback.
+
+    `RpcTimeoutError` sets the precedent in this file by subclassing the
+    builtin `TimeoutError`.
+    """
 
     def __init__(
         self,
@@ -392,7 +410,11 @@ class RpcClient:
 
         Raises:
             RpcTimeoutError: If no response within timeout
-            RpcError: If not connected
+            RpcError: If not connected, or if the serial transport failed.
+                Transport failures arrive as `RuntimeError` from
+                `PyserialMonitor.write` and are normalized here, so this
+                contract holds rather than leaking the transport's own type
+                (#4191).
         """
         if not self.is_connected:
             raise RpcError("Not connected")
@@ -439,6 +461,16 @@ class RpcClient:
             except RpcTimeoutError as e:
                 last_error = e
                 continue
+            except RpcError:
+                # Already this contract's currency; retrying a transport that
+                # reported a definite failure is not the same as retrying a
+                # timeout, so it propagates.
+                raise
+            except RuntimeError as e:
+                # `PyserialMonitor.write` reports a failed write this way.
+                # Letting it through would break `send`'s contract and every
+                # caller that handles `(RpcError, RpcTimeoutError)` (#4191).
+                raise RpcError(f"{function}: {e}") from e
 
         raise last_error or RpcTimeoutError(
             f"No response after {retries} attempts (total timeout: {effective_timeout}s)"

--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -249,14 +249,14 @@ def test_settle_link_retries_a_failed_serial_write() -> None:
     """A failed write must be retried, and must name the board when it isn't.
 
     `PyserialMonitor.write` converts `serial.SerialException` into
-    `RuntimeError("Serial write error: ...")`, and `RpcClient.send` only
-    retries `RpcTimeoutError` -- so a write failure arrives here as a bare
-    `RuntimeError`. Before this was caught, it escaped the retry entirely and
+    `RuntimeError("Serial write error: ...")`. `RpcClient.send` normalizes
+    that into `RpcError` (#4191), so it is what a caller sees and what this
+    mocks. Before the retry caught it, a write failure escaped entirely and
     surfaced as a transport error naming neither the board nor the call,
     which is the failure #3956 exists to fix.
     """
     client = MagicMock()
-    client.send = AsyncMock(side_effect=RuntimeError("Serial write error: boom"))
+    client.send = AsyncMock(side_effect=RpcError("Serial write error: boom"))
 
     with pytest.raises(RpcTimeoutError) as caught:
         asyncio.run(_settle_link(client, "primary (COM18)", lambda: 30.0))
@@ -275,7 +275,8 @@ def test_settle_link_returns_once_the_board_answers() -> None:
     client = MagicMock()
     client.send = AsyncMock(
         side_effect=[
-            RuntimeError("Serial write error: boom"),
+            # What `send` raises for a failed write since #4191.
+            RpcError("Serial write error: boom"),
             _response({"success": True}),
         ]
     )

--- a/ci/tests/test_rpc_client_errors.py
+++ b/ci/tests/test_rpc_client_errors.py
@@ -11,22 +11,24 @@ from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 
 
 class _ErrorSerial:
-    async def connect(self) -> None:
+    async def connect(self: "_ErrorSerial") -> None:
         pass
 
-    async def close(self) -> None:
+    async def close(self: "_ErrorSerial") -> None:
         pass
 
-    async def write(self, data: str) -> None:
+    async def write(self: "_ErrorSerial", data: str) -> None:
         assert '"id":1' in data
 
-    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+    async def read_lines(self: "_ErrorSerial", timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
         yield (
             'REMOTE: {"jsonrpc":"2.0","id":1,'
             '"error":{"code":-32601,"message":"Method not found: missing"}}'
         )
 
-    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+    async def reset_device(
+        self: "_ErrorSerial", board: str | None
+    ) -> bool:  # pragma: no cover
         return True
 
 
@@ -47,40 +49,46 @@ def test_json_rpc_error_is_not_masked_as_timeout() -> None:
 class _WriteFailsSerial:
     """A transport whose write fails the way `PyserialMonitor.write` does."""
 
-    async def connect(self) -> None:
+    async def connect(self: "_WriteFailsSerial") -> None:
         pass
 
-    async def close(self) -> None:
+    async def close(self: "_WriteFailsSerial") -> None:
         pass
 
-    async def write(self, data: str) -> None:  # noqa: ARG002
+    async def write(self: "_WriteFailsSerial", data: str) -> None:  # noqa: ARG002
         raise RuntimeError("Serial write error: [Errno 5] Input/output error")
 
-    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+    async def read_lines(
+        self: "_WriteFailsSerial", timeout: float
+    ) -> AsyncIterator[str]:  # noqa: ARG002
         return
         yield ""  # pragma: no cover - makes this an async generator
 
-    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+    async def reset_device(
+        self: "_WriteFailsSerial", board: str | None
+    ) -> bool:  # pragma: no cover
         return True
 
 
 class _CrashSerial:
     """A transport whose response is a device crash, not a write failure."""
 
-    async def connect(self) -> None:
+    async def connect(self: "_CrashSerial") -> None:
         pass
 
-    async def close(self) -> None:
+    async def close(self: "_CrashSerial") -> None:
         pass
 
-    async def write(self, data: str) -> None:
+    async def write(self: "_CrashSerial", data: str) -> None:
         pass
 
-    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+    async def read_lines(self: "_CrashSerial", timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
         raise RpcCrashError("device crashed", ["#0 boom"])
         yield ""  # pragma: no cover - makes this an async generator
 
-    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+    async def reset_device(
+        self: "_CrashSerial", board: str | None
+    ) -> bool:  # pragma: no cover
         return True
 
 

--- a/ci/tests/test_rpc_client_errors.py
+++ b/ci/tests/test_rpc_client_errors.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from ci.rpc_client import RpcClient, RpcError
+from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
 
 
 class _ErrorSerial:
@@ -39,6 +39,105 @@ def test_json_rpc_error_is_not_masked_as_timeout() -> None:
         assert caught.value.code == -32601
         assert caught.value.message == "Method not found: missing"
         assert caught.value.data is None
+        await client.close()
+
+    asyncio.run(_run())
+
+
+class _WriteFailsSerial:
+    """A transport whose write fails the way `PyserialMonitor.write` does."""
+
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+    async def write(self, data: str) -> None:  # noqa: ARG002
+        raise RuntimeError("Serial write error: [Errno 5] Input/output error")
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        return
+        yield ""  # pragma: no cover - makes this an async generator
+
+    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+        return True
+
+
+class _CrashSerial:
+    """A transport whose response is a device crash, not a write failure."""
+
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+    async def write(self, data: str) -> None:
+        pass
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:  # noqa: ARG002
+        raise RpcCrashError("device crashed", ["#0 boom"])
+        yield ""  # pragma: no cover - makes this an async generator
+
+    async def reset_device(self, board: str | None) -> bool:  # pragma: no cover
+        return True
+
+
+def test_rpc_error_is_a_runtime_error() -> None:
+    """Callers reporting transport failures catch `RuntimeError` (#4191).
+
+    `ci/autoresearch/decode.py` and `ci/autoresearch/gpio.py` both end their
+    RPC paths with a bare `except RuntimeError` that prints the failure and
+    returns. Normalizing serial write failures into `RpcError` would have
+    turned those clean exits into tracebacks unless `RpcError` widened to
+    include them, so this is the property that makes the normalization safe.
+    """
+
+    assert issubclass(RpcError, RuntimeError)
+    assert issubclass(RpcCrashError, RpcError)
+    # And not the other way round: a timeout is not a transport failure, and
+    # the callers that retry on one must not catch the other by accident.
+    assert not issubclass(RpcTimeoutError, RpcError)
+
+
+def test_a_failed_write_arrives_as_rpc_error() -> None:
+    """`send` promises `RpcTimeoutError` or `RpcError` and now keeps that.
+
+    `PyserialMonitor.write` reports a failed write as a bare
+    `RuntimeError`, which used to propagate out of `send` unchanged -- so
+    every caller handling `(RpcError, RpcTimeoutError)` missed it. Found in
+    the peer-OTA path (#4178), where it meant no retry and an error naming
+    neither the board nor the call.
+    """
+
+    async def _run() -> None:
+        client = RpcClient("FAKE", serial_interface=_WriteFailsSerial())
+        await client.connect(boot_wait=0, drain_boot=False)
+        with pytest.raises(RpcError, match=r"ping: Serial write error") as caught:
+            await client.send("ping", {}, timeout=0.1)
+        # The call is named, which the bare RuntimeError never was.
+        assert "ping" in str(caught.value)
+        assert isinstance(caught.value.__cause__, RuntimeError)
+        await client.close()
+
+    asyncio.run(_run())
+
+
+def test_a_crash_keeps_its_own_type_and_decoded_lines() -> None:
+    """The normalization must not flatten richer errors on its way past.
+
+    `RpcCrashError` is an `RpcError`, so a naive `except RuntimeError`
+    rewrap would swallow it and lose `decoded_lines` -- the stack trace is
+    the whole point of that type.
+    """
+
+    async def _run() -> None:
+        client = RpcClient("FAKE", serial_interface=_CrashSerial())
+        await client.connect(boot_wait=0, drain_boot=False)
+        with pytest.raises(RpcCrashError) as caught:
+            await client.send("boom", {}, timeout=0.1)
+        assert caught.value.decoded_lines == ["#0 boom"]
         await client.close()
 
     asyncio.run(_run())


### PR DESCRIPTION
Closes #4191.

## The leak

`PyserialMonitor.write` converts `serial.SerialException` into
`RuntimeError("Serial write error: ...")`. `RpcClient.send` retried only
`RpcTimeoutError`, so that `RuntimeError` came straight out — past `send`'s own
documented contract of `RpcTimeoutError` or `RpcError`.

Every caller handling `(RpcError, RpcTimeoutError)` therefore missed a failed
write. Found in `_settle_link` on the peer-OTA path (#4178), where it meant no
retry and an error naming neither the board nor the call — the exact failure
#3956 exists to fix.

## The audit that unblocks it

#4191 stopped short of Option 1 because normalizing to a type not derived from
`RuntimeError` would turn clean exits into tracebacks, and the 31 modules that
import `RpcClient` had not been checked. So I checked them.

Of **31** `except RuntimeError` handlers under `ci/`, only **three files** can
reach one from an RPC path:

| handler | what it does |
|---|---|
| `autoresearch/gpio.py:195` | prints "GPIO PRE-TEST ERROR / Serial connection error", returns `False` |
| `autoresearch/gpio.py:399` | prints "PIN DISCOVERY ERROR / Serial error", falls back to default pins |
| `autoresearch/decode.py:258` | prints `Error: ...`, returns 1 (after its own `except RpcTimeoutError`) |
| `autoresearch/decode.py:356` | prints `Error: ...`, returns 1 |
| `autoresearch/ota.py:82` | the #4178 workaround, retired here |

Every one is a transport-failure reporter. An `RpcError` arriving there is
precisely what it means to catch — **today it escapes them as a traceback**. So
the widening does not merely preserve these handlers, it fixes all four.

## The change

- `RpcError` derives from `RuntimeError`. `RpcTimeoutError` already sets the
  precedent in the same file by deriving from the builtin `TimeoutError`.
- `send` converts a transport `RuntimeError` into `RpcError`, naming the call.
- `RpcError` is re-raised *ahead* of that conversion, so `RpcCrashError` keeps
  its type and its `decoded_lines` — the stack trace is the whole point of that
  type, and a naive rewrap would swallow it.
- The `_settle_link` workaround — a widened except tuple carrying a comment
  saying the real fix belonged at the `send` boundary — is gone, and the tuple
  is back to the contract `send` documents.

## Tests

Two existing tests in `test_autoresearch_net.py` mocked `client.send` raising a
bare `RuntimeError`. That modelled the leak, not the contract; now that `send`
never emits one, they raise what `send` actually raises. Widening them back
would have left them passing while asserting nothing.

Three new cases, and three mutations, all caught:

| mutation | result |
|---|---|
| `RpcError` back to `Exception` | `test_rpc_error_is_a_runtime_error` fails |
| drop the normalization | `test_a_failed_write_arrives_as_rpc_error` fails with the bare `RuntimeError` |
| rewrap `RpcError` too | `test_a_crash_keeps_its_own_type_and_decoded_lines` fails, plus the pre-existing JSON-RPC error test |

323 passed / 3 skipped across the rpc, ota, autoresearch, net, decode and
serial selection. `bash lint` clean.

Note on the full local `pytest ci/tests/` run: it crawls on this machine
(11% after several minutes) — I confirmed that reproduces on a clean `master`
checkout, so it is not from this change. CI's `test / build` is the
authoritative full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of serial communication failures during remote procedure calls, providing consistent and actionable error reporting.
  * Prevented already-classified communication errors from being retried unnecessarily.
  * Ensured link-settling failures are propagated correctly instead of being incorrectly reported as timeouts.
  * Preserved device crash errors and their diagnostic stack details for troubleshooting.
  * Improved error consistency across remote communication and link-settling operations, making failures easier to diagnose and reducing misleading timeout messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->