### PR TITLE
ci: declare the platforms a uv resolution must be installable on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -517,6 +517,33 @@ autoImportCompletions = false
 indexing = false
 functionSignatureDisplay = "compact"
 
+[tool.uv]
+# The platforms a resolution must actually be installable on.
+#
+# Without this, uv resolves to the newest version of every dependency and only
+# discovers a missing wheel at install time. That took CI down on 2026-09-09:
+# `ty` published v0.0.80 and CI resolved to it mid-upload, when the x86_64
+# Linux wheel had not landed yet, so every job on ubuntu died with
+#
+#     error: Distribution `ty==0.0.80` can't be installed because it doesn't
+#     have a source distribution or wheel for the current platform
+#     hint: You're on Linux (`manylinux_2_39_x86_64`), but `ty` (v0.0.80) only
+#     has wheels for: manylinux_2_17_aarch64, armv7l, ppc64le, i686, macosx...
+#
+# `uv.lock` is gitignored here, so every run resolves fresh and every run was
+# exposed. Declaring the environments makes resolution *backtrack* to a
+# version that has wheels for all of them instead of failing at install, so a
+# partial upload of somebody's newest release is no longer a repo-wide outage.
+#
+# These are the four the project actually runs on: CI's ubuntu, macos and
+# windows runners, and Apple silicon locally.
+required-environments = [
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
+
 [tool.pytest.ini_options]
 markers = [
     "full: marks tests as requiring the full test suite (deselected during quick Python-only runs)",


### PR DESCRIPTION
## CI went down at 21:18 today

Every job running `uv sync` died:

```
error: Distribution `ty==0.0.80 @ registry+https://pypi.org/simple` can't be
installed because it doesn't have a source distribution or wheel for the
current platform

hint: You're on Linux (`manylinux_2_39_x86_64`), but `ty` (v0.0.80) only has
wheels for: manylinux_2_17_aarch64, manylinux_2_17_armv7l,
manylinux_2_17_ppc64le, manylinux_2_17_i686, linux_armv6l,
macosx_10_12_x86_64, macosx_11_0_arm64
```

Hit on #4200's `build / build` (teensy41) and an ESP32-S3 shard. Not that
branch's doing — it touches no Python packaging.

**PyPI now lists `ty-0.0.80-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.**
It did not at 21:18. `ty` publishes 18 artifacts per release, and CI resolved
mid-upload. So a partial upload of somebody else's release took out every build
in this repo.

## Why every run was exposed

`ty` is pinned `>=0.0.15` with no upper bound, and `uv.lock` is gitignored here
(CLAUDE.md: *"the pin is the only committed half of the cascade"*), so **every
run resolves fresh** and adopts whatever was published minutes earlier.

The exposure is the problem rather than the version. uv resolves to the newest
release and only discovers at *install* time whether it can run on this machine.
A pin bump would fix today and leave the shape intact for the next publisher.

## The fix

`tool.uv.required-environments` — which is what uv's own hint suggests —
declares the platforms a resolution must be *installable* on. Resolution then
backtracks to a version with wheels for all of them instead of failing at
install.

Verified locally:

```
$ uv lock --refresh
Resolved 172 packages in 1.09s
$ uv run python -c "import importlib.metadata as md; print(md.version('ty'))"
0.0.78          # backtracked from 0.0.80, which has no x86_64 Linux wheel
```

`bash lint` passes on that resolution, `ty` check included.

The four environments are the ones this project actually runs on: CI's ubuntu,
macOS and Windows runners, plus Apple silicon locally. A dependency with no
wheel for one of them still falls back to its sdist as before — this constrains
resolution, it does not forbid source builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added supported platform configurations for Linux, macOS, and Windows installations.
  * Dependency resolution now favors versions compatible with available platform-specific packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->