### PR TITLE
fix(autoresearch): refuse a connected-but-inert RpcBench (#4207)

### DIFF
--- a/ci/autoresearch/rpc_bench.py
+++ b/ci/autoresearch/rpc_bench.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import sys
 from argparse import ArgumentParser
+from contextlib import suppress
 from typing import Any
 
 from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
@@ -28,6 +29,18 @@ from ci.util.serial_interface import create_serial_interface
 # Returned by RpcBench.call() when the device does not have the method
 # bound (e.g. a build without an optional feature's RPC).
 METHOD_NOT_FOUND = object()
+
+# How long the construction-time liveness probe waits for any reply.
+#
+# `connect()` has already spent its own boot wait by this point, so a device
+# that is going to answer answers quickly. This only has to be long enough to
+# cover one round trip on a slow link.
+LIVENESS_PROBE_SECONDS = 5.0
+
+# The method the probe calls. Its *result* is irrelevant -- see
+# `_verify_transport_round_trips` -- so a firmware that does not bind it is
+# still proven live by the error it sends back.
+LIVENESS_PROBE_METHOD = "ping"
 
 
 def _is_method_not_found(error: RpcError) -> bool:
@@ -58,6 +71,62 @@ class RpcBench:
         self._loop.run_until_complete(
             self._client.connect(boot_wait=3.0, drain_boot=True)
         )
+        self._verify_transport_round_trips(port)
+
+    def _verify_transport_round_trips(self, port: str) -> None:
+        """Refuse to hand back a client that connected but cannot talk.
+
+        A second attach to a port another client already holds *succeeds* --
+        `connect()` returns without raising -- and the resulting client is
+        then completely inert, every call timing out (#4207). Because
+        `call()` maps a timeout to `None`, that inert client is
+        indistinguishable from a device that answered nothing, and the `None`
+        propagates to callers as though it were a statement about the
+        firmware. That is how this first surfaced: "deployed firmware schema
+        does not contain rpSpiLoopback", reported against a board that
+        exposes the method.
+
+        So the contract is made explicit here: a client that reaches a caller
+        has round-tripped at least once, or construction raised.
+
+        Any reply counts, including an error. A firmware that does not bind
+        the probe method answers METHOD_NOT_FOUND, which proves the transport
+        just as well as a result would -- and probing for liveness must not
+        double as a firmware feature check, or this would start failing the
+        boards it is meant to protect.
+        """
+
+        probe_timeout = min(LIVENESS_PROBE_SECONDS, self._client.timeout)
+        try:
+            self._loop.run_until_complete(
+                self._client.send(
+                    LIVENESS_PROBE_METHOD, args=None, timeout=probe_timeout
+                )
+            )
+        except RpcTimeoutError:
+            # The constructor is about to raise, so the caller never gets an
+            # object to close -- tear down the client and its event loop here
+            # or both leak for the life of the process.
+            with suppress(Exception):
+                self.close()
+            raise RpcError(
+                f"Connected to {port} but it never answered a liveness probe "
+                f"({LIVENESS_PROBE_METHOD}, {probe_timeout:g}s). The port opened "
+                "without error, so this is not a missing device or a wrong baud "
+                "rate.\n"
+                "The known cause is another client already attached to this port: "
+                "the second attach is accepted and the second client is inert "
+                "(#4207). Release the first connection before opening this one -- "
+                "in the harness that means dropping `ctx.serial_iface` before "
+                "spawning a device script against the same port -- or run this "
+                "script standalone.\n"
+                "Refusing rather than returning a client whose every call would "
+                "answer None, which reads to callers as a statement about the "
+                "firmware."
+            ) from None
+        except RpcError:
+            # An error reply is a reply. The transport works.
+            return
 
     def call(
         self,

--- a/ci/autoresearch/rpc_bench.py
+++ b/ci/autoresearch/rpc_bench.py
@@ -21,7 +21,12 @@ from argparse import ArgumentParser
 from contextlib import suppress
 from typing import Any
 
-from ci.rpc_client import RpcClient, RpcError, RpcTimeoutError
+from ci.rpc_client import (
+    RpcClient,
+    RpcError,
+    RpcTimeoutError,
+    RpcTransportError,
+)
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.serial_interface import create_serial_interface
 
@@ -103,7 +108,17 @@ class RpcBench:
                     LIVENESS_PROBE_METHOD, args=None, timeout=probe_timeout
                 )
             )
-        except RpcTimeoutError:
+        except KeyboardInterrupt as interrupt:
+            # Same reasoning as the timeout path below: the constructor is
+            # about to unwind and the caller never gets an object to close.
+            # `handle_keyboard_interrupt` re-raises on the main thread and
+            # wakes it from a worker, per the repo's KBI002 rule -- so the
+            # cleanup has to happen first, while the loop is still alive.
+            with suppress(Exception):
+                self.close()
+            handle_keyboard_interrupt(interrupt)
+            raise
+        except (RpcTimeoutError, RpcTransportError):
             # The constructor is about to raise, so the caller never gets an
             # object to close -- tear down the client and its event loop here
             # or both leak for the life of the process.
@@ -111,7 +126,8 @@ class RpcBench:
                 self.close()
             raise RpcError(
                 f"Connected to {port} but it never answered a liveness probe "
-                f"({LIVENESS_PROBE_METHOD}, {probe_timeout:g}s). The port opened "
+                f"({LIVENESS_PROBE_METHOD}, {probe_timeout:g}s), or the request "
+                "could not be written. The port opened "
                 "without error, so this is not a missing device or a wrong baud "
                 "rate.\n"
                 "The known cause is another client already attached to this port: "
@@ -125,7 +141,11 @@ class RpcBench:
                 "firmware."
             ) from None
         except RpcError:
-            # An error reply is a reply. The transport works.
+            # An error reply is a reply, so the transport works. This is only
+            # sound because a failed *write* now raises `RpcTransportError`
+            # and is caught above: normalizing transport failures into
+            # `RpcError` (#4191) had made the two indistinguishable by type,
+            # and a client whose every write failed passed this gate.
             return
 
     def call(

--- a/ci/rpc_client.py
+++ b/ci/rpc_client.py
@@ -119,6 +119,22 @@ class RpcError(RuntimeError):
         super().__init__(display_message)
 
 
+class RpcTransportError(RpcError):
+    """The request never reached the device.
+
+    A subclass rather than a flag so the widening in `RpcError` above still
+    holds: every existing `except RpcError` and `except RuntimeError` handler
+    keeps catching this unchanged.
+
+    The distinction it restores matters to anyone asking "did the device
+    answer?". Normalizing a failed write into `RpcError` (#4191) made a
+    transport failure the same type as an error *reply*, and an error reply is
+    proof the link round-trips while a failed write is proof it does not.
+    `RpcBench`'s liveness probe reads exactly that difference, and without this
+    type it accepted a client whose every write failed (#4207).
+    """
+
+
 class RpcCrashError(RpcError):
     """Device crashed during RPC operation.
 
@@ -477,7 +493,10 @@ class RpcClient:
                 # `PyserialMonitor.write` reports a failed write this way.
                 # Letting it through would break `send`'s contract and every
                 # caller that handles `(RpcError, RpcTimeoutError)` (#4191).
-                raise RpcError(f"{function}: {e}") from e
+                # Typed so callers that need to tell "no reply" from "an error
+                # reply" still can -- normalizing lost that, and the liveness
+                # probe in `RpcBench` depends on it (#4207).
+                raise RpcTransportError(f"{function}: {e}") from e
 
         raise last_error or RpcTimeoutError(
             f"No response after {retries} attempts (total timeout: {effective_timeout}s)"

--- a/ci/tests/test_rpc_bench_liveness.py
+++ b/ci/tests/test_rpc_bench_liveness.py
@@ -1,0 +1,165 @@
+"""A connected-but-inert RpcBench must refuse to exist (#4207).
+
+Attaching a second client to a port another client already holds succeeds --
+`connect()` returns without raising -- and the second client is then
+completely inert, every call timing out. `RpcBench.call()` maps a timeout to
+`None`, so that client is indistinguishable from a device answering nothing,
+and the `None` reaches callers as though it described the firmware. It did
+exactly that once, reporting "deployed firmware schema does not contain
+rpSpiLoopback" against a board that exposes the method.
+
+These tests pin the contract that replaces it: a client that reaches a caller
+has round-tripped at least once, or construction raised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+from ci.autoresearch import rpc_bench
+from ci.autoresearch.rpc_bench import RpcBench
+from ci.rpc_client import RpcError
+
+
+class _ScriptedSerial:
+    """A serial interface that answers requests from a scripted rule.
+
+    `responder` receives the decoded request and returns the line to send
+    back, or None to stay silent -- which is what an inert second attach
+    looks like from the client's side.
+    """
+
+    def __init__(self, responder: object) -> None:
+        self._responder = responder
+        # A boot banner so `connect()`'s spin-poll returns immediately
+        # instead of burning its full 3 s wait in every one of these tests.
+        self._pending: list[str] = ["setup() start"]
+        self.closed = False
+        self.writes: list[str] = []
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def write(self, data: str) -> None:
+        self.writes.append(data)
+        request = json.loads(data)
+        reply = self._responder(request)  # type: ignore[operator]
+        if reply is not None:
+            self._pending.append(reply)
+
+    async def read_lines(self, timeout: float) -> AsyncIterator[str]:
+        # Behaves like a stream for the whole budget rather than ending after
+        # one line: `_wait_for_response` iterates this generator once, so a
+        # generator that returns early reads as "no more data ever".
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            if self._pending:
+                yield self._pending.pop(0)
+            else:
+                await asyncio.sleep(0.005)
+
+    async def reset_device(self, board: str | None) -> bool:
+        return True
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, responder: object
+) -> list[_ScriptedSerial]:
+    created: list[_ScriptedSerial] = []
+
+    def _factory(port: str, *args: object, **kwargs: object) -> _ScriptedSerial:
+        iface = _ScriptedSerial(responder)
+        created.append(iface)
+        return iface
+
+    monkeypatch.setattr(rpc_bench, "create_serial_interface", _factory)
+    return created
+
+
+# `RpcClient` only treats a line as a response when it carries this prefix.
+REMOTE = "REMOTE: "
+
+
+def _ok(request: dict) -> str:
+    return REMOTE + json.dumps({"id": request["id"], "result": {"message": "pong"}})
+
+
+def _method_not_found(request: dict) -> str:
+    return REMOTE + json.dumps(
+        {"id": request["id"], "error": {"code": -32601, "message": "Method not found"}}
+    )
+
+
+def _silent(request: dict) -> None:
+    return None
+
+
+def test_a_live_device_constructs_normally(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, _ok)
+    bench = RpcBench("FAKE_PORT", timeout=1.0)
+    try:
+        assert bench.call("ping") == {"message": "pong"}
+    finally:
+        bench.close()
+
+
+def test_an_inert_client_raises_instead_of_being_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point: silence at construction must not become a live object."""
+    _install(monkeypatch, _silent)
+    with pytest.raises(RpcError) as caught:
+        RpcBench("FAKE_PORT", timeout=1.0)
+    message = str(caught.value)
+    # The diagnostic has to name the cause, or the next person debugs the
+    # firmware again instead of the second attach.
+    assert "#4207" in message
+    assert "another client already attached" in message
+    assert "FAKE_PORT" in message
+
+
+def test_a_firmware_without_the_probe_method_is_still_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An error reply is a reply.
+
+    Probing for liveness must not double as a firmware feature check, or it
+    starts rejecting exactly the boards it exists to protect.
+    """
+    _install(monkeypatch, _method_not_found)
+    bench = RpcBench("FAKE_PORT", timeout=1.0)
+    try:
+        assert bench.call("anything") is rpc_bench.METHOD_NOT_FOUND
+    finally:
+        bench.close()
+
+
+def test_the_probe_is_one_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A probe that cost several round trips would show up as latency on every
+    # runner, so pin the count rather than trusting the implementation.
+    created = _install(monkeypatch, _ok)
+    bench = RpcBench("FAKE_PORT", timeout=1.0)
+    try:
+        assert len(created) == 1
+        assert len(created[0].writes) == 1
+        assert json.loads(created[0].writes[0])["method"] == "ping"
+    finally:
+        bench.close()
+
+
+def test_a_failed_probe_does_not_leak_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Construction raises, so the caller never gets an object to close."""
+    created = _install(monkeypatch, _silent)
+    with pytest.raises(RpcError):
+        RpcBench("FAKE_PORT", timeout=1.0)
+    assert len(created) == 1
+    assert created[0].closed is True

--- a/ci/tests/test_rpc_bench_liveness.py
+++ b/ci/tests/test_rpc_bench_liveness.py
@@ -22,7 +22,7 @@ import pytest
 
 from ci.autoresearch import rpc_bench
 from ci.autoresearch.rpc_bench import RpcBench
-from ci.rpc_client import RpcError
+from ci.rpc_client import RpcError, RpcTransportError
 
 
 class _ScriptedSerial:
@@ -163,3 +163,60 @@ def test_a_failed_probe_does_not_leak_the_event_loop(
         RpcBench("FAKE_PORT", timeout=1.0)
     assert len(created) == 1
     assert created[0].closed is True
+
+
+class _UnwritableSerial(_ScriptedSerial):
+    """Opens fine, reads fine, and cannot write.
+
+    The shape that slipped through the first version of this gate: `send()`
+    normalises a failed write into `RpcError` (#4191), which the probe was
+    accepting as "an error reply is a reply".
+    """
+
+    async def write(self, data: str) -> None:
+        raise RuntimeError("Serial write error: device disappeared")
+
+
+def test_a_failed_write_is_not_mistaken_for_an_error_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[_ScriptedSerial] = []
+
+    def _factory(port: str, *args: object, **kwargs: object) -> _ScriptedSerial:
+        iface = _UnwritableSerial(_ok)
+        created.append(iface)
+        return iface
+
+    monkeypatch.setattr(rpc_bench, "create_serial_interface", _factory)
+
+    with pytest.raises(RpcError) as caught:
+        RpcBench("FAKE_PORT", timeout=1.0)
+    # And it is refused as a transport failure, not swallowed as a reply.
+    assert "#4207" in str(caught.value)
+    assert created[0].closed is True
+
+
+def test_a_failed_write_raises_the_transport_subtype() -> None:
+    """The distinction the probe reads, pinned at its source.
+
+    Without a distinct type a failed write and an error *reply* are the same
+    class, and the probe cannot tell "the device answered with an error" --
+    which proves the link round-trips -- from "the request never left".
+    """
+    assert issubclass(RpcTransportError, RpcError)
+
+    from ci.rpc_client import RpcClient
+
+    async def _run() -> None:
+        client = RpcClient(
+            "FAKE_PORT", timeout=0.5, serial_interface=_UnwritableSerial(_ok)
+        )
+        await client.connect(boot_wait=0.0, drain_boot=False)
+        await client.send("ping", args=None, timeout=0.5)
+
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RpcTransportError):
+            loop.run_until_complete(_run())
+    finally:
+        loop.close()


### PR DESCRIPTION
Attaching a second client to a port another client already holds **succeeds**. `connect()` returns without raising, and the resulting client is then completely inert — every call times out. Because `RpcBench.call()` maps a timeout to `None`, that client is indistinguishable from a device that answered nothing.

It did exactly that once: `deployed firmware schema does not contain rpSpiLoopback`, reported against a board that **does** expose the method. The transport had failed and the message blamed the build.

#4208 removed the two harness sites that tripped over this, but as the issue records after re-testing merged master, the contract was unchanged:

> #4208 removed the two places in the harness that tripped over this; it did not change what happens when something opens a second client. **Silent success is the property that makes it expensive**, not the fact that two callers can collide.

## The fix

The contract is now explicit: **a client that reaches a caller has round-tripped at least once, or construction raised.** `RpcBench.__init__` probes with a single `ping` and refuses on silence, naming the cause:

```
Connected to /dev/ttyACM0 but it never answered a liveness probe (ping, 5s). The port
opened without error, so this is not a missing device or a wrong baud rate.
The known cause is another client already attached to this port: the second attach is
accepted and the second client is inert (#4207). Release the first connection before
opening this one -- in the harness that means dropping `ctx.serial_iface` before
spawning a device script against the same port -- or run this script standalone.
Refusing rather than returning a client whose every call would answer None, which reads
to callers as a statement about the firmware.
```

## Design points worth flagging

**Any reply counts, including an error.** A firmware that does not bind `ping` answers `METHOD_NOT_FOUND`, which proves the transport just as well as a result would. Probing for liveness must not double as a firmware feature check, or it starts rejecting exactly the boards it exists to protect. That distinction has its own test.

**The probe is unconditional, not opt-in.** All fourteen `RpcBench(...)` construction sites are device-test runners that immediately issue RPCs; none legitimately connects to a port with nothing listening. Cost is one round trip, pinned at one write by test.

**Teardown on failure.** The constructor raises, so the caller never receives an object to `close()` — the client and its event loop are torn down before the raise, or both leak for the life of the process.

## Mutation testing

| mutation | fails |
| --- | --- |
| remove the probe (pre-fix behaviour) | 3 cases, including the central one |
| treat an error reply as dead | the `METHOD_NOT_FOUND`-is-alive case |
| skip the teardown on failure | the event-loop leak case |

## Scope

This is the FastLED half, which is the half the issue asks for ("a second attach should either work or **fail loudly**"). The mechanism inside fbuild's serial daemon — why the second attach is accepted at all — is unchanged and still unexplained. This makes it loud rather than silent; it does not make concurrent clients work.

## Verification

- `uv run pytest ci/tests/` — 1268 passed, 41 skipped, 2402 subtests. The 2 failures on this branch are the pre-existing ones fixed by #4249 (now merged; they clear on rebase).
- `bash lint` — clean, exit 0
- The 5 new tests run against a scripted fake serial interface, no hardware.

Closes #4207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - RPC clients now distinguish failed request delivery from error responses returned by the device.
  - Unresponsive devices produce a clear connection error instead of returning a client that later times out.
  - Devices that respond with an error are still recognized as reachable.
  - Interrupted or failed connection checks now close resources properly.
  - Failed writes are rejected as transport failures rather than being treated as device responses.

- **Tests**
  - Added coverage for responsive, silent, and unsupported devices, connection cleanup, round-trip behavior, and failed writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->