### PR TITLE
ci(esp32s3): show where the flash went when the bloat gate fails (#4165)

### DIFF
--- a/ci/tests/test_esp32s3_bloat_report.py
+++ b/ci/tests/test_esp32s3_bloat_report.py
@@ -16,9 +16,7 @@ from tests.test_esp32s3_bloat_regression import largest_flash_symbols
 
 
 @typechecked
-def _symbol(
-    size: int, name: str, region: str = "flash", archive: str = "libFastLED.a"
-) -> dict[str, Any]:
+def _symbol(size: int, name: str, region: str, archive: str) -> dict[str, Any]:
     return {
         "mangled": f"_Z{len(name)}{name}",
         "demangled": name,
@@ -33,9 +31,9 @@ def _symbol(
 def test_largest_symbols_are_ordered_by_size() -> None:
     report = {
         "symbols": [
-            _symbol(100, "small"),
-            _symbol(9000, "huge"),
-            _symbol(2500, "middling"),
+            _symbol(100, "small", "flash", "libFastLED.a"),
+            _symbol(9000, "huge", "flash", "libFastLED.a"),
+            _symbol(2500, "middling", "flash", "libFastLED.a"),
         ]
     }
     got = largest_flash_symbols(report, 3)
@@ -49,8 +47,8 @@ def test_only_flash_symbols_are_counted() -> None:
 
     report = {
         "symbols": [
-            _symbol(9000, "in_ram", region="ram"),
-            _symbol(120, "in_flash"),
+            _symbol(9000, "in_ram", "ram", "libFastLED.a"),
+            _symbol(120, "in_flash", "flash", "libFastLED.a"),
         ]
     }
     got = largest_flash_symbols(report, 5)
@@ -67,11 +65,11 @@ def test_unsized_and_malformed_entries_are_skipped() -> None:
 
     report = {
         "symbols": [
-            _symbol(0, "zero_sized"),
+            _symbol(0, "zero_sized", "flash", "libFastLED.a"),
             {"demangled": "no_size", "region": "flash"},
             {"size": 500, "region": "flash"},  # no name at all
             "not a dict",
-            _symbol(700, "real"),
+            _symbol(700, "real", "flash", "libFastLED.a"),
         ]
     }
     got = largest_flash_symbols(report, 5)
@@ -86,6 +84,32 @@ def test_a_report_without_symbols_yields_nothing() -> None:
 
 @typechecked
 def test_the_count_is_respected() -> None:
-    report = {"symbols": [_symbol(i * 10, f"sym{i}") for i in range(1, 40)]}
+    symbols: list[dict[str, Any]] = []
+    for index in range(1, 40):
+        symbols.append(_symbol(index * 10, f"sym{index}", "flash", "libFastLED.a"))
+    report = {"symbols": symbols}
     assert len(largest_flash_symbols(report, 25)) == 25
     assert len(largest_flash_symbols(report, 5)) == 5
+
+
+@typechecked
+def test_a_boolean_size_is_not_a_one_byte_symbol() -> None:
+    """`isinstance(True, int)` is true in Python.
+
+    A JSON `true` in the size field would otherwise be accepted as a one-byte
+    flash symbol and could displace a real entry from a 25-row table.
+    """
+
+    report = {
+        "symbols": [
+            {
+                "demangled": "boolean_size",
+                "size": True,
+                "region": "flash",
+                "archive": "libFastLED.a",
+            },
+            _symbol(700, "real", "flash", "libFastLED.a"),
+        ]
+    }
+    got = largest_flash_symbols(report, 5)
+    assert [s.name for s in got] == ["real"]

--- a/ci/tests/test_esp32s3_bloat_report.py
+++ b/ci/tests/test_esp32s3_bloat_report.py
@@ -1,0 +1,91 @@
+"""The bloat gate must show where the flash went, not send you to rebuild it.
+
+The gate holds `report.json` on the very runner that produced it, and used to
+respond to a regression by telling the reader to run `bash bloat esp32s3`
+locally -- which means an ESP32 toolchain and a three-minute compile to see
+data CI already had (FastLED#4165).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typeguard import typechecked
+
+from tests.test_esp32s3_bloat_regression import largest_flash_symbols
+
+
+@typechecked
+def _symbol(
+    size: int, name: str, region: str = "flash", archive: str = "libFastLED.a"
+) -> dict[str, Any]:
+    return {
+        "mangled": f"_Z{len(name)}{name}",
+        "demangled": name,
+        "size": size,
+        "region": region,
+        "archive": archive,
+        "object": "fl.gfx+_abcd.o",
+    }
+
+
+@typechecked
+def test_largest_symbols_are_ordered_by_size() -> None:
+    report = {
+        "symbols": [
+            _symbol(100, "small"),
+            _symbol(9000, "huge"),
+            _symbol(2500, "middling"),
+        ]
+    }
+    got = largest_flash_symbols(report, 3)
+    assert [s.name for s in got] == ["huge", "middling", "small"]
+    assert [s.size for s in got] == [9000, 2500, 100]
+
+
+@typechecked
+def test_only_flash_symbols_are_counted() -> None:
+    """A RAM symbol is not flash, and the gate is a flash gate."""
+
+    report = {
+        "symbols": [
+            _symbol(9000, "in_ram", region="ram"),
+            _symbol(120, "in_flash"),
+        ]
+    }
+    got = largest_flash_symbols(report, 5)
+    assert [s.name for s in got] == ["in_flash"]
+
+
+@typechecked
+def test_unsized_and_malformed_entries_are_skipped() -> None:
+    """The report is data from another tool; it must not crash the gate.
+
+    A regression report that raised here would replace a legible byte count
+    with a traceback, which is worse than the behaviour being fixed.
+    """
+
+    report = {
+        "symbols": [
+            _symbol(0, "zero_sized"),
+            {"demangled": "no_size", "region": "flash"},
+            {"size": 500, "region": "flash"},  # no name at all
+            "not a dict",
+            _symbol(700, "real"),
+        ]
+    }
+    got = largest_flash_symbols(report, 5)
+    assert [s.name for s in got] == ["real", "(anonymous)"]
+
+
+@typechecked
+def test_a_report_without_symbols_yields_nothing() -> None:
+    assert largest_flash_symbols({}, 10) == []
+    assert largest_flash_symbols({"symbols": "not a list"}, 10) == []
+
+
+@typechecked
+def test_the_count_is_respected() -> None:
+    report = {"symbols": [_symbol(i * 10, f"sym{i}") for i in range(1, 40)]}
+    assert len(largest_flash_symbols(report, 25)) == 25
+    assert len(largest_flash_symbols(report, 5)) == 5

--- a/tests/test_esp32s3_bloat_regression.py
+++ b/tests/test_esp32s3_bloat_regression.py
@@ -29,7 +29,9 @@ import argparse
 import json
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -46,6 +48,78 @@ def read_baseline() -> int:
         )
         sys.exit(2)
     return int(raw)
+
+
+@dataclass(frozen=True, slots=True)
+class FlashSymbol:
+    """One sized symbol from the bloat report."""
+
+    size: int
+    name: str
+    archive: str
+    object_file: str
+
+
+def largest_flash_symbols(report: dict[str, Any], count: int) -> list[FlashSymbol]:
+    """The `count` biggest flash symbols in the report, largest first."""
+
+    raw = report.get("symbols")
+    if not isinstance(raw, list):
+        return []
+    sized: list[FlashSymbol] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("region") != "flash":
+            continue
+        size = entry.get("size")
+        if not isinstance(size, int) or size <= 0:
+            continue
+        name = entry.get("demangled") or entry.get("mangled") or "(anonymous)"
+        sized.append(
+            FlashSymbol(
+                size=size,
+                name=str(name),
+                archive=str(entry.get("archive") or "(none)"),
+                object_file=str(entry.get("object") or "(none)"),
+            )
+        )
+    sized.sort(key=lambda symbol: symbol.size, reverse=True)
+    return sized[:count]
+
+
+def print_largest_symbols(report: dict[str, Any], count: int) -> None:
+    """Print the biggest flash symbols this build produced.
+
+    The gate has `report.json` in hand on the runner that built it, and used
+    to tell the reader to reproduce the build locally instead -- which means
+    an ESP32 toolchain and a three-minute compile to see data CI already had
+    (#4165). Printing it turns "go and reproduce this" into "here is where
+    the bytes went".
+    """
+
+    symbols = largest_flash_symbols(report, count)
+    if not symbols:
+        print(
+            "esp32s3-bloat-regression: report.json carried no sized flash "
+            "symbols, so there is no table to show.",
+            file=sys.stderr,
+        )
+        return
+    print(
+        f"esp32s3-bloat-regression: {len(symbols)} largest flash symbols in "
+        "this build:",
+        file=sys.stderr,
+    )
+    print(f"    {'BYTES':>9}  {'ARCHIVE':<22} SYMBOL", file=sys.stderr)
+    for symbol in symbols:
+        name = symbol.name
+        if len(name) > 88:
+            name = name[:85] + "..."
+        print(
+            f"    {symbol.size:>9,}  {symbol.archive[:22]:<22} {name}",
+            file=sys.stderr,
+        )
 
 
 def run_bloat(skip_build: bool) -> None:
@@ -114,15 +188,13 @@ def main() -> int:
     print(
         "esp32s3-bloat-regression: if the regression is intentional, update "
         f"{BASELINE_FILE.relative_to(PROJECT_ROOT).as_posix()} in the same PR. "
-        "Otherwise inspect the top-N table:",
+        "Otherwise, this is where the flash went:",
         file=sys.stderr,
     )
+    print_largest_symbols(data, 25)
     print(
-        "    bash bloat esp32s3 --top 25",
-        file=sys.stderr,
-    )
-    print(
-        "Then diff against the previous build with "
+        "esp32s3-bloat-regression: to compare against another build, run "
+        "`bash bloat esp32s3 --top 25` locally and diff with "
         ".claude/symbolaudit/diff.py (see agents/docs/binary-size-analysis.md).",
         file=sys.stderr,
     )

--- a/tests/test_esp32s3_bloat_regression.py
+++ b/tests/test_esp32s3_bloat_regression.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from typeguard import typechecked
+
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_FILE = PROJECT_ROOT / "tests" / "data" / "esp32s3_bloat_baseline.txt"
@@ -50,6 +52,7 @@ def read_baseline() -> int:
     return int(raw)
 
 
+@typechecked
 @dataclass(frozen=True, slots=True)
 class FlashSymbol:
     """One sized symbol from the bloat report."""
@@ -73,7 +76,10 @@ def largest_flash_symbols(report: dict[str, Any], count: int) -> list[FlashSymbo
         if entry.get("region") != "flash":
             continue
         size = entry.get("size")
-        if not isinstance(size, int) or size <= 0:
+        # `isinstance(True, int)` is true in Python, so a JSON `true` would
+        # otherwise be accepted as a one-byte symbol and could displace a real
+        # entry from the table.
+        if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
             continue
         name = entry.get("demangled") or entry.get("mangled") or "(anonymous)"
         sized.append(


### PR DESCRIPTION
Part of #4165.

## The gate throws away the answer

The bloat gate parses `report.json` for `total_flash` — and on a regression tells
the reader to go and reproduce the build:

```
esp32s3-bloat-regression: FAIL — total_flash=342,843 B exceeds baseline=342,409 B by 434 B.
esp32s3-bloat-regression: ... Otherwise inspect the top-N table:
    bash bloat esp32s3 --top 25
```

That advice is unactionable on a hosted runner, and it needs an ESP32 toolchain
and a three-minute compile from anyone else — to see data the failing job was
already holding. It is why the 434 B regression on #4200 has sat undiagnosed
across several iterations: the number was visible and its cause was not.

## What it prints now

The 25 largest flash symbols, with sizes and owning archives, from the report it
had already loaded. Real output, exercised against this repo's own 4,289-symbol
report:

```
esp32s3-bloat-regression: ... Otherwise, this is where the flash went:
esp32s3-bloat-regression: 25 largest flash symbols in this build:
        BYTES  ARCHIVE                SYMBOL
       60,188  (none)                 fl::ClocklessIdf5<4, fl::TIMING_WS2812_800KHZ, ...
       11,413  libc.a                 _vfprintf_r
        4,036  libFastLED.a           fl::Channel::showPixels(PixelController<...>&)
        1,151  libFastLED.a           fl::basic_string::write(char const*, unsigned int)
        ...
```

The pointer to `.claude/symbolaudit/diff.py` for cross-build comparison stays —
that genuinely does need two builds.

## Defensive on purpose

`report.json` is another tool's output, so a malformed or unsized entry is
skipped rather than raised on. A traceback there would replace a legible byte
count with a crash, which is strictly worse than the behaviour being fixed.

## Verification

Exercised end to end against the real report by forcing a failure
(`--no-build --baseline 1`), plus five unit tests. Three mutations, all caught:

| mutation | result |
|---|---|
| stop filtering to the flash region | RAM-symbol test fails |
| drop the sort | ordering and skip tests fail |
| drop the malformed-entry guard | two tests fail (it raises) |

`bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ESP32-S3 flash-size regression failures display the largest flash-consuming symbols directly in the failure output.
  - Symbol details include size and source information to help identify contributors to flash growth.
  - Results are filtered and ordered to highlight valid flash-resident symbols, with a configurable number of entries shown.

- **Bug Fixes**
  - Invalid Boolean symbol sizes are no longer treated as valid flash usage.

- **Tests**
  - Expanded coverage for filtering, ordering, malformed reports, missing data, and result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->