### PR TITLE
fix(gfx): two crashes the dormant channel test was hiding (#4201)

### DIFF
--- a/src/fl/gfx/pixel_iterator_any.h
+++ b/src/fl/gfx/pixel_iterator_any.h
@@ -61,6 +61,49 @@ class PixelIteratorAny {
         mXyMap = xymap;
     }
 
+    /// @brief Copy: the iterator must be re-aimed, not copied.
+    ///
+    /// This class is self-referential -- `mPixelIterator` is a type-erased
+    /// `PixelIterator` holding a `void*` into `mAnyController`, a member of
+    /// the same object. The compiler-generated copy carried that pointer
+    /// across unchanged, so the copy's iterator kept reading the *source*
+    /// object's controller. Where the source was a temporary, as in
+    /// `ReorderingPixelIteratorAny`'s addressing branch, that was a read of
+    /// dead stack on every addressed frame (#4201).
+    PixelIteratorAny(const PixelIteratorAny& other) FL_NO_EXCEPT
+        : mAnyController(other.mAnyController), mRgbw(other.mRgbw),
+          mRgbww(other.mRgbww), mXyMap(other.mXyMap) {
+        bindIterator();
+    }
+
+    PixelIteratorAny(PixelIteratorAny&& other) FL_NO_EXCEPT
+        : mAnyController(fl::move(other.mAnyController)), mRgbw(other.mRgbw),
+          mRgbww(other.mRgbww), mXyMap(fl::move(other.mXyMap)) {
+        bindIterator();
+    }
+
+    PixelIteratorAny& operator=(const PixelIteratorAny& other) FL_NO_EXCEPT {
+        if (this != &other) {
+            mAnyController = other.mAnyController;
+            mRgbw = other.mRgbw;
+            mRgbww = other.mRgbww;
+            mXyMap = other.mXyMap;
+            bindIterator();
+        }
+        return *this;
+    }
+
+    PixelIteratorAny& operator=(PixelIteratorAny&& other) FL_NO_EXCEPT {
+        if (this != &other) {
+            mAnyController = fl::move(other.mAnyController);
+            mRgbw = other.mRgbw;
+            mRgbww = other.mRgbww;
+            mXyMap = fl::move(other.mXyMap);
+            bindIterator();
+        }
+        return *this;
+    }
+
     /// @brief Initialize the adapter with color order conversion
     void init(PixelController<RGB> &controller, EOrder newOrder) {
         // Step 1: Create the appropriate PixelController variant based on color order
@@ -85,7 +128,17 @@ class PixelIteratorAny {
             break;
         }
 
-        // Step 2: Use visitor pattern to construct PixelIterator with correct pointer type
+        // Step 2: aim the type-erased iterator at whichever alternative
+        // `mAnyController` now holds.
+        bindIterator();
+    }
+
+  private:
+    /// @brief Point `mPixelIterator` at this object's own controller.
+    ///
+    /// Every path that changes `mAnyController` has to end here, because the
+    /// iterator holds a raw pointer into it and nothing else fixes that up.
+    void bindIterator() {
         // Note: fl::Optional::emplace takes a constructed object, not constructor args
         struct PixelIteratorInitVisitor {
             PixelIteratorInitVisitor(Rgbw rgbw, Rgbww rgbww)
@@ -120,7 +173,6 @@ class PixelIteratorAny {
         mAnyController.visit(visitor);
     }
 
-  private:
     fl::variant<PixelController<RGB>, PixelController<RBG>,
                 PixelController<GRB>, PixelController<GBR>,
                 PixelController<BRG>, PixelController<BGR>>

--- a/src/fl/math/xymap.cpp.hpp
+++ b/src/fl/math/xymap.cpp.hpp
@@ -44,8 +44,15 @@ XYMap XYMap::constructWithLookUpTable(u16 width, u16 height,
                                       u16 offset) {
     XYMap out(width, height, kLookUpTable);
     out.mLookUpTable = fl::make_shared<LUT16>(width * height);
-    fl::memcpy(out.mLookUpTable->getDataMutable(), lookUpTable,
-                width * height * sizeof(u16));
+    // A null table means "allocate it, I will fill it" -- which is what
+    // `fromXMap` below asks for, and it used to `memcpy` from nullptr and
+    // segfault every caller of `Channel::setScreenMap(const XMap&)`
+    // (#4201). `LUT16` zeroes its storage, so the unfilled case is an
+    // identity-free map rather than garbage.
+    if (lookUpTable != nullptr) {
+        fl::memcpy(out.mLookUpTable->getDataMutable(), lookUpTable,
+                   width * height * sizeof(u16));
+    }
     out.mOffset = offset;
     return out;
 }
@@ -62,8 +69,9 @@ XYMap XYMap::fromXMap(const XMap& xmap) {
     // This treats the 1D strip as a 2D grid with height 1
     u16 length = xmap.getLength();
 
-    // Create a user function that dispatches to the XMap
-    // Since we can't capture xmap directly, we create a LUT and use that
+    // Null rather than a table: the LUT is allocated here and filled just
+    // below, which is what the null case in `constructWithLookUpTable`
+    // exists for.
     auto out = XYMap::constructWithLookUpTable(length, 1, nullptr);
     fl::shared_ptr<LUT16> lut = fl::make_shared<LUT16>(length);
     u16* data = lut->getDataMutable();

--- a/tests/fl/gfx/pixel_iterator_any.cpp
+++ b/tests/fl/gfx/pixel_iterator_any.cpp
@@ -1,0 +1,108 @@
+/// @file tests/fl/gfx/pixel_iterator_any.cpp
+/// @brief `PixelIteratorAny` must survive being copied or moved (#4201).
+
+#include "fl/gfx/pixel_iterator_any.h"
+#include "fl/stl/int.h"
+#include "pixel_controller.h"
+#include "test.h"
+
+FL_TEST_FILE(FL_FILEPATH) {
+
+using namespace fl;
+
+namespace {
+
+/// Read three bytes per pixel through an adapter, in wire order.
+void drain(PixelIteratorAny& adapter, int count, fl::vector<u8>* out) {
+    PixelIterator& iterator = adapter.get();
+    for (int i = 0; i < count && iterator.has(1); ++i) {
+        u8 r = 0;
+        u8 g = 0;
+        u8 b = 0;
+        iterator.loadAndScaleRGB(&r, &g, &b);
+        out->push_back(r);
+        out->push_back(g);
+        out->push_back(b);
+        iterator.advanceData();
+    }
+}
+
+}  // namespace
+
+FL_TEST_CASE("[#4201] A moved PixelIteratorAny reads its own controller") {
+    // This class is self-referential: it holds the controller by value in
+    // `mAnyController`, and the type-erased `PixelIterator` inside it holds a
+    // raw pointer *into that member*. The compiler-generated move carried
+    // that pointer across unchanged, so the destination kept reading the
+    // source's controller -- and where the source was a temporary, as in
+    // `Channel::showPixels`'s addressing branch, that was a read of dead
+    // stack on every addressed frame. ASAN called it stack-use-after-scope.
+    //
+    // Assigning from a temporary inside a scope that then ends is the shape
+    // that crashed; reading the right bytes afterwards is the claim.
+    CRGB leds[2] = {CRGB(10, 20, 30), CRGB(40, 50, 60)};
+
+    PixelController<RGB> source(leds, 2, ColorAdjustment::noAdjustment(), DISABLE_DITHER);
+    PixelIteratorAny adapter(source, RGB, Rgbw());
+    {
+        PixelController<RGB> temporary(leds, 2, ColorAdjustment::noAdjustment(), DISABLE_DITHER);
+        adapter = PixelIteratorAny(temporary, RGB, Rgbw());
+    }
+
+    fl::vector<u8> bytes;
+    drain(adapter, 2, &bytes);
+
+    FL_REQUIRE(bytes.size() == 6u);
+    FL_CHECK_EQ(static_cast<int>(bytes[0]), 10);
+    FL_CHECK_EQ(static_cast<int>(bytes[1]), 20);
+    FL_CHECK_EQ(static_cast<int>(bytes[2]), 30);
+    FL_CHECK_EQ(static_cast<int>(bytes[3]), 40);
+    FL_CHECK_EQ(static_cast<int>(bytes[4]), 50);
+    FL_CHECK_EQ(static_cast<int>(bytes[5]), 60);
+}
+
+FL_TEST_CASE("[#4201] A copied PixelIteratorAny is independent of its source") {
+    // The copy must own its iteration, not share the original's position --
+    // which it would if the copied pointer still aimed at the original's
+    // controller.
+    CRGB leds[2] = {CRGB(1, 2, 3), CRGB(4, 5, 6)};
+    PixelController<RGB> source(leds, 2, ColorAdjustment::noAdjustment(), DISABLE_DITHER);
+    PixelIteratorAny original(source, RGB, Rgbw());
+
+    // Consume the first pixel through the original.
+    fl::vector<u8> first;
+    drain(original, 1, &first);
+    FL_REQUIRE(first.size() == 3u);
+
+    PixelIteratorAny copy(original);
+
+    // The copy resumes where the original was, and advancing it must not
+    // move the original.
+    fl::vector<u8> from_copy;
+    drain(copy, 1, &from_copy);
+    fl::vector<u8> from_original;
+    drain(original, 1, &from_original);
+
+    FL_REQUIRE(from_copy.size() == 3u);
+    FL_REQUIRE(from_original.size() == 3u);
+    FL_CHECK_EQ(static_cast<int>(from_copy[0]), 4);
+    FL_CHECK_EQ(static_cast<int>(from_original[0]), 4);
+}
+
+FL_TEST_CASE("[#4201] Colour order survives the copy") {
+    // The order lives in which alternative `mAnyController` holds, so a copy
+    // that re-aims the iterator has to re-aim it at the *same* alternative.
+    CRGB leds[1] = {CRGB(10, 20, 30)};
+    PixelController<RGB> source(leds, 1, ColorAdjustment::noAdjustment(), DISABLE_DITHER);
+    PixelIteratorAny original(source, BGR, Rgbw());
+    PixelIteratorAny copy(original);
+
+    fl::vector<u8> bytes;
+    drain(copy, 1, &bytes);
+    FL_REQUIRE(bytes.size() == 3u);
+    FL_CHECK_EQ(static_cast<int>(bytes[0]), 30);
+    FL_CHECK_EQ(static_cast<int>(bytes[1]), 20);
+    FL_CHECK_EQ(static_cast<int>(bytes[2]), 10);
+}
+
+}  // FL_TEST_FILE

--- a/tests/fl/math/xymap.cpp
+++ b/tests/fl/math/xymap.cpp
@@ -3,6 +3,7 @@
 
 #include "fl/math/xymap.h"
 #include "fl/math/screenmap.h"
+#include "fl/math/xmap.h"
 #include "test.h"
 
 using namespace fl;
@@ -287,6 +288,35 @@ FL_TEST_CASE("XYMap addressing with GBR color order (another permutation)") {
     FL_CHECK_EQ(output[0].r, 1);
     FL_CHECK_EQ(output[1].r, 4);
     FL_CHECK_EQ(output[5].r, 10);
+}
+
+
+FL_TEST_CASE("[#4201] XYMap::fromXMap builds its own lookup table") {
+    // Regression. `fromXMap` asks `constructWithLookUpTable` to allocate the
+    // table and passes `nullptr` for the contents, meaning "I will fill it".
+    // The helper copied from that pointer unconditionally, so this crashed in
+    // `memcpy` -- taking every caller of `Channel::setScreenMap(const XMap&)`
+    // with it. The dormant `tests/fl/channels/channel.cpp` was the only thing
+    // exercising that path, so nothing caught it.
+    fl::XMap reverse = fl::XMap(4, true);
+    fl::XYMap mapped = fl::XYMap::fromXMap(reverse);
+
+    FL_CHECK_EQ(mapped.getWidth(), 4);
+    FL_CHECK_EQ(mapped.getHeight(), 1);
+    // Reverse addressing: physical 0 reads source 3, and so on.
+    for (fl::u16 i = 0; i < 4; ++i) {
+        FL_CHECK_EQ(mapped.mapToIndex(i, 0), reverse.mapToIndex(i));
+    }
+}
+
+FL_TEST_CASE("[#4201] constructWithLookUpTable copies a table when given one") {
+    // The other half of the same guard: a real table must still be copied,
+    // so the null case cannot be implemented by ignoring the argument.
+    const fl::u16 table[4] = {3, 2, 1, 0};
+    fl::XYMap mapped = fl::XYMap::constructWithLookUpTable(4, 1, table);
+    for (fl::u16 i = 0; i < 4; ++i) {
+        FL_CHECK_EQ(mapped.mapToIndex(i, 0), table[i]);
+    }
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Part of #4201.

#4201 reported that `tests/fl/channels/channel.cpp` registers no test cases and
that waking it segfaults. It turns out to hide **two separate live bugs** in
`src/`, both reachable from ordinary user code.

## 1. `PixelIteratorAny` is self-referential, with generated copy/move

The class holds the controller **by value** in `mAnyController`, and the
type-erased `PixelIterator` inside it holds a raw `void*` **into that member**.
It declared no copy or move, so the compiler-generated ones carried that
pointer across unchanged — leaving the destination reading the *source's*
controller.

`Channel::showPixels` assigns one from a temporary on its addressing branch:

```cpp
mPixelIterator = PixelIteratorAny(mAddressedController.value(), rgbOrder, rgbw, rgbww);
```

so **every channel with an XYMap or screen map has been reading dead stack on
every frame**. ASAN names it exactly:

```
ERROR: AddressSanitizer: stack-use-after-scope
READ of size 4 at ... 
    #0 PixelController<...>::has(int) src/pixel_controller.h:374
    #3 fl::detail::ScaledPixelIteratorRGB::advance()
    #6 fl::PixelIterator::writeAPA102<...>
    #7 fl::Channel::showPixels(...)
...
[1056, 1304) 'ref.tmp' (line 108) <== Memory access ... is inside this variable
```

`line 108` is the assignment above, in `channel.cpp.hpp`.

The class now has real copy and move members that re-aim the iterator at their
own controller through a new `bindIterator()`, which `init()` also ends with —
so every path that touches `mAnyController` goes through it.

## 2. `XYMap::fromXMap` memcpys from `nullptr`

```cpp
auto out = XYMap::constructWithLookUpTable(length, 1, nullptr);  // "allocate it, I'll fill it"
```
```cpp
fl::memcpy(out.mLookUpTable->getDataMutable(), lookUpTable, width * height * sizeof(u16));
```

So `Channel::setScreenMap(const XMap&)` segfaulted in `memcpy` **for every
caller**. A null table now leaves the allocation alone; `LUT16` allocates via
`PSRamAllocate(size, /*zero=*/true)`, so the unfilled case is an identity-free
map rather than garbage.

## Why `channel.cpp` stays dormant

With both crashes fixed the file runs 10 cases, and **4 still fail** on
behaviour unrelated to either:

| case | failure |
|---|---|
| Serpentine 2x2 with APA102 | every pixel R/B-swapped vs the expected APA102 `[br][B][G][R]` |
| XMap reverse with APA102 | same |
| [#2517] Normal flush path | `0 == 3` enqueue count |
| [#2517] Re-enabling the driver | latch counts off by one |

Each needs its own investigation to decide whether the test or the code is
wrong, and waking the file now would just turn CI red. Filed separately, so
`KNOWN_DORMANT` is unchanged here.

The fixes are covered directly instead, which is better regression coverage
than the original file gave: `tests/fl/gfx/pixel_iterator_any.cpp` (new, 3
cases) and two cases in `tests/fl/math/xymap.cpp`.

## Verification

Four mutations, all caught:

| mutation | result |
|---|---|
| remove the null-table guard | xymap test crashes |
| ignore the table argument entirely | `constructWithLookUpTable` copy test fails |
| restore compiler-generated copy/move | move test fails |
| copy ctor that skips `bindIterator()` | copy test fails |

`bash test --cpp --clean`: **384 passed, 0 failed** (300 unit, 84 examples).
The new test is also clean under ASAN, on the same build where the old path
reported `stack-use-after-scope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed copying and moving of pixel iterators so they continue reading from the correct data source.
  - Preserved color order when pixel iterators are copied.
  - Improved lookup-table handling for coordinate maps, including cases where no table is initially provided.

- **Tests**
  - Added regression coverage for pixel iterator copying, moving, and color ordering.
  - Added tests verifying coordinate-map lookup-table construction and value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->