### PR TITLE
feat(color): gamut mapper for two white emitters (P7, #4041)

### DIFF
--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -410,6 +410,25 @@ produced an optimal edge. Two whites of the *same* colour are the exception,
 and there the reference's own tie-break — lexicographically smallest drives —
 is the end the closed form takes anyway.
 
+### The mapper has to target the two-white hull too
+
+The same argument as one emitter down. Testing a two-white device against the
+*one-white* hull under-reports what it can produce, and every under-reported
+target gets compressed despite being reachable exactly.
+
+Measured on the corpus's cool/warm device, over a deterministic 4⁵ sweep of
+its own five-emitter zonotope — so every target is reachable by construction:
+**418 of 1024, 41%**, are refused by the one-white allocation. That is the
+same magnitude as the 43% the RGB-only solve refuses on a four-emitter device.
+
+So `mapAndAllocateRgbwwQ16` runs the same eight halvings as the other two
+paths and takes every feasibility decision through the two-white allocation.
+Its lightness bound is derived the same way, and the second white is worth
+having there: the brightest reachable D65 neutral goes from **87 723** to
+**98 293** in OKLab L (s16.16). Dropping the second white's column from the
+relaxation drops it to 87 424, below the one-white bound, which is what pins
+that term in the test suite.
+
 `allocateTwoWhiteDrivesQ16` is the s16.16 implementation. It costs up to 25
 divisions per pixel against the one-white path's six, which is recorded
 rather than optimized away: cross-multiplying the pairwise comparisons would

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -110,6 +110,17 @@ struct RgbwFeasible {
     }
 };
 
+/// Feasibility against the device's real hull when it has two white
+/// emitters.
+struct RgbwwFeasible {
+    const TwoWhiteAllocationQ16& allocation;
+
+    bool operator()(const i32 (&xyz)[3]) const FL_NO_EXCEPT {
+        i32 drives[5];
+        return allocateTwoWhiteDrivesQ16(allocation, xyz, drives);
+    }
+};
+
 /// Largest chroma factor the hull accepts, by a fixed count of halvings.
 ///
 /// Shared by both mappers so the search cannot drift between them; only the
@@ -357,6 +368,143 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
         drives[1] = 0;
         drives[2] = 0;
         drives[3] = 0;
+    }
+}
+
+
+bool buildGamutMapRgbwwQ16(const EmitterProfile& profile,
+                           const i32 (&white1_xyz)[3],
+                           const i32 (&white2_xyz)[3],
+                           WhiteAllocationPolicy policy,
+                           GamutMapRgbwwQ16* out) FL_NO_EXCEPT {
+    if (out == nullptr) {
+        return false;
+    }
+    if (!buildTwoWhiteAllocationQ16(profile, white1_xyz, white2_xyz, policy,
+                                    &out->allocation)) {
+        return false;
+    }
+
+    i32 neutral_drives[3];
+    solveRgbDrivesQ16(out->allocation.rgb_solve, kGamutD65Q16, neutral_drives);
+    for (int i = 0; i < 3; ++i) {
+        // As in the other two builds: every drive, not just the largest.
+        if (neutral_drives[i] <= 0) {
+            return false;
+        }
+    }
+
+    // The three-emitter bound, reached with both whites off, and always
+    // attainable.
+    i32 largest_neutral_drive = neutral_drives[0];
+    for (int i = 1; i < 3; ++i) {
+        if (neutral_drives[i] > largest_neutral_drive) {
+            largest_neutral_drive = neutral_drives[i];
+        }
+    }
+    i64 reachable = (static_cast<i64>(kGamutFullDrive) << 16) /
+                    static_cast<i64>(largest_neutral_drive);
+
+    // The one-white relaxation with a second white added. Along the D65 ray
+    // the RGB drives are `s*d0 - w1*dW1 - w2*dW2`, so the upper limit on
+    // drive i is loosest with each white at full when its column is positive
+    // and off when it is not -- hence a `max(.., 0)` term per white.
+    // Dropping the lower limits, and letting each channel choose its own
+    // whites, are both relaxations, so this is an upper bound.
+    //
+    // `per_white1` is not stored: the allocation keeps the second column and
+    // the difference, because that is all the per-pixel path needs. It is
+    // recovered here rather than widening the struct for a bind-time sum.
+    i64 optimistic = static_cast<i64>(kOklabQ16MaxMagnitude);
+    for (int i = 0; i < 3; ++i) {
+        const i32 per_white2 = out->allocation.per_white2[i];
+        const i32 per_white1 = out->allocation.difference[i] + per_white2;
+        i64 numerator = static_cast<i64>(kGamutFullDrive);
+        if (per_white1 > 0) {
+            numerator += static_cast<i64>(per_white1);
+        }
+        if (per_white2 > 0) {
+            numerator += static_cast<i64>(per_white2);
+        }
+        const i64 candidate =
+            (numerator << 16) / static_cast<i64>(neutral_drives[i]);
+        if (candidate < optimistic) {
+            optimistic = candidate;
+        }
+    }
+
+    // Bisected against the attainable bound rather than trusted, for exactly
+    // the reason spelled out on the one-white path: the relaxation enforces
+    // only the upper limits, and full white can push a different channel
+    // negative. Once per profile, never per pixel (A3/B11).
+    if (optimistic > reachable) {
+        i64 low = reachable;
+        i64 high = optimistic;
+        for (int step = 0; step < 24; ++step) {
+            const i64 middle = (low + high) / 2;
+            const i32 trial_scale = static_cast<i32>(middle);
+            const i32 trial[3] = {
+                scaleGamutQ16(kGamutD65Q16[0], trial_scale),
+                scaleGamutQ16(kGamutD65Q16[1], trial_scale),
+                scaleGamutQ16(kGamutD65Q16[2], trial_scale),
+            };
+            i32 trial_drives[5];
+            if (allocateTwoWhiteDrivesQ16(out->allocation, trial, trial_drives)) {
+                low = middle;
+            } else {
+                high = middle;
+            }
+        }
+        reachable = low;
+    }
+
+    const i32 scale = static_cast<i32>(reachable);
+    const i32 brightest_neutral[3] = {
+        scaleGamutQ16(kGamutD65Q16[0], scale),
+        scaleGamutQ16(kGamutD65Q16[1], scale),
+        scaleGamutQ16(kGamutD65Q16[2], scale),
+    };
+    i32 lab[3];
+    xyzToOklabQ16(brightest_neutral, lab);
+    out->max_neutral_lightness = lab[0];
+    return true;
+}
+
+void mapAndAllocateRgbwwQ16(const GamutMapRgbwwQ16& map, const i32 (&xyz)[3],
+                            i32 (&drives)[5]) FL_NO_EXCEPT {
+    if (allocateTwoWhiteDrivesQ16(map.allocation, xyz, drives)) {
+        // Already inside the device's hull, which with two whites is larger
+        // again than the one-white one.
+        return;
+    }
+
+    i32 lab[3];
+    xyzToOklabQ16(xyz, lab);
+    i32 lightness = lab[0];
+    if (lightness > map.max_neutral_lightness) {
+        lightness = map.max_neutral_lightness;
+    }
+    if (lightness < 0) {
+        lightness = 0;
+    }
+
+    const i32 factor =
+        largestFeasibleChroma(lab, lightness, RgbwwFeasible{map.allocation});
+    i32 mapped_xyz[3];
+    chromaCandidateXyz(lab, lightness, factor, mapped_xyz);
+    if (allocateTwoWhiteDrivesQ16(map.allocation, mapped_xyz, drives)) {
+        return;
+    }
+    // Same last resort as the other paths: the accepted candidate can fall a
+    // few ULP outside on the final re-solve, and the neutral at this
+    // lightness is guaranteed reachable by the bound above.
+    const i32 neutral_lab[3] = {lightness, 0, 0};
+    i32 neutral_xyz[3];
+    oklabToXyzQ16(neutral_lab, neutral_xyz);
+    if (!allocateTwoWhiteDrivesQ16(map.allocation, neutral_xyz, drives)) {
+        for (int i = 0; i < 5; ++i) {
+            drives[i] = 0;
+        }
     }
 }
 

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -268,6 +268,18 @@ bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
     i64 reachable = (static_cast<i64>(kGamutFullDrive) << 16) /
                     static_cast<i64>(largest_neutral_drive);
 
+    // Clamped for the same reason the three-emitter build clamps it, and to
+    // the same place: `buildRgbSolveMatrixQ16` accepts emitter luminances up
+    // to 1e6, so a profile bright enough to reach D65 on one or two raw
+    // units of drive puts `2^32 / largest` at or past i32's range -- exactly
+    // 2^31 at largest == 2. `optimistic` starts at `kOklabQ16MaxMagnitude`,
+    // so for such a profile the bisection below is skipped and the narrowing
+    // is reached directly. 64.0 is where the OKLab transform's domain ends,
+    // so nothing downstream can tell the difference.
+    if (reachable > kOklabQ16MaxMagnitude) {
+        reachable = kOklabQ16MaxMagnitude;
+    }
+
     // An upper bound on what the white emitter can add. Along the D65 ray
     // the RGB drives are s * d0 - w * dW, so the *upper* limit on drive i is
     // loosest at w = 1 when dW_i is positive and at w = 0 when it is
@@ -404,6 +416,18 @@ bool buildGamutMapRgbwwQ16(const EmitterProfile& profile,
     }
     i64 reachable = (static_cast<i64>(kGamutFullDrive) << 16) /
                     static_cast<i64>(largest_neutral_drive);
+
+    // Clamped for the same reason the three-emitter build clamps it, and to
+    // the same place: `buildRgbSolveMatrixQ16` accepts emitter luminances up
+    // to 1e6, so a profile bright enough to reach D65 on one or two raw
+    // units of drive puts `2^32 / largest` at or past i32's range -- exactly
+    // 2^31 at largest == 2. `optimistic` starts at `kOklabQ16MaxMagnitude`,
+    // so for such a profile the bisection below is skipped and the narrowing
+    // is reached directly. 64.0 is where the OKLab transform's domain ends,
+    // so nothing downstream can tell the difference.
+    if (reachable > kOklabQ16MaxMagnitude) {
+        reachable = kOklabQ16MaxMagnitude;
+    }
 
     // The one-white relaxation with a second white added. Along the D65 ray
     // the RGB drives are `s*d0 - w1*dW1 - w2*dW2`, so the upper limit on

--- a/src/fl/gfx/gamut_map.h
+++ b/src/fl/gfx/gamut_map.h
@@ -105,6 +105,48 @@ bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
 void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
                            i32 (&drives)[4]) FL_NO_EXCEPT;
 
+/// The same mapper for a device with two white emitters.
+///
+/// Two whites enlarge the reachable set again, and the one-white mapper
+/// under-reports it for the same reason the three-emitter one under-reports
+/// a device with one white: it tests feasibility against a hull the device
+/// is bigger than. `tests/fl/gfx/gamut_map.cpp` measures how much on the
+/// corpus's cool/warm device.
+struct GamutMapRgbwwQ16 {
+    TwoWhiteAllocationQ16 allocation;
+
+    /// OKLab lightness of the brightest D65 neutral this device can reach.
+    ///
+    /// Derived the same way as the one-white bound and for the same reason:
+    /// the relaxation that ignores the lower limits on the RGB drives is an
+    /// upper bound but not attainable, so it is bisected against the
+    /// always-reachable three-emitter bound rather than trusted. Once per
+    /// profile, never per pixel.
+    i32 max_neutral_lightness;
+};
+
+/// Derive the mapper for a three-primary profile plus two white emitters.
+///
+/// `white1_xyz` / `white2_xyz` are each white's XYZ at full drive, in
+/// s16.16. `policy` is C3's per-profile choice of which end of the feasible
+/// *total* to take; as with one white it changes the drives, never which
+/// targets are reachable.
+bool buildGamutMapRgbwwQ16(const EmitterProfile& profile,
+                           const i32 (&white1_xyz)[3],
+                           const i32 (&white2_xyz)[3],
+                           WhiteAllocationPolicy policy,
+                           GamutMapRgbwwQ16* out) FL_NO_EXCEPT;
+
+/// One pixel: XYZ in s16.16 to five in-gamut drives -- red, green, blue,
+/// white1, white2.
+///
+/// Same shape as the other two paths: one forward OKLab transform, one
+/// lightness comparison, then eight halvings, with every feasibility test
+/// going through the two-white allocation so the hull is the device's real
+/// one.
+void mapAndAllocateRgbwwQ16(const GamutMapRgbwwQ16& map, const i32 (&xyz)[3],
+                            i32 (&drives)[5]) FL_NO_EXCEPT;
+
 /// Derive the mapper for a three-emitter profile.
 ///
 /// False on the same degenerate profiles `buildRgbSolveMatrixQ16` rejects,

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -932,15 +932,29 @@ FL_TEST_CASE("RGBWW mapper always returns drives inside [0, 1]") {
         const float xyz_f[3] = {6.0f * t + 0.05f, 1.5f * t + 0.02f,
                                 9.0f * (1.0f - t) + 0.05f};
         const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+
+        // Count only the targets that actually reach the halving search.
+        // Incrementing on every iteration would have made the assertion
+        // below restate the loop bound: it could not fail, and if the hull
+        // ever grew to contain all of these the compression path would go
+        // untested in silence.
+        i32 probe[5];
+        const bool needs_compression =
+            !allocateTwoWhiteDrivesQ16(map.allocation, xyz, probe);
+
         i32 drives[5];
         mapAndAllocateRgbwwQ16(map, xyz, drives);
         for (int i = 0; i < 5; ++i) {
             FL_CHECK_GE(drives[i], 0);
             FL_CHECK_LE(drives[i], kFullDrive);
         }
-        ++exercised;
+        if (needs_compression) {
+            ++exercised;
+        }
     }
-    FL_CHECK_EQ(exercised, 21);
+    // Most of this ramp is outside the hull; the assertion is that it is
+    // genuinely being compressed, not that the loop ran.
+    FL_CHECK_GT(exercised, 10);
 }
 
 FL_TEST_CASE("RGBWW mapper moves smoothly enough to animate") {
@@ -1028,6 +1042,55 @@ FL_TEST_CASE("RGBWW mapper rejects a degenerate profile") {
     FL_CHECK_FALSE(buildGamutMapRgbwwQ16(broken, kWhiteD65, kWhiteD50Map,
                                          WhiteAllocationPolicy::WhitePreferred,
                                          &map));
+}
+
+
+FL_TEST_CASE("White-emitter builds survive a profile bright enough to overflow") {
+    // The three-emitter build clamps `2^32 / largest_neutral_drive` before
+    // narrowing it, because `EmitterProfile` accepts luminances up to 1e6 and
+    // a profile reaching D65 on one or two raw units of drive puts that at
+    // 2^31. Both white builds compute the same quantity, and neither clamped
+    // it: `optimistic` starts at `kOklabQ16MaxMagnitude`, so for such a
+    // profile the bisection is skipped and the unclamped value is narrowed
+    // directly -- implementation-defined, and the stored bound meaningless.
+    //
+    // Same fixture as the three-emitter case, for the same reason: a uniform
+    // huge luminance does not reach the overflow, because every drive rounds
+    // to zero and the neutral check rejects the profile first.
+    EmitterProfile blazing = rgbDevice();
+    blazing.lum_r = 6966.4768f;
+    blazing.lum_g = 23435.6736f;
+    blazing.lum_b = 2365.8496f;
+
+    // Pin that the fixture really does reach the overflow case.
+    EmitterSolveMatrixQ16 probe;
+    FL_REQUIRE(buildRgbSolveMatrixQ16(blazing, &probe));
+    i32 neutral[3];
+    const i32 d65[3] = {62289, 65536, 71372};
+    solveRgbDrivesQ16(probe, d65, neutral);
+    i32 largest = 0;
+    for (int i = 0; i < 3; ++i) {
+        FL_REQUIRE_GT(neutral[i], 0);
+        if (neutral[i] > largest) {
+            largest = neutral[i];
+        }
+    }
+    FL_REQUIRE_LE(largest, 2);
+
+    GamutMapRgbwQ16 one;
+    if (buildGamutMapRgbwQ16(blazing, kWhiteD65,
+                             WhiteAllocationPolicy::WhitePreferred, &one)) {
+        // A sane, positive bound rather than a narrowed 2^31.
+        FL_CHECK_GT(one.max_neutral_lightness, 0);
+        FL_CHECK_LE(one.max_neutral_lightness, kOklabQ16MaxMagnitude);
+    }
+
+    GamutMapRgbwwQ16 two;
+    if (buildGamutMapRgbwwQ16(blazing, kWhiteD65, kWhiteD50Map,
+                              WhiteAllocationPolicy::WhitePreferred, &two)) {
+        FL_CHECK_GT(two.max_neutral_lightness, 0);
+        FL_CHECK_LE(two.max_neutral_lightness, kOklabQ16MaxMagnitude);
+    }
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -792,4 +792,242 @@ FL_TEST_CASE("Gamut map rejects a degenerate profile") {
     FL_CHECK_FALSE(buildGamutMapQ16(rgbDevice(), nullptr));
 }
 
+
+// ---------------------------------------------------------------------------
+// Two white emitters (P7, #4041)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// The corpus's warm white: D50 at unit luminance, in s16.16.
+constexpr i32 kWhiteD50Map[3] = {63196, 65536, 54074};
+
+/// XYZ of a five-emitter drive vector on the cool/warm device.
+void reproduceRgbww(const float (&drives)[5], float (&out)[3]) {
+    const EmitterProfile profile = rgbDevice();
+    float columns[5][3];
+    colorimetric_response::xyY_to_XYZ(profile.xy_r[0], profile.xy_r[1],
+                                      profile.lum_r, columns[0]);
+    colorimetric_response::xyY_to_XYZ(profile.xy_g[0], profile.xy_g[1],
+                                      profile.lum_g, columns[1]);
+    colorimetric_response::xyY_to_XYZ(profile.xy_b[0], profile.xy_b[1],
+                                      profile.lum_b, columns[2]);
+    for (int i = 0; i < 3; ++i) {
+        columns[3][i] = toFloat(kWhiteD65[i]);
+        columns[4][i] = toFloat(kWhiteD50Map[i]);
+    }
+    for (int i = 0; i < 3; ++i) {
+        out[i] = 0.0f;
+        for (int e = 0; e < 5; ++e) {
+            out[i] += columns[e][i] * drives[e];
+        }
+    }
+}
+
+}  // namespace
+
+FL_TEST_CASE("RGBWW mapper leaves alone what the one-white hull wrongly rejects") {
+    // The reason this variant exists, and the same argument the RGBW variant
+    // makes one emitter down: testing a two-white device against the
+    // one-white hull under-reports what it can produce, and every
+    // under-reported target gets compressed despite being reachable exactly.
+    //
+    // Measured here rather than asserted: targets are drawn from inside the
+    // device's own five-emitter zonotope, so every one is reachable by
+    // construction, and the count is how many the one-white allocation
+    // refuses.
+    GamutMapRgbwwQ16 rgbww;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &rgbww));
+    WhiteAllocationQ16 one_white;
+    FL_REQUIRE(buildWhiteAllocationQ16(rgbDevice(), kWhiteD65,
+                                       WhiteAllocationPolicy::WhitePreferred,
+                                       &one_white));
+
+    int reachable = 0;
+    int refused_by_one_white = 0;
+    // A deterministic sweep of the zonotope rather than a random one, so the
+    // number this reports is the same on every machine.
+    for (int r = 0; r <= 3; ++r) {
+        for (int g = 0; g <= 3; ++g) {
+            for (int b = 0; b <= 3; ++b) {
+                for (int w1 = 0; w1 <= 3; ++w1) {
+                    for (int w2 = 0; w2 <= 3; ++w2) {
+                        const float sample[5] = {
+                            static_cast<float>(r) / 3.0f,
+                            static_cast<float>(g) / 3.0f,
+                            static_cast<float>(b) / 3.0f,
+                            static_cast<float>(w1) / 3.0f,
+                            static_cast<float>(w2) / 3.0f};
+                        float xyz_f[3];
+                        reproduceRgbww(sample, xyz_f);
+                        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]),
+                                            q16(xyz_f[2])};
+
+                        i32 five[5];
+                        FL_REQUIRE(allocateTwoWhiteDrivesQ16(rgbww.allocation,
+                                                             xyz, five));
+                        ++reachable;
+
+                        i32 four[4];
+                        if (!allocateEmitterDrivesQ16(one_white, xyz, four)) {
+                            ++refused_by_one_white;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    FL_CHECK_EQ(reachable, 1024);
+    // Not a rare corner. If this ever drops to zero the test has stopped
+    // measuring anything and the variant has stopped being justified.
+    FL_CHECK_GT(refused_by_one_white, 100);
+}
+
+FL_TEST_CASE("RGBWW mapper returns an in-gamut target untouched") {
+    GamutMapRgbwwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+
+    const float samples[][5] = {
+        {0.20f, 0.40f, 0.60f, 0.30f, 0.10f},
+        {0.10f, 0.90f, 0.20f, 0.70f, 0.60f},
+        {0.05f, 0.05f, 0.05f, 0.90f, 0.90f},
+    };
+    for (const auto& sample : samples) {
+        float xyz_f[3];
+        reproduceRgbww(sample, xyz_f);
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+
+        i32 drives[5];
+        mapAndAllocateRgbwwQ16(map, xyz, drives);
+
+        float as_float[5];
+        for (int i = 0; i < 5; ++i) {
+            as_float[i] = toFloat(drives[i]);
+        }
+        float reproduced[3];
+        reproduceRgbww(as_float, reproduced);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_LT(fl::fabsf(reproduced[i] - xyz_f[i]), 0.01f);
+        }
+    }
+}
+
+FL_TEST_CASE("RGBWW mapper always returns drives inside [0, 1]") {
+    // Including for targets far outside the hull, which is the case the
+    // halving search and its fallback exist for.
+    GamutMapRgbwwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+
+    int exercised = 0;
+    for (int step = 0; step <= 20; ++step) {
+        const float t = static_cast<float>(step) / 20.0f;
+        // A saturated ramp pushed well past anything the device can make.
+        const float xyz_f[3] = {6.0f * t + 0.05f, 1.5f * t + 0.02f,
+                                9.0f * (1.0f - t) + 0.05f};
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+        i32 drives[5];
+        mapAndAllocateRgbwwQ16(map, xyz, drives);
+        for (int i = 0; i < 5; ++i) {
+            FL_CHECK_GE(drives[i], 0);
+            FL_CHECK_LE(drives[i], kFullDrive);
+        }
+        ++exercised;
+    }
+    FL_CHECK_EQ(exercised, 21);
+}
+
+FL_TEST_CASE("RGBWW mapper moves smoothly enough to animate") {
+    // P7's continuity criterion, for the two-white hull. A ramp that crosses
+    // out of the gamut must not jump: neighbouring inputs one step apart
+    // have to land within a bounded distance of each other, or an animation
+    // walking through the boundary shows a visible seam.
+    GamutMapRgbwwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+
+    const int kSteps = 240;
+    float previous[3] = {0.0f, 0.0f, 0.0f};
+    float worst_jump = 0.0f;
+    for (int step = 0; step <= kSteps; ++step) {
+        const float t = static_cast<float>(step) / static_cast<float>(kSteps);
+        // Sweeps from deep inside the hull to well outside it.
+        const float xyz_f[3] = {0.2f + 4.0f * t, 0.3f + 3.0f * t,
+                                0.4f + 5.0f * t};
+        const i32 xyz[3] = {q16(xyz_f[0]), q16(xyz_f[1]), q16(xyz_f[2])};
+        i32 drives[5];
+        mapAndAllocateRgbwwQ16(map, xyz, drives);
+
+        float as_float[5];
+        for (int i = 0; i < 5; ++i) {
+            as_float[i] = toFloat(drives[i]);
+        }
+        float produced[3];
+        reproduceRgbww(as_float, produced);
+
+        if (step > 0) {
+            for (int i = 0; i < 3; ++i) {
+                const float jump = fl::fabsf(produced[i] - previous[i]);
+                if (jump > worst_jump) {
+                    worst_jump = jump;
+                }
+            }
+        }
+        for (int i = 0; i < 3; ++i) {
+            previous[i] = produced[i];
+        }
+    }
+    // The input moves about 0.05 per step in Y. A mapper that stepped
+    // discontinuously at the hull boundary would show a jump many times
+    // that; this bounds it at one input step's worth.
+    FL_CHECK_LT(worst_jump, 0.05f);
+}
+
+FL_TEST_CASE("RGBWW lightness bound is the brightest neutral it can reach") {
+    // Two whites buy more neutral headroom than one, and the bound has to
+    // find it -- and still be attainable, which the bisection is for.
+    GamutMapRgbwwQ16 two;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &two));
+    GamutMapRgbwQ16 one;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                    WhiteAllocationPolicy::WhitePreferred,
+                                    &one));
+    FL_CHECK_GT(two.max_neutral_lightness, one.max_neutral_lightness);
+
+    // Attainable, not merely optimistic: the neutral at the stored bound
+    // must actually allocate.
+    const i32 neutral_lab[3] = {two.max_neutral_lightness, 0, 0};
+    i32 neutral_xyz[3];
+    oklabToXyzQ16(neutral_lab, neutral_xyz);
+    i32 drives[5];
+    FL_CHECK(allocateTwoWhiteDrivesQ16(two.allocation, neutral_xyz, drives));
+
+    // And a hair above it is not, so the bound is tight rather than timid.
+    const i32 above_lab[3] = {two.max_neutral_lightness + 2000, 0, 0};
+    i32 above_xyz[3];
+    oklabToXyzQ16(above_lab, above_xyz);
+    i32 above_drives[5];
+    FL_CHECK_FALSE(allocateTwoWhiteDrivesQ16(two.allocation, above_xyz,
+                                             above_drives));
+}
+
+FL_TEST_CASE("RGBWW mapper rejects a degenerate profile") {
+    EmitterProfile broken = rgbDevice();
+    broken.xy_g[0] = broken.xy_r[0];
+    broken.xy_g[1] = broken.xy_r[1];
+    GamutMapRgbwwQ16 map;
+    FL_CHECK_FALSE(buildGamutMapRgbwwQ16(broken, kWhiteD65, kWhiteD50Map,
+                                         WhiteAllocationPolicy::WhitePreferred,
+                                         &map));
+}
+
 }  // FL_TEST_FILE

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1077,9 +1077,17 @@ FL_TEST_CASE("White-emitter builds survive a profile bright enough to overflow")
     }
     FL_REQUIRE_LE(largest, 2);
 
+    // Both bound checks are conditional, because a build is allowed to
+    // reject this profile outright. Counting them is what stops the test
+    // passing while asserting nothing at all: if both builds ever started
+    // refusing the fixture, the clamp regression coverage would vanish in
+    // silence -- the same vacuity the `exercised` counter above had.
+    int built = 0;
+
     GamutMapRgbwQ16 one;
     if (buildGamutMapRgbwQ16(blazing, kWhiteD65,
                              WhiteAllocationPolicy::WhitePreferred, &one)) {
+        ++built;
         // A sane, positive bound rather than a narrowed 2^31.
         FL_CHECK_GT(one.max_neutral_lightness, 0);
         FL_CHECK_LE(one.max_neutral_lightness, kOklabQ16MaxMagnitude);
@@ -1088,9 +1096,12 @@ FL_TEST_CASE("White-emitter builds survive a profile bright enough to overflow")
     GamutMapRgbwwQ16 two;
     if (buildGamutMapRgbwwQ16(blazing, kWhiteD65, kWhiteD50Map,
                               WhiteAllocationPolicy::WhitePreferred, &two)) {
+        ++built;
         FL_CHECK_GT(two.max_neutral_lightness, 0);
         FL_CHECK_LE(two.max_neutral_lightness, kOklabQ16MaxMagnitude);
     }
+
+    FL_CHECK_GT(built, 0);
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Part of #4041 (P7), under #4034. Builds on #4236.

## The gap

P7 asks for the white emitter to be **"included in the gamut volume the mapper
targets"**. `GamutMapRgbwQ16` does that for one white. A device with two had
nothing — it had to map against the one-white hull, which under-reports what it
can produce for exactly the reason the three-emitter mapper under-reports a
device with one white.

## Measured, not argued

Over a deterministic 4⁵ sweep of the cool/warm device's own five-emitter
zonotope — so every target is reachable by construction:

| | |
|---|---:|
| reachable targets swept | 1024 |
| **refused by the one-white allocation** | **418 (41%)** |

Every one of those would have been compressed despite the device reproducing it
exactly. That is the same magnitude as the **43%** the RGB-only solve refuses on
a four-emitter device — the measurement that justified the one-white variant in
the first place.

The sweep is deterministic rather than random so the number is the same on every
machine, and the test asserts it stays well above zero: if it ever collapses,
the variant has stopped being justified and the test says so instead of going
quiet.

## The implementation

`mapAndAllocateRgbwwQ16` keeps the shape of the other two paths — one forward
OKLab transform, one lightness comparison, eight halvings, **no per-pixel
iteration** (A3/B11) — with every feasibility test going through
`allocateTwoWhiteDrivesQ16`, so the hull is the device's real one.

The lightness bound generalizes the one-white relaxation by adding a term per
white, then **bisects against the always-attainable three-emitter bound rather
than trusting it**, for the reason already spelled out on the one-white path:
the relaxation enforces only the upper limits, and full white can push a
different channel negative. Once per profile, never per pixel.

The second white is worth having there — brightest reachable D65 neutral, OKLab
L in s16.16:

| | |
|---|---:|
| one white | 87,723 |
| **two whites** | **98,293** |

`per_white1` is reconstructed from the difference column rather than widening
`TwoWhiteAllocationQ16`, which deliberately keeps only what the per-pixel path
needs.

## Tests

P7's acceptance criterion for this hull: in-gamut targets untouched, drives
always inside `[0, 1]` including far outside the hull, the bound both
**attainable** (the neutral at it allocates) and **tight** (a hair above it does
not), degenerate-profile rejection, and **continuity** — a 240-step ramp
crossing out of the gamut, worst inter-step jump 0.025 against a bound of 0.05.

Three mutations, all caught:

| mutation | result |
|---|---|
| feasibility tested through the one-white allocation | in-gamut test fails |
| the accepted candidate discarded | in-gamut test fails |
| first white dropped from the optimistic bound | bound falls to 87,424, below the one-white bound |

**One process note.** I first read that third mutation as surviving. It had
failed to *compile* — `-Werror` on the now-unused variable — and a build failure
produces no `FAIL:` lines, so counting those read as zero failures. Redone so it
builds, it is caught. A mutation that does not compile looks exactly like one
that survives if you only count assertions.

`bash test --cpp --clean`: 383 passed, 0 failed. `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gamut mapping for displays with RGB plus two white emitters.
  * Converts out-of-gamut colors into valid five-channel drive values while preserving lightness and color quality where possible.
  * Improves reachable neutral brightness compared with one-white mapping.
  * Handles profiles with very limited neutral-drive ranges safely.

* **Tests**
  * Added coverage for reachability, drive limits, smooth transitions, brightness bounds, and invalid profiles.

* **Documentation**
  * Documented two-white gamut behavior and reachable brightness improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->