### PR TITLE
fix(power): stop scaling the part of the draw brightness cannot reach (#4156 R4)

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -467,12 +467,19 @@ void CFastLED::setDither(fl::u8 ditherMode)  {
 }
 
 fl::u32 CFastLED::getEstimatedPowerInMilliWatts(bool apply_limiter) const {
-	fl::u32 total_power_mW = 0;
+	fl::u32 fixed_power_mW = 0;
+	fl::u32 controllable_power_mW = 0;
 
-	// Sum unscaled power from all LED controllers using visitor pattern
-	CLEDController::visitControllers([&total_power_mW](const CLEDController* /*controller*/, fl::span<const CRGB> leds) {
+	// Sum unscaled power from all LED controllers using visitor pattern.
+	// The dark-current baseline is kept apart from the part brightness scales,
+	// because it is drawn at every brightness including zero (#4156 R4).
+	const fl::u32 dark_mW_per_led = get_power_model().dark_mW;
+	CLEDController::visitControllers([&](const CLEDController* /*controller*/, fl::span<const CRGB> leds) {
 		if (!leds.empty()) {
-			total_power_mW += calculate_unscaled_power_mW(leds);
+			const fl::u32 unscaled_mW = calculate_unscaled_power_mW(leds);
+			const fl::u32 dark_mW = dark_mW_per_led * static_cast<fl::u32>(leds.size());
+			fixed_power_mW += dark_mW;
+			controllable_power_mW += unscaled_mW > dark_mW ? unscaled_mW - dark_mW : 0;
 		}
 	});
 
@@ -485,9 +492,12 @@ fl::u32 CFastLED::getEstimatedPowerInMilliWatts(bool apply_limiter) const {
 		effective_brightness = (*mPPowerFunc)(mScale, mNPowerData);
 	}
 
-	// Scale by the configured power-brightness response.
+	// Scale only the emitter share by the configured power-brightness response
+	// and add the baseline back, so the estimate matches what the limiter now
+	// budgets against.
 	// Note: MCU power consumption is NOT included - caller should add platform-specific MCU power if needed
-	return scale_power_for_brightness(total_power_mW, effective_brightness);
+	return fixed_power_mW +
+	       scale_power_for_brightness(controllable_power_mW, effective_brightness);
 }
 
 //

--- a/src/power_mgt.cpp.hpp
+++ b/src/power_mgt.cpp.hpp
@@ -217,13 +217,26 @@ static fl::u8 brightness_within_budget(fl::u32 fixed_mW, fl::u32 controllable_mW
         // division from dividing by zero on an all-dark strip.
         return 0;
     }
+    // The ratio is taken over the whole 0-255 scaled range, because
+    // `controllable_mW` is the demand at *full* brightness. Scaling it by the
+    // requested brightness first would answer "what fraction of the request
+    // fits", which is smaller than "what brightness fits" by exactly that
+    // fraction -- and the step-down below only ever decreases, so it cannot
+    // recover it. The cap is where the request comes back in.
+    //
+    // The cap cannot actually fire from here: the caller only reaches this
+    // branch when the request is already over budget, which is the same
+    // inequality. It is kept because that argument runs through
+    // `map_power_value`'s rounding, and a helper that clamps to its own
+    // argument is cheaper than depending on that.
     const fl::u32 headroom_mW = max_power_mW - fixed_mW;
     const fl::u8 target_scaled = map_power_value(target_brightness);
-    fl::u32 recommended_scaled =
-        (static_cast<fl::u32>(target_scaled) * headroom_mW) / controllable_mW;
-    if (recommended_scaled > 255) {
-        recommended_scaled = 255;
+    fl::u64 allowed_scaled =
+        (static_cast<fl::u64>(255) * headroom_mW) / controllable_mW;
+    if (allowed_scaled > target_scaled) {
+        allowed_scaled = target_scaled;
     }
+    const fl::u32 recommended_scaled = static_cast<fl::u32>(allowed_scaled);
     fl::u8 recommended = unmap_power_value(static_cast<fl::u8>(recommended_scaled));
 
     // Then check the answer instead of trusting the division. Inverting the

--- a/src/power_mgt.cpp.hpp
+++ b/src/power_mgt.cpp.hpp
@@ -185,23 +185,74 @@ fl::u32 calculate_unscaled_power_mW( const CRGB* ledbuffer, fl::u16 numLeds ) //
 }
 
 
+// The part of the estimate a brightness scalar cannot touch: every controller
+// IC draws its quiescent current whether or not an emitter is lit, and the MCU
+// draws its own regardless of what the strip is doing. #4156 R4:
+//
+//     Fixed idle consumption cannot be reduced by multiplying LED flux.
+//
+// Scaling that baseline along with the emitters is what let the limiter
+// under-report. At 300 WS2812s on the default model the baseline is 1500 mW,
+// and a 2000 mW budget used to be answered with a brightness that draws 3461.
+static fl::u32 fixed_power_mW(fl::u32 led_count) {
+    return static_cast<fl::u32>(gPowerModel().dark_mW) * led_count;
+}
+
+// Largest brightness whose *total* demand -- baseline included -- stays inside
+// the budget. Zero when the baseline alone is already over it: no brightness
+// meets the budget then, and answering with a lit strip would promise a bound
+// that cannot be held at any setting.
+static fl::u8 brightness_within_budget(fl::u32 fixed_mW, fl::u32 controllable_mW,
+                                       fl::u8 target_brightness,
+                                       fl::u32 max_power_mW) {
+    const fl::u32 requested_mW =
+        fixed_mW + scale_power_for_brightness(controllable_mW, target_brightness);
+    if (requested_mW <= max_power_mW) {
+        return target_brightness;
+    }
+    if (controllable_mW == 0 || max_power_mW <= fixed_mW) {
+        // Nothing left to scale, or the baseline alone is already over the
+        // budget. Either way no brightness meets it, and returning here is
+        // also what keeps the subtraction below from underflowing and the
+        // division from dividing by zero on an all-dark strip.
+        return 0;
+    }
+    const fl::u32 headroom_mW = max_power_mW - fixed_mW;
+    const fl::u8 target_scaled = map_power_value(target_brightness);
+    fl::u32 recommended_scaled =
+        (static_cast<fl::u32>(target_scaled) * headroom_mW) / controllable_mW;
+    if (recommended_scaled > 255) {
+        recommended_scaled = 255;
+    }
+    fl::u8 recommended = unmap_power_value(static_cast<fl::u8>(recommended_scaled));
+
+    // Then check the answer instead of trusting the division. Inverting the
+    // ratio in scaled space is off by the rounding of whichever `scale32by8`
+    // the platform compiled -- the FASTLED_SCALE8_FIXED form computes
+    // `i * (s + 1) >> 8`, so the closed form lands about `controllable/256`
+    // over the budget, which was 176 mW of a 5000 mW budget on the default
+    // model. Demand is monotone in brightness, so stepping down until it fits
+    // is exact whatever the rounding, and terminates: 0 always fits here,
+    // because the branch above already returned for a budget under baseline.
+    while (recommended > 0 &&
+           fixed_mW + scale_power_for_brightness(controllable_mW, recommended) >
+               max_power_mW) {
+        --recommended;
+    }
+    return recommended;
+}
+
 fl::u8 calculate_max_brightness_for_power_vmA(const CRGB* ledbuffer, fl::u16 numLeds, fl::u8 target_brightness, fl::u32 max_power_V, fl::u32 max_power_mA) {
 	return calculate_max_brightness_for_power_mW(ledbuffer, numLeds, target_brightness, max_power_V * max_power_mA);
 }
 
 fl::u8 calculate_max_brightness_for_power_mW(const CRGB* ledbuffer, fl::u16 numLeds, fl::u8 target_brightness, fl::u32 max_power_mW) {
- 	fl::u32 total_mW = calculate_unscaled_power_mW( ledbuffer, numLeds);
+	const fl::u32 total_mW = calculate_unscaled_power_mW( ledbuffer, numLeds);
+	const fl::u32 fixed_mW = fixed_power_mW(numLeds);
+	const fl::u32 controllable_mW = total_mW > fixed_mW ? total_mW - fixed_mW : 0;
 
-	fl::u8 target_brightness_scaled = map_power_value(target_brightness);
-	fl::u32 requested_power_mW = scale_power_for_brightness(total_mW, target_brightness);
-
-	fl::u8 recommended_brightness = target_brightness;
-	if(requested_power_mW > max_power_mW) { 
-        fl::u8 recommended_scaled = (fl::u32)(target_brightness_scaled * (fl::u32)(max_power_mW)) / requested_power_mW;
-        recommended_brightness = unmap_power_value(recommended_scaled);
-	}
-
-	return recommended_brightness;
+	return brightness_within_budget(fixed_mW, controllable_mW, target_brightness,
+	                                max_power_mW);
 }
 
 // sets brightness to
@@ -209,21 +260,29 @@ fl::u8 calculate_max_brightness_for_power_mW(const CRGB* ledbuffer, fl::u16 numL
 //  - no more than max_mW milliwatts
 fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 max_power_mW)
 {
-    fl::u32 total_mW = gMCU_mW;
+    // gMCU_mW and every controller's dark current are baseline: present at any
+    // brightness, and so kept out of the part the scalar acts on (#4156 R4).
+    fl::u32 fixed_mW = gMCU_mW;
+    fl::u32 controllable_mW = 0;
 
     CLEDController *pCur = CLEDController::head();
 	while(pCur) {
-        total_mW += calculate_unscaled_power_mW( pCur->leds(), pCur->size());
+        const fl::u32 count = pCur->size();
+        const fl::u32 unscaled_mW =
+            calculate_unscaled_power_mW(fl::span<const CRGB>(pCur->leds(), count));
+        const fl::u32 dark_mW = fixed_power_mW(count);
+        fixed_mW += dark_mW;
+        controllable_mW += unscaled_mW > dark_mW ? unscaled_mW - dark_mW : 0;
 		pCur = pCur->next();
 	}
 
 #if POWER_DEBUG_PRINT == 1
     Serial.print("power demand at full brightness mW = ");
-    Serial.println( total_mW);
+    Serial.println( fixed_mW + controllable_mW);
 #endif
 
-    fl::u8 target_brightness_scaled = map_power_value(target_brightness);
-    fl::u32 requested_power_mW = scale_power_for_brightness(total_mW, target_brightness);
+    const fl::u32 requested_power_mW =
+        fixed_mW + scale_power_for_brightness(controllable_mW, target_brightness);
 #if POWER_DEBUG_PRINT == 1
     if( target_brightness != 255 ) {
         Serial.print("power demand at scaled brightness mW = ");
@@ -233,7 +292,7 @@ fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 
     Serial.println( max_power_mW);
 #endif
 
-    if( requested_power_mW < max_power_mW) {
+    if( requested_power_mW <= max_power_mW) {
 #if POWER_LED > 0
         if( gMaxPowerIndicatorLEDPinNumber ) {
             Pin(gMaxPowerIndicatorLEDPinNumber).lo(); // turn the LED off
@@ -245,13 +304,14 @@ fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 
         return target_brightness;
     }
 
-    fl::u8 recommended_scaled = (fl::u32)(target_brightness_scaled * (fl::u32)(max_power_mW)) / ((fl::u32)(requested_power_mW));
-    fl::u8 recommended_brightness = unmap_power_value(recommended_scaled);
+    const fl::u8 recommended_brightness = brightness_within_budget(
+        fixed_mW, controllable_mW, target_brightness, max_power_mW);
 #if POWER_DEBUG_PRINT == 1
     Serial.print("recommended brightness # = ");
     Serial.println( recommended_brightness);
 
-    fl::u32 resultant_power_mW = scale_power_for_brightness(total_mW, recommended_brightness);
+    fl::u32 resultant_power_mW =
+        fixed_mW + scale_power_for_brightness(controllable_mW, recommended_brightness);
     Serial.print("resultant power demand mW = ");
     Serial.println( resultant_power_mW);
 

--- a/src/power_mgt.h
+++ b/src/power_mgt.h
@@ -259,7 +259,12 @@ fl::u32 calculate_unscaled_power_mW( const CRGB* ledbuffer, fl::u16 numLeds);
 /// @param leds span of LED data to check
 fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds);
 
-/// Applies the configured power-scaling response to a total power value
+/// Applies the configured power-scaling response to a total power value.
+///
+/// Pass the *scalable* share only. `calculate_unscaled_power_mW()` includes the
+/// per-LED `dark_mW` baseline, which brightness does not reduce; scaling that
+/// with the emitters under-reports demand at low brightness (#4156 R4).
+///
 /// @param total_mW unscaled total power at full brightness
 /// @param brightness requested brightness in FastLED's 0-255 brightness space
 /// @returns estimated power after applying the configured brightness-to-power response
@@ -267,12 +272,29 @@ fl::u32 scale_power_for_brightness(fl::u32 total_mW, fl::u8 brightness);
 
 /// Determines the highest brightness level you can use and still stay under
 /// the specified power budget for a given set of LEDs.
+///
+/// What the budget bounds, stated rather than implied (#4156 R4):
+///
+/// - **The baseline is not scalable.** `PowerModel::dark_mW` is drawn per LED
+///   at every brightness including zero, so it is subtracted from the budget
+///   first and only the remainder is divided among the emitters. A budget at
+///   or below the baseline returns **0**: no brightness meets it, and a lit
+///   strip would be promising a bound that cannot be held at any setting.
+/// - **The bound is on the pre-dither frame.** Demand is computed from the
+///   `CRGB` values, and `BINARY_DITHER` adds its offset afterwards, inside the
+///   encoder. That offset is shared across the frame, so a dithered frame can
+///   exceed the budgeted demand by up to one native code per channel per
+///   pixel -- about 0.8 mW per LED on the default WS2812 model. The multi-frame
+///   mean is what the budget holds; a single latched frame can sit that much
+///   above it.
+///
 /// @param ledbuffer the LED data to check
 /// @param numLeds the number of LEDs in the data array
 /// @param target_brightness the brightness you'd ideally like to use
 /// @param max_power_mW the max power draw desired, in milliwatts
 /// @returns a limited brightness value. No higher than the target brightness,
-/// but may be lower depending on the power limit.
+/// but may be lower depending on the power limit. Zero when the budget is at
+/// or below the unscalable baseline.
 fl::u8 calculate_max_brightness_for_power_mW(const CRGB* ledbuffer, fl::u16 numLeds, fl::u8 target_brightness, fl::u32 max_power_mW);
 
 /// @copybrief calculate_max_brightness_for_power_mW()

--- a/tests/fl/power_estimation.cpp
+++ b/tests/fl/power_estimation.cpp
@@ -84,7 +84,19 @@ FL_TEST_CASE_FIXTURE(PowerEstimationFixture,"Power estimation - brightness scali
     // Verify scaling relationship
     FL_REQUIRE(power_full > power_half);
     FL_REQUIRE(power_half > power_zero);
-    FL_REQUIRE(power_zero == 0);
+
+    // Not zero. This asserted `power_zero == 0` and that was the defect in
+    // #4156 R4: every controller IC draws its quiescent current whether or not
+    // an emitter is lit, so brightness zero is a dark strip and 10 x dark_mW
+    // of draw, not an unpowered one. The estimate used to multiply that
+    // baseline by brightness along with the emitters, which is also why the
+    // limiter could hand back a brightness that went over budget.
+    // Controllers accumulate across cases in this file, so the baseline here
+    // covers at least this case's ten LEDs and possibly earlier ones.
+    const uint32_t baseline_mW = get_power_model().dark_mW * 10u;
+    FL_REQUIRE(baseline_mW > 0);
+    FL_REQUIRE(power_zero >= baseline_mW);
+    FL_REQUIRE(power_zero % get_power_model().dark_mW == 0);
 }
 
 // Test power estimation without power limiting
@@ -135,9 +147,15 @@ FL_TEST_CASE_FIXTURE(PowerEstimationFixture,"Power estimation - zero brightness"
     uint32_t with_limiter = FastLED.getEstimatedPowerInMilliWatts(true);
     uint32_t without_limiter = FastLED.getEstimatedPowerInMilliWatts(false);
 
-    // Both should be zero at zero brightness
-    FL_REQUIRE(with_limiter == 0);
-    FL_REQUIRE(without_limiter == 0);
+    // Both are the dark-current baseline at zero brightness, not zero: the
+    // strip is dark, not unpowered (#4156 R4). The limiter has nothing to do
+    // here either, since the baseline is well inside the 1000 mW budget.
+    // Controllers accumulate across cases in this file, so this is at least
+    // this case's ten LEDs of dark current.
+    const uint32_t baseline_mW = get_power_model().dark_mW * 10u;
+    FL_REQUIRE(baseline_mW > 0);
+    FL_REQUIRE(with_limiter >= baseline_mW);
+    FL_REQUIRE(without_limiter == with_limiter);
 }
 
 // Test power estimation - power limit high enough to not limit

--- a/tests/power_mgt.cpp
+++ b/tests/power_mgt.cpp
@@ -256,4 +256,149 @@ FL_TEST_CASE("Power scaling exponent - limiter becomes more conservative") {
     }
 }
 
+// #4156 R4: "Fixed idle consumption cannot be reduced by multiplying LED
+// flux." These pin the three things that finding asked for -- the baseline,
+// a budget below it, and the encoded demand against the declared bound.
+
+namespace {
+
+struct ScopedDefaultPowerModel {
+    ScopedDefaultPowerModel() : previous_model(get_power_model()) {
+        set_power_model(PowerModelRGB());
+    }
+    ~ScopedDefaultPowerModel() { set_power_model(previous_model); }
+    PowerModelRGB previous_model;
+};
+
+// What the strip really draws at a brightness: the dark current of every
+// controller IC, which no scalar touches, plus the scaled emitter share.
+fl::u32 true_demand_mW(fl::span<const CRGB> leds, fl::u8 brightness) {
+    const fl::u32 fixed_mW =
+        static_cast<fl::u32>(get_power_model().dark_mW) * leds.size();
+    const fl::u32 total_mW = calculate_unscaled_power_mW(leds);
+    const fl::u32 controllable_mW = total_mW - fixed_mW;
+    return fixed_mW + scale_power_for_brightness(controllable_mW, brightness);
+}
+
+} // namespace
+
+FL_TEST_CASE("Power limiter - the recommendation stays inside the budget") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    const fl::u32 baseline_mW =
+        static_cast<fl::u32>(get_power_model().dark_mW) * kCount;
+
+    // Every one of these used to come back over budget, by 5.6% at 20 W and
+    // by 73% at 2 W: the whole estimate including the baseline was multiplied
+    // by brightness, so lowering brightness "reduced" a draw that is constant.
+    const fl::u32 budgets[] = {60000u, 40000u, 20000u, 10000u, 5000u, 3000u, 2000u};
+    for (fl::u32 budget : budgets) {
+        const fl::u8 recommended =
+            calculate_max_brightness_for_power_mW(leds, kCount, 255, budget);
+        FL_CHECK_GT(budget, baseline_mW);
+        FL_CHECK_LE(true_demand_mW(span, recommended), budget);
+    }
+}
+
+FL_TEST_CASE("Power limiter - the recommendation is the largest that fits") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+
+    // Staying under the budget is trivially satisfied by returning zero. The
+    // limiter has to be tight as well as safe, so one step up must not fit.
+    const fl::u32 budgets[] = {40000u, 20000u, 10000u, 5000u, 3000u};
+    for (fl::u32 budget : budgets) {
+        const fl::u8 recommended =
+            calculate_max_brightness_for_power_mW(leds, kCount, 255, budget);
+        FL_CHECK_GT(recommended, 0);
+        FL_CHECK_GT(true_demand_mW(span, static_cast<fl::u8>(recommended + 1)),
+                    budget);
+    }
+}
+
+FL_TEST_CASE("Power limiter - zero brightness still draws the dark current") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    // The baseline is the whole point of the finding: at brightness zero the
+    // strip is dark and still drawing 1500 mW on this model.
+    const fl::u32 baseline_mW =
+        static_cast<fl::u32>(get_power_model().dark_mW) * kCount;
+    FL_CHECK_EQ(true_demand_mW(fl::span<const CRGB>(leds, kCount), 0),
+                baseline_mW);
+    FL_CHECK_GT(baseline_mW, 0);
+}
+
+FL_TEST_CASE("Power limiter - a budget under the baseline turns the strip off") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::u32 baseline_mW =
+        static_cast<fl::u32>(get_power_model().dark_mW) * kCount;
+
+    // No brightness meets a budget below the dark current, so the only honest
+    // answer is zero. It used to return a lit strip and claim the budget was
+    // met -- 1000 mW asked for, 2480 mW drawn.
+    const fl::u32 budgets[] = {baseline_mW - 1, baseline_mW / 2, 1u};
+    for (fl::u32 budget : budgets) {
+        FL_CHECK_EQ(calculate_max_brightness_for_power_mW(leds, kCount, 255, budget),
+                    0);
+    }
+    // Exactly at the baseline nothing can be lit either, since any emitter
+    // adds to it.
+    FL_CHECK_EQ(
+        calculate_max_brightness_for_power_mW(leds, kCount, 255, baseline_mW), 0);
+}
+
+FL_TEST_CASE("Power limiter - an all-dark strip over budget is still answerable") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB::Black;
+    }
+    // Black leaves nothing for brightness to scale, so the controllable share
+    // is zero. Reaching the ratio with that as its denominator divides by
+    // zero, and a budget under the baseline is the one path that gets there.
+    const fl::u32 baseline_mW =
+        static_cast<fl::u32>(get_power_model().dark_mW) * kCount;
+    FL_CHECK_EQ(calculate_unscaled_power_mW(leds, kCount), baseline_mW);
+    FL_CHECK_EQ(
+        calculate_max_brightness_for_power_mW(leds, kCount, 255, baseline_mW / 2),
+        0);
+    // And under a budget it does fit, the request is untouched.
+    FL_CHECK_EQ(
+        calculate_max_brightness_for_power_mW(leds, kCount, 255, baseline_mW * 2),
+        255);
+}
+
+FL_TEST_CASE("Power limiter - a budget over demand leaves brightness alone") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 60;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(64, 64, 64);
+    }
+    // Nothing above should have made the limiter pessimistic in the ordinary
+    // case, where the budget is not binding at all.
+    FL_CHECK_EQ(calculate_max_brightness_for_power_mW(leds, kCount, 200, 1000000u),
+                200);
+}
+
 } // FL_TEST_FILE

--- a/tests/power_mgt.cpp
+++ b/tests/power_mgt.cpp
@@ -326,6 +326,38 @@ FL_TEST_CASE("Power limiter - the recommendation is the largest that fits") {
     }
 }
 
+FL_TEST_CASE("Power limiter - a binding budget is maximal below full brightness") {
+    ScopedDefaultPowerModel guard;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+
+    // Every case above asks at brightness 255, where the scaled target is 255
+    // and a ratio taken against it happens to be right. Below full brightness
+    // it is not: `controllable_mW` is the demand at *full* brightness, so
+    // scaling the headroom ratio by the request answers "what fraction of the
+    // request fits" rather than "what brightness fits", and the step-down can
+    // only make that smaller. The answer must still be the largest that fits.
+    const fl::u8 targets[] = {200, 128, 64, 32};
+    const fl::u32 budgets[] = {40000u, 20000u, 10000u, 5000u, 3000u};
+    for (fl::u8 target : targets) {
+        for (fl::u32 budget : budgets) {
+            const fl::u8 recommended =
+                calculate_max_brightness_for_power_mW(leds, kCount, target, budget);
+            FL_CHECK_LE(recommended, target);
+            FL_CHECK_LE(true_demand_mW(span, recommended), budget);
+            if (recommended < target) {
+                FL_CHECK_GT(
+                    true_demand_mW(span, static_cast<fl::u8>(recommended + 1)),
+                    budget);
+            }
+        }
+    }
+}
+
 FL_TEST_CASE("Power limiter - zero brightness still draws the dark current") {
     ScopedDefaultPowerModel guard;
     const int kCount = 300;


### PR DESCRIPTION
Refs #4156 (R4).

The triage on that issue marked R4, R8 and R10 as **not checked**. I checked R4. It is real, and by more than the finding claimed.

> Fixed idle consumption cannot be reduced by multiplying LED flux.

## What was wrong

`calculate_max_brightness_for_power_mW` built one total — `gMCU_mW`, every LED's `dark_mW`, and the emitter demand — and multiplied the whole thing by brightness. Two of those three are drawn at any brightness including zero.

300 WS2812s at full white on the default model, where the baseline is 1500 mW:

| budget | was recommended | actually drew | over |
|---|---|---|---|
| 20 000 mW | 79 | 21 110 mW | +5.6% |
| 5 000 mW | 19 | 6 402 mW | **+28%** |
| 2 000 mW | 7 | 3 461 mW | **+73%** |
| 1 000 mW | 3 | 2 480 mW | **+148%** |

The last row is the second half of R4's question — "define behavior when the requested budget is below baseline". 1000 mW is below the 1500 mW the strip draws with every emitter off, so no brightness meets it, and the old code answered with a lit strip regardless.

## What it does now

Baseline is subtracted from the budget first; only the remainder is divided among the emitters. Every achievable budget in that table is now met exactly, and the recommendation is still the largest that fits (one step up is asserted not to fit).

**Behaviour change worth calling out:** a budget at or below the baseline returns **0**. A sketch asking for less than its strip's dark current now goes dark, where it used to light dimly and exceed the ask. That is the only answer that is true, but it is visible.

## Two things found while fixing it

- **The closed form overshot even with no baseline.** Inverting the ratio in scaled space is off by whichever `scale32by8` the platform compiled — the `FASTLED_SCALE8_FIXED` form computes `i * (s + 1) >> 8`, landing about `controllable/256` over, which was 176 mW of a 5000 mW budget. Demand is monotone in brightness, so the answer is now verified and stepped down until it fits: exact whatever the rounding. This was pre-existing and independent of R4.
- **An all-dark strip over budget divided by zero.** Black leaves nothing for brightness to scale, and that is the denominator. Guarded, with the case that reaches it — the mutation that removes the guard crashes with SIGFPE.

`getEstimatedPowerInMilliWatts` had the same fold and is split the same way. Two assertions in `tests/fl/power_estimation.cpp` said the estimate at brightness zero is zero — that was the defect written down as a test, and they now say it is the dark-current baseline.

## R4's other half: confirmed, not fixed

Dither *can* push a latched frame above a pre-quantization budget. `BINARY_DITHER` applies `pixel = scale8(qadd8(pixel, d), brightness)` inside the encoder, after demand is computed from the raw `CRGB` values, and the offset is shared across the frame. Bounded at one native code per channel per pixel — about 0.8 mW per LED on the default model, ~247 mW on a 300-LED strip.

R4 asked for that contract to be *declared* rather than changed, so it is now on the function: **the budget holds the multi-frame mean; a single latched frame can sit that much above it.**

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: folding the baseline back in fails three cases; dropping the zero/below-baseline guard crashes on divide-by-zero; dropping the step-down fails the budget case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Power estimates now include fixed dark-current consumption, even when brightness is set to zero.
  * Power limiting scales only brightness-controlled output while preserving baseline controller and LED consumption.
  * Brightness recommendations remain within the configured power budget and return zero when baseline consumption alone exceeds it.
  * Improved handling for all-dark LED strips and non-binding power limits.

* **Documentation**
  * Clarified power-budget behavior, including non-scalable dark current and brightness-limit calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->