### PR TITLE
study(color): the feasible chroma ray is not always connected (#4041)

### DIFF
--- a/ci/color_ray_roots.py
+++ b/ci/color_ray_roots.py
@@ -27,6 +27,23 @@ two samples, however narrow.
 That is what this module computes. It answers the ray exactly and leaves the
 lightness/hue grid sampled, which is the honest split -- and it is enough,
 because the thing the sampled sweeps could not see turns out to be there.
+
+Two limits on "exact", stated here rather than left to be discovered:
+
+* it is exact *given* that `real_roots` returns every real root. A closed-form
+  cubic loses accuracy on a near-double root, and can merge two roots that are
+  closer together than the polished result can separate. `feasible_runs`
+  therefore unions the roots with a uniform guard grid, so the worst this can
+  degrade to is the resolution of a sampled scan at that grid's density --
+  never worse, which is the point of carrying it;
+* an exact tangency -- a drive touching a bound with even multiplicity -- is
+  not resolvable in floating point at all. Horner at a double root returns
+  something of order 1e-18 with an arbitrary sign. `runs_from_cubics`
+  classifies cut points so that such a touch is reported where the arithmetic
+  is exact, but a grid does not land on one anyway: tangency is measure-zero
+  in lightness and hue, and what a grid meets is the near-tangency beside it,
+  which is an ordinary narrow interval and is exactly how this study's wedge
+  presents.
 """
 
 from __future__ import annotations
@@ -279,26 +296,63 @@ def feasible_runs(
                 if 0.0 < root < max_chroma:
                     cuts.add(root)
 
-    ordered = sorted(cuts)
+    return RayScan(lightness, hue_degrees, runs_from_cubics(cubics, sorted(cuts)))
+
+
+def _inside(cubics: tuple[RayCubic, ...], chroma: float) -> bool:
+    for cubic in cubics:
+        drive = evaluate(cubic, chroma)
+        if drive < 0.0 or drive > 1.0:
+            return False
+    return True
+
+
+@typechecked
+def runs_from_cubics(
+    cubics: tuple[RayCubic, ...], ordered: list[float]
+) -> tuple[ChromaInterval, ...]:
+    """Maximal feasible runs over a partition, cut points and open cells alike.
+
+    The cut points are classified as well as the cells between them because a
+    drive with an even-multiplicity root at a bound touches the boundary
+    without crossing it: the ray meets the hull at exactly one chroma, and that
+    chroma is feasible while every neighbourhood of it is not. Testing
+    midpoints alone drops that point, and `RayScan` promises maximal runs
+    rather than runs wider than zero.
+
+    Such a touch is measure-zero in lightness and hue, so no grid finds one by
+    landing on it. What a grid does find is the near-tangency beside it, which
+    is a genuinely narrow interval -- and that is exactly how the wedge this
+    module was written to find presents itself.
+    """
+
+    if not ordered:
+        return ()
+
+    # Point, cell, point, cell, ..., point -- each carrying the chroma range it
+    # stands for, so a merged run reports the union without special cases.
+    atoms: list[tuple[float, float, bool]] = []
+    for index in range(len(ordered)):
+        edge = ordered[index]
+        atoms.append((edge, edge, _inside(cubics, edge)))
+        if index + 1 < len(ordered):
+            middle = (edge + ordered[index + 1]) / 2.0
+            atoms.append((edge, ordered[index + 1], _inside(cubics, middle)))
+
     intervals: list[ChromaInterval] = []
-    start: float | None = None
-    for index in range(len(ordered) - 1):
-        middle = (ordered[index] + ordered[index + 1]) / 2.0
-        inside = True
-        for cubic in cubics:
-            drive = evaluate(cubic, middle)
-            if drive < 0.0 or drive > 1.0:
-                inside = False
-                break
-        if inside:
-            if start is None:
-                start = ordered[index]
-        elif start is not None:
-            intervals.append(ChromaInterval(start, ordered[index]))
-            start = None
-    if start is not None:
-        intervals.append(ChromaInterval(start, ordered[-1]))
-    return RayScan(lightness, hue_degrees, tuple(intervals))
+    low: float | None = None
+    high = 0.0
+    for atom_low, atom_high, feasible in atoms:
+        if feasible:
+            if low is None:
+                low = atom_low
+            high = atom_high
+        elif low is not None:
+            intervals.append(ChromaInterval(low, high))
+            low = None
+    if low is not None:
+        intervals.append(ChromaInterval(low, high))
+    return tuple(intervals)
 
 
 @typechecked

--- a/ci/color_ray_roots.py
+++ b/ci/color_ray_roots.py
@@ -1,0 +1,335 @@
+"""Exact feasible chroma along one ray, by polynomial roots (P7, #4041).
+
+`docs/color-gamut-algorithm-selection.md` records that the shipped eight-halving
+chroma bisection is only a valid *search* if the feasible chroma along a
+fixed-lightness, fixed-hue ray is a single interval, and that the claim rests
+on sampling: 1.9 million feasibility evaluations on the three-emitter device
+and 7.5 million more across the wide hulls, none of which found a disconnected
+ray. The report names what is missing:
+
+    What none of it supplies is option 2, an analytic bound. The claim
+    remains empirical.
+
+Sampling cannot supply it, and not merely for want of density. The report's own
+method note explains why an answer is available without sampling at all: an
+inverse-OKLab fixed-lightness, fixed-hue ray is *cubic* in chroma. Writing that
+out, each emitter drive along the ray is
+
+    d_i(c) = sum_j K_ij * (p_j + q_j * c)^3
+
+with `p_j` fixed by the lightness, `q_j` by the hue, and `K` the product of the
+inverse emitter matrix with the inverse OKLab LMS matrix. Expanding the cube
+gives an ordinary cubic in `c` per drive, so `{c : 0 <= d_i(c) <= 1}` is decided
+by the real roots of `d_i` and `d_i - 1` rather than by how finely `c` was
+walked. The feasible set is then exact for that ray: no gap can hide between
+two samples, however narrow.
+
+That is what this module computes. It answers the ray exactly and leaves the
+lightness/hue grid sampled, which is the honest split -- and it is enough,
+because the thing the sampled sweeps could not see turns out to be there.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from typeguard import typechecked
+
+from ci.color_reference import Matrix3, _invert_3x3
+from ci.color_wide_hull_study import ChromaInterval, RayScan
+
+
+# The two matrices `color_reference._xyz_from_oklab` inverts on every call.
+# Named here because the cubic factorisation needs their inverses as
+# coefficients rather than as a function; `test_the_factorisation_matches_the
+# _reference_conversion` pins the two against each other so a change to one
+# cannot drift from the other silently.
+_OKLAB_FROM_LMS_ROOT = Matrix3(
+    (0.2104542553, 0.7936177850, -0.0040720468),
+    (1.9779984951, -2.4285922050, 0.4505937099),
+    (0.0259040371, 0.7827717662, -0.8086757660),
+)
+_LMS_FROM_XYZ = Matrix3(
+    (0.8190224432164319, 0.3619062562801221, -0.12887378261216414),
+    (0.0329836671980271, 0.9292868468965546, 0.03614466816999844),
+    (0.048177199566046255, 0.26423952494422764, 0.6335478258136937),
+)
+
+# A cubic whose leading coefficient is this much smaller than its largest is
+# solved as a quadratic instead. Cardano's formula divides by the leading
+# coefficient, so keeping a numerically-zero one loses accuracy in the roots
+# that do exist rather than finding an extra one.
+_DEGENERACY_RATIO = 1e-12
+
+# Roots are polished by this many Newton steps. The closed form is accurate to
+# a few ULP on well-separated roots and much worse on near-double ones, which
+# is exactly the case this study is about.
+_POLISH_STEPS = 4
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class RayCubic:
+    """One emitter drive as a cubic in chroma: `cube*c^3 + ... + constant`."""
+
+    cube: float
+    square: float
+    linear: float
+    constant: float
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class DisconnectedRay:
+    """A ray whose feasible chroma is more than one interval.
+
+    `gap` is what a bisection bracketed at the neutral axis gives up: it stops
+    at the end of the first interval and never sees the rest.
+    """
+
+    lightness: float
+    hue_degrees: float
+    intervals: tuple[ChromaInterval, ...]
+    gap: float
+
+
+def _rows(matrix: Matrix3) -> tuple[tuple[float, ...], ...]:
+    return (matrix.row0, matrix.row1, matrix.row2)
+
+
+# Inverted once. `ray_cubics` is called a few hundred thousand times by a
+# sweep, and inverting these two per call dominated everything else in it.
+_LMS_ROOT_FROM_OKLAB = _rows(_invert_3x3(_OKLAB_FROM_LMS_ROOT))
+_XYZ_FROM_LMS = _rows(_invert_3x3(_LMS_FROM_XYZ))
+
+
+@typechecked
+def ray_cubics(
+    inverse: Matrix3, lightness: float, hue_degrees: float
+) -> tuple[RayCubic, ...]:
+    """The three drive polynomials for one fixed-lightness, fixed-hue ray."""
+
+    lms_root_from_oklab = _LMS_ROOT_FROM_OKLAB
+    xyz_from_lms = _XYZ_FROM_LMS
+    drive_from_xyz = _rows(inverse)
+
+    radians = math.radians(hue_degrees)
+    cosine = math.cos(radians)
+    sine = math.sin(radians)
+
+    # The LMS cube roots are affine in chroma: constant part from lightness,
+    # slope from the hue direction.
+    offsets: list[float] = []
+    slopes: list[float] = []
+    for axis in range(3):
+        row = lms_root_from_oklab[axis]
+        offsets.append(row[0] * lightness)
+        slopes.append(row[1] * cosine + row[2] * sine)
+
+    # Fold the two linear stages after the cube into one matrix so the cube is
+    # the only nonlinearity between chroma and drive.
+    mixing: list[list[float]] = []
+    for drive in range(3):
+        row: list[float] = []
+        for axis in range(3):
+            total = 0.0
+            for middle in range(3):
+                total += drive_from_xyz[drive][middle] * xyz_from_lms[middle][axis]
+            row.append(total)
+        mixing.append(row)
+
+    cubics: list[RayCubic] = []
+    for drive in range(3):
+        cube = 0.0
+        square = 0.0
+        linear = 0.0
+        constant = 0.0
+        for axis in range(3):
+            weight = mixing[drive][axis]
+            offset = offsets[axis]
+            slope = slopes[axis]
+            cube += weight * slope * slope * slope
+            square += weight * 3.0 * offset * slope * slope
+            linear += weight * 3.0 * offset * offset * slope
+            constant += weight * offset * offset * offset
+        cubics.append(RayCubic(cube, square, linear, constant))
+    return tuple(cubics)
+
+
+@typechecked
+def evaluate(cubic: RayCubic, chroma: float) -> float:
+    """Horner evaluation of one drive polynomial."""
+
+    value = cubic.cube
+    value = value * chroma + cubic.square
+    value = value * chroma + cubic.linear
+    value = value * chroma + cubic.constant
+    return value
+
+
+def _polish(cubic: RayCubic, offset: float, root: float) -> float:
+    value = root
+    for _ in range(_POLISH_STEPS):
+        residual = evaluate(cubic, value) - offset
+        slope = (3.0 * cubic.cube * value + 2.0 * cubic.square) * value + cubic.linear
+        if slope == 0.0:
+            break
+        value -= residual / slope
+    return value
+
+
+def _quadratic_roots(square: float, linear: float, constant: float) -> list[float]:
+    if square == 0.0:
+        if linear == 0.0:
+            return []
+        return [-constant / linear]
+    discriminant = linear * linear - 4.0 * square * constant
+    if discriminant < 0.0:
+        return []
+    root = math.sqrt(discriminant)
+    return [(-linear + root) / (2.0 * square), (-linear - root) / (2.0 * square)]
+
+
+@typechecked
+def real_roots(cubic: RayCubic, offset: float) -> tuple[float, ...]:
+    """Every real `c` with `cubic(c) == offset`, closed form then polished."""
+
+    magnitudes = (
+        abs(cubic.cube),
+        abs(cubic.square),
+        abs(cubic.linear),
+        abs(cubic.constant - offset),
+    )
+    largest = max(magnitudes)
+    if largest == 0.0:
+        return ()
+    if abs(cubic.cube) < _DEGENERACY_RATIO * largest:
+        found = _quadratic_roots(cubic.square, cubic.linear, cubic.constant - offset)
+        polished: list[float] = []
+        for root in found:
+            polished.append(_polish(cubic, offset, root))
+        return tuple(polished)
+
+    square = cubic.square / cubic.cube
+    linear = cubic.linear / cubic.cube
+    constant = (cubic.constant - offset) / cubic.cube
+    shift = square / 3.0
+    depressed_linear = linear - square * shift
+    depressed_constant = constant - shift * linear + 2.0 * shift * shift * shift
+    half = depressed_constant / 2.0
+    third = depressed_linear / 3.0
+    discriminant = half * half + third * third * third
+
+    raw: list[float] = []
+    if discriminant > 0.0:
+        root = math.sqrt(discriminant)
+        first = -half + root
+        second = -half - root
+        raw.append(
+            math.copysign(abs(first) ** (1.0 / 3.0), first)
+            + math.copysign(abs(second) ** (1.0 / 3.0), second)
+            - shift
+        )
+    elif discriminant == 0.0:
+        single = math.copysign(abs(-half) ** (1.0 / 3.0), -half)
+        raw.append(2.0 * single - shift)
+        raw.append(-single - shift)
+    else:
+        radius = math.sqrt(-third * third * third)
+        angle = math.acos(max(-1.0, min(1.0, -half / radius)))
+        scale = 2.0 * math.sqrt(-third)
+        for turn in range(3):
+            raw.append(scale * math.cos((angle + 2.0 * math.pi * turn) / 3.0) - shift)
+
+    polished = []
+    for root in raw:
+        polished.append(_polish(cubic, offset, root))
+    return tuple(polished)
+
+
+@typechecked
+def feasible_runs(
+    inverse: Matrix3,
+    lightness: float,
+    hue_degrees: float,
+    max_chroma: float,
+    guard_cells: int,
+) -> RayScan:
+    """Every maximal feasible chroma interval on one ray, from the roots.
+
+    The partition is the union of the polynomial roots and a uniform grid of
+    `guard_cells` cells. The roots are what makes this exact; the grid is
+    defensive, so that a root the closed form loses on a near-double case can
+    only cost this the resolution of a sampled scan, never more.
+    """
+
+    if max_chroma <= 0.0:
+        raise ValueError("max_chroma must be positive")
+    if guard_cells <= 0:
+        raise ValueError("guard_cells must be positive")
+
+    cubics = ray_cubics(inverse, lightness, hue_degrees)
+    cuts = {0.0, max_chroma}
+    for cell in range(1, guard_cells):
+        cuts.add(max_chroma * cell / guard_cells)
+    for cubic in cubics:
+        for offset in (0.0, 1.0):
+            for root in real_roots(cubic, offset):
+                if 0.0 < root < max_chroma:
+                    cuts.add(root)
+
+    ordered = sorted(cuts)
+    intervals: list[ChromaInterval] = []
+    start: float | None = None
+    for index in range(len(ordered) - 1):
+        middle = (ordered[index] + ordered[index + 1]) / 2.0
+        inside = True
+        for cubic in cubics:
+            drive = evaluate(cubic, middle)
+            if drive < 0.0 or drive > 1.0:
+                inside = False
+                break
+        if inside:
+            if start is None:
+                start = ordered[index]
+        elif start is not None:
+            intervals.append(ChromaInterval(start, ordered[index]))
+            start = None
+    if start is not None:
+        intervals.append(ChromaInterval(start, ordered[-1]))
+    return RayScan(lightness, hue_degrees, tuple(intervals))
+
+
+@typechecked
+def sweep_disconnected(
+    inverse: Matrix3,
+    lightness_steps: int,
+    hue_steps: int,
+    max_chroma: float,
+    guard_cells: int,
+) -> list[DisconnectedRay]:
+    """Every ray on a lightness x hue grid whose feasible chroma is not one run."""
+
+    if lightness_steps <= 0 or hue_steps <= 0:
+        raise ValueError("lightness_steps and hue_steps must be positive")
+
+    broken: list[DisconnectedRay] = []
+    for lightness_step in range(1, lightness_steps):
+        lightness = lightness_step / lightness_steps
+        for hue_step in range(hue_steps):
+            hue_degrees = 360.0 * hue_step / hue_steps
+            scan = feasible_runs(
+                inverse, lightness, hue_degrees, max_chroma, guard_cells
+            )
+            if scan.is_connected:
+                continue
+            broken.append(
+                DisconnectedRay(
+                    lightness,
+                    hue_degrees,
+                    scan.intervals,
+                    scan.intervals[1].low - scan.intervals[0].high,
+                )
+            )
+    return broken

--- a/ci/tests/test_color_gamut_study.py
+++ b/ci/tests/test_color_gamut_study.py
@@ -334,9 +334,16 @@ class TestColorGamutStudy(unittest.TestCase):
     ) -> None:
         """Bisection assumes the feasible chroma ray is connected.
 
-        The reference does not assume that, so the assumption is checked here
-        rather than asserted in prose. A coarse sweep on every run; the dense
-        1.9M-sample sweep behind the report's claim is recorded there.
+        That assumption is false, and `ci/tests/test_color_ray_roots.py`
+        carries the witness: a hue wedge about 0.14 degrees wide near 264
+        degrees where the feasible chroma is two intervals at every lightness.
+
+        This case is kept, unchanged, for what it now says instead. The wedge
+        contains no multiple of the 30 degrees walked here -- nor of the 3
+        degrees walked by the dense sweep behind the report -- so this passes,
+        and it passing is the point: a sampled grid reports connectivity on a
+        device that does not have it, and the failure is invisible from
+        inside the sample.
         """
 
         for lightness_step in range(1, 10):
@@ -357,8 +364,10 @@ class TestColorGamutStudy(unittest.TestCase):
                         with self.subTest(lightness=lightness, hue=hue_degrees):
                             self.assertFalse(
                                 seen_infeasible,
-                                "feasible chroma is disconnected here; "
-                                "bisection would discard the far interval",
+                                "feasible chroma is disconnected on this "
+                                "grid too; the known wedge near 264 degrees "
+                                "is off it, so this is a second case and "
+                                "test_color_ray_roots.py should gain it",
                             )
                     else:
                         seen_infeasible = True

--- a/ci/tests/test_color_ray_roots.py
+++ b/ci/tests/test_color_ray_roots.py
@@ -1,0 +1,259 @@
+"""The feasible chroma ray is not always one interval (P7, #4041).
+
+`docs/color-gamut-algorithm-selection.md` recorded connectivity as an
+empirical claim resting on 1.9 million sampled feasibility evaluations, and
+asked for an analytic bound it did not have. Computing the ray exactly instead
+of sampling it refutes the claim: on the primaries FastLED ships there is a
+hue wedge about 0.14 degrees wide near 264 degrees where the feasible chroma
+is two intervals, at every lightness the sweep covers.
+
+These tests pin the witness, pin the two distinct reasons a sampled sweep
+walks past it, and pin the parts that would silently invalidate the method.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from ci.color_gamut_study import emitter_matrix, is_feasible
+from ci.color_ray_roots import (
+    RayCubic,
+    evaluate,
+    feasible_runs,
+    ray_cubics,
+    real_roots,
+    sweep_disconnected,
+)
+from ci.color_reference import Matrix3, _invert_3x3, _matvec, _xyz_from_oklab
+from ci.color_wide_hull_study import scan_ray
+
+
+PRIMARIES = ((0.6400, 0.3300), (0.3000, 0.6000), (0.1500, 0.0600))
+MAX_CHROMA = 0.5
+GUARD_CELLS = 64
+
+# The witness. Found by computing the ray exactly on a 0.1-degree hue grid;
+# the wedge runs from about 264.06 to 264.20 degrees and spans every
+# lightness from 0.05 up.
+WITNESS_LIGHTNESS = 0.5
+WITNESS_HUE = 264.06
+
+
+def _inverse() -> Matrix3:
+    return _invert_3x3(emitter_matrix(PRIMARIES))
+
+
+def _target(lightness: float, hue_degrees: float, chroma: float) -> tuple[float, ...]:
+    radians = math.radians(hue_degrees)
+    return _xyz_from_oklab(
+        (lightness, chroma * math.cos(radians), chroma * math.sin(radians))
+    )
+
+
+class TestTheFactorisation(unittest.TestCase):
+    def test_the_cubics_reproduce_the_reference_conversion(
+        self: "TestTheFactorisation",
+    ) -> None:
+        # The whole method rests on the drive being this cubic and nothing
+        # else. If the two ever drift, every result here is about a curve the
+        # pipeline does not follow.
+        inverse = _inverse()
+        for lightness in (0.05, 0.4, 0.8, 1.1):
+            for hue_degrees in (0.0, 37.0, WITNESS_HUE, 300.0):
+                cubics = ray_cubics(inverse, lightness, hue_degrees)
+                for chroma in (0.0, 0.05, 0.2, 0.35):
+                    reference = _matvec(
+                        inverse, _target(lightness, hue_degrees, chroma)
+                    )
+                    for index in range(3):
+                        self.assertAlmostEqual(
+                            evaluate(cubics[index], chroma),
+                            reference[index],
+                            delta=1e-12,
+                        )
+
+    def test_roots_land_on_the_polynomial(self: "TestTheFactorisation") -> None:
+        # A root the solver reports but the polynomial does not have would cut
+        # the partition in a place that is not a boundary, which shows up as a
+        # spurious interval rather than as an error.
+        inverse = _inverse()
+        for cubic in ray_cubics(inverse, WITNESS_LIGHTNESS, WITNESS_HUE):
+            for offset in (0.0, 1.0):
+                for root in real_roots(cubic, offset):
+                    self.assertAlmostEqual(evaluate(cubic, root), offset, delta=1e-10)
+
+    def test_a_degenerate_leading_coefficient_still_solves(
+        self: "TestTheFactorisation",
+    ) -> None:
+        # Cardano divides by the cubic term. A hue where it vanishes is not
+        # exotic -- it is wherever the ray's LMS slopes cancel -- and dividing
+        # by it there loses the roots that do exist.
+        quadratic = RayCubic(0.0, 2.0, -3.0, 1.0)
+        roots = sorted(real_roots(quadratic, 0.0))
+        self.assertEqual(len(roots), 2)
+        self.assertAlmostEqual(roots[0], 0.5, delta=1e-12)
+        self.assertAlmostEqual(roots[1], 1.0, delta=1e-12)
+
+
+class TestTheWitness(unittest.TestCase):
+    def test_the_feasible_chroma_is_two_intervals(self: "TestTheWitness") -> None:
+        scan = feasible_runs(
+            _inverse(), WITNESS_LIGHTNESS, WITNESS_HUE, MAX_CHROMA, GUARD_CELLS
+        )
+        self.assertFalse(scan.is_connected)
+        self.assertEqual(len(scan.intervals), 2)
+        near, far = scan.intervals
+        self.assertAlmostEqual(near.low, 0.0, delta=1e-12)
+        self.assertAlmostEqual(near.high, 0.29443, delta=1e-4)
+        self.assertAlmostEqual(far.low, 0.34575, delta=1e-4)
+        self.assertAlmostEqual(far.high, 0.34644, delta=1e-4)
+
+    def test_the_far_island_is_confirmed_by_the_studys_own_oracle(
+        self: "TestTheWitness",
+    ) -> None:
+        # The intervals come from polynomial roots; `is_feasible` comes from
+        # the matrix path the rest of the study uses. Agreeing here is what
+        # separates a real gap from an artefact of the factorisation.
+        inverse = _inverse()
+        scan = feasible_runs(
+            inverse, WITNESS_LIGHTNESS, WITNESS_HUE, MAX_CHROMA, GUARD_CELLS
+        )
+        near, far = scan.intervals
+        inside_near = near.high * 0.5
+        inside_gap = (near.high + far.low) / 2.0
+        inside_far = (far.low + far.high) / 2.0
+        for chroma, expected in (
+            (inside_near, True),
+            (inside_gap, False),
+            (inside_far, True),
+        ):
+            with self.subTest(chroma=chroma):
+                point = _target(WITNESS_LIGHTNESS, WITNESS_HUE, chroma)
+                self.assertEqual(is_feasible(inverse, point), expected)
+
+    def test_the_far_island_is_a_colour_the_device_can_make(
+        self: "TestTheWitness",
+    ) -> None:
+        # Drives inside [0, 1] is the definition of feasible, but a target can
+        # satisfy it while sitting outside the cone of physical colour. Both
+        # halves are checked so the witness cannot be dismissed as a target
+        # nothing would ever ask for.
+        inverse = _inverse()
+        scan = feasible_runs(
+            inverse, WITNESS_LIGHTNESS, WITNESS_HUE, MAX_CHROMA, GUARD_CELLS
+        )
+        far = scan.intervals[1]
+        point = _target(WITNESS_LIGHTNESS, WITNESS_HUE, (far.low + far.high) / 2.0)
+        lms = _matvec(
+            Matrix3(
+                (0.8190224432164319, 0.3619062562801221, -0.12887378261216414),
+                (0.0329836671980271, 0.9292868468965546, 0.03614466816999844),
+                (0.048177199566046255, 0.26423952494422764, 0.6335478258136937),
+            ),
+            point,
+        )
+        for response in lms:
+            self.assertGreater(response, 0.0)
+        for drive in _matvec(inverse, point):
+            self.assertGreaterEqual(drive, 0.0)
+            self.assertLessEqual(drive, 1.0)
+
+    def test_bisection_gives_up_a_sixth_of_the_reachable_chroma(
+        self: "TestTheWitness",
+    ) -> None:
+        # The cost, stated as a number rather than as "the search may be
+        # wrong". A bracket seeded at the neutral axis converges inside the
+        # near interval and never reaches the far one.
+        scan = feasible_runs(
+            _inverse(), WITNESS_LIGHTNESS, WITNESS_HUE, MAX_CHROMA, GUARD_CELLS
+        )
+        near, far = scan.intervals
+        self.assertGreater(far.high - near.high, 0.05)
+        self.assertGreater((far.high - near.high) / far.high, 0.15)
+
+
+class TestWhyTheSweepsMissedIt(unittest.TestCase):
+    def test_the_reports_hue_grid_steps_over_the_wedge(
+        self: "TestWhyTheSweepsMissedIt",
+    ) -> None:
+        # The dense sweep behind the report walks hue every 3 degrees. The
+        # wedge is about 0.14 degrees wide and contains no multiple of 3, so
+        # no amount of extra chroma sampling on that grid could have found it.
+        broken = sweep_disconnected(_inverse(), 20, 120, MAX_CHROMA, GUARD_CELLS)
+        self.assertEqual(broken, [])
+
+    def test_a_tenth_degree_grid_finds_it(self: "TestWhyTheSweepsMissedIt") -> None:
+        # Same device, same chroma range, hue thirty times finer. Kept small
+        # in lightness so this stays a unit test; the full sweep is in the
+        # report.
+        broken = sweep_disconnected(_inverse(), 8, 3600, MAX_CHROMA, GUARD_CELLS)
+        self.assertGreater(len(broken), 0)
+        for ray in broken:
+            with self.subTest(hue=ray.hue_degrees):
+                self.assertGreater(ray.gap, 0.0)
+                self.assertAlmostEqual(ray.hue_degrees, 264.1, delta=0.2)
+
+    def test_chroma_sampling_misses_it_even_on_the_right_ray(
+        self: "TestWhyTheSweepsMissedIt",
+    ) -> None:
+        # The second failure mode, and the one that matters more: even handed
+        # the exact hue, the sampled scan reports a single interval, because
+        # the far island is narrower than its 0.00125 chroma step. Density is
+        # not the fix -- whatever the step, some ray's island is thinner.
+        inverse = _inverse()
+        sampled = scan_ray(
+            lambda point: is_feasible(inverse, point),
+            WITNESS_LIGHTNESS,
+            WITNESS_HUE,
+            MAX_CHROMA,
+            401,
+        )
+        self.assertTrue(sampled.is_connected)
+        exact = feasible_runs(
+            inverse, WITNESS_LIGHTNESS, WITNESS_HUE, MAX_CHROMA, GUARD_CELLS
+        )
+        self.assertFalse(exact.is_connected)
+        far = exact.intervals[1]
+        self.assertLess(far.high - far.low, MAX_CHROMA / 400.0)
+
+
+class TestTheOrdinaryRayIsStillConnected(unittest.TestCase):
+    def test_hues_away_from_the_wedge_are_one_interval_anchored_at_zero(
+        self: "TestTheOrdinaryRayIsStillConnected",
+    ) -> None:
+        # A refutation is only worth something if the thing it refutes was
+        # nearly true. Away from the wedge the report's picture holds exactly,
+        # which is why this is a narrow correction and not a rewrite.
+        inverse = _inverse()
+        for lightness_step in range(1, 10):
+            lightness = lightness_step / 10.0
+            for hue_step in range(0, 360, 15):
+                with self.subTest(lightness=lightness, hue=hue_step):
+                    scan = feasible_runs(
+                        inverse, lightness, float(hue_step), MAX_CHROMA, GUARD_CELLS
+                    )
+                    self.assertTrue(scan.is_connected)
+                    self.assertTrue(scan.starts_at_zero)
+
+
+class TestInputValidation(unittest.TestCase):
+    def test_degenerate_sweep_arguments_are_refused(
+        self: "TestInputValidation",
+    ) -> None:
+        # Each of these returns an empty result rather than failing, and an
+        # empty result here reads as "no disconnected ray exists" -- the
+        # claim this module was written to overturn.
+        inverse = _inverse()
+        with self.assertRaises(ValueError):
+            feasible_runs(inverse, 0.5, 0.0, 0.0, GUARD_CELLS)
+        with self.assertRaises(ValueError):
+            feasible_runs(inverse, 0.5, 0.0, MAX_CHROMA, 0)
+        with self.assertRaises(ValueError):
+            sweep_disconnected(inverse, 0, 120, MAX_CHROMA, GUARD_CELLS)
+        with self.assertRaises(ValueError):
+            sweep_disconnected(inverse, 20, 0, MAX_CHROMA, GUARD_CELLS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_color_ray_roots.py
+++ b/ci/tests/test_color_ray_roots.py
@@ -23,6 +23,7 @@ from ci.color_ray_roots import (
     feasible_runs,
     ray_cubics,
     real_roots,
+    runs_from_cubics,
     sweep_disconnected,
 )
 from ci.color_reference import Matrix3, _invert_3x3, _matvec, _xyz_from_oklab
@@ -235,6 +236,44 @@ class TestTheOrdinaryRayIsStillConnected(unittest.TestCase):
                     )
                     self.assertTrue(scan.is_connected)
                     self.assertTrue(scan.starts_at_zero)
+
+
+class TestTangency(unittest.TestCase):
+    def test_a_touch_point_is_kept_as_a_zero_width_run(self: "TestTangency") -> None:
+        # -(c - 0.5)^2 (c + 1) = -c^3 + 0.75c - 0.25 is zero at c = 0.5 and
+        # negative everywhere else, so 0.5 is feasible and no neighbourhood of
+        # it is. Testing only the midpoints of the cells between cut points
+        # drops it, and the run list is then not the maximal one `RayScan`
+        # promises.
+        #
+        # Every coefficient and every cut below is dyadic, which is not
+        # decoration: Horner on a double root evaluates to something on the
+        # order of 1e-18 with an arbitrary sign, so a touch point is only
+        # detectable at all where the arithmetic happens to be exact. That is
+        # the real limit here -- an exact tangency is not a thing floating
+        # point can resolve, and what a grid meets instead is the near-tangency
+        # beside it, which is an ordinary narrow interval.
+        touching = RayCubic(-1.0, 0.0, 0.75, -0.25)
+        self.assertEqual(evaluate(touching, 0.5), 0.0)
+        self.assertLess(evaluate(touching, 0.25), 0.0)
+        self.assertLess(evaluate(touching, 0.75), 0.0)
+        elsewhere = RayCubic(0.0, 0.0, 0.0, 0.5)
+        cubics = (touching, elsewhere, elsewhere)
+        runs = runs_from_cubics(cubics, [0.0, 0.25, 0.5, 0.75, 1.0])
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0].low, 0.5)
+        self.assertEqual(runs[0].high, 0.5)
+
+    def test_an_ordinary_run_still_spans_its_cells(self: "TestTangency") -> None:
+        # The control: without a tangency the point classification must not
+        # fragment a run into one interval per cut point.
+        everywhere = RayCubic(0.0, 0.0, 0.0, 0.5)
+        runs = runs_from_cubics(
+            (everywhere, everywhere, everywhere), [0.0, 0.1, 0.2, 0.3]
+        )
+        self.assertEqual(len(runs), 1)
+        self.assertAlmostEqual(runs[0].low, 0.0, delta=1e-12)
+        self.assertAlmostEqual(runs[0].high, 0.3, delta=1e-12)
 
 
 class TestInputValidation(unittest.TestCase):

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -211,21 +211,80 @@ Widening lms makes the mapper *worse*, and widening XYZ -- which the whole
 P6 working domain would have to follow -- only improves it about fourfold.
 Neither buys anything the budget needs, so the simpler implementation ships.
 
-## Is the feasible chroma ray actually connected?
+## Is the feasible chroma ray actually connected? No.
 
 Bisection assumes it is. The reference does not, so the assumption was tested
 rather than argued: 4 680 rays (lightness on a 40-step grid, hue every 3
 degrees), each sampled at 401 chroma values -- about 1.9 million feasibility
-evaluations.
+evaluations. **No disconnected interval was found**, and the same held across
+another 7.5 million evaluations on the four white-emitter devices in "Wide
+hulls" below.
 
-**No disconnected interval was found.** On every ray sampled, the feasible
-chroma was a single interval starting at zero.
+The assumption is false anyway. Sampling was the wrong instrument, and the
+number of samples was never going to fix it.
 
-That is strong evidence for this device, not a proof. The >=4-emitter case,
-where the zonotope gains a redundant generator, is swept separately in "Wide
-hulls" below -- another 7.5 million evaluations across the four white-emitter
-devices, also with no disconnected interval. A coarser sweep of both runs on
-every test invocation so the assumption cannot rot silently.
+The ray does not have to be sampled. As the method note below already says, an
+inverse-OKLab fixed-lightness, fixed-hue ray is cubic in chroma; written out,
+each drive along the ray is `d_i(c) = sum_j K_ij (p_j + q_j c)^3`, an ordinary
+cubic in `c`. So `{c : 0 <= d_i(c) <= 1}` is decided by the real roots of `d_i`
+and `d_i - 1`, and the feasible set for a ray is *exact* -- no gap can hide
+between two samples, however narrow. That is `ci/color_ray_roots.py`.
+
+Computed that way, on the primaries this report uses:
+
+| | |
+| --- | --- |
+| lightness | 0.5 |
+| hue | 264.06 degrees |
+| feasible chroma | `[0, 0.29443]` and `[0.34575, 0.34644]` |
+| what a bisection returns | 0.29443 |
+| what is actually reachable | 0.34644 |
+| chroma given up | 0.0520, **17.6% of the reachable maximum** |
+
+The far interval is a real colour, not an artefact: its LMS response is
+positive on all three cones and its drives are `(0.000005, 0.000214, 0.097553)`
+-- a deep blue at a tenth of full drive. Re-rendering those drives through the
+forward matrix returns `L = 0.500000, C = 0.346092, h = 264.0600`, the target
+it was asked for.
+
+### Why 1.9 million samples walked past it
+
+Two independent reasons, and the second is the one that matters.
+
+**The wedge is thinner than the hue grid.** Disconnection holds for hue in
+roughly `[264.06, 264.20]` degrees -- about 0.14 degrees wide, and present at
+every lightness from 0.05 to 0.75. It contains no multiple of 3, so the dense
+sweep's hue grid steps over it. At 264.0 degrees the set is one interval
+ending at 0.28995; by 264.25 the two have merged into one interval ending at
+0.34578. The disconnection lives in the fold between.
+
+**Density is not the fix.** Handed the exact hue, a 401-sample chroma scan
+*still* reports one interval, because the far island is 0.00069 wide against a
+0.00125 sample step. Refining the grid moves the problem rather than solving
+it: whatever the step, some ray's island is thinner than it.
+
+### What it costs, and what it does not
+
+Narrow: 0.14 degrees of 360, so 0.04% of hues. Inside it, an out-of-gamut
+target above 0.34644 chroma is mapped to 0.29443 instead -- under-saturated,
+hue exact, still in gamut. The mapper returns a producible colour that is
+merely less saturated than one it could have produced, so this is a quality
+loss in a sliver, not a correctness failure anywhere.
+
+It is still worth having on the record as fact rather than as an assumption,
+because the shipped search's validity was resting on it, and because the same
+argument shows what a future device would need: the wedge exists where the ray
+runs nearly along the `red = 0` face, so a different primary set puts it
+somewhere else rather than removing it.
+
+### Scope
+
+The exact method is for the three-emitter case, where feasibility is "the
+unique preimage lands in the box" and each drive is one cubic. With a white
+emitter the preimage stops being unique and feasibility becomes a linear
+program, so the wide hulls in "Wide hulls" below remain swept rather than
+solved. Their claim is still the sampled one, and now known to be the weaker
+kind of evidence.
 
 ## Lightness must be clamped before chroma
 
@@ -260,8 +319,13 @@ Recording this rather than leaving it implicit: the table above is evidence
 for the *objective*, and only provisional evidence for the *search*.
 
 Option 1 has since been taken as far as sampling can take it, for the wide
-hulls as well as this one -- see "Wide hulls" below. What none of it supplies
-is option 2, an analytic bound. The claim remains empirical.
+hulls as well as this one -- see "Wide hulls" below, and it found nothing.
+Option 2 was then taken for the three-emitter device by solving the cubic
+instead of sampling it, and it did not produce a bound: it produced a
+counterexample. See "Is the feasible chroma ray actually connected? No."
+above. The paragraph this section opens with -- that feasibility along the ray
+"can in principle be disconnected" -- turns out to describe this device rather
+than a hypothetical one.
 
 ## Is the mapping continuous enough to animate?
 
@@ -555,6 +619,15 @@ these devices, not a proof. The interval detector is given a predicate with a
 hole punched in it and required to report two intervals, so the sweep cannot
 pass by never firing.
 
+**Read that row with the three-emitter refutation in mind.** The identical
+sweep, at the identical density, reported a clean zero on a device that does
+have a disconnected ray -- see "Is the feasible chroma ray actually connected?
+No." above. A zero in this column means "the grid did not land on one", and
+these numbers are the same grid. The exact method that found the wedge does
+not carry over here, because a white emitter makes feasibility a linear
+program rather than one cubic per drive, so for the wide hulls the question is
+genuinely still open rather than answered in the affirmative.
+
 ### The composition holds, once both halves use the same hull
 
 Scored over roughly 28 000 out-of-gamut targets, mapped at the shipped eight
@@ -704,5 +777,7 @@ The composition is scored against the reference objective and against itself,
 not against measured hardware -- that is P10's gate.
 
 Ray connectivity above four emitters is measured on the four devices the
-corpus ships. A device whose whites are close enough to be near-parallel
-generators, or one with more than two whites, is outside what was swept.
+corpus ships, and only by sampling. A device whose whites are close enough to
+be near-parallel generators, or one with more than two whites, is outside what
+was swept. The three-emitter case is no longer in this list: it is solved
+exactly, and the answer is that the ray is sometimes disconnected.

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -230,6 +230,16 @@ cubic in `c`. So `{c : 0 <= d_i(c) <= 1}` is decided by the real roots of `d_i`
 and `d_i - 1`, and the feasible set for a ray is *exact* -- no gap can hide
 between two samples, however narrow. That is `ci/color_ray_roots.py`.
 
+Exact given that the solver returns every real root, which is worth stating
+because the closed form loses accuracy on a near-double root and can merge two
+that sit closer than the polished result separates. The partition is therefore
+the union of the roots with a uniform guard grid, so the failure mode degrades
+to the resolution of a sampled scan rather than past it. An exact tangency --
+a drive touching a bound with even multiplicity -- is not resolvable in
+floating point at all; it is also measure-zero in lightness and hue, so what a
+grid meets is the near-tangency beside it, which is an ordinary narrow
+interval and is how the wedge below presents.
+
 Computed that way, on the primaries this report uses:
 
 | | |


### PR DESCRIPTION
Refs #4041.

`docs/color-gamut-algorithm-selection.md` gave itself two ways to close the last open question about the shipped eight-halving bisection:

> 1. extend the corpus with a target constructed to sit on a disconnected interval, and re-run this study; or
> 2. bound the error of bisection against the global search analytically for the primaries FastLED ships.

Option 1 was already taken as far as sampling goes — 1.9M feasibility evaluations here, 7.5M more on the wide hulls, nothing found. This is option 2. It does not produce a bound; **it produces a counterexample.**

## The ray never needed sampling

The method note in the same document already says an inverse-OKLab fixed-lightness, fixed-hue ray is *cubic* in chroma. Written out, each drive along the ray is

```
d_i(c) = sum_j K_ij * (p_j + q_j * c)^3
```

an ordinary cubic in `c`. So `{c : 0 <= d_i(c) <= 1}` follows from the real roots of `d_i` and `d_i - 1`, exactly — no gap can hide between two samples, however narrow. That is `ci/color_ray_roots.py`.

## The witness

On the primaries the report uses, at **lightness 0.5, hue 264.06°**:

| | |
|---|---|
| feasible chroma | `[0, 0.29443]` **and** `[0.34575, 0.34644]` |
| what bisection returns | 0.29443 |
| what is actually reachable | 0.34644 |
| given up | 0.0520 — **17.6% of the reachable maximum** |

Checked three ways before believing it:

1. the intervals agree with the study's own `is_feasible` matrix path, not just with the factorisation;
2. the far island's LMS response is positive on all three cones — a physical colour;
3. re-rendering its drives `(0.000005, 0.000214, 0.097553)` through the forward matrix returns `L=0.500000  C=0.346092  h=264.0600`, the target it was asked for. A deep blue at a tenth of full drive.

## Why 8.4 million evaluations walked past it

Two independent reasons, and the second is the one that matters:

- **The wedge is thinner than the hue grid.** Disconnection holds for hue in roughly `[264.06, 264.20]` — 0.14° wide, at every lightness from 0.05 to 0.75 — and contains no multiple of the 3° the dense sweep steps by. At 264.0° the set is one interval ending at 0.28995; by 264.25° the two have merged.
- **Density is not the fix.** Handed the exact hue, a 401-sample chroma scan *still* reports one interval, because the far island is 0.00069 wide against a 0.00125 step. Whatever the step, some ray's island is thinner than it.

## What it costs

Narrow, and said as such: 0.14° of 360, so **0.04% of hues**. Inside it an out-of-gamut target above 0.34644 chroma maps to 0.29443 — under-saturated, hue exact, still in gamut. A quality loss in a sliver, not a correctness failure. It is on the record because the search's validity was resting on it, and because the wedge sits where the ray runs nearly along the `red = 0` face — a different primary set moves it rather than removing it.

## What this does to the existing claims

- `test_feasible_chroma_is_one_interval_for_this_device` is **kept unchanged and still passes**. Its docstring now says why that is the finding rather than the reassurance: a sampled grid reports connectivity on a device that does not have it.
- The wide-hull table gets the same caveat. That identical sweep, at that identical density, reported a clean zero on a device that *does* have a disconnected ray — so a zero in that column means "the grid did not land on one". The exact method does not carry over there, because a white emitter makes feasibility a linear program rather than one cubic per drive.

## Verification

- `uv run python -m pytest ci/tests/test_color_ray_roots.py ci/tests/test_color_gamut_study.py ci/tests/test_color_wide_hull_study.py -q` — 42 passed, 2578 subtests
- `bash lint` — 0 errors
- Mutation-tested: partitioning from the guard grid alone (i.e. sampling) loses the witness; dropping any term of the factorisation fails the reference comparison; removing the degenerate-cubic branch fails its case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of zero-width feasible chroma ranges at boundary tangencies.
  * Added reliable reporting of disconnected feasible chroma ranges along fixed-lightness, fixed-hue rays.
* **Bug Fixes**
  * Corrected missed feasible ranges caused by midpoint-only and coarse sampling approaches.
* **Tests**
  * Added regression coverage for tangencies, disconnected ranges, root handling, feasibility checks, and sampling limitations.
* **Documentation**
  * Updated algorithm guidance with counterexamples, exactness limitations, and applicability details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->