### PR TITLE
docs(mp3): the huffman lead was stale and its premise was wrong (#4155)

### DIFF
--- a/agents/docs/mp3-decoder-performance.md
+++ b/agents/docs/mp3-decoder-performance.md
@@ -196,20 +196,55 @@ the IMDCT -- and Helix spends 301,950,654 instructions in `Subband` plus
 192,621,420 in `PolyphaseStereo`, the same stage under different names. Any
 serious attempt starts there.
 
-Per-frame host medians (`uv run python ci/codec_cpu/audit.py --host`),
-minimp3-float:
+Per-frame host medians (`uv run python ci/codec_cpu/audit.py --host`), both
+builds, three consecutive runs agreeing to better than 1%:
 
-| stage | ns/frame |
-|---|---|
-| synthesis | 20,598 |
-| huffman | 7,373 |
-| imdct | 3,440 |
-| antialias | 962 |
-| scalefactors | 599 |
+| stage | float | fixed | fixed/float |
+|---|---|---|---|
+| synthesis | 19,602 | 25,466 | 1.30x |
+| huffman (+ dequant) | 7,336 | 9,127 | 1.24x |
+| imdct | 3,339 | 10,182 | **3.05x** |
+| antialias | 924 | 2,384 | 2.58x |
+| stereo | 406 | 1,124 | 2.77x |
+| scalefactors | 570 | 526 | 0.92x |
 
-The fixed build's huffman stage is notably worse than the float build's
-(12,134 vs 7,373 ns/frame) despite huffman being integer work in both, which is
-a concrete lead.
+Absolute numbers are host-relative and not comparable across machines; the
+ratio column is the part that travels.
+
+### The huffman stage is not the lead it looked like
+
+An earlier revision of this table recorded the fixed build's huffman at 12,134
+ns/frame, a 1.65x gap, and called it a concrete lead on the grounds that
+huffman is integer work in both builds. Both halves of that have since failed.
+
+**The number is stale.** Re-measured it is 9,127, and the ratio is 1.24x. The
+float side reproduces its old 7,373 to within 0.5% on the same host, which is
+what makes the fixed side's change believable rather than machine drift.
+`ecb3d0588d` trimmed the scratch clear between the two measurements.
+
+**And the premise was wrong.** The stage is not integer-only work. `audit.py`
+declares `dequant` fused into `huffman` for both minimp3 backends -- which is
+why the `dequant` row reads 0.0 ns -- because minimp3 dequantises inline as it
+decodes. The two builds differ there by construction:
+
+```c
+// fixed
+#define MP3D_HUFF_TAB(idx)  mp3d_dequant(one_m, one_e, g_pow43_mant[idx], \
+                                         g_pow43_exp[idx])
+// float
+#define MP3D_HUFF_TAB(idx)  (g_pow43[idx]*one)
+```
+
+One float multiply per coefficient against a mantissa/exponent dequant call.
+So a residual 1.24x on this stage is the arithmetic doing what it was changed
+to do, not an anomaly waiting to be explained.
+
+The Callgrind diff of `L3_huffman` that FastLED#4155 asked for would have shown
+this and nothing else, which is why it was not run.
+
+**Where the time actually goes** is the IMDCT at 3.05x, antialias at 2.58x and
+stereo at 2.77x -- all genuine DSP stages, all larger multiples than huffman
+ever was.
 
 ## Where the gap is: saturation, not DSP
 

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -66,6 +66,37 @@ entry:
     assert result.stage_sites["huffman"] == 1
 
 
+def test_the_huffman_stage_carries_dequant_for_both_minimp3_builds() -> None:
+    """The measured "huffman" stage is not integer-only work.
+
+    minimp3 dequantises inline as it decodes, so `L3_huffman` covers both and
+    the separate `dequant` row reads 0.0 ns. FastLED#4155 called the fixed
+    build's huffman timing "a concrete lead ... despite huffman being integer
+    work in both", which follows only if the stage really is integer-only. It
+    is not, and a residual float/fixed gap there is the arithmetic doing what
+    it was changed to do.
+
+    Pinned structurally rather than by timing so it cannot rot into that
+    reading again.
+    """
+
+    for backend in ("minimp3-float", "minimp3-fixed"):
+        assert AUDIT._FUSED_STAGES[backend]["dequant"] == "huffman"
+
+    # And the fusion is not cosmetic: the per-coefficient dequant genuinely
+    # differs between the two builds, which is where the gap comes from.
+    source = (ROOT / "src" / "third_party" / "minimp3" / "minimp3.h").read_text(
+        encoding="utf-8"
+    )
+    definitions = [
+        line for line in source.splitlines() if "define MP3D_HUFF_TAB" in line
+    ]
+    assert len(definitions) == 2, definitions
+    fixed, float_ = definitions
+    assert "mp3d_dequant" in fixed
+    assert "g_pow43[idx]" in float_
+
+
 def test_integer_product_selection_ignores_address_and_size_math() -> None:
     """`mul` is ambiguous in a way `fmul` is not: at -O0 the fixed-point
     decoder's arithmetic and the compiler's address/size arithmetic share the

--- a/ci/tests/test_codec_cpu_audit.py
+++ b/ci/tests/test_codec_cpu_audit.py
@@ -88,9 +88,10 @@ def test_the_huffman_stage_carries_dequant_for_both_minimp3_builds() -> None:
     source = (ROOT / "src" / "third_party" / "minimp3" / "minimp3.h").read_text(
         encoding="utf-8"
     )
-    definitions = [
-        line for line in source.splitlines() if "define MP3D_HUFF_TAB" in line
-    ]
+    definitions: list[str] = []
+    for line in source.splitlines():
+        if "define MP3D_HUFF_TAB" in line:
+            definitions.append(line)
     assert len(definitions) == 2, definitions
     fixed, float_ = definitions
     assert "mp3d_dequant" in fixed


### PR DESCRIPTION
#4155 item 2 asks for a Callgrind diff of `L3_huffman` between the float and fixed builds to explain a 1.6x gap, and says to **re-measure first** because `ecb3d0588d` trimmed the scratch clear. Re-measuring settles it without the diff — and both halves of the original claim fail.

## The number is stale

Three consecutive `audit.py --host` runs agreeing to better than 1%:

| stage | float | fixed | fixed/float |
|---|---|---|---|
| synthesis | 19,602 | 25,466 | 1.30x |
| huffman (+ dequant) | 7,336 | 9,127 | **1.24x** |
| imdct | 3,339 | 10,182 | **3.05x** |
| antialias | 924 | 2,384 | 2.58x |
| stereo | 406 | 1,124 | 2.77x |
| scalefactors | 570 | 526 | 0.92x |

The doc recorded **12,134** for fixed huffman and a **1.65x** ratio. It is 9,127 and 1.24x.

What makes that believable rather than machine drift is the control: **the float side reproduces its recorded 7,373 to within 0.5%** on the same host in the same runs. So the float baseline is intact and the fixed side genuinely moved.

## And the premise was wrong

> despite huffman being integer work in both

That holds for huffman *decoding*. It does not hold for the stage as instrumented. `audit.py` declares `dequant` **fused into** `huffman` for both minimp3 backends — which is why the `dequant` row reads `0.0 ns` — because minimp3 dequantises inline as it decodes. The two builds differ there by construction:

```c
// fixed
#define MP3D_HUFF_TAB(idx)  mp3d_dequant(one_m, one_e, g_pow43_mant[idx], \
                                         g_pow43_exp[idx])
// float
#define MP3D_HUFF_TAB(idx)  (g_pow43[idx]*one)
```

One float multiply per coefficient against a mantissa/exponent dequant call. So a residual 1.24x on that stage is **the arithmetic doing what it was changed to do**, not an anomaly waiting to be explained.

The Callgrind diff the issue asked for would have shown this and nothing else, which is why I did not run it.

## Where the time actually goes

IMDCT at **3.05x**, stereo at 2.77x, antialias at 2.58x — all genuine DSP stages, all larger multiples than huffman ever was. The old table listed only the float column, which made huffman look like the outlier; with both columns it plainly is not.

## Guard

Pinned **structurally, not by timing**, so the "integer work in both" reading cannot come back: a test asserts the `dequant -> huffman` fusion for both backends and checks the two `MP3D_HUFF_TAB` definitions really do differ (so the fusion is not cosmetic).

Mutation-tested — unfusing the stage fails it, and so does making the two macro definitions identical.

## Scope

This closes item 2 of #4155. Item 1 (the dead `codec_cpu_ledger.md` path filter) was already done in #4176. Item 3 is opening an issue against `lieff/minimp3`, which is a third-party repo and a maintainer call, so I have left it.

## Verification

- `uv run pytest ci/tests/` — 1267 passed, 41 skipped, 2402 subtests
- `bash lint` — clean, exit 0

Refs #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MP3 decoder performance guidance with comparative per-stage benchmarks.
  * Corrected huffman timing data and clarified how dequantization contributes to the measured stage.
  * Identified IMDCT, antialias, and stereo processing as the primary DSP performance areas.

* **Tests**
  * Added coverage for huffman/dequantization fusion in floating-point and fixed-point builds.
  * Verified consistent stage attribution and backend-specific definitions across decoder configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->