### PR TITLE
docs(lessons): daemon growth vs stray processes; stranded commits

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -303,10 +303,13 @@
   unattended campaigns died to host memory pressure. Each time I checked for
   orphaned `autoresearch`/`esptool` processes, found none, saw `MemAvailable`
   looking healthy, and concluded the pressure was external. It was not:
-  `zccache-daemon` had grown to 4.4 GB and `fbuild-daemon` to 3.5 GB, ~9 GB of
+  `zccache-daemon` had grown to 4.4 GB and `fbuild-daemon` to 3.5 GB, ~8 GB of
   reclaimable cache sitting idle between runs. Killing both -- they respawn on
-  demand -- took available memory from 82 GB to 91 GB and the run that had
-  failed nine times completed immediately. Every mitigation applied before
+  demand -- moved `MemAvailable` from 82 GB to 91 GB, and the run that had
+  failed nine times completed immediately. The 9 GB recovered exceeds the
+  8 GB those two processes reported as RSS; page cache and shared mappings
+  released alongside them make up the difference, so treat the two numbers as
+  separate measurements rather than one. Every mitigation applied before
   that was real but aimed elsewhere: pre-building images removed the build
   spike, `--skip-lint` removed the lint phase, a memory floor gated each run,
   smaller batches limited the loss. None of them touched a daemon idling on
@@ -317,6 +320,8 @@
   earlier commit while three later pushes sat on the branch; the branch still
   existed, the PR read MERGED, and none of that work was on master. I caught it
   only because I grepped the merged file for each fix instead of trusting the
-  merge status -- one of them came back `0`. Verify content, not state, and
+  merge status -- `grep -c` for one of the fixes printed `0`, i.e. it matched
+  zero times, which is not the same signal as grep's exit status. Verify
+  content, not state, and
   when commits are stranded rebuild them onto current master as a fresh PR
   rather than reopening the merged one.

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -298,3 +298,25 @@
   would have reported a wedged board and halted the loop for nothing. Scan
   the whole vendor family and wait for re-enumeration before calling a board
   lost.
+- "Are stray processes accumulating?" and "have my long-lived daemons grown?"
+  are different questions, and I only asked the first one for nine kills. Nine
+  unattended campaigns died to host memory pressure. Each time I checked for
+  orphaned `autoresearch`/`esptool` processes, found none, saw `MemAvailable`
+  looking healthy, and concluded the pressure was external. It was not:
+  `zccache-daemon` had grown to 4.4 GB and `fbuild-daemon` to 3.5 GB, ~9 GB of
+  reclaimable cache sitting idle between runs. Killing both -- they respawn on
+  demand -- took available memory from 82 GB to 91 GB and the run that had
+  failed nine times completed immediately. Every mitigation applied before
+  that was real but aimed elsewhere: pre-building images removed the build
+  spike, `--skip-lint` removed the lint phase, a memory floor gated each run,
+  smaller batches limited the loss. None of them touched a daemon idling on
+  4 GB. When a resource problem survives several plausible fixes, enumerate
+  what is actually holding the resource before absorbing the failure as
+  environmental. See [[worktree-memory-exhaustion]].
+- A merged PR does not mean your last commits are in. #4233 was merged from an
+  earlier commit while three later pushes sat on the branch; the branch still
+  existed, the PR read MERGED, and none of that work was on master. I caught it
+  only because I grepped the merged file for each fix instead of trusting the
+  merge status -- one of them came back `0`. Verify content, not state, and
+  when commits are stranded rebuild them onto current master as a fresh PR
+  rather than reopening the merged one.


### PR DESCRIPTION
Two lessons from the RP2350W bench session.

**Daemon growth is not the same as process accumulation.** Nine unattended campaigns died to host memory pressure. Each time I checked for orphaned `autoresearch`/`esptool` processes, found none, saw `MemAvailable` healthy, and treated it as external. It was not — `zccache-daemon` had grown to 4.4 GB and `fbuild-daemon` to 3.5 GB, ~9 GB of reclaimable cache idle between runs. Killing both (they respawn) took available memory 82 GB → 91 GB and the run that had failed nine times completed immediately.

Every mitigation applied before that was real but aimed elsewhere: pre-building images, `--skip-lint`, a per-run memory floor, smaller batches. None touched a daemon idling on 4 GB.

**A merged PR does not mean your last commits are in.** #4233 merged from an earlier commit while three later pushes sat on the branch. The branch still existed, the PR read MERGED, and none of that work was on master — caught only by grepping the merged file for each fix and finding one at `0`. Rebuilt onto master as #4259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the combined daemon cache was approximately 8 GB.
  * Documented the separate recovery of available memory from 82 GB to 91 GB, including why the 9 GB increase exceeded daemon RSS.
  * Clarified that `grep -c` reporting `0` indicates zero matches and differs from the command’s no-match exit status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->