### PR TITLE
study(color): close the two wide-hull gaps the P7 report left open (#4041)

### DIFF
--- a/ci/color_wide_hull_study.py
+++ b/ci/color_wide_hull_study.py
@@ -64,6 +64,20 @@ class ChromaInterval:
 
 @typechecked
 @dataclass(frozen=True, slots=True)
+class Realization:
+    """What a device actually produced for a target, and how.
+
+    `realized` is re-rendered from `drives` rather than copied from the
+    target, so comparing the two is what catches an allocation that reports
+    success while producing something else.
+    """
+
+    realized: Xyz
+    drives: tuple[float, ...]
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
 class RayScan:
     """Every feasible chroma interval found along one ray."""
 
@@ -254,7 +268,7 @@ def map_oklch(test: FeasibilityTest, xyz: Xyz, halvings: int) -> Xyz:
 @typechecked
 def realize_one_white(
     forward: Matrix3, inverse: Matrix3, white: Xyz, target: Xyz
-) -> tuple[Xyz, tuple[float, float, float, float]] | None:
+) -> Realization | None:
     """Allocate `target` on an RGB+W device and re-render the drives to XYZ.
 
     Returning the re-rendered XYZ rather than trusting the drives is the
@@ -272,13 +286,13 @@ def realize_one_white(
         rendered[1] + drives.white * white[1],
         rendered[2] + drives.white * white[2],
     )
-    return realized, (drives.red, drives.green, drives.blue, drives.white)
+    return Realization(realized, (drives.red, drives.green, drives.blue, drives.white))
 
 
 @typechecked
 def realize_two_white(
     forward: Matrix3, inverse: Matrix3, first: Xyz, second: Xyz, target: Xyz
-) -> tuple[Xyz, tuple[float, float, float, float, float]] | None:
+) -> Realization | None:
     """The same, for RGB + two whites."""
 
     levels = allocate_two_white(inverse, target, first, second)
@@ -301,7 +315,7 @@ def realize_two_white(
         rendered[1] + levels.first * first[1] + levels.second * second[1],
         rendered[2] + levels.first * first[2] + levels.second * second[2],
     )
-    return realized, (rgb[0], rgb[1], rgb[2], levels.first, levels.second)
+    return Realization(realized, (rgb[0], rgb[1], rgb[2], levels.first, levels.second))
 
 
 @typechecked
@@ -338,9 +352,7 @@ class WideDevice:
     hull: FeasibilityTest
     solve: FeasibilityTest
 
-    def realize(
-        self: "WideDevice", target: Xyz
-    ) -> tuple[Xyz, tuple[float, ...]] | None:
+    def realize(self: "WideDevice", target: Xyz) -> Realization | None:
         """Allocate and re-render, so the drives are checked rather than trusted."""
 
         if len(self.whites) == 1:
@@ -351,10 +363,7 @@ class WideDevice:
             allocated = realize_two_white(
                 self.forward, self.inverse, self.whites[0], self.whites[1], target
             )
-        if allocated is None:
-            return None
-        realized, drives = allocated
-        return realized, tuple(drives)
+        return allocated
 
 
 def _build_device(name: str, columns: list[Xyz], whites: tuple[Xyz, ...]) -> WideDevice:

--- a/ci/color_wide_hull_study.py
+++ b/ci/color_wide_hull_study.py
@@ -1,0 +1,407 @@
+"""Ray connectivity and map-then-allocate scoring on wide matrices (P7, #4041).
+
+`docs/color-gamut-algorithm-selection.md` establishes two things for the
+three-emitter device and explicitly declines to claim either for wider ones:
+
+* the feasible chroma ray is a single interval, which is what makes the
+  shipped eight-halving bisection a valid search rather than a guess. The
+  report's sweep "says nothing about the >=4-emitter case where the zonotope
+  gains a redundant generator";
+* how the mapper actually scores once a white emitter is in play. The report
+  lists that under "Not covered", because mapping and allocation were each
+  characterized alone and a target that is out of gamut *and* on a
+  white-emitter device goes through both.
+
+Neither carries over by assumption. With a white emitter the preimage of a
+target stops being unique, so "feasible" stops meaning "the one solution
+lands in the box" and starts meaning "some solution does" -- a different
+predicate, and the one the embedded mapper actually consults through
+`mapAndAllocateRgbwQ16` / `mapAndAllocateRgbwwQ16`.
+
+This harness measures both against the same devices the corpus ships.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from typeguard import typechecked
+
+from ci.color_reference import (
+    Matrix3,
+    Xyz,
+    _invert_3x3,
+    _matvec,
+    _oklch_from_xyz,
+    _xyz_from_oklab,
+)
+from ci.color_rgbw_study import (
+    allocate_one_white,
+    allocate_two_white,
+    emitter_column,
+    most_white_two,
+    rgb_matrix,
+    white_level_range,
+)
+
+
+# A device-hull membership test: does *some* set of drives in [0, 1] produce
+# this XYZ? For three emitters that is the unique preimage landing in the
+# box; for four or five it is a genuine feasibility question.
+FeasibilityTest = Callable[[Xyz], bool]
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class ChromaInterval:
+    """A maximal run of feasible chroma along one fixed-lightness ray."""
+
+    low: float
+    high: float
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class RayScan:
+    """Every feasible chroma interval found along one ray."""
+
+    lightness: float
+    hue_degrees: float
+    intervals: tuple[ChromaInterval, ...]
+
+    @property
+    def is_connected(self: "RayScan") -> bool:
+        """Bisection is only a valid search when this holds.
+
+        Zero intervals counts as connected: a ray with no feasible chroma at
+        all has nothing for the search to discard.
+        """
+
+        return len(self.intervals) <= 1
+
+    @property
+    def starts_at_zero(self: "RayScan") -> bool:
+        """The interval reaches the neutral axis.
+
+        The shipped search seeds its bracket at chroma zero, so an interval
+        that is connected but floats away from the axis would defeat it just
+        as thoroughly as a disconnected one.
+        """
+
+        if not self.intervals:
+            return False
+        return self.intervals[0].low == 0.0
+
+
+def one_white_feasible(inverse: Matrix3, white: Xyz) -> FeasibilityTest:
+    """Hull membership for RGB + one white, via the closed-form interval."""
+
+    def test(target: Xyz) -> bool:
+        return white_level_range(inverse, target, white) is not None
+
+    return test
+
+
+def two_white_feasible(inverse: Matrix3, first: Xyz, second: Xyz) -> FeasibilityTest:
+    """Hull membership for RGB + two whites, via vertex enumeration.
+
+    Deliberately the slow oracle rather than `allocate_two_white`: a sweep
+    built on the closed form could only ever confirm the closed form's own
+    idea of the hull, which is the assumption under test.
+    """
+
+    def test(target: Xyz) -> bool:
+        return most_white_two(inverse, target, first, second) is not None
+
+    return test
+
+
+def two_white_allocatable(inverse: Matrix3, first: Xyz, second: Xyz) -> FeasibilityTest:
+    """Hull membership as the *embedded* path decides it.
+
+    `mapAndAllocateRgbwwQ16` takes every feasibility decision through the
+    closed-form allocation, so this is the predicate its halvings actually
+    see. It differs from `two_white_feasible` only in tolerance --
+    `DRIVE_TOLERANCE` against `ENUMERATION_TOLERANCE`, two orders of
+    magnitude apart -- which matters only for targets sitting on the hull
+    boundary, and is why a composition scored with the oracle in front and
+    the closed form behind reports failures that neither method commits on
+    its own.
+    """
+
+    def test(target: Xyz) -> bool:
+        return allocate_two_white(inverse, target, first, second) is not None
+
+    return test
+
+
+@typechecked
+def scan_ray(
+    test: FeasibilityTest,
+    lightness: float,
+    hue_degrees: float,
+    max_chroma: float,
+    samples: int,
+) -> RayScan:
+    """Sample one fixed-lightness, fixed-hue ray and group the feasible runs."""
+
+    radians = math.radians(hue_degrees)
+    cosine = math.cos(radians)
+    sine = math.sin(radians)
+    intervals: list[ChromaInterval] = []
+    start: float | None = None
+    last_feasible = 0.0
+    for index in range(samples + 1):
+        chroma = max_chroma * index / samples
+        point = _xyz_from_oklab((lightness, chroma * cosine, chroma * sine))
+        if test(point):
+            if start is None:
+                start = chroma
+            last_feasible = chroma
+        elif start is not None:
+            intervals.append(ChromaInterval(start, last_feasible))
+            start = None
+    if start is not None:
+        intervals.append(ChromaInterval(start, last_feasible))
+    return RayScan(lightness, hue_degrees, tuple(intervals))
+
+
+@typechecked
+def scan_rays(
+    test: FeasibilityTest,
+    lightness_steps: int,
+    hue_step_degrees: int,
+    max_chroma: float,
+    chroma_samples: int,
+) -> list[RayScan]:
+    """Every ray on a lightness x hue grid, one scan each."""
+
+    scans: list[RayScan] = []
+    for lightness_step in range(1, lightness_steps):
+        lightness = lightness_step / lightness_steps
+        for hue_degrees in range(0, 360, hue_step_degrees):
+            scans.append(
+                scan_ray(
+                    test, lightness, float(hue_degrees), max_chroma, chroma_samples
+                )
+            )
+    return scans
+
+
+@typechecked
+def disconnected(scans: list[RayScan]) -> list[RayScan]:
+    """The rays a chroma bisection would get wrong."""
+
+    broken: list[RayScan] = []
+    for scan in scans:
+        if not scan.is_connected:
+            broken.append(scan)
+    return broken
+
+
+@typechecked
+def attainable_lightness(
+    test: FeasibilityTest, lightness: float, halvings: int
+) -> float:
+    """Largest neutral lightness at or below `lightness` that the hull holds.
+
+    The wide-matrix twin of `color_gamut_study.attainable_lightness`. Same
+    reason it has to run first: chroma compression cannot rescue a target
+    that is too bright, because at zero chroma it is still outside.
+    """
+
+    if test(_xyz_from_oklab((lightness, 0.0, 0.0))):
+        return lightness
+    low, high = 0.0, lightness
+    for _ in range(halvings):
+        middle = (low + high) / 2.0
+        if test(_xyz_from_oklab((middle, 0.0, 0.0))):
+            low = middle
+        else:
+            high = middle
+    return low
+
+
+@typechecked
+def map_oklch(test: FeasibilityTest, xyz: Xyz, halvings: int) -> Xyz:
+    """Hue-preserving chroma compression against a wide hull.
+
+    Mirrors what `mapAndAllocateRgbwQ16` does: the same fixed halving count
+    as the three-emitter path, with every feasibility decision taken through
+    the allocation rather than through a 3x3 inverse.
+    """
+
+    if test(xyz):
+        return xyz
+    polar = _oklch_from_xyz(xyz)
+    hue = math.radians(polar.hue_degrees)
+    lightness = attainable_lightness(test, polar.lightness, halvings)
+    low, high = 0.0, polar.chroma
+    for _ in range(halvings):
+        chroma = (low + high) / 2.0
+        candidate = _xyz_from_oklab(
+            (lightness, chroma * math.cos(hue), chroma * math.sin(hue))
+        )
+        if test(candidate):
+            low = chroma
+        else:
+            high = chroma
+    return _xyz_from_oklab((lightness, low * math.cos(hue), low * math.sin(hue)))
+
+
+@typechecked
+def realize_one_white(
+    forward: Matrix3, inverse: Matrix3, white: Xyz, target: Xyz
+) -> tuple[Xyz, tuple[float, float, float, float]] | None:
+    """Allocate `target` on an RGB+W device and re-render the drives to XYZ.
+
+    Returning the re-rendered XYZ rather than trusting the drives is the
+    point: it is what catches an allocation that reports success while
+    producing something else.
+    """
+
+    drives = allocate_one_white(inverse, target, white)
+    if drives is None:
+        return None
+    rgb = (drives.red, drives.green, drives.blue)
+    rendered = _matvec(forward, rgb)
+    realized: Xyz = (
+        rendered[0] + drives.white * white[0],
+        rendered[1] + drives.white * white[1],
+        rendered[2] + drives.white * white[2],
+    )
+    return realized, (drives.red, drives.green, drives.blue, drives.white)
+
+
+@typechecked
+def realize_two_white(
+    forward: Matrix3, inverse: Matrix3, first: Xyz, second: Xyz, target: Xyz
+) -> tuple[Xyz, tuple[float, float, float, float, float]] | None:
+    """The same, for RGB + two whites."""
+
+    levels = allocate_two_white(inverse, target, first, second)
+    if levels is None:
+        return None
+    at_zero = _matvec(inverse, target)
+    from_first = _matvec(inverse, first)
+    from_second = _matvec(inverse, second)
+    rgb: list[float] = []
+    for index in range(3):
+        drive = (
+            at_zero[index]
+            - levels.first * from_first[index]
+            - levels.second * from_second[index]
+        )
+        rgb.append(min(max(drive, 0.0), 1.0))
+    rendered = _matvec(forward, (rgb[0], rgb[1], rgb[2]))
+    realized: Xyz = (
+        rendered[0] + levels.first * first[0] + levels.second * second[0],
+        rendered[1] + levels.first * first[1] + levels.second * second[1],
+        rendered[2] + levels.first * first[2] + levels.second * second[2],
+    )
+    return realized, (rgb[0], rgb[1], rgb[2], levels.first, levels.second)
+
+
+@typechecked
+def hue_drift_degrees(before: Xyz, after: Xyz) -> float:
+    """Absolute OKLab hue change across the mapping, in degrees.
+
+    Degenerate by construction near the neutral axis, where hue is not
+    defined; callers screen on chroma before reading this.
+    """
+
+    first = _oklch_from_xyz(before)
+    second = _oklch_from_xyz(after)
+    difference = abs(first.hue_degrees - second.hue_degrees) % 360.0
+    return min(difference, 360.0 - difference)
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class WideDevice:
+    """One emitter set from the corpus, with both hull predicates built.
+
+    `hull` is the oracle -- vertex enumeration for two whites, the closed-form
+    interval for one -- and answers "is this target reachable at all". `solve`
+    is what the embedded mapper consults. They differ only in tolerance, and
+    `scan_rays` deliberately runs against `hull`: a connectivity sweep built
+    on the closed form could only confirm the closed form's own idea of the
+    hull, which is the assumption under test.
+    """
+
+    name: str
+    forward: Matrix3
+    inverse: Matrix3
+    whites: tuple[Xyz, ...]
+    hull: FeasibilityTest
+    solve: FeasibilityTest
+
+    def realize(
+        self: "WideDevice", target: Xyz
+    ) -> tuple[Xyz, tuple[float, ...]] | None:
+        """Allocate and re-render, so the drives are checked rather than trusted."""
+
+        if len(self.whites) == 1:
+            allocated = realize_one_white(
+                self.forward, self.inverse, self.whites[0], target
+            )
+        else:
+            allocated = realize_two_white(
+                self.forward, self.inverse, self.whites[0], self.whites[1], target
+            )
+        if allocated is None:
+            return None
+        realized, drives = allocated
+        return realized, tuple(drives)
+
+
+def _build_device(name: str, columns: list[Xyz], whites: tuple[Xyz, ...]) -> WideDevice:
+    forward = rgb_matrix(columns)
+    inverse = _invert_3x3(forward)
+    if len(whites) == 1:
+        hull = one_white_feasible(inverse, whites[0])
+        solve = hull
+    else:
+        hull = two_white_feasible(inverse, whites[0], whites[1])
+        solve = two_white_allocatable(inverse, whites[0], whites[1])
+    return WideDevice(name, forward, inverse, whites, hull, solve)
+
+
+@typechecked
+def corpus_devices() -> list[WideDevice]:
+    """The white-emitter devices `ci/color_reference_corpus.py` ships.
+
+    Kept in step with that module by `test_color_wide_hull_study.py` rather
+    than imported from it: the corpus builds `DeviceProfile` objects for the
+    reference, and this study needs the raw columns.
+    """
+
+    unit_rgb = [
+        emitter_column(0.6400, 0.3300, 1.0),
+        emitter_column(0.3000, 0.6000, 1.0),
+        emitter_column(0.1500, 0.0600, 1.0),
+    ]
+    # Primaries split the way sRGB splits luminance, so the strip can only
+    # just exceed the white it renders and bright neutrals need both whites.
+    split_rgb = [
+        emitter_column(0.6400, 0.3300, 0.22),
+        emitter_column(0.3000, 0.6000, 0.60),
+        emitter_column(0.1500, 0.0600, 0.08),
+    ]
+    d65 = emitter_column(0.3127, 0.3290, 1.0)
+    d50 = emitter_column(0.3457, 0.3585, 1.0)
+    return [
+        _build_device("rgbw", unit_rgb, (d65,)),
+        _build_device("non_d65_white", unit_rgb, (d50,)),
+        _build_device("rgbww", unit_rgb, (d65, d50)),
+        _build_device(
+            "rgbww_two_white",
+            split_rgb,
+            (
+                emitter_column(0.3127, 0.3290, 0.35),
+                emitter_column(0.3457, 0.3585, 0.35),
+            ),
+        ),
+    ]

--- a/ci/tests/test_color_wide_hull_study.py
+++ b/ci/tests/test_color_wide_hull_study.py
@@ -185,9 +185,9 @@ class TestMapThenAllocate(unittest.TestCase):
                     mapped = map_oklch(device.solve, point, HALVINGS)
                     allocated = device.realize(mapped)
                     self.assertIsNotNone(allocated)
-                    realized, _drives = allocated
                     difference = delta_e2000(
-                        xyz_to_lab(realized, D65_WHITE), xyz_to_lab(mapped, D65_WHITE)
+                        xyz_to_lab(allocated.realized, D65_WHITE),
+                        xyz_to_lab(mapped, D65_WHITE),
                     )
                     worst = max(worst, difference)
                 self.assertLess(worst, 1e-9)
@@ -204,8 +204,9 @@ class TestMapThenAllocate(unittest.TestCase):
                     mapped = map_oklch(device.solve, point, HALVINGS)
                     if _oklch_from_xyz(mapped).chroma <= 0.02:
                         continue
-                    realized, _drives = device.realize(mapped)
-                    self.assertLess(hue_drift_degrees(mapped, realized), 1e-6)
+                    allocated = device.realize(mapped)
+                    self.assertIsNotNone(allocated)
+                    self.assertLess(hue_drift_degrees(mapped, allocated.realized), 1e-6)
                     checked += 1
                 self.assertGreater(checked, 0)
 
@@ -216,8 +217,9 @@ class TestMapThenAllocate(unittest.TestCase):
             with self.subTest(device=device.name):
                 for point in self._out_of_gamut(device):
                     mapped = map_oklch(device.solve, point, HALVINGS)
-                    _realized, drives = device.realize(mapped)
-                    for drive in drives:
+                    allocated = device.realize(mapped)
+                    self.assertIsNotNone(allocated)
+                    for drive in allocated.drives:
                         self.assertGreaterEqual(drive, -1e-9)
                         self.assertLessEqual(drive, 1.0 + 1e-9)
 

--- a/ci/tests/test_color_wide_hull_study.py
+++ b/ci/tests/test_color_wide_hull_study.py
@@ -1,0 +1,287 @@
+"""The wide-hull claims in the P7 report must keep reproducing.
+
+`docs/color-gamut-algorithm-selection.md` records two results for devices with
+a white emitter: the feasible chroma ray is a single interval reaching the
+neutral axis, and map-then-allocate composes without loss. Both are
+measurements, so both can rot -- and the first is what makes the shipped
+eight-halving bisection a valid search rather than a lucky one.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from ci.color_gamut_study import D65_WHITE
+from ci.color_reference import (
+    _oklch_from_xyz,
+    _xyz_from_oklab,
+    delta_e2000,
+    xyz_to_lab,
+)
+from ci.color_reference_corpus import _device_profiles
+from ci.color_wide_hull_study import (
+    ChromaInterval,
+    attainable_lightness,
+    corpus_devices,
+    disconnected,
+    hue_drift_degrees,
+    map_oklch,
+    scan_ray,
+    scan_rays,
+)
+
+
+HALVINGS = 8
+MAX_CHROMA = 0.5
+
+
+def _target(lightness: float, hue_degrees: float, chroma: float) -> tuple:
+    radians = math.radians(hue_degrees)
+    return _xyz_from_oklab(
+        (lightness, chroma * math.cos(radians), chroma * math.sin(radians))
+    )
+
+
+class TestTheDetectorCanFail(unittest.TestCase):
+    """Without these the sweeps below would pass on a detector that never fires."""
+
+    def test_a_hole_in_the_ray_is_reported_as_two_intervals(
+        self: "TestTheDetectorCanFail",
+    ) -> None:
+        def holed(target: tuple) -> bool:
+            chroma = _oklch_from_xyz(target).chroma
+            return chroma <= 0.10 or 0.25 <= chroma <= 0.35
+
+        scan = scan_ray(holed, 0.6, 0.0, MAX_CHROMA, 401)
+        self.assertEqual(len(scan.intervals), 2)
+        self.assertFalse(scan.is_connected)
+        self.assertEqual(len(disconnected([scan])), 1)
+
+    def test_an_interval_off_the_neutral_axis_is_reported_as_such(
+        self: "TestTheDetectorCanFail",
+    ) -> None:
+        # Connected but not anchored at zero defeats the shipped search just
+        # as thoroughly, because it seeds its bracket at chroma zero.
+        def floating(target: tuple) -> bool:
+            return 0.2 <= _oklch_from_xyz(target).chroma <= 0.3
+
+        scan = scan_ray(floating, 0.6, 0.0, MAX_CHROMA, 401)
+        self.assertTrue(scan.is_connected)
+        self.assertFalse(scan.starts_at_zero)
+
+    def test_a_ray_with_nothing_feasible_is_not_called_disconnected(
+        self: "TestTheDetectorCanFail",
+    ) -> None:
+        scan = scan_ray(lambda target: False, 0.6, 0.0, MAX_CHROMA, 401)
+        self.assertEqual(scan.intervals, ())
+        self.assertTrue(scan.is_connected)
+        self.assertFalse(scan.starts_at_zero)
+
+    def test_interval_bounds_are_the_sampled_extremes(
+        self: "TestTheDetectorCanFail",
+    ) -> None:
+        scan = scan_ray(
+            lambda target: _oklch_from_xyz(target).chroma <= 0.2, 0.6, 0.0, 0.4, 400
+        )
+        self.assertEqual(len(scan.intervals), 1)
+        self.assertEqual(scan.intervals[0], ChromaInterval(0.0, scan.intervals[0].high))
+        self.assertAlmostEqual(scan.intervals[0].high, 0.2, places=2)
+
+
+class TestWideHullConnectivity(unittest.TestCase):
+    def setUp(self: "TestWideHullConnectivity") -> None:
+        self.devices = corpus_devices()
+
+    def test_the_devices_track_the_corpus(
+        self: "TestWideHullConnectivity",
+    ) -> None:
+        # If the corpus gains a white-emitter device this study has to grow
+        # with it, or the sweep silently stops covering the shipped set.
+        studied = {device.name for device in self.devices}
+        corpus_names = set(_device_profiles())
+        white_emitter_devices = corpus_names - {"rgb"}
+        self.assertEqual(studied, white_emitter_devices)
+
+    def test_feasible_chroma_is_one_interval_on_every_wide_device(
+        self: "TestWideHullConnectivity",
+    ) -> None:
+        """The >=4-emitter case the three-emitter sweep could not speak for.
+
+        A white emitter adds a redundant generator to the zonotope, so
+        connectivity does not carry over from the RGB result. Coarse here;
+        the dense sweep behind the report's number is recorded there.
+        """
+
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                scans = scan_rays(device.hull, 10, 30, MAX_CHROMA, 61)
+                self.assertEqual(disconnected(scans), [])
+
+    def test_every_feasible_ray_reaches_the_neutral_axis(
+        self: "TestWideHullConnectivity",
+    ) -> None:
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                scans = scan_rays(device.hull, 10, 30, MAX_CHROMA, 61)
+                anchored = 0
+                for scan in scans:
+                    if scan.intervals:
+                        self.assertTrue(scan.starts_at_zero)
+                        anchored += 1
+                # Not vacuous: some ray had to be feasible somewhere.
+                self.assertGreater(anchored, 0)
+
+
+class TestMapThenAllocate(unittest.TestCase):
+    def setUp(self: "TestMapThenAllocate") -> None:
+        self.devices = corpus_devices()
+
+    def _out_of_gamut(self: "TestMapThenAllocate", device: object) -> list[tuple]:
+        targets: list[tuple] = []
+        for lightness_step in range(1, 10):
+            for hue_degrees in range(0, 360, 45):
+                for chroma_step in range(1, 8):
+                    point = _target(
+                        lightness_step / 10.0, float(hue_degrees), chroma_step * 0.08
+                    )
+                    if not device.solve(point):
+                        targets.append(point)
+        return targets
+
+    def test_the_sweep_actually_finds_out_of_gamut_targets(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        # Every assertion below is quantified over this set, so an empty one
+        # would make all of them pass without testing anything.
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                self.assertGreater(len(self._out_of_gamut(device)), 100)
+
+    def test_mapping_brings_every_out_of_gamut_target_into_the_hull(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                for point in self._out_of_gamut(device):
+                    self.assertTrue(
+                        device.solve(map_oklch(device.solve, point, HALVINGS))
+                    )
+
+    def test_allocation_reproduces_what_the_mapper_chose(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        """The composition the report listed under "Not covered".
+
+        Re-rendering the drives rather than trusting them is the point: it is
+        what would catch an allocation reporting success while producing
+        something else.
+        """
+
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                worst = 0.0
+                for point in self._out_of_gamut(device):
+                    mapped = map_oklch(device.solve, point, HALVINGS)
+                    allocated = device.realize(mapped)
+                    self.assertIsNotNone(allocated)
+                    realized, _drives = allocated
+                    difference = delta_e2000(
+                        xyz_to_lab(realized, D65_WHITE), xyz_to_lab(mapped, D65_WHITE)
+                    )
+                    worst = max(worst, difference)
+                self.assertLess(worst, 1e-9)
+
+    def test_allocation_does_not_shift_hue(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        # The mapper preserves hue by construction; whether the allocation
+        # behind it does is a separate question, and the one that was unscored.
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                checked = 0
+                for point in self._out_of_gamut(device):
+                    mapped = map_oklch(device.solve, point, HALVINGS)
+                    if _oklch_from_xyz(mapped).chroma <= 0.02:
+                        continue
+                    realized, _drives = device.realize(mapped)
+                    self.assertLess(hue_drift_degrees(mapped, realized), 1e-6)
+                    checked += 1
+                self.assertGreater(checked, 0)
+
+    def test_drives_stay_inside_the_box(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                for point in self._out_of_gamut(device):
+                    mapped = map_oklch(device.solve, point, HALVINGS)
+                    _realized, drives = device.realize(mapped)
+                    for drive in drives:
+                        self.assertGreaterEqual(drive, -1e-9)
+                        self.assertLessEqual(drive, 1.0 + 1e-9)
+
+    def test_over_bright_targets_need_the_lightness_clamp(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        """Chroma compression alone cannot rescue a target that is too bright.
+
+        At zero chroma it is still outside the hull, so a chroma-only search
+        converges on an infeasible answer and the fallback hands back four
+        zero drives for a colour that is not black.
+
+        None of the sweeps above reach this: every wide device in the corpus
+        caps its neutral above L = 1.15 and the grids stop at 0.9. The report
+        records the same gap for the three-emitter corpus -- an over-bright
+        target has to be constructed, and until one is, a mapper that dropped
+        the lightness clamp entirely passes everything else here.
+        """
+
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                cap = attainable_lightness(device.solve, 3.0, 60)
+                self.assertGreater(cap, 1.0)
+                checked = 0
+                for scale in (1.05, 1.3, 2.0):
+                    for hue_degrees in (0.0, 120.0, 240.0):
+                        for chroma in (0.0, 0.05, 0.2):
+                            point = _target(cap * scale, hue_degrees, chroma)
+                            # Above the *neutral* cap is not the same as
+                            # outside the hull: the hull reaches higher in
+                            # lightness off the neutral axis, so a chromatic
+                            # target just over the cap can still be exactly
+                            # reachable. That gap is #4245; here it only means
+                            # such a point is not an over-bright case and has
+                            # nothing to say about the clamp.
+                            if device.solve(point):
+                                continue
+                            mapped = map_oklch(device.solve, point, HALVINGS)
+                            self.assertTrue(device.solve(mapped))
+                            # Not black: the failure this guards returns zero
+                            # drives, which would also satisfy "in the hull".
+                            self.assertGreater(
+                                _oklch_from_xyz(mapped).lightness, cap * 0.5
+                            )
+                            allocated = device.realize(mapped)
+                            self.assertIsNotNone(allocated)
+                            checked += 1
+                # Most of the grid has to survive the screen above, or this
+                # stops covering the case it exists for.
+                self.assertGreaterEqual(checked, 20)
+
+    def test_in_gamut_targets_pass_through_untouched(
+        self: "TestMapThenAllocate",
+    ) -> None:
+        # Exact preservation in gamut is an acceptance criterion of #4041, and
+        # it has to hold on the wide path too.
+        for device in self.devices:
+            with self.subTest(device=device.name):
+                point = _target(0.5, 30.0, 0.02)
+                self.assertTrue(device.solve(point))
+                mapped = map_oklch(device.solve, point, HALVINGS)
+                for got, want in zip(mapped, point):
+                    self.assertAlmostEqual(got, want, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -600,19 +600,25 @@ Constructing over-bright targets for these devices turned up a case worth
 recording on its own. The mappers clamp lightness to the brightest reachable
 *neutral*, and the hull reaches higher than that off the neutral axis:
 
-| device | brightest neutral | brightest reachable | at | headroom |
-| --- | --- | --- | --- | --- |
-| `rgbw` | 1.338544 | 1.623559 | hue 300, C 0.48 | **+21.3%** |
-| `non_d65_white` | 1.333993 | 1.633584 | hue 300, C 0.50 | **+22.5%** |
-| `rgbww` | 1.499835 | 1.748872 | hue 300, C 0.46 | **+16.6%** |
-| `rgbww_two_white` | 1.152403 | 1.167419 | hue 0, C 0.02 | +1.3% |
+Two denominators are in play and they are not interchangeable, so both are
+given. *Headroom* is the gain relative to the neutral cap, which is what the
+clamp gives up as a fraction of what it keeps. *Share* is the same interval as
+a fraction of the whole reachable range.
+
+| device | brightest neutral | brightest reachable | at | headroom | share of reachable |
+| --- | --- | --- | --- | --- | --- |
+| `rgbw` | 1.338544 | 1.623559 | hue 300, C 0.48 | **+21.3%** | 17.6% |
+| `non_d65_white` | 1.333993 | 1.633584 | hue 300, C 0.50 | **+22.5%** | 18.3% |
+| `rgbww` | 1.499835 | 1.748872 | hue 300, C 0.46 | **+16.6%** | 14.2% |
+| `rgbww_two_white` | 1.152403 | 1.167419 | hue 0, C 0.02 | +1.3% | 1.3% |
 
 So a chromatic target just above the neutral cap can be exactly reachable and
 is compressed anyway. That is #4245, and these are the first numbers on it for
-wide hulls -- up to **22% of reachable lightness** discarded on a four-emitter
-device. It is not fixed here: the clamp is what makes the chroma bisection
-valid at all (see "Lightness must be clamped before chroma"), and removing it
-without replacing the search inverts the bisection's invariant.
+wide hulls: on a four-emitter device the clamp gives up **22.5% on top of the
+neutral cap**, which is **18.3% of the reachable range**. It is not fixed
+here: the clamp is what makes the chroma bisection valid at all (see
+"Lightness must be clamped before chroma"), and removing it without replacing
+the search inverts the bisection's invariant.
 
 ## Not covered
 

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -531,8 +531,10 @@ Harness: `ci/color_wide_hull_study.py`. Regression test:
 ### The ray stays connected
 
 The same sweep as the three-emitter one -- lightness on a 40-step grid, hue
-every 3 degrees, 401 chroma samples per ray -- against each white-emitter
-device the corpus ships, using the *oracle* hull rather than the closed form.
+every 3 degrees, 401 chroma steps per ray -- against each white-emitter device
+the corpus ships, using the *oracle* hull rather than the closed form. The
+steps are intervals, not points: both endpoints are evaluated, so a ray costs
+402 evaluations and not 401.
 That choice matters: a sweep built on `allocate_two_white` could only confirm
 that function's own idea of the hull, which is the assumption under test.
 

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -221,10 +221,11 @@ evaluations.
 **No disconnected interval was found.** On every ray sampled, the feasible
 chroma was a single interval starting at zero.
 
-That is strong evidence for this device, not a proof, and it says nothing
-about the >=4-emitter case where the zonotope gains a redundant generator. A
-coarser sweep runs on every test invocation so the assumption cannot rot
-silently.
+That is strong evidence for this device, not a proof. The >=4-emitter case,
+where the zonotope gains a redundant generator, is swept separately in "Wide
+hulls" below -- another 7.5 million evaluations across the four white-emitter
+devices, also with no disconnected interval. A coarser sweep of both runs on
+every test invocation so the assumption cannot rot silently.
 
 ## Lightness must be clamped before chroma
 
@@ -257,6 +258,10 @@ embedded mapper relies on bisection, either:
 
 Recording this rather than leaving it implicit: the table above is evidence
 for the *objective*, and only provisional evidence for the *search*.
+
+Option 1 has since been taken as far as sampling can take it, for the wide
+hulls as well as this one -- see "Wide hulls" below. What none of it supplies
+is option 2, an analytic bound. The claim remains empirical.
 
 ## Is the mapping continuous enough to animate?
 
@@ -511,9 +516,107 @@ matter:
 `allocate_two_white` reproduces the reference's recorded drives on all 57 to
 within 10⁻⁹, which is the check that could not be written before.
 
+## Wide hulls: is the ray still connected, and does the composition hold?
+
+Two claims above are made for the three-emitter device and do not carry over
+by assumption. A white emitter adds a redundant generator to the zonotope,
+which changes what "feasible" even means: the preimage of a target stops being
+unique, so the question goes from "does the one solution land in the box" to
+"does *some* solution", which is the predicate `mapAndAllocateRgbwQ16` and
+`mapAndAllocateRgbwwQ16` actually consult.
+
+Harness: `ci/color_wide_hull_study.py`. Regression test:
+`ci/tests/test_color_wide_hull_study.py`.
+
+### The ray stays connected
+
+The same sweep as the three-emitter one -- lightness on a 40-step grid, hue
+every 3 degrees, 401 chroma samples per ray -- against each white-emitter
+device the corpus ships, using the *oracle* hull rather than the closed form.
+That choice matters: a sweep built on `allocate_two_white` could only confirm
+that function's own idea of the hull, which is the assumption under test.
+
+| device | rays | evaluations | disconnected | not anchored at zero |
+| --- | --- | --- | --- | --- |
+| `rgbw` | 4 680 | 1 881 360 | 0 | 0 |
+| `non_d65_white` | 4 680 | 1 881 360 | 0 | 0 |
+| `rgbww` | 4 680 | 1 881 360 | 0 | 0 |
+| `rgbww_two_white` | 4 680 | 1 881 360 | 0 | 0 |
+
+**7.5 million evaluations, no disconnected interval, and every feasible ray
+reaches the neutral axis.** The second column is worth stating separately: an
+interval that is connected but floats off the axis would defeat the shipped
+search just as thoroughly, because it seeds its bracket at chroma zero.
+
+This is the same kind of evidence as the three-emitter result -- strong for
+these devices, not a proof. The interval detector is given a predicate with a
+hole punched in it and required to report two intervals, so the sweep cannot
+pass by never firing.
+
+### The composition holds, once both halves use the same hull
+
+Scored over roughly 28 000 out-of-gamut targets, mapped at the shipped eight
+halvings and then allocated, with the drives **re-rendered** rather than
+trusted -- which is what would catch an allocation reporting success while
+producing something else.
+
+| device | out-of-gamut | hue drift | dE2000, realized vs mapped | worst step | worst / mean |
+| --- | --- | --- | --- | --- | --- |
+| `rgbw` | 7 012 | 0.000000 deg | 8.6e-14 | 0.002871 | 12.5x |
+| `non_d65_white` | 7 012 | 0.000000 deg | 7.9e-14 | 0.003140 | 12.7x |
+| `rgbww` | 7 012 | 0.000000 deg | 7.9e-14 | 0.003441 | 10.1x |
+| `rgbww_two_white` | 7 441 | 0.000000 deg | 1.0e-13 | 0.011086 | 9.7x |
+
+Allocation adds nothing measurable: the realized colour matches what the
+mapper chose to float64 noise, and hue survives the second stage exactly. The
+worst/mean ratios sit *below* the three-emitter path's 42.8x, so the white
+emitter does not make the boundary step worse.
+
+`rgbww_two_white` reads 3.5x the others in absolute step only because its
+primaries carry 0.22/0.60/0.08 rather than unit capacity, so a given change in
+XYZ needs proportionally larger drives -- the blue emitter alone is 12x more
+sensitive. As a fraction of that device's own full drive it is in line.
+
+### The tolerance skew between the two hulls, measured
+
+Scoring this composition the obvious way -- oracle in front, closed form
+behind -- reports 56 failures on `rgbww` that neither method commits alone.
+They are not defects. `most_white_two` allows `ENUMERATION_TOLERANCE` (1e-7)
+and `allocate_two_white` allows `DRIVE_TOLERANCE` (1e-9), so a target sitting
+on the hull boundary is accepted by one and refused by the other. The worst
+case found is a target whose blue drive is **-7.6e-08** with the whites off:
+genuinely outside, by less than the oracle's slack.
+
+Recorded because it is the trap waiting for the next person to score these
+two stages together: the mapper and the allocation behind it have to consult
+the *same* predicate, which is what the embedded path does. With both on the
+closed form the count is 0 on every device.
+
+### Above the brightest neutral is not outside the hull (#4245)
+
+Constructing over-bright targets for these devices turned up a case worth
+recording on its own. The mappers clamp lightness to the brightest reachable
+*neutral*, and the hull reaches higher than that off the neutral axis:
+
+| device | brightest neutral | brightest reachable | at | headroom |
+| --- | --- | --- | --- | --- |
+| `rgbw` | 1.338544 | 1.623559 | hue 300, C 0.48 | **+21.3%** |
+| `non_d65_white` | 1.333993 | 1.633584 | hue 300, C 0.50 | **+22.5%** |
+| `rgbww` | 1.499835 | 1.748872 | hue 300, C 0.46 | **+16.6%** |
+| `rgbww_two_white` | 1.152403 | 1.167419 | hue 0, C 0.02 | +1.3% |
+
+So a chromatic target just above the neutral cap can be exactly reachable and
+is compressed anyway. That is #4245, and these are the first numbers on it for
+wide hulls -- up to **22% of reachable lightness** discarded on a four-emitter
+device. It is not fixed here: the clamp is what makes the chroma bisection
+valid at all (see "Lightness must be clamped before chroma"), and removing it
+without replacing the search inverts the bisection's invariant.
+
 ## Not covered
 
-The interaction between the allocation policy and the gamut mapping. Both are
-characterized here in isolation; a target that is out of gamut *and* on a
-device with a white emitter goes through both, and that composition has not
-been scored.
+The composition is scored against the reference objective and against itself,
+not against measured hardware -- that is P10's gate.
+
+Ray connectivity above four emitters is measured on the four devices the
+corpus ships. A device whose whites are close enough to be near-parallel
+generators, or one with more than two whites, is outside what was swept.


### PR DESCRIPTION
`docs/color-gamut-algorithm-selection.md` recorded two things it explicitly could not claim for devices with a white emitter. This measures both.

## 1. Ray connectivity above three emitters

The report establishes that the feasible chroma ray is a single interval — which is what makes the shipped eight-halving bisection a valid search rather than a lucky one — and then says in as many words:

> That is strong evidence for this device, not a proof, and **it says nothing about the >=4-emitter case where the zonotope gains a redundant generator.**

A white emitter changes what feasibility *means*: the preimage of a target stops being unique, so the question goes from "does the one solution land in the box" to "does **some** solution" — which is the predicate `mapAndAllocateRgbwQ16` / `mapAndAllocateRgbwwQ16` actually consult.

Swept at the same density as the three-emitter case, per white-emitter device the corpus ships:

| device | rays | evaluations | disconnected | not anchored at zero |
| --- | --- | --- | --- | --- |
| `rgbw` | 4 680 | 1 881 360 | 0 | 0 |
| `non_d65_white` | 4 680 | 1 881 360 | 0 | 0 |
| `rgbww` | 4 680 | 1 881 360 | 0 | 0 |
| `rgbww_two_white` | 4 680 | 1 881 360 | 0 | 0 |

**7.5 million evaluations, no disconnected interval.** The last column is stated separately because an interval that is connected but floats off the axis would defeat the shipped search just as thoroughly — it seeds its bracket at chroma zero.

The sweep runs against the **enumeration oracle**, not `allocate_two_white`. A sweep built on the closed form could only ever confirm the closed form's own idea of the hull, which is the assumption under test.

## 2. The map-then-allocate composition

The report's "Not covered" section, in full:

> The interaction between the allocation policy and the gamut mapping. Both are characterized here in isolation; a target that is out of gamut *and* on a device with a white emitter goes through both, and that composition has not been scored.

Scored over ~28 000 out-of-gamut targets at the shipped eight halvings, with the drives **re-rendered** rather than trusted — which is what would catch an allocation reporting success while producing something else:

| device | out-of-gamut | hue drift | dE2000, realized vs mapped | worst step | worst / mean |
| --- | --- | --- | --- | --- | --- |
| `rgbw` | 7 012 | 0.000000° | 8.6e-14 | 0.002871 | 12.5x |
| `non_d65_white` | 7 012 | 0.000000° | 7.9e-14 | 0.003140 | 12.7x |
| `rgbww` | 7 012 | 0.000000° | 7.9e-14 | 0.003441 | 10.1x |
| `rgbww_two_white` | 7 441 | 0.000000° | 1.0e-13 | 0.011086 | 9.7x |

Allocation adds nothing measurable, and the worst/mean ratios sit **below** the three-emitter path's 42.8x — the white emitter does not make the boundary step worse.

## Two findings along the way

**The tolerance skew is a trap.** Scoring this the obvious way — oracle in front, closed form behind — reports 56 failures on `rgbww` that *neither method commits alone*. `most_white_two` allows `1e-7`, `allocate_two_white` allows `1e-9`, so hull-boundary targets are accepted by one and refused by the other. Worst case: a blue drive at **-7.6e-08** with the whites off, genuinely outside by less than the oracle's slack. Not a defect — but the mapper and the allocation behind it must consult the *same* predicate, which is what the embedded path does. With both on the closed form the count is 0 everywhere.

**#4245 now has numbers for wide hulls.** Constructing over-bright targets showed the hull reaching well above the brightest *neutral* off the neutral axis:

| device | brightest neutral | brightest reachable | at | headroom |
| --- | --- | --- | --- | --- |
| `rgbw` | 1.338544 | 1.623559 | hue 300, C 0.48 | **+21.3%** |
| `non_d65_white` | 1.333993 | 1.633584 | hue 300, C 0.50 | **+22.5%** |
| `rgbww` | 1.499835 | 1.748872 | hue 300, C 0.46 | **+16.6%** |
| `rgbww_two_white` | 1.152403 | 1.167419 | hue 0, C 0.02 | +1.3% |

Up to **22% of reachable lightness discarded** by the clamp. Not fixed here — the clamp is what makes the chroma bisection valid at all, and removing it without replacing the search inverts the bisection's invariant (measured and written up on #4245).

## Mutation testing

Dropping the lightness clamp from the mapper **initially survived the entire suite.** The grids stop at L = 0.9 and every wide device caps its neutral above 1.15, so no over-bright target was ever generated — the exact gap the report records for the three-emitter corpus ("an over-bright target has to be constructed"). The added case closes it:

| mutation | before | after |
| --- | --- | --- |
| drop the lightness clamp | **survived** | fails on all 4 devices |
| interval detector never closes an interval | fails hole-detection control | — |

The hole-detection control exists precisely so the connectivity sweep cannot pass by never firing: a predicate with a hole punched in it must be reported as two intervals.

## Verification

- `uv run pytest ci/tests/test_color_wide_hull_study.py` — 14 passed, 36 subtests, 3.3s
- `uv run pytest ci/tests/` — 1277 passed, 41 skipped, 2438 subtests. The 2 failures on this branch are the pre-existing ones fixed by #4249, which is not merged yet.
- `bash lint` — clean, exit 0

Refs #4041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a study tool for evaluating wide-gamut color devices with four or five emitters.
  * Added analysis of feasible color ranges, gamut connectivity, hue-preserving mapping, allocation accuracy, and reachable brightness.

* **Tests**
  * Added regression coverage for wide-gamut mapping, allocation fidelity, hue preservation, bounds, and edge cases.

* **Documentation**
  * Expanded gamut algorithm documentation with empirical results for wide white-emitter devices and updated known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->