### PR TITLE
study(color): characterise the 8-bit shaping paths, ruling two out (#4042)

### DIFF
--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -8,6 +8,12 @@ from ci.compiler.argument_parser import CompilationArgumentParser
 
 ROOT = Path(__file__).resolve().parents[2]
 
+# The shard count the esp32s3 workflow is expected to run. Declared here rather
+# than read back out of the workflow so the assertions below stay meaningful:
+# changing the workflow's fan-out has to be a deliberate edit in both places,
+# not something that silently redefines its own expectation.
+SHARD_COUNT = 3
+
 
 def test_esp32s3_workflow_names_each_shard_explicitly() -> None:
     workflow_path = ROOT / ".github/workflows/build_esp32s3.yml"
@@ -15,11 +21,12 @@ def test_esp32s3_workflow_names_each_shard_explicitly() -> None:
     build_job = workflow["jobs"]["build"]
 
     assert build_job["name"] == (
-        "ESP32-S3 examples shard ${{ matrix.shard_index }} (8 total)"
+        f"ESP32-S3 examples shard ${{{{ matrix.shard_index }}}} ({SHARD_COUNT} total)"
     )
-    assert build_job["strategy"]["matrix"]["shard_index"] == list(range(8))
+    assert build_job["strategy"]["matrix"]["shard_index"] == list(range(SHARD_COUNT))
     assert build_job["with"]["args"] == (
-        "esp32s3 all --shard-index ${{ matrix.shard_index }} --shard-count 8"
+        "esp32s3 all --shard-index ${{ matrix.shard_index }} "
+        f"--shard-count {SHARD_COUNT}"
     )
 
 
@@ -35,10 +42,10 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
                 "--shard-index",
                 str(index),
                 "--shard-count",
-                "8",
+                str(SHARD_COUNT),
             ]
         ).examples
-        for index in range(8)
+        for index in range(SHARD_COUNT)
     ]
 
     flattened = [example for shard in shards for example in shard]

--- a/ci/tests/test_compile_example_sharding.py
+++ b/ci/tests/test_compile_example_sharding.py
@@ -34,8 +34,9 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
     parser = CompilationArgumentParser(ROOT)
     all_examples = parser._discover_all_examples()
 
-    shards = [
-        parser.parse(
+    shards: list[list[str]] = []
+    for index in range(SHARD_COUNT):
+        parsed = parser.parse(
             [
                 "esp32s3",
                 "all",
@@ -44,11 +45,14 @@ def test_all_example_shards_are_disjoint_and_exhaustive() -> None:
                 "--shard-count",
                 str(SHARD_COUNT),
             ]
-        ).examples
-        for index in range(SHARD_COUNT)
-    ]
+        )
+        shards.append(parsed.examples)
 
-    flattened = [example for shard in shards for example in shard]
+    flattened: list[str] = []
+    for shard in shards:
+        for example in shard:
+            flattened.append(example)
+
     assert sorted(flattened) == all_examples
     assert len(flattened) == len(set(flattened))
     assert max(map(len, shards)) - min(map(len, shards)) <= 1

--- a/ci/tests/test_every_test_file_registers.py
+++ b/ci/tests/test_every_test_file_registers.py
@@ -25,16 +25,14 @@ TESTS = PROJECT_ROOT / "tests"
 # legitimately includes `fltest.h` directly.
 HARNESS_OWN_TEST = "fl/test/fltest.cpp"
 
-# Known-dormant, and deliberately still dormant. Enabling this one segfaults
-# in `ScaledPixelIteratorRGB::advance()` via `writeAPA102` -- reproduced on a
-# clean checkout with nothing changed but the include, so the crash predates
-# the discovery and wants someone with context on that path. Tracked on
-# #4201.
+# Empty, and meant to stay that way. `fl/channels/channel.cpp` was the last
+# entry; its two crashes were fixed in #4239 and its four assertion failures
+# in #4240, so every test file under `tests/` now registers its cases.
 #
-# The exemption is a single named file rather than a pattern on purpose: the
-# test below asserts the list has not grown, so a second dormant file cannot
-# be waved through by adding it here without a reviewer noticing.
-KNOWN_DORMANT = ("fl/channels/channel.cpp",)
+# The mechanism is kept as a ratchet at zero rather than deleted: the test
+# below asserts the tuple is still empty, so re-dormanting a file cannot be
+# waved through silently -- it takes a visible edit here that a reviewer sees.
+KNOWN_DORMANT: tuple[str, ...] = ()
 
 DEFINES_A_CASE = re.compile(r"^\s*FL_TEST_CASE\s*\(", re.M)
 INCLUDES_HARNESS = re.compile(r'^\s*#\s*include\s+"test\.h"', re.M)
@@ -71,17 +69,23 @@ class TestEveryTestFileRegisters(unittest.TestCase):
             ),
         )
 
-    def test_the_dormant_list_has_not_grown(
+    def test_the_dormant_list_is_empty(
         self: "TestEveryTestFileRegisters",
     ) -> None:
-        # A ratchet, not an allowance. The point of naming the exemption is
-        # that adding a second one has to be a visible edit here.
-        self.assertEqual(KNOWN_DORMANT, ("fl/channels/channel.cpp",))
-        for relative in KNOWN_DORMANT:
-            self.assertTrue(
-                (TESTS / relative).is_file(),
-                msg=f"{relative} is exempted but does not exist; drop the exemption",
-            )
+        # A ratchet, not an allowance. Every test file registers its cases
+        # today, so any new exemption has to be a visible edit here.
+        self.assertEqual(KNOWN_DORMANT, ())
+
+    def test_the_file_that_was_last_dormant_now_registers(
+        self: "TestEveryTestFileRegisters",
+    ) -> None:
+        # Guards the specific regression this list existed for. Without it the
+        # sweep above would still pass if channel.cpp were deleted outright.
+        woken = TESTS / "fl/channels/channel.cpp"
+        self.assertTrue(woken.is_file(), msg=f"{woken} is missing")
+        source = woken.read_text(encoding="utf-8")
+        self.assertIsNotNone(DEFINES_A_CASE.search(source))
+        self.assertIsNotNone(INCLUDES_HARNESS.search(source))
 
     def test_the_check_can_actually_fail(
         self: "TestEveryTestFileRegisters",

--- a/ci/tests/test_rp2350w_board_config.py
+++ b/ci/tests/test_rp2350w_board_config.py
@@ -299,8 +299,12 @@ def test_rp2350w_http_responses_wait_for_passive_peer_close() -> None:
     assert "state.response_complete = true;" in poll
     assert "state.response_complete && !state.client->connected()" in poll
     assert "state.client.reset();" in poll
+    # Anchored on the over-budget comparison. `millis()` was hoisted into a
+    # local `now_ms` in #4222 so the stall and budget checks read one clock,
+    # so the elapsed expression names that local rather than calling millis()
+    # inline.
     timeout = poll[
-        poll.index("millis() - state.request_started_ms") : poll.index(
+        poll.index("now_ms - state.request_started_ms") : poll.index(
             "while (state.client->available()"
         )
     ]

--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -1,0 +1,149 @@
+# WS2812-class 8-bit shaping paths: what each one costs on its own (P8)
+
+Section 5 of the colour-pipeline spec asks which strategy best spends a
+WS2812's eight bits: independent RGB gamma, value-only shaping, the HUE16/HSV
+path, `colorBoost()`, or linear-light temporal dithering, scored on dark-level
+hue and neutral-axis error rather than on smoothness.
+
+That comparison cannot be run until each candidate is characterised *alone*. A
+path that moves hue or tints neutrals by itself is not a re-encoding, and no
+amount of smoothness makes it one. This document is that first step, and it
+removes two of the five candidates.
+
+Harness: the `ws2812_shaping` section of `tests/fl/gfx/hsv16.cpp`. It is grouped
+into that file rather than standing alone because the paths under test --
+`HSV16::ToRGB` and `CRGB::colorBoost` -- both live in `fl/gfx/hsv16.h`, and the
+repo prefers consolidating tests over paying another file's compile time.
+
+## Why this runs in C++
+
+`#4042` left the harness's shape open, and the reason was specific:
+
+> `colorBoost()`, the HUE16/HSV path and the gamma LUTs are real
+> implementations in `src/fl/gfx/`, and re-modelling them in Python risks
+> scoring a paraphrase rather than the code that ships.
+
+So the paths here *are* the shipping functions, called directly. The scoring
+is the shipping colorimetry too — `rgb_source_to_XYZ` against the WS2812B
+profile, then `xyzToOklabQ16` — rather than a second copy of it. Nothing in
+this study is a model of FastLED; it is FastLED, measured.
+
+Metrics are OKLab-based because the pipeline's own objective is defined in
+OKLCh (A3). A1's ΔE2000 budget is a whole-pipeline claim and is checked
+against the P5 reference elsewhere; it is not what distinguishes these paths.
+
+## Method
+
+360 samples: twelve hues, three saturations (96, 176, 255) and ten levels
+from code 1 to 255, weighted into the bottom of the range because that is
+where the earlier baseline measurement showed the error lives — linear
+quantisation is already inside a quarter of a ΔE2000 above about ten percent
+drive.
+
+Two details that decide whether the numbers mean anything:
+
+* **Saturation has to vary.** A fully saturated sweep makes
+  `colorBoost(EASE_IN_QUAD, …)` a no-op — there is no headroom left to boost —
+  and it then scores as perfectly colour-preserving, for the one reason that
+  says nothing about it. The first version of this harness had that bug and
+  reported a chroma gain of exactly 1.000x.
+* **Hue is screened on visible chroma.** Hue is ill-conditioned near the
+  neutral axis, so a path that merely desaturates would otherwise report a
+  huge drift that is arithmetic rather than appearance. Only samples staying
+  above 0.01 OKLab chroma on both sides are scored, and the count of scored
+  samples is asserted so the screen cannot quietly empty the set.
+
+## Result
+
+| path | worst hue drift | chroma ratio | collapses to black |
+| --- | --- | --- | --- |
+| identity (control) | 0.000 deg | 1.000x | 0 / 360 |
+| HSV16 round trip | **0.649 deg** | 0.973x .. 1.003x | 0 / 360 |
+| `colorBoost(EASE_IN_QUAD, EASE_NONE)` | **142.969 deg** | 0.170x .. 6.479x | 0 / 360 |
+| `colorBoost(EASE_NONE, EASE_IN_QUAD)` | 143.798 deg | 0.288x .. 2.123x | **254 / 360** |
+
+### The HSV16 round trip is colour-preserving
+
+Under two thirds of a degree of hue, and under 3% chroma either way, across
+the whole sweep including the darkest codes. The worst case is a single code
+of green:
+
+```
+(83, 226, 25) -> (83, 227, 25)
+```
+
+So the HUE16 path can carry a shaping strategy without contributing error of
+its own. It stays a candidate.
+
+### `colorBoost` is an appearance control, not an encoding
+
+The worst case is small enough to check by hand, which is why it is worth
+quoting:
+
+```
+(1, 3, 1) -> (0, 3, 0)
+```
+
+A dim, lightly saturated colour becomes *pure green*. Both minor channels are
+zeroed, and the hue moves 143 degrees. This is not the near-axis
+ill-conditioning described above — the sample stays visibly chromatic on both
+sides, and all 360 samples survive the chroma screen.
+
+The mechanism is straightforward once seen: easing saturation upward at low
+codes has nothing to work with, and rounding takes the minor channels to
+zero. The range where section 5 needs a strategy is exactly the range where
+`colorBoost` destroys the colour.
+
+**Ruled out** as a hue-preserving 8-bit shaping stage. It remains a perfectly
+good appearance control, which is what it was written to be — it changes the
+colour on purpose, and this document exists so a later comparison cannot
+mistake it for a neutral re-encoding.
+
+### Luminance easing is a dimming curve
+
+`colorBoost(EASE_NONE, EASE_IN_QUAD)` drives **254 of 360 samples to black**.
+Quadratic easing on an eight-bit value annihilates dark content. Also **ruled
+out**; it is a brightness curve and belongs with brightness, not with
+encoding.
+
+### The neutral axis leaves the axis before any path touches it
+
+Measured on a real D65 neutral target — solved to drives, then rounded —
+rather than on equal codes:
+
+| | worst OKLab chroma on a neutral |
+| --- | --- |
+| identity | **0.0605**, at 2% luminance |
+| HSV16 round trip | 0.0605 (identical) |
+| `colorBoost` luminance easing | 0.0676 (worse) |
+
+**0.0605 of chroma on what should be a neutral, from rounding three drives to
+eight bits.** Neither existing path improves it and the boost makes it worse,
+so this is the number a dithering strategy has to beat — it is the whole
+opportunity at the dark end of the neutral axis.
+
+That the metric is evaluated on a solved neutral and not on equal codes is
+load-bearing. This profile normalises each emitter to unit luminance, so an
+equal-code triple is neither D65 nor unit luminance; scoring it measures the
+device normalisation instead of the path, and produces numbers that look
+alarming and mean nothing. The test pins the correct form — substituting equal
+drives fails it.
+
+## What this leaves for section 5
+
+Two of the five candidates are gone, and the remaining comparison is between
+independent RGB gamma, value-only shaping over the HSV16 path, and
+linear-light temporal dithering, with 0.0605 OKLab chroma at 2% luminance as
+the neutral-axis target to beat.
+
+## Not covered
+
+Temporal dithering, which is stateful and needs the frame cadence P6 wires up;
+it is a separate P8 deliverable. The gamma LUT paths are not scored here
+either — they are shaping *strategies* rather than fixed paths, and scoring
+them requires the strategy-space definition that the section-5 comparison
+proper has to settle.
+
+Only the WS2812B placeholder profile is used. It is marked
+`uncalibrated`; the numbers describe the quantisation geometry, not a measured
+part. P10 owns measured profiles.

--- a/src/fl/channels/manager.cpp.hpp
+++ b/src/fl/channels/manager.cpp.hpp
@@ -237,6 +237,12 @@ void ChannelManager::clearAllDrivers() {
 
     // Clear all drivers (shared_ptr handles cleanup automatically)
     mDrivers.clear();
+
+    // Drop the exclusive-driver filter along with the registry it refers to.
+    // Leaving it set would name a driver that no longer exists, and
+    // addDriver() consults it -- so every driver registered afterwards would
+    // arrive silently disabled, with no diagnostic and nothing to clear it.
+    mExclusiveDriver.clear();
 }
 
 void ChannelManager::setDriverEnabled(const char* name, bool enabled) {

--- a/src/fl/channels/manager.h
+++ b/src/fl/channels/manager.h
@@ -86,6 +86,10 @@ public:
     /// @note Clears the entire driver registry
     /// @note Useful for FastLED.reset() with CHANNEL_DRIVERS flag
     /// @note Waits for all drivers to become READY before clearing (1 second timeout)
+    /// @note Also clears any exclusive-driver filter set by
+    ///       `setExclusiveDriver*()`. The filter names a driver in the
+    ///       registry being emptied, and `addDriver()` consults it, so keeping
+    ///       it would silently disable every subsequently added driver.
     void clearAllDrivers() FL_NO_EXCEPT;
 
     /// @brief Enable or disable a driver by name at runtime

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -439,9 +439,35 @@ FL_TEST_CASE("cfg.options.mBus = Bus::BIT_BANG binds the BIT_BANG driver on host
 
     auto bitbangDriver = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
     FL_REQUIRE(bitbangDriver != nullptr);
-    FL_CHECK_EQ(bitbangDriver.get(), &BusTraits<Bus::BIT_BANG>::instance());
 
     channel->removeFromDrawList();
+}
+
+// `registerWithManager()` must register the BusTraits singleton itself, not a
+// freshly constructed driver of the same type -- a copy would collect state
+// nothing ever transmits.
+//
+// Asserted against a registration *this* translation unit performs. The
+// obvious form, comparing the driver `fl::enableAllDrivers()` registered
+// against `&BusTraits<Bus::BIT_BANG>::instance()`, is not portable:
+// `instancePtr()` keeps its singleton in a function-local static inside a
+// header, and `enableAllDrivers()` lives in the FastLED library image while
+// the expression above is evaluated in the test image. Where those are
+// separate modules the loader does not merge -- `fastled_lib` is a
+// `shared_library` and every test is another, so that is every Windows DLL
+// build -- each module holds its own copy and the pointers differ by
+// construction. That compares the harness's linkage, not the registration.
+FL_TEST_CASE("BusTraits::registerWithManager registers the singleton itself") {
+    auto& mgr = freshBusTestManager();
+    FL_REQUIRE(mgr.getDriverCount() == 0);
+
+    BusTraits<Bus::BIT_BANG>::registerWithManager();
+
+    auto cleanup = fl::make_scope_exit([&]() { mgr.clearAllDrivers(); });
+
+    auto registered = mgr.getDriverByName(fl::string::from_literal("BIT_BANG"));
+    FL_REQUIRE(registered != nullptr);
+    FL_CHECK_EQ(registered.get(), &BusTraits<Bus::BIT_BANG>::instance());
 }
 
 FL_TEST_CASE("mBus = Bus::AUTO falls back to priority dispatch") {

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -20,10 +20,12 @@
 #include "fl/stl/span.h"
 #include "fl/stl/string.h"
 #include "fl/stl/vector.h"
-#include "fl/test/fltest.h"
+#include "test.h"
 #include "platforms/stub/bus_traits.h"
 
 using namespace fl;
+
+FL_TEST_FILE(FL_FILEPATH) {
 
 // ============ Channel + Addressing Integration Tests ============
 // End-to-end byte capture tests for Channel API with XYMap addressing
@@ -88,7 +90,7 @@ FL_TEST_CASE("Serpentine 2x2 with APA102 encodes pixels in expected byte order")
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
 
-    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
+    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), BGR, options);
     auto channel = Channel::create(config);
     FL_CHECK(channel != nullptr);
 
@@ -318,7 +320,7 @@ FL_TEST_CASE("XMap reverse addressing with APA102 encodes pixels in reverse orde
     SpiChipsetConfig spiConfig{5, 6, encoder};
     ChannelOptions options;
 
-    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), RGB, options);
+    ChannelConfig config(spiConfig, fl::span<CRGB>(workspace, NUM_LEDS), BGR, options);
     auto channel = Channel::create(config);
     FL_CHECK(channel != nullptr);
 
@@ -691,3 +693,5 @@ FL_TEST_CASE("[#2517] Re-enabling the driver resumes enqueue and re-arms the lat
     channel->showLeds(0);
     FL_CHECK_EQ(fakeDriver->enqueueCount, 2);
 }
+
+}  // FL_TEST_FILE

--- a/tests/fl/gfx/hsv16.cpp
+++ b/tests/fl/gfx/hsv16.cpp
@@ -683,7 +683,11 @@ FL_TEST_CASE("colorBoost zeroes minor channels at low codes, moving hue a long w
     // sides -- so this is a real hue shift, not the ill-conditioning that
     // afflicts hue near the neutral axis.
     FL_CHECK(worst_hue > 100.0f);
-    FL_CHECK(scored > 300);
+    // Every sample, not most of them. The claim above is that the 143 deg is
+    // not near-axis ill-conditioning, and that rests on the whole population
+    // surviving the chroma screen -- a loose bound here would let a
+    // desaturation regression shrink the population instead of failing.
+    FL_CHECK_EQ(scored, static_cast<int>(darkHueSweep().size()));
 }
 
 FL_TEST_CASE("colorBoost luminance easing is a dimming curve, not an encoding") {

--- a/tests/fl/gfx/hsv16.cpp
+++ b/tests/fl/gfx/hsv16.cpp
@@ -8,6 +8,12 @@
 #include "fl/stl/stdint.h"
 #include "test.h"
 #include "hsv2rgb.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/gfx/crgb.h"
+#include "fl/gfx/oklab_q16.h"
+#include "fl/math/ease.h"
+#include "fl/math/math.h"
+#include "fl/stl/int.h"
 
 
 FL_TEST_CASE("RGB to HSV16 to RGB") {
@@ -401,3 +407,322 @@ FL_TEST_CASE("colorBoost() preserves hue - hard cases") {
 FL_TEST_FILE(FL_FILEPATH) {
 
 } // FL_TEST_FILE
+
+// Intrinsic hue and neutral distortion of FastLED's 8-bit shaping paths,
+// for the colour pipeline's P8 section-5 study (#4042).
+//
+// Section 5 asks which strategy best spends a WS2812's 8 bits. Before that
+// can be answered, each candidate path has to be characterised on its own:
+// a path that moves hue or tints neutrals by itself cannot be part of the
+// answer, whatever it does for smoothness.
+//
+// The paths run here are the shipping functions, not models of them --
+// re-implementing `colorBoost()` or the HSV16 round trip in a harness would
+// score a paraphrase. Scoring likewise uses the shipping colorimetry
+// (`rgb_source_to_XYZ` + `xyzToOklabQ16`) rather than a second copy.
+//
+// Measured numbers and what they rule in or out:
+// docs/color-ws2812-shaping-paths.md
+//
+// Grouped into `tests/fl/gfx/hsv16.cpp` rather than standing alone: the
+// paths under test are `HSV16::ToRGB` and `CRGB::colorBoost`, both of which
+// live in `fl/gfx/hsv16.h`, and each extra test file costs compile time.
+
+
+using namespace fl;
+using namespace fl::colorimetric_response;
+
+namespace ws2812_shaping {
+namespace {
+
+constexpr float kQ16 = 65536.0f;
+constexpr float kPi = 3.14159265358979323846f;
+
+struct Oklab {
+    float lightness;
+    float a;
+    float b;
+};
+
+/// Built by value on each call rather than cached in a function-local
+/// static. A static inside a header gets one copy per module that links it,
+/// which is a real portability trap (see the BusTraits singleton note in
+/// tests/fl/channels/channel.cpp) and buys nothing here: this is a 3x3
+/// inverse.
+RgbColorimetricCache ws2812Cache() {
+    RgbColorimetricCache cache;
+    const bool built = build_rgb_colorimetric_cache(
+        fl::colorimetric_response::profiles::WS2812B, &cache);
+    FL_ASSERT(built, "WS2812B primaries must not be singular");
+    return cache;
+}
+
+/// The light an 8-bit code triple actually produces, in OKLab.
+///
+/// A WS2812 drives its diodes with linear PWM, so the code *is* the drive.
+/// Nothing here re-applies a transfer function: that is the point of the
+/// measurement, since every path under test is claiming to shape the codes.
+Oklab lightOf(const CRGB& code) {
+    float xyz[3];
+    const RgbColorimetricCache cache = ws2812Cache();
+    rgb_source_to_XYZ(cache, static_cast<float>(code.r) / 255.0f,
+                      static_cast<float>(code.g) / 255.0f,
+                      static_cast<float>(code.b) / 255.0f, xyz);
+    const i32 q16[3] = {
+        static_cast<i32>(xyz[0] * kQ16 + 0.5f),
+        static_cast<i32>(xyz[1] * kQ16 + 0.5f),
+        static_cast<i32>(xyz[2] * kQ16 + 0.5f),
+    };
+    i32 lab[3];
+    xyzToOklabQ16(q16, lab);
+    return Oklab{static_cast<float>(lab[0]) / kQ16,
+                 static_cast<float>(lab[1]) / kQ16,
+                 static_cast<float>(lab[2]) / kQ16};
+}
+
+float chromaOf(const Oklab& lab) {
+    return fl::sqrtf(lab.a * lab.a + lab.b * lab.b);
+}
+
+/// Absolute hue difference in degrees, wrapped into [0, 180].
+///
+/// Returns 180 -- the worst possible answer -- when either colour has
+/// collapsed to the neutral axis while the other has not. Hue is undefined
+/// there, and returning 0 would let a path that destroys all chroma score as
+/// perfectly hue-preserving, which is the failure this metric exists to
+/// catch.
+float hueDriftDegrees(const Oklab& before, const Oklab& after) {
+    constexpr float kChromaFloor = 1e-6f;
+    const float chroma_before = chromaOf(before);
+    const float chroma_after = chromaOf(after);
+    const bool before_neutral = chroma_before < kChromaFloor;
+    const bool after_neutral = chroma_after < kChromaFloor;
+    if (before_neutral && after_neutral) {
+        return 0.0f;
+    }
+    if (before_neutral != after_neutral) {
+        return 180.0f;
+    }
+    const float first = fl::atan2f(before.b, before.a);
+    const float second = fl::atan2f(after.b, after.a);
+    float difference = (second - first) * 180.0f / kPi;
+    while (difference > 180.0f) {
+        difference -= 360.0f;
+    }
+    while (difference < -180.0f) {
+        difference += 360.0f;
+    }
+    return fl::fabsf(difference);
+}
+
+CRGB pathIdentity(const CRGB& in) { return in; }
+
+CRGB pathHsv16RoundTrip(const CRGB& in) { return HSV16(in).ToRGB(); }
+
+CRGB pathColorBoostSaturation(const CRGB& in) {
+    return in.colorBoost(EaseType::EASE_IN_QUAD, EaseType::EASE_NONE);
+}
+
+CRGB pathColorBoostLuminance(const CRGB& in) {
+    return in.colorBoost(EaseType::EASE_NONE, EaseType::EASE_IN_QUAD);
+}
+
+/// Saturated inputs across the hue circle, at the drive levels that matter.
+///
+/// The interesting range is the bottom few percent: linear quantisation is
+/// already inside a quarter of a dE2000 above ten percent, so a path only
+/// has to earn its keep down low.
+struct Sample {
+    CRGB code;
+    int level;
+    int saturation;
+};
+
+fl::vector<Sample> darkHueSweep() {
+    fl::vector<Sample> samples;
+    const int levels[] = {1, 2, 3, 5, 8, 13, 26, 64, 128, 255};
+    // Saturation has to vary. A fully saturated sweep makes
+    // `colorBoost(EASE_IN_QUAD, ...)` a no-op -- there is no headroom left to
+    // boost -- and it would score as perfectly colour-preserving for the one
+    // reason that says nothing about it.
+    const int saturations[] = {96, 176, 255};
+    for (int level : levels) {
+        for (int saturation : saturations) {
+            for (int step = 0; step < 12; ++step) {
+                const CHSV hsv(static_cast<u8>(step * 21),
+                               static_cast<u8>(saturation),
+                               static_cast<u8>(level));
+                CRGB rgb;
+                hsv2rgb_rainbow(hsv, rgb);
+                samples.push_back(Sample{rgb, level, saturation});
+            }
+        }
+    }
+    return samples;
+}
+
+/// True when a path has driven a coloured input all the way to black.
+///
+/// Tracked separately from hue drift: folding it in reports 180 degrees,
+/// which is arithmetically right and analytically useless -- the interesting
+/// fact is that the colour is gone, not that its hue moved.
+bool collapsedToBlack(const CRGB& before, const CRGB& after) {
+    const bool had_light = before.r != 0 || before.g != 0 || before.b != 0;
+    const bool has_light = after.r != 0 || after.g != 0 || after.b != 0;
+    return had_light && !has_light;
+}
+
+/// Codes that render a D65 neutral at the given luminance on this profile.
+///
+/// Equal codes are NOT a neutral here: the profile normalises each emitter to
+/// unit luminance, so an equal-drive triple is neither D65 nor unit
+/// luminance. Measuring "does grey stay grey" on equal drives scores the
+/// device normalisation rather than the path -- the mistake this helper
+/// exists to prevent.
+CRGB neutralCodes(float luminance) {
+    float target[3];
+    xyY_to_XYZ(0.3127f, 0.3290f, luminance, target);
+    float drives[3];
+    const RgbColorimetricCache cache = ws2812Cache();
+    matvec3(cache.P_RGB_inv, target, drives);
+    CRGB out;
+    out.r = quantize_u8(drives[0]);
+    out.g = quantize_u8(drives[1]);
+    out.b = quantize_u8(drives[2]);
+    return out;
+}
+
+}  // namespace
+
+FL_TEST_CASE("The sweep reaches the dark, partly-saturated inputs the study is about") {
+    // Every bound below is quantified over this sweep. An all-bright or
+    // fully-saturated one would make them pass without measuring anything --
+    // and a fully saturated sweep in particular makes `colorBoost`'s
+    // saturation easing a no-op, since there is no headroom left to boost.
+    const fl::vector<Sample> samples = darkHueSweep();
+    FL_CHECK_EQ(samples.size(), fl::size(360));
+    int dark = 0;
+    int unsaturated = 0;
+    for (const Sample& sample : samples) {
+        if (sample.level <= 13) {
+            ++dark;
+        }
+        if (sample.saturation < 255) {
+            ++unsaturated;
+        }
+    }
+    FL_CHECK_EQ(dark, 216);
+    FL_CHECK_EQ(unsaturated, 240);
+}
+
+FL_TEST_CASE("Identity is hue-exact, so the metric is not reporting round-trip noise") {
+    // A control. Without it every number below could be measuring the
+    // colorimetry round trip rather than the path.
+    float worst = 0.0f;
+    for (const Sample& sample : darkHueSweep()) {
+        worst = fl::max(worst, hueDriftDegrees(lightOf(sample.code),
+                                               lightOf(pathIdentity(sample.code))));
+    }
+    FL_CHECK_EQ(worst, 0.0f);
+}
+
+FL_TEST_CASE("The HSV16 round trip is colour-preserving to within a code") {
+    float worst_hue = 0.0f;
+    float worst_gain = 0.0f;
+    float worst_loss = 2.0f;
+    int collapses = 0;
+    for (const Sample& sample : darkHueSweep()) {
+        const CRGB out = pathHsv16RoundTrip(sample.code);
+        if (collapsedToBlack(sample.code, out)) {
+            ++collapses;
+            continue;
+        }
+        const Oklab before = lightOf(sample.code);
+        const Oklab after = lightOf(out);
+        if (chromaOf(before) > 0.01f && chromaOf(after) > 0.01f) {
+            worst_hue = fl::max(worst_hue, hueDriftDegrees(before, after));
+            const float ratio = chromaOf(after) / chromaOf(before);
+            worst_gain = fl::max(worst_gain, ratio);
+            worst_loss = fl::min(worst_loss, ratio);
+        }
+    }
+    // Measured 0.649 deg, 0.973x .. 1.003x. Bracketed on both sides: a
+    // one-sided bound would still pass if the metric collapsed to zero.
+    FL_CHECK(worst_hue < 1.0f);
+    FL_CHECK(worst_hue > 0.1f);
+    FL_CHECK(worst_gain < 1.05f);
+    FL_CHECK(worst_loss > 0.95f);
+    FL_CHECK_EQ(collapses, 0);
+}
+
+FL_TEST_CASE("colorBoost zeroes minor channels at low codes, moving hue a long way") {
+    // The finding that rules it out as a hue-preserving re-encoding. It is an
+    // appearance control and changes the colour on purpose; section 5 needs
+    // to know it cannot be used as a neutral 8-bit shaping stage.
+    const CRGB dim(1, 3, 1);
+    const CRGB boosted = pathColorBoostSaturation(dim);
+    FL_CHECK_EQ(boosted.r, u8(0));
+    FL_CHECK_EQ(boosted.g, u8(3));
+    FL_CHECK_EQ(boosted.b, u8(0));
+
+    float worst_hue = 0.0f;
+    int scored = 0;
+    for (const Sample& sample : darkHueSweep()) {
+        const CRGB out = pathColorBoostSaturation(sample.code);
+        if (collapsedToBlack(sample.code, out)) {
+            continue;
+        }
+        const Oklab before = lightOf(sample.code);
+        const Oklab after = lightOf(out);
+        if (chromaOf(before) > 0.01f && chromaOf(after) > 0.01f) {
+            worst_hue = fl::max(worst_hue, hueDriftDegrees(before, after));
+            ++scored;
+        }
+    }
+    // 142.969 deg measured, on a sample that stays visibly chromatic on both
+    // sides -- so this is a real hue shift, not the ill-conditioning that
+    // afflicts hue near the neutral axis.
+    FL_CHECK(worst_hue > 100.0f);
+    FL_CHECK(scored > 300);
+}
+
+FL_TEST_CASE("colorBoost luminance easing is a dimming curve, not an encoding") {
+    int collapses = 0;
+    const fl::vector<Sample> samples = darkHueSweep();
+    for (const Sample& sample : samples) {
+        if (collapsedToBlack(sample.code, pathColorBoostLuminance(sample.code))) {
+            ++collapses;
+        }
+    }
+    // 254 of 360 measured. Quadratic easing on an 8-bit value drives dark
+    // content to zero, which is exactly the range section 5 is about.
+    FL_CHECK(collapses > 200);
+    FL_CHECK(collapses < static_cast<int>(samples.size()));
+}
+
+FL_TEST_CASE("The neutral axis leaves the axis from quantization alone") {
+    // Evaluated on a real D65 neutral target, not on equal drives: this
+    // profile normalises each emitter to unit luminance, so equal codes are
+    // neither D65 nor unit luminance, and scoring them measures the device
+    // normalisation instead of the path.
+    float worst_identity = 0.0f;
+    float worst_hsv16 = 0.0f;
+    float worst_boost = 0.0f;
+    for (int step = 1; step <= 100; ++step) {
+        const CRGB grey = neutralCodes(static_cast<float>(step) / 100.0f);
+        worst_identity = fl::max(worst_identity, chromaOf(lightOf(grey)));
+        worst_hsv16 =
+            fl::max(worst_hsv16, chromaOf(lightOf(pathHsv16RoundTrip(grey))));
+        worst_boost =
+            fl::max(worst_boost, chromaOf(lightOf(pathColorBoostLuminance(grey))));
+    }
+    // 0.0605 at 2% luminance, from rounding three drives to 8 bits. This is
+    // the number any section-5 dithering strategy has to beat.
+    FL_CHECK(worst_identity > 0.05f);
+    FL_CHECK(worst_identity < 0.07f);
+    // Neither existing path improves it, and the boost makes it worse.
+    FL_CHECK_EQ(worst_hsv16, worst_identity);
+    FL_CHECK(worst_boost > worst_identity);
+}
+
+}  // namespace ws2812_shaping


### PR DESCRIPTION
Section 5 of P8 asks which strategy best spends a WS2812's eight bits. That comparison cannot start until each candidate is characterised **alone** — a path that moves hue or tints neutrals by itself is not a re-encoding, whatever it does for smoothness.

This measures the existing paths against the real functions and **removes two of the five candidates**.

## Why C++, settling the open question on #4042

The issue left the harness shape open for a specific reason:

> `colorBoost()`, the HUE16/HSV path and the gamma LUTs are real implementations in `src/fl/gfx/`, and **re-modelling them in Python risks scoring a paraphrase** rather than the code that ships.

So the paths here *are* the shipping functions, called directly, and the scoring is the shipping colorimetry (`rgb_source_to_XYZ` against the WS2812B profile, then `xyzToOklabQ16`) rather than a second copy of it. Nothing here is a model of FastLED; it is FastLED, measured.

## Result

360 samples: twelve hues × three saturations × ten levels, weighted into the bottom of the range where the earlier baseline showed the error lives.

| path | worst hue drift | chroma ratio | collapses to black |
| --- | --- | --- | --- |
| identity (control) | 0.000° | 1.000x | 0 / 360 |
| HSV16 round trip | **0.649°** | 0.973x .. 1.003x | 0 / 360 |
| `colorBoost(EASE_IN_QUAD, EASE_NONE)` | **142.969°** | 0.170x .. 6.479x | 0 / 360 |
| `colorBoost(EASE_NONE, EASE_IN_QUAD)` | 143.798° | 0.288x .. 2.123x | **254 / 360** |

**HSV16 round trip survives** — under two thirds of a degree of hue and under 3% chroma either way, across the darkest codes. Worst case is a single code of green: `(83, 226, 25) -> (83, 227, 25)`.

**`colorBoost` is ruled out.** Its worst case is small enough to check by hand, which is why it is worth quoting:

```
(1, 3, 1)  ->  (0, 3, 0)
```

A dim, lightly saturated colour becomes *pure green* — rounding takes both minor channels to zero and the hue moves 143°. This is **not** the ill-conditioning hue suffers near the neutral axis: the sample stays visibly chromatic on both sides, and all 360 samples survive the chroma screen. The range where section 5 needs a strategy is exactly the range where `colorBoost` destroys the colour.

It remains a perfectly good appearance control, which is what it was written to be. This document exists so a later comparison cannot mistake it for a neutral re-encoding.

**Luminance easing is ruled out** as a dimming curve: 254 of 360 samples driven to black.

## The number section 5 has to beat

Measured on a real D65 neutral target — solved to drives, then rounded — not on equal codes:

| | worst OKLab chroma on a neutral |
| --- | --- |
| identity | **0.0605**, at 2% luminance |
| HSV16 round trip | 0.0605 (identical) |
| `colorBoost` luminance easing | 0.0676 (worse) |

**0.0605 of chroma on what should be a neutral, from rounding three drives to eight bits.** Neither existing path improves it, so that is the whole opportunity at the dark end of the neutral axis.

## Two harness bugs found by measuring, not by reading

Recording both, because either one silently invalidates the result:

1. **A fully saturated sweep makes `colorBoost`'s saturation easing a no-op** — there is no headroom left to boost — and it then scores as perfectly colour-preserving, for the one reason that says nothing about it. The first run reported a chroma gain of exactly `1.000x`.
2. **The neutral metric has to use a solved D65 target, not equal codes.** This profile normalises each emitter to unit luminance, so equal codes are neither D65 nor unit luminance; scoring them measures the device normalisation. I had written this down on #4042 and then repeated it here.

## Mutation testing

Each mutation dies on exactly the assertion it should:

| mutation | fails |
| --- | --- |
| `hueDriftDegrees` always returns 0 | HSV16 + colorBoost cases |
| `colorBoost` saturation path becomes identity | colorBoost case |
| collapse-to-black detector never fires | dimming case |
| **equal drives substituted for the solved neutral** | neutral case |

The last one matters most: the test actively guards against the mistake described above.

## Verification

- `bash test --cpp` — **386/386** unit + examples
- `bash lint` — clean, exit 0
- 14 cases in `fl_gfx_hsv16` (8 pre-existing + 6 added), all passing

Grouped into `tests/fl/gfx/hsv16.cpp` rather than a standalone file: both paths under test live in `fl/gfx/hsv16.h`, and `TestPathStructureChecker` prefers consolidating over paying another file's compile time. (It also caught a function-local `static` I had put in a header — the same per-module-copy trap as the BusTraits singleton in #4249.)

Refs #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing all channel drivers now also resets exclusive-driver filtering, preventing newly registered drivers from being unintentionally disabled.
  - Corrected APA102 color-order configuration and improved BIT_BANG driver registration behavior.

- **Documentation**
  - Added analysis of WS2812 color-shaping paths, including color accuracy, luminance behavior, and quantization results.

- **Tests**
  - Updated ESP32-S3 sharding expectations from eight shards to three.
  - Confirmed all test files register cases and aligned RP2350W timeout coverage with current polling behavior.
  - Added coverage for WS2812 color-shaping behavior and neutral-axis quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->