### PR TITLE
fix(color): refuse a declared source space that cannot be built (#4156 R6)

### DIFF
--- a/src/fl/gfx/colorimetric_response.h
+++ b/src/fl/gfx/colorimetric_response.h
@@ -390,15 +390,25 @@ struct RgbColorimetricCache {
 };
 
 // Build the precomputed primaries / inverse matrices for `p`. Returns false
-// only when the device-emitter primary matrix is singular (collinear
-// chromaticities); the cache is still populated with zeros so callers can
-// safely fall back to the no-op solve.
+// when the device-emitter primary matrix is singular (collinear
+// chromaticities), or when a declared source space cannot be built; the
+// cache is still populated with zeros so callers can safely fall back to the
+// no-op solve.
 //
 // Source-space handling matches the RGBW path (#2705 semantics): when
 // `input_xy_w[1]` is effectively zero, the input RGB triple IS treated as
 // drive coordinates. Otherwise a source-primary matrix is built and
 // normalized so that the source white at unit drive lands on the maximum
 // per-channel column — keeping outputs in [0, 1] for in-gamut inputs.
+//
+// "No source space declared" and "a source space was declared and is
+// unusable" are different answers and must not collapse into one. Folding
+// the second into the first leaves `has_source_space` false, which means the
+// caller's RGB is reinterpreted as device drive coordinates -- a different
+// colour, produced silently, from primaries the caller believed were in
+// effect. FastLED#4156 R6 asks for that specifically: a near-singular
+// transform needs deterministic rejection, not an arbitrary fallback that
+// destroys the accuracy promise.
 inline bool build_rgb_colorimetric_cache(const EmitterProfile& p,
                                          RgbColorimetricCache* cache) FL_NO_EXCEPT {
     xyY_to_XYZ(p.xy_r[0], p.xy_r[1], p.lum_r, cache->P_R);
@@ -411,7 +421,8 @@ inline bool build_rgb_colorimetric_cache(const EmitterProfile& p,
         { cache->P_R[2], cache->P_G[2], cache->P_B[2] },
     };
     const bool ok_rgb = invert3x3(P_RGB, cache->P_RGB_inv);
-    cache->has_source_space = (p.input_xy_w[1] > 1e-6f)
+    const bool declares_source_space = (p.input_xy_w[1] > 1e-6f);
+    cache->has_source_space = declares_source_space
                            && build_source_matrix(p.input_xy_r, p.input_xy_g,
                                                   p.input_xy_b, p.input_xy_w,
                                                   cache->M_src);
@@ -444,6 +455,9 @@ inline bool build_rgb_colorimetric_cache(const EmitterProfile& p,
                 cache->M_src[i][j] = 0.0f;
             }
         }
+    }
+    if (declares_source_space && !cache->has_source_space) {
+        return false;
     }
     return ok_rgb;
 }

--- a/tests/fl/gfx/colorimetric_response.cpp
+++ b/tests/fl/gfx/colorimetric_response.cpp
@@ -471,3 +471,55 @@ FL_TEST_CASE("The generated profile header carries the artifact's numbers") {
     FL_CHECK(fl::colorimetric_response::build_rgb_colorimetric_cache(profile,
                                                                     &cache));
 }
+
+// ============ Declared-but-unusable source space (#4156 R6) ============
+
+FL_TEST_CASE("A declared source space that cannot be built is refused") {
+    // The failure this guards is silent, not loud: folding "declared and
+    // unusable" into "not declared" leaves has_source_space false, which
+    // means the caller's RGB is reinterpreted as device drive coordinates.
+    // The sketch then renders a different colour from primaries it believed
+    // were in effect, with nothing said.
+    fl::colorimetric_response::EmitterProfile profile =
+        fl::colorimetric_response::profiles::WS2812B;
+
+    // Collinear source primaries: a declared space with no usable transform.
+    profile.input_xy_r[0] = 0.30f;  profile.input_xy_r[1] = 0.30f;
+    profile.input_xy_g[0] = 0.35f;  profile.input_xy_g[1] = 0.35f;
+    profile.input_xy_b[0] = 0.40f;  profile.input_xy_b[1] = 0.40f;
+    profile.input_xy_w[0] = 0.3127f; profile.input_xy_w[1] = 0.3290f;
+
+    fl::colorimetric_response::RgbColorimetricCache cache;
+    FL_CHECK(!fl::colorimetric_response::build_rgb_colorimetric_cache(profile,
+                                                                     &cache));
+    FL_CHECK(!cache.has_source_space);
+}
+
+FL_TEST_CASE("Declaring no source space at all is still fine") {
+    // #2705 semantics: an absent source white means the input RGB *is* the
+    // drive triple. That is a supported mode, not a degenerate profile, so
+    // the check above must not swallow it.
+    fl::colorimetric_response::EmitterProfile profile =
+        fl::colorimetric_response::profiles::WS2812B;
+    FL_CHECK_EQ(profile.input_xy_w[1], 0.0f);
+
+    fl::colorimetric_response::RgbColorimetricCache cache;
+    FL_CHECK(fl::colorimetric_response::build_rgb_colorimetric_cache(profile,
+                                                                    &cache));
+    FL_CHECK(!cache.has_source_space);
+}
+
+FL_TEST_CASE("A usable declared source space still builds") {
+    // Guards the rejection from becoming "refuse every declared space".
+    fl::colorimetric_response::EmitterProfile profile =
+        fl::colorimetric_response::profiles::WS2812B;
+    profile.input_xy_r[0] = 0.6400f; profile.input_xy_r[1] = 0.3300f;
+    profile.input_xy_g[0] = 0.3000f; profile.input_xy_g[1] = 0.6000f;
+    profile.input_xy_b[0] = 0.1500f; profile.input_xy_b[1] = 0.0600f;
+    profile.input_xy_w[0] = 0.3127f; profile.input_xy_w[1] = 0.3290f;
+
+    fl::colorimetric_response::RgbColorimetricCache cache;
+    FL_CHECK(fl::colorimetric_response::build_rgb_colorimetric_cache(profile,
+                                                                    &cache));
+    FL_CHECK(cache.has_source_space);
+}


### PR DESCRIPTION
`build_rgb_colorimetric_cache` computed:

```cpp
has_source_space = (input_xy_w[1] > 1e-6f) && build_source_matrix(...)
```

which folds **two different answers into one**. "No source space declared" and "a source space was declared and is unusable" both left `has_source_space` false — and false means #2705's legacy mode: the caller's RGB triple *is* the device drive triple.

So a profile with degenerate custom primaries — collinear, or a zero `y` — did not fail. It **silently switched interpretation**, and the sketch rendered a different colour from primaries it believed were in effect, with nothing said.

#4156 R6 names exactly this:

> Its cache builder can also treat source-matrix failure as absence of a source space, **which must not silently become managed-path behavior.** […] Near-singular transforms need deterministic rejection or a separately bounded path, not arbitrary clamping that destroys the accuracy promise.

## The fix

The two states are now distinct and the builder returns false for the second.

Three tests pin all three outcomes, because collapsing this in **either** direction is a silent behaviour change:

| profile | outcome |
| --- | --- |
| declared and unusable (collinear primaries) | **refused** |
| not declared at all (`input_xy_w[1] == 0`) | still fine — a supported mode, not a degenerate profile |
| declared and usable | still builds — the rejection must not degrade into "refuse every declared space" |

## Safe to tighten the contract

No caller in `src/` uses this yet — the Q16 path goes through `buildRgbSolveMatrixQ16` — and the existing tests assert true for profiles that stay true.

## Mutation testing

| mutation | fails |
| --- | --- |
| restore the silent fold | the rejection case |
| reject every declared source space | the usable case |

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — clean, exit 0

Refs #4156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of RGB color profiles with invalid declared source spaces.
  - Profiles without a declared source white continue to work as expected.
  - Valid source-space definitions continue to build successfully.

- **Tests**
  - Added coverage for valid, invalid, and undeclared RGB source-space scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->