### PR TITLE
fix(mp3): the SIMD gate measures the runner fleet, not the kernel (#4183)

### DIFF
--- a/tests/fl/codec/mp3_fixed_point.hpp
+++ b/tests/fl/codec/mp3_fixed_point.hpp
@@ -376,19 +376,40 @@ FL_TEST_CASE("minimp3 fixed-point SIMD is not slower than scalar") {
         return; // nothing was vectorised; the ratio measures noise
     }
 #if defined(__OPTIMIZE__)
-    // The enforced half of #4055's perf bar: whatever the machine, the vector
-    // path must not be *slower* than the scalar one it replaces. The 5%
-    // tolerance is for timer noise on a shared runner, not for a real
-    // regression -- x86 measures ~1.10x, and the SSE2 emulation this replaced
-    // came in at 0.95x, well outside it.
-    FL_CHECK_GE(ratio, 0.95);
+    // A floor, not a parity claim (#4183).
+    //
+    // This asserted `ratio >= 0.95` and took the default branch red at
+    // random. The measured ratio across CI is bimodal, not noisy around one
+    // value: 0.904, 0.920, 0.922, 0.924, 0.945 on some machines against
+    // 1.080 on others, with a macOS ARM runner at 0.922. The fastest scalar
+    // time of the lot produced the *worst* ratio, so this is not contention
+    // -- the kernel is genuinely faster on part of the fleet and genuinely
+    // slower on the rest, and both are correct measurements of different
+    // hardware.
+    //
+    // 0.95 sits inside that spread. A threshold there cannot tell "the SIMD
+    // kernel regressed" from "this run landed on the other runner class", so
+    // as a gate it reports the fleet rather than the code.
+    //
+    // What survives is a floor far outside any fleet variation: a vector path
+    // twice as slow as the scalar one it replaces is a defect on any machine.
+    // It will not catch a subtle regression -- nothing measured here can,
+    // which is the finding -- and that job belongs to
+    // `ci/codec_cpu/audit.py`, which builds optimised and compares against
+    // recorded baselines rather than against the scalar path on whatever
+    // silicon it drew.
+    //
+    // The ratio is still printed above on every run, so a shift in either
+    // population stays visible.
+    FL_CHECK_GE(ratio, 0.5);
 #else
     // Deliberately not asserted in an unoptimised build. Intrinsics are hit
     // far harder than scalar integer code by -O0 (every vector temporary
     // round-trips through the stack), so the ratio there measures the compiler
-    // rather than the kernel: this same code measures 0.93x at -O0 and 1.10x
-    // at -O3. The gate that counts runs in ci/codec_cpu/audit.py, which builds
-    // optimised.
+    // rather than the kernel: this same code measures 0.93x at -O0, against
+    // 0.90x-1.08x at -O3 depending on the runner. The gate that counts runs in
+    // ci/codec_cpu/audit.py, which builds optimised and compares against
+    // recorded baselines.
     printf("[simd-perf] unoptimised build; ratio not enforced here\n");
 #endif
 }


### PR DESCRIPTION
`FL_CHECK_GE(ratio, 0.95)` has taken the default branch red at random and is the only thing blocking #4175. **It also just failed an unrelated lint-tooling PR** (#4256, which touches only `ci/tools/`) at `speedup=0.922x`, which is what prompted this.

## The cause is settled; two measurements are new

Your investigation on the issue established the shape: the ratio is **bimodal across the fleet**, not noisy around one value — 0.904, 0.920, 0.922, 0.924, 0.945 on some machines against 1.080 on others. The decisive detail was that the *fastest* scalar time of the lot produced the worst ratio, so it is not contention.

Two things this adds:

- **The 0.922 above came from a macOS ARM runner** (`/Users/runner`, `/opt/homebrew`), so the slow population is not only GHA x86 as the issue supposed.
- **An optimised build on my host measures 0.993x–1.005x across runs** — between the two populations, and itself straddling the margin that 0.95 depended on.

So 0.95 sits inside the spread. As a gate it reports which runner drew the job.

## What replaces it

A floor far outside any fleet variation: `ratio >= 0.5`. A vector path twice as slow as the scalar one it replaces is a defect on any machine.

**Stated plainly, because it is a real loss:** this will not catch a subtle regression. Nothing measured here can — that is the finding — and that job belongs to `ci/codec_cpu/audit.py`, which builds optimised and compares against **recorded baselines** rather than against the scalar path on whatever silicon it drew. The in-source comment already named that as the gate that counts; this makes the two stop overlapping.

The ratio is still printed on every run, so a shift in either population stays visible.

This is option 1 from your list, with a floor kept rather than dropping the assertion entirely. Option 2 (threshold ~0.88) I did not take: the slow population reaches 0.904, so 0.88 leaves ~2% of margin against a distribution that has already moved 19%.

## The "~1.10x" claim is corrected

It describes the fast population only, and read as though there were one answer.

## Verification note

The assertion is `__OPTIMIZE__`-gated, so quick mode compiles it out. My first attempt at this mutation ran against a stale binary and looked like a survivor — the same trap as earlier in this program. Redone in a release build:

| mutation | result |
|---|---|
| scale the ratio to a quarter | **FAIL** — the floor fires |
| unmutated | passes at 0.993x |

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `bash lint` — clean, exit 0

Refs #4183, #4175, #4155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the optimized-build performance threshold for fixed-point SIMD MP3 decoding tests to account for variance across CI environments.
  * Updated test documentation with observed performance ranges and clarified that regression detection is handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->