### PR TITLE
perf(bitbang): fetch the CPU frequency once, not three times per bit (#4203)

### DIFF
--- a/ci/tests/test_bitbang_hoists_the_clock_query.py
+++ b/ci/tests/test_bitbang_hoists_the_clock_query.py
@@ -84,6 +84,28 @@ class TestTheClockQueryIsHoisted(unittest.TestCase):
     ) -> None:
         self.assertEqual(self.text.count("fl::cpuFrequencyHz()"), 1)
 
+    def test_the_fetch_is_outside_every_loop(
+        self: "TestTheClockQueryIsHoisted",
+    ) -> None:
+        """Once per transmission, not once per timing group.
+
+        The first version of this put the fetch inside the loop over timing
+        groups. A strip with two timing configurations is still one
+        transmission, so that reintroduced an ESP-IDF call on a path meant not
+        to have one -- while the comment above it claimed otherwise.
+        """
+
+        index = self.text.index("fl::cpuFrequencyHz()")
+        function_start = self.text.rindex(
+            "void BitBangChannelDriver::transmitClockless", 0, index
+        )
+        preceding = self.text[function_start:index]
+        self.assertNotIn(
+            "for (",
+            preceding,
+            msg="the frequency fetch sits inside a loop in transmitClockless",
+        )
+
     def test_the_detector_would_catch_a_one_argument_call(
         self: "TestTheClockQueryIsHoisted",
     ) -> None:

--- a/ci/tests/test_bitbang_hoists_the_clock_query.py
+++ b/ci/tests/test_bitbang_hoists_the_clock_query.py
@@ -1,0 +1,97 @@
+"""The clockless bit loop must not re-derive the CPU frequency per delay (#4203).
+
+`delayNanoseconds(ns)` looks up the CPU frequency on every call, and on ESP32
+that is an ESP-IDF call rather than a constant -- three of them per bit in the
+hottest loop this driver has. The maintainer's instruction on that issue is
+the rule this encodes: *any expensive clock related calculations should be
+done once before entering into repeated inner loops.*
+
+Structural rather than timed, because the cost is per-platform and the
+property is not. A microbenchmark on the host would measure a machine that
+does not have the problem.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DRIVER = (
+    PROJECT_ROOT
+    / "src"
+    / "platforms"
+    / "shared"
+    / "bitbang"
+    / "bitbang_channel_driver.cpp.hpp"
+)
+
+COMMENT = re.compile(r"//[^\n]*|/\*.*?\*/", re.S)
+
+# `delayNanoseconds(x)` -- one argument, so the frequency is looked up inside.
+# The two-argument form takes a frequency the caller already has.
+ONE_ARG_DELAY = re.compile(r"\bdelayNanoseconds\s*\(\s*[^(),]+\s*\)")
+
+
+def _bit_loop_body(text: str) -> str:
+    start = text.index("void BitBangChannelDriver::transmitClocklessBit")
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : index + 1]
+    raise AssertionError("transmitClocklessBit body not found")
+
+
+class TestTheClockQueryIsHoisted(unittest.TestCase):
+    def setUp(self: "TestTheClockQueryIsHoisted") -> None:
+        self.text = COMMENT.sub(" ", DRIVER.read_text(encoding="utf-8"))
+
+    def test_the_bit_function_takes_a_frequency(
+        self: "TestTheClockQueryIsHoisted",
+    ) -> None:
+        self.assertIn("transmitClocklessBit", self.text)
+        self.assertRegex(self.text, r"transmitClocklessBit\([^)]*u32 hz")
+
+    def test_the_bit_loop_never_uses_the_one_argument_delay(
+        self: "TestTheClockQueryIsHoisted",
+    ) -> None:
+        body = _bit_loop_body(self.text)
+        offenders = ONE_ARG_DELAY.findall(body)
+        self.assertEqual(
+            offenders,
+            [],
+            msg=(
+                "one-argument delayNanoseconds in the per-bit path re-derives "
+                "the CPU frequency each call: " + ", ".join(offenders)
+            ),
+        )
+
+    def test_the_body_really_does_delay(self: "TestTheClockQueryIsHoisted") -> None:
+        # Without this the check above passes on a function that stopped
+        # delaying at all.
+        body = _bit_loop_body(self.text)
+        self.assertEqual(body.count("delayNanoseconds"), 3)
+
+    def test_the_frequency_is_fetched_once_outside_the_loop(
+        self: "TestTheClockQueryIsHoisted",
+    ) -> None:
+        self.assertEqual(self.text.count("fl::cpuFrequencyHz()"), 1)
+
+    def test_the_detector_would_catch_a_one_argument_call(
+        self: "TestTheClockQueryIsHoisted",
+    ) -> None:
+        # A positive control: the pattern has to match the shape it forbids,
+        # or the sweep above passes for a detector that never fires.
+        self.assertTrue(ONE_ARG_DELAY.search("fl::delayNanoseconds(t1_ns);"))
+        self.assertFalse(ONE_ARG_DELAY.search("fl::delayNanoseconds(t1_ns, hz);"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/platforms/cpu_frequency.h
+++ b/src/platforms/cpu_frequency.h
@@ -87,6 +87,25 @@ namespace fl {
 u32 esp_clk_cpu_freq_impl() FL_NO_EXCEPT;
 #endif
 
+/// The CPU frequency a nanosecond-to-cycle conversion should use, fetched once.
+///
+/// `delayNanoseconds(ns)` re-derives this on *every* call. On ESP32 that is an
+/// ESP-IDF call, not a constant, so a loop calling the one-argument form pays
+/// for it per iteration -- three times per bit in a clockless bit-bang inner
+/// loop (FastLED#4203).
+///
+/// Anything with a per-bit or per-byte loop should call this once outside the
+/// loop and pass the result to `delayNanoseconds(ns, hz)`. The value is stable
+/// for the duration of such a loop: a frequency change mid-transmission would
+/// break the timing whichever form was used.
+FASTLED_FORCE_INLINE u32 cpuFrequencyHz() FL_NO_EXCEPT {
+#if defined(ESP32)
+    return esp_clk_cpu_freq_impl();
+#else
+    return static_cast<u32>(FL_CPU_FREQUENCY());
+#endif
+}
+
 } // namespace fl
 
 #endif // __INC_FASTLED_PLATFORMS_CPU_FREQUENCY_H

--- a/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
+++ b/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
@@ -142,6 +142,13 @@ void BitBangChannelDriver::transmitClockless(
     // collecting channels that share the same timing.
     fl::vector<bool> processed(channels.size(), false);
 
+    // Once for the whole transmission -- outside the timing-group loop as
+    // well as the per-bit one. A strip with two timing configurations is
+    // still one transmission, and querying per group would put an ESP-IDF
+    // call back on a path that is meant not to have one. See
+    // `transmitClocklessBit`.
+    const u32 hz = fl::cpuFrequencyHz();
+
     for (fl::size i = 0; i < channels.size(); ++i) {
         if (processed[i] || !channels[i] || !channels[i]->isClockless()) continue;
 
@@ -171,10 +178,6 @@ void BitBangChannelDriver::transmitClockless(
             size_t sz = channels[groupIndices[gi]]->getSize();
             if (sz > maxBytes) maxBytes = sz;
         }
-
-        // Fetched once for the whole transmission, not per delay call. See
-        // `transmitClocklessBit`.
-        const u32 hz = fl::cpuFrequencyHz();
 
         // Disable interrupts for timing-critical section
 #if defined(FL_IS_AVR)

--- a/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
+++ b/src/platforms/shared/bitbang/bitbang_channel_driver.cpp.hpp
@@ -5,6 +5,7 @@
 
 #include "platforms/shared/bitbang/bitbang_channel_driver.h"
 #include "fl/system/delay.h"
+#include "platforms/cpu_frequency.h"
 #include "fl/log/log.h"
 #include "fl/system/pin.h"
 #include "fl/stl/algorithm.h"
@@ -110,20 +111,26 @@ void BitBangChannelDriver::rebuildPinConfig(
 }
 
 void BitBangChannelDriver::transmitClocklessBit(u8 onesMask, u32 t1_ns,
-                                                  u32 t2_ns, u32 t3_ns) FL_NO_EXCEPT {
+                                                  u32 t2_ns, u32 t3_ns,
+                                                  u32 hz) FL_NO_EXCEPT {
+    // `hz` is passed in rather than looked up here. The one-argument
+    // `delayNanoseconds(ns)` re-derives the CPU frequency on every call, and
+    // on ESP32 that is an ESP-IDF call -- three of them per bit, in the
+    // hottest loop this driver has (FastLED#4203).
+    //
     // Phase 1: ALL active lines HIGH
     mMultiWriter.writeByte(mActiveSlotMask);
 
     // Phase 2: After T1, '0'-bit lanes go LOW (only '1' lanes stay HIGH)
-    fl::delayNanoseconds(t1_ns);
+    fl::delayNanoseconds(t1_ns, hz);
     mMultiWriter.writeByte(onesMask);
 
     // Phase 3: After T2, ALL lines go LOW
-    fl::delayNanoseconds(t2_ns);
+    fl::delayNanoseconds(t2_ns, hz);
     mMultiWriter.writeByte(0x00);
 
     // Phase 4: Low tail
-    fl::delayNanoseconds(t3_ns);
+    fl::delayNanoseconds(t3_ns, hz);
 }
 
 void BitBangChannelDriver::transmitClockless(
@@ -165,6 +172,10 @@ void BitBangChannelDriver::transmitClockless(
             if (sz > maxBytes) maxBytes = sz;
         }
 
+        // Fetched once for the whole transmission, not per delay call. See
+        // `transmitClocklessBit`.
+        const u32 hz = fl::cpuFrequencyHz();
+
         // Disable interrupts for timing-critical section
 #if defined(FL_IS_AVR)
         cli();
@@ -196,7 +207,7 @@ void BitBangChannelDriver::transmitClockless(
                         onesMask |= (1 << slot);
                     }
                 }
-                transmitClocklessBit(onesMask, t1, t2, t3);
+                transmitClocklessBit(onesMask, t1, t2, t3, hz);
             }
         }
 

--- a/src/platforms/shared/bitbang/bitbang_channel_driver.h
+++ b/src/platforms/shared/bitbang/bitbang_channel_driver.h
@@ -61,7 +61,11 @@ private:
 
     // Clockless transmission
     void transmitClockless(fl::span<const ChannelDataPtr> channels) FL_NO_EXCEPT;
-    void transmitClocklessBit(u8 onesMask, u32 t1_ns, u32 t2_ns, u32 t3_ns) FL_NO_EXCEPT;
+    /// One clockless bit. `hz` is the CPU frequency, fetched once by the
+    /// caller: the one-argument `delayNanoseconds` re-derives it per call,
+    /// which on ESP32 is an ESP-IDF call three times per bit (FastLED#4203).
+    void transmitClocklessBit(u8 onesMask, u32 t1_ns, u32 t2_ns, u32 t3_ns,
+                              u32 hz) FL_NO_EXCEPT;
 
     // SPI transmission
     void transmitSpi(fl::span<const ChannelDataPtr> channels) FL_NO_EXCEPT;


### PR DESCRIPTION
Acting on your instruction on that issue:

> any expensive clock related calculations should be done once before entering into repeated inner loops

## What was being recomputed

`delayNanoseconds(ns)` re-derives the CPU frequency on **every call**. On ESP32 that is not a constant:

```cpp
FASTLED_FORCE_INLINE void delayNanoseconds_impl(u32 ns) FL_NO_EXCEPT {
  u32 hz = esp_clk_cpu_freq_impl();     // an ESP-IDF call
  delayNanoseconds_impl(ns, hz);
}
```

`transmitClocklessBit` makes three of those per bit, in the hottest loop this driver has.

`fl::cpuFrequencyHz()` is the accessor for the hoisted form — the ESP runtime query where that exists, `FL_CPU_FREQUENCY()` elsewhere. The driver fetches it once per transmission and passes it to the two-argument `delayNanoseconds(ns, hz)`. The value is stable across a transmission by construction: a frequency change mid-frame would break the timing whichever form was used.

## Guarded structurally, not by a benchmark

The cost is per-platform; the property is not. A host microbenchmark would measure a machine that does not have the problem. So the test asserts the per-bit path never uses the one-argument form, that it still performs three delays, and that the frequency is fetched exactly once — with a positive control proving the pattern matches the shape it forbids.

| mutation | fails |
|---|---|
| revert to the one-argument form | the sweep |
| fetch the frequency inside the bit function | the fetched-once case |

## This does not close #4203

Your own arithmetic in that thread puts post-#4204 per-bit overhead at **~6300ns against a ~150ns budget**, and concludes the remaining problem is the *shape* of the inner loop rather than the cost of its callees. This removes one callee's fixed cost on ESP32. **The driver will still not decode**, and the wire capture is the test that counts — which needs hardware I do not have.

## One related finding, reported rather than changed

`src/platforms/shared/spi_bitbang/generic_software_spi.h:153-154` has the same shape on Teensy 4.x:

```cpp
#define DELAY_NS (1000 / (SPI_SPEED/1000000))
#define CLOCK_HI_DELAY do { delayNanoseconds((DELAY_NS/4)); } while(0);
```

`DELAY_NS` derives from the `SPI_SPEED` template parameter, so it is a compile-time constant — but this calls the **runtime** form, paying both the conversion and the clock query per clock edge in an SPI bit-bang loop. The fix there is `delayNanoseconds<(DELAY_NS/4)>()`, which removes the cost entirely rather than amortising it.

I have not made that change: it is `FL_IS_TEENSY_4X`-gated and I cannot compile that platform here, so I am not pushing a one-line edit to timing-critical code I have not built.

## Verification

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `uv run pytest ci/tests/` — 1328 passed, 41 skipped, 2448 subtests
- `bash lint` — clean, exit 0

Refs #4203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved clockless LED data transmission efficiency by determining the CPU frequency once per transmission instead of repeatedly for each bit.
  - Preserved consistent nanosecond delay timing across supported platforms while reducing runtime overhead on ESP32.

- **Tests**
  - Added structural coverage validating CPU-frequency handling, delay usage, and timing behavior during clockless bit transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->