### PR TITLE
fix(channels): clear the exclusive-driver filter in clearAllDrivers, waking channel.cpp (#4240)

### DIFF
--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -8,6 +8,12 @@ from ci.compiler.argument_parser import CompilationArgumentParser
 
 ROOT = Path(__file__).resolve().parents[2]
 
+# The shard count the esp32s3 workflow is expected to run. Declared here rather
+# than read back out of the workflow so the assertions below stay meaningful:
+# changing the workflow's fan-out has to be a deliberate edit in both places,
+# not something that silently redefines its own expectation.
+SHARD_COUNT = 3
+
 
 def test_esp32s3_workflow_names_each_shard_explicitly() -> None:
     workflow_path = ROOT / ".github/workflows/build_esp32s3.yml"
@@ -15,11 +21,12 @@ def test_esp32s3_workflow_names_each_shard_explicitly() -> None:
     build_job = workflow["jobs"]["build"]
 
     assert build_job["name"] == (
-        "ESP32-S3 examples shard ${{ matrix.shard_index }} (8 total)"
+        f"ESP32-S3 examples shard ${{{{ matrix.shard_index }}}} ({SHARD_COUNT} total)"
     )
-    assert build_job["strategy"]["matrix"]["shard_index"] == list(range(8))
+    assert build_job["strategy"]["matrix"]["shard_index"] == list(range(SHARD_COUNT))
     assert build_job["with"]["args"] == (
-        "esp32s3 all --shard-index ${{ matrix.shard_index }} --shard-count 8"
+        "esp32s3 all --shard-index ${{ matrix.shard_index }} "
+        f"--shard-count {SHARD_COUNT}"
     )
 
 
@@ -35,10 +42,10 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
                 "--shard-index",
                 str(index),
                 "--shard-count",
-                "8",
+                str(SHARD_COUNT),
             ]
         ).examples
-        for index in range(8)
+        for index in range(SHARD_COUNT)
     ]
 
     flattened = [example for shard in shards for example in shard]

--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -34,8 +34,9 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
     parser = CompilationArgumentParser(ROOT)
     all_examples = parser._discover_all_examples()
 
-    shards = [
-        parser.parse(
+    shards: list[list[str]] = []
+    for index in range(SHARD_COUNT):
+        parsed = parser.parse(
             [
                 "esp32s3",
                 "all",
@@ -44,11 +45,14 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
                 "--shard-count",
                 str(SHARD_COUNT),
             ]
-        ).examples
-        for index in range(SHARD_COUNT)
-    ]
+        )
+        shards.append(parsed.examples)
 
-    flattened = [example for shard in shards for example in shard]
+    flattened: list[str] = []
+    for shard in shards:
+        for example in shard:
+            flattened.append(example)
+
     assert sorted(flattened) == all_examples
     assert len(flattened) == len(set(flattened))
     assert max(map(len, shards)) - min(map(len, shards)) <= 1

--- a/ci/tests/test_every_test_file_registers.py
+++ b/ci/tests/test_every_test_file_registers.py
@@ -25,16 +25,14 @@ TESTS = PROJECT_ROOT / "tests"
 # legitimately includes `fltest.h` directly.
 HARNESS_OWN_TEST = "fl/test/fltest.cpp"
 
-# Known-dormant, and deliberately still dormant. Enabling this one segfaults
-# in `ScaledPixelIteratorRGB::advance()` via `writeAPA102` -- reproduced on a
-# clean checkout with nothing changed but the include, so the crash predates
-# the discovery and wants someone with context on that path. Tracked on
-# #4201.
+# Empty, and meant to stay that way. `fl/channels/channel.cpp` was the last
+# entry; its two crashes were fixed in #4239 and its four assertion failures
+# in #4240, so every test file under `tests/` now registers its cases.
 #
-# The exemption is a single named file rather than a pattern on purpose: the
-# test below asserts the list has not grown, so a second dormant file cannot
-# be waved through by adding it here without a reviewer noticing.
-KNOWN_DORMANT = ("fl/channels/channel.cpp",)
+# The mechanism is kept as a ratchet at zero rather than deleted: the test
+# below asserts the tuple is still empty, so re-dormanting a file cannot be
+# waved through silently -- it takes a visible edit here that a reviewer sees.
+KNOWN_DORMANT: tuple[str, ...] = ()
 
 DEFINES_A_CASE = re.compile(r"^\s*FL_TEST_CASE\s*\(", re.M)
 INCLUDES_HARNESS = re.compile(r'^\s*#\s*include\s+"test\.h"', re.M)
@@ -71,17 +69,23 @@ class TestEveryTestFileRegisters(unittest.TestCase):
             ),
         )
 
-    def test_the_dormant_list_has_not_grown(
+    def test_the_dormant_list_is_empty(
         self: "TestEveryTestFileRegisters",
     ) -> None:
-        # A ratchet, not an allowance. The point of naming the exemption is
-        # that adding a second one has to be a visible edit here.
-        self.assertEqual(KNOWN_DORMANT, ("fl/channels/channel.cpp",))
-        for relative in KNOWN_DORMANT:
-            self.assertTrue(
-                (TESTS / relative).is_file(),
-                msg=f"{relative} is exempted but does not exist; drop the exemption",
-            )
+        # A ratchet, not an allowance. Every test file registers its cases
+        # today, so any new exemption has to be a visible edit here.
+        self.assertEqual(KNOWN_DORMANT, ())
+
+    def test_the_file_that_was_last_dormant_now_registers(
+        self: "TestEveryTestFileRegisters",
+    ) -> None:
+        # Guards the specific regression this list existed for. Without it the
+        # sweep above would still pass if channel.cpp were deleted outright.
+        woken = TESTS / "fl/channels/channel.cpp"
+        self.assertTrue(woken.is_file(), msg=f"{woken} is missing")
+        source = woken.read_text(encoding="utf-8")
+        self.assertIsNotNone(DEFINES_A_CASE.search(source))
+        self.assertIsNotNone(INCLUDES_HARNESS.search(source))
 
     def test_the_check_can_actually_fail(
         self: "TestEveryTestFileRegisters",

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -299,8 +299,12 @@ def test_rp2350w_http_responses_wait_for_passive_peer_close() -> None:
     assert "state.response_complete = true;" in poll
     assert "state.response_complete && !state.client->connected()" in poll
     assert "state.client.reset();" in poll
+    # Anchored on the over-budget comparison. `millis()` was hoisted into a
+    # local `now_ms` in #4222 so the stall and budget checks read one clock,
+    # so the elapsed expression names that local rather than calling millis()
+    # inline.
     timeout = poll[
-        poll.index("millis() - state.request_started_ms") : poll.index(
+        poll.index("now_ms - state.request_started_ms") : poll.index(
             "while (state.client->available()"
         )
     ]

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -237,6 +237,12 @@ void ChannelManager::clearAllDrivers() {
 
     // Clear all drivers (shared_ptr handles cleanup automatically)
     mDrivers.clear();
+
+    // Drop the exclusive-driver filter along with the registry it refers to.
+    // Leaving it set would name a driver that no longer exists, and
+    // addDriver() consults it -- so every driver registered afterwards would
+    // arrive silently disabled, with no diagnostic and nothing to clear it.
+    mExclusiveDriver.clear();
 }
 
 void ChannelManager::setDriverEnabled(const char* name, bool enabled) {

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -86,6 +86,10 @@ public:
     /// @note Clears the entire driver registry
     /// @note Useful for FastLED.reset() with CHANNEL_DRIVERS flag
     /// @note Waits for all drivers to become READY before clearing (1 second timeout)
+    /// @note Also clears any exclusive-driver filter set by
+    ///       `setExclusiveDriver*()`. The filter names a driver in the
+    ///       registry being emptied, and `addDriver()` consults it, so keeping
+    ///       it would silently disable every subsequently added driver.
     void clearAllDrivers() FL_NO_EXCEPT;
 
     /// @brief Enable or disable a driver by name at runtime

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -439,9 +439,35 @@ FL_TEST_CASE("cfg.options.mBus = Bus::BIT_BANG binds the BIT_BANG driver on host
 
     auto bitbangDriver = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
     FL_REQUIRE(bitbangDriver != nullptr);
-    FL_CHECK_EQ(bitbangDriver.get(), &BusTraits<Bus::BIT_BANG>::instance());
 
     channel->removeFromDrawList();
+}
+
+// `registerWithManager()` must register the BusTraits singleton itself, not a
+// freshly constructed driver of the same type -- a copy would collect state
+// nothing ever transmits.
+//
+// Asserted against a registration *this* translation unit performs. The
+// obvious form, comparing the driver `fl::enableAllDrivers()` registered
+// against `&BusTraits<Bus::BIT_BANG>::instance()`, is not portable:
+// `instancePtr()` keeps its singleton in a function-local static inside a
+// header, and `enableAllDrivers()` lives in the FastLED library image while
+// the expression above is evaluated in the test image. Where those are
+// separate modules the loader does not merge -- `fastled_lib` is a
+// `shared_library` and every test is another, so that is every Windows DLL
+// build -- each module holds its own copy and the pointers differ by
+// construction. That compares the harness's linkage, not the registration.
+FL_TEST_CASE("BusTraits::registerWithManager registers the singleton itself") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    BusTraits<Bus::BIT_BANG>::registerWithManager();
+
+    auto cleanup = fl::make_scope_exit([&]() { mgr.clearAllDrivers(); });
+
+    auto registered = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
+    FL_REQUIRE(registered != nullptr);
+    FL_CHECK_EQ(registered.get(), &BusTraits<Bus::BIT_BANG>::instance());
 }
 
 FL_TEST_CASE("mBus = Bus::AUTO falls back to priority dispatch") {

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -20,10 +20,12 @@
 #include "fl/stl/span.h"
 #include "fl/stl/string.h"
 #include "fl/stl/vector.h"
-#include "fl/test/fltest.h"
+#include "test.h"
 #include "platforms/stub/bus_traits.h"
 
 using namespace fl;
+
+FL_TEST_FILE(FL_FILEPATH) {
 
 // ============ Channel + Addressing Integration Tests ============
 // End-to-end byte capture tests for Channel API with XYMap addressing
@@ -88,7 +90,7 @@ FL_TEST_CASE("Serpentine 2x2 with APA102 encodes pixels in expected byte order")
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
 
-    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
+    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), BGR, options);
     auto channel = Channel::create(config);
     FL_CHECK(channel != nullptr);
 
@@ -318,7 +320,7 @@ FL_TEST_CASE("XMap reverse addressing with APA102 encodes pixels in reverse orde
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
 
-    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
+    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), BGR, options);
     auto channel = Channel::create(config);
     FL_CHECK(channel != nullptr);
 
@@ -691,3 +693,5 @@ FL_TEST_CASE("[#2517] Re-enabling the driver resumes enqueue and re-arms the lat
     channel->showLeds(0);
     FL_CHECK_EQ(fakeDriver->enqueueCount, 2);
 }
+
+}  // FL_TEST_FILE


### PR DESCRIPTION
Settles the four failures in #4240 and wakes the last dormant test file, closing #4201.

## The #2517 pair was not an off-by-one

`enqueueCount` was **0**, not one low — the channel never enqueued at all.

`ChannelManager::clearAllDrivers()` emptied the registry but left `mExclusiveDriver` naming a driver that no longer existed. `addDriver()` consults that field and auto-disables anything whose name does not match, so **every driver registered after a clear arrived silently disabled** — no diagnostic, and nothing short of another `setExclusiveDriver*()` call could clear it.

The first #2517 case ends with `setExclusiveDriverByName("DOES_NOT_EXIST")`. Its cleanup called `clearAllDrivers()`, which did not drop that filter, so the next two cases registered `HAPPY_DRIVER` and `RECOVERY_DRIVER` into a manager that refused to enable either.

This is **not test-only**: `FastLED.clear(CHANNEL_ENGINES)` is the production caller. A filter naming a driver in the registry being emptied is meaningless state, so the clear now drops it.

## The APA102 pair was the tests being wrong

`encodeAPA102` performs no reordering — it writes the three bytes its iterator yields, and those arrive in the channel's own `EOrder`. For APA102 the channel order *is* the wire order, which is what FastLED's own examples say (`// BGR ordering is typical`). Both cases asserted `[br][B][G][R]` while constructing with `RGB`. They now construct with `BGR`, which keeps them testing the documented wire order rather than rewriting expectations to match observed output.

## Waking the file

`tests/fl/channels/channel.cpp` now includes `test.h` and wraps its body in `FL_TEST_FILE`: **0 registered cases → 10 passing**. Verified against the built object rather than the runner's summary, since "All tests passed" over zero cases is the exact failure mode #4201 is about:

```
$ ./.build/meson-quick/tests/runner .build/meson-quick/tests/fl_channels_channel.so
[doctest] test cases: 10 | 10 passed | 0 failed
```

`KNOWN_DORMANT` is now empty. It is kept as a ratchet at zero rather than deleted, so re-dormanting a file stays a visible edit a reviewer sees, plus a guard that the previously-dormant file still registers.

## Mutation testing

Each fix was reverted in turn to confirm it is load-bearing for exactly the pair it targets:

| mutation | result |
|---|---|
| revert `mExclusiveDriver.clear()` | 8 passed, **2 failed** — both #2517 cases |
| revert `BGR` → `RGB` | 8 passed, **2 failed** — both APA102 cases |
| revert `channel.cpp` include | dormancy guard fails on 2 assertions |
| delete `state.client->stop()` | re-anchored rp2350w guard fails |

## Second commit: two stale CI guards

Both were **already failing on master**, unrelated to this work, and both are stale expectations rather than regressions:

- `test_compile_example_sharding` still pinned 8 shards after #4236 measured the esp32s3 fan-out down to 3. Now a `SHARD_COUNT` constant shared by both assertions. Declared, not read back from the workflow — reading it would make the assertion compare the workflow to itself and pass for any value.
- `test_rp2350w_http_responses_wait_for_passive_peer_close` sliced on `millis() - state.request_started_ms`; #4222 hoisted `millis()` into a local `now_ms` so the stall and budget checks read one clock, and the slice raised `ValueError: substring not found`. Re-anchored on the over-budget comparison; the guarded behaviour is unchanged.

## Verification

- `bash test --cpp` — **300/300 unit, 84/84 examples**. Nothing depended on the old sticky-filter behaviour.
- `uv run pytest ci/tests/` — **1266 passed**, 41 skipped, 2402 subtests.
- `bash lint` — clean, exit 0, including `ty`.

Closes #4240
Closes #4201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing all channel drivers now also clears exclusive-driver settings, preventing newly added drivers from being unintentionally disabled.
  - Corrected APA102 channel color-order handling for serpentine and reverse-addressing configurations.

- **Tests**
  - Updated example sharding checks to use the configured shard count consistently.
  - Confirmed all channel test files are registered and active.
  - Improved board configuration timeout validation.
  - Added coverage for direct driver registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->