### PR TITLE
fix(fled): reject chromaticities that are not chromaticities (#4156 R6)

### DIFF
--- a/src/fl/fled/color.cpp.hpp
+++ b/src/fl/fled/color.cpp.hpp
@@ -56,7 +56,33 @@ bool isLinearRgb(fl::u8 pf) FL_NO_EXCEPT {
     return pf == static_cast<fl::u8>(PixelFormat::Rgb16Linear);
 }
 
+// True for a real, ordinary number: not NaN, not an infinity.
+//
+// `NaN != NaN` is the definition; the magnitude bound catches both
+// infinities without needing <cmath>, and 1e30 is far outside any
+// chromaticity while remaining exactly representable.
+bool isOrdinaryNumber(float v) FL_NO_EXCEPT {
+    if (v != v) return false;
+    return v > -1e30f && v < 1e30f;
+}
+
 // Reads one CIE xy pair: a 2-element array of numbers.
+//
+// Shape alone is not admission (FastLED#4156 R6). Two properties are checked
+// here because neither is a matter of taste:
+//
+//   * the values must be ordinary numbers -- a JSON `1e400` parses to an
+//     infinity, and an infinite coordinate is not a chromaticity;
+//   * `y` must be positive, since xyY -> XYZ divides by it. At y = 0 the
+//     conversion yields a zero column, and the profile is refused later as a
+//     singular matrix -- correct, but reported far from the field that
+//     caused it.
+//
+// Deliberately NOT checked: whether the pair lies inside the xy simplex.
+// Primaries outside it are imaginary, wide-gamut encodings legitimately use
+// them, and R6 asks for that to be an explicit decision rather than a
+// side effect of a range check. It has not been made, so nothing here
+// forecloses it.
 bool readXy(const fl::json& node, float* outX, float* outY) FL_NO_EXCEPT {
     if (!node.is_array()) return false;
     // Exactly two, not at least two: [0.64, 0.33, 1] would otherwise resolve
@@ -66,8 +92,12 @@ bool readXy(const fl::json& node, float* outX, float* outY) FL_NO_EXCEPT {
     auto x = node[static_cast<fl::size>(0)].as_float();
     auto y = node[static_cast<fl::size>(1)].as_float();
     if (!x || !y) return false;
-    *outX = static_cast<float>(*x);
-    *outY = static_cast<float>(*y);
+    const float fx = static_cast<float>(*x);
+    const float fy = static_cast<float>(*y);
+    if (!isOrdinaryNumber(fx) || !isOrdinaryNumber(fy)) return false;
+    if (fy <= 0.0f) return false;
+    *outX = fx;
+    *outY = fy;
     return true;
 }
 

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -347,6 +347,46 @@ FL_TEST_CASE("FLED_COLOR - malformed custom primaries are rejected") {
                      kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
 }
 
+FL_TEST_CASE("FLED_COLOR - a zero y is not a chromaticity") {
+    // xyY -> XYZ divides by y. At zero the primary becomes a zero column and
+    // the profile is refused later as a singular matrix -- correct, but
+    // reported far from the field that caused it (#4156 R6).
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[0.64,0.0],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+    // Negative y likewise: below the axis is not a lower luminance, it is
+    // not a chromaticity at all.
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[0.64,-0.33],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+}
+
+FL_TEST_CASE("FLED_COLOR - a non-finite coordinate is rejected") {
+    // A JSON literal well past float range parses to an infinity, and an
+    // infinite coordinate is not a chromaticity.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[1e400,0.33],\"green\":[0.3,0.6],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::MalformedCustomPrimaries);
+}
+
+FL_TEST_CASE("FLED_COLOR - primaries outside the xy simplex still resolve") {
+    // Imaginary primaries. Wide-gamut encodings legitimately use them, and
+    // #4156 R6 asks for that to be an explicit decision rather than the side
+    // effect of a range check. No decision has been made, so the checks above
+    // must not foreclose one.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":{"
+                     "\"red\":[1.2,0.4],\"green\":[-0.2,1.1],"
+                     "\"blue\":[0.15,0.06],\"white\":[0.31,0.33]}}}}",
+                     kRgb8, &c) == ColorStatus::Ok);
+    FL_CHECK(c.primaries == ColorPrimaries::Custom);
+}
+
 // ============================================================================
 // Diagnostics
 // ============================================================================


### PR DESCRIPTION
R6's remaining half. `readXy` checked that a `video.color` primary was a two-element array of numbers — nothing about whether the pair *is* a chromaticity.

Two properties are now required, and neither is a matter of taste.

## Ordinary numbers

A JSON literal past float range does not fail to parse here — `as_float()` hands back an out-of-range value, and an infinite coordinate is not a chromaticity.

**Worth recording how that was confirmed, because the obvious probe lies.** `FL_WARN` printed the value as `-21474836.48` for *every* over-range input:

```
PROBE {"v":[1e400,0.33]} has=1 v=-21474836.48 nan=0 huge=1
PROBE {"v":[1e39,0.33]}  has=1 v=-21474836.48 nan=0 huge=1
PROBE {"v":[1e300,0.33]} has=1 v=-21474836.48 nan=0 huge=1
```

That looks like a finite number and is not — it is `FL_WARN`'s own float formatter overflowing an int32 (`-2147483648/100`). The `huge` column, comparing against a magnitude bound, shows the value really is beyond 1e30. Reading the printed number would have led me to conclude the check was dead code and delete it.

## Positive `y`

xyY → XYZ divides by it. At zero the primary becomes a zero column and the profile is refused later as a singular matrix — correct, but reported far from the field that caused it. A negative `y` is not a dimmer colour; it is not a chromaticity at all.

## Deliberately **not** decided: the xy simplex

Primaries outside it are imaginary, wide-gamut encodings legitimately use them, and R6 says so explicitly:

> Decide explicitly whether imaginary source primaries are supported **rather than banning them accidentally.**

No such decision exists, so a test asserts those primaries still resolve. Adding the simplex rejection fails that test — which is how the open question stays open instead of being closed as a side effect of a range check.

## Mutation testing

| mutation | fails |
| --- | --- |
| finite check becomes a no-op | the non-finite case |
| `y > 0` check becomes a no-op | the zero-y case |
| **also** reject outside the simplex | the imaginary-primaries case |

Two of these initially read as **survivors**: removing the finite check tripped `-Werror,-Wunused-function`, the build failed, and the runner scored a stale `.so` at 37/37. Rewritten so they compile, both die correctly. Same trap as earlier in this program — a mutation that does not build is not a mutation that survived.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — clean, exit 0

Refs #4156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom color primaries now reject non-finite chromaticity values.
  * Custom primaries with zero or negative y-coordinates are reported as malformed.
  * Valid custom primaries outside the xy simplex continue to be accepted.

* **Tests**
  * Added coverage for invalid chromaticity coordinates and accepted out-of-simplex primaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->