### PR TITLE
study(color): the black floor is the source quantization, and it is hard (#4156 R8)

### DIFF
--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -183,8 +183,8 @@ knowing before spending effort ranking them.
 
 ## The black floor is the source quantization, and it is hard
 
-#4156 R8 asks for the black floor, the luminance-error denominator and the
-unsupported low-light region to be defined rather than inferred from wider
+Issue #4156 R8 asks for the black floor, the luminance-error denominator and
+the unsupported low-light region to be defined rather than inferred from wider
 arithmetic, and gives the arithmetic that motivates it: an identity linear16
 input of `1/65535` is 0.0039 of an 8-bit code, so its nearest 8-bit output is
 zero -- 100% relative luminance error. Matching it by alternating codes 0 and 1

--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -181,6 +181,73 @@ has not done. What it establishes is that the remaining candidates are being
 compared against a floor that is lower than it needs to be, which is worth
 knowing before spending effort ranking them.
 
+## The black floor is the source quantization, and it is hard
+
+#4156 R8 asks for the black floor, the luminance-error denominator and the
+unsupported low-light region to be defined rather than inferred from wider
+arithmetic, and gives the arithmetic that motivates it: an identity linear16
+input of `1/65535` is 0.0039 of an 8-bit code, so its nearest 8-bit output is
+zero -- 100% relative luminance error. Matching it by alternating codes 0 and 1
+needs one code-1 frame in 257, about 4.28 seconds at 60 Hz, which is not a
+cadence anything can display.
+
+Measured against the shipped path, the situation is simpler than that and
+worse. `PixelController::dither()` is
+
+```cpp
+return b ? fl::qadd8(b, pc.d[RO(SLOT)]) : 0;
+```
+
+so a source code of zero is excluded from dithering by construction. **Nothing
+below one source code is reachable at any brightness, any refresh rate, or any
+dither cycle length.** R8's 4.28-second cadence is not the obstacle; the
+obstacle is that the mechanism never runs on the value in question. The floor
+is the quantization of the source, not a dead zone above it: one code up, the
+cycle emits light.
+
+That answers the "unsupported low-light region" directly. For an identity
+mapping it is every source value that quantizes to 8-bit zero.
+
+### Above the floor, dithering does what it claims
+
+At 1/16 brightness a source code of 1 asks for 0.06 output codes, which no
+single frame can emit. The eight-frame cycle emits code 1 once and zero seven
+times, so the mean lands between two output codes. Sub-output-code precision
+is real.
+
+### And the lowest codes render brighter than they ask for
+
+The correction that turns `scale8`'s truncation into round-to-nearest is a
+constant addition of about half a dither quantum. At the bottom of the range
+that is a large fraction of the value itself. Summed over a full cycle, so
+these are time-averaged light and not single-frame rounding:
+
+| premixed | source code | emitted | exact | error |
+| --- | --- | --- | --- | --- |
+| 255 | 1 | 11 | 8 | **+37.5%** |
+| 255 | 2 | 19 | 16 | +18.8% |
+| 255 | 64 | -- | -- | under +2% |
+
+The last row is the point: the bias is a constant in absolute terms, so it
+disappears as a fraction almost immediately. It is only the bottom two or
+three codes that carry it.
+
+At `premixed = 255` it is not a trade at all. `scale8(i, 255)` is exact under
+`FASTLED_SCALE8_FIXED` -- `(i * 256) >> 8` is `i` -- so no fractional precision
+is lost there, there is nothing for a rounding correction to recover, and
+every code the dither adds is gain. `DISABLE_DITHER` makes that path exact.
+Note that `premixed` is brightness *times* colour correction, so the exact
+case is `UncorrectedColor` at full brightness rather than the common default.
+
+This is what R8 means by a quantized reference concealing optical error:
+against an 8-bit reference every one of these matches, and against the light
+they are asking for they do not. The denominator has to be emitted light.
+
+`tests/pixel_controller.cpp` carries all of it as measurements rather than
+prose. No change to the dither is proposed here -- R8 asks for the contract to
+be defined, and shifting the low-code rendering of every existing sketch is a
+decision, not a cleanup.
+
 ## What this leaves for section 5
 
 Two of the five candidates are gone, and the remaining comparison is between

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -76,8 +76,13 @@ int cycleSum(fl::u8 value, fl::u8 premixed) {
 }
 
 // What the cycle should sum to if the path were exact.
-int idealSum(fl::u8 value, fl::u8 premixed) {
-    return kDitherCycle * static_cast<int>(value) * static_cast<int>(premixed) / 255;
+//
+// Floating point on purpose. An integer version truncates, and the row this
+// is compared against most -- premixed 16, source code 1 -- has an exact
+// ideal of 0.502 codes. Truncating that to 0 turns a +99% error into a
+// division by zero and reads as though the error were unbounded.
+double idealSum(fl::u8 value, fl::u8 premixed) {
+    return static_cast<double>(kDitherCycle) * value * premixed / 255.0;
 }
 
 } // namespace
@@ -117,9 +122,9 @@ FL_TEST_CASE("Dither - the lowest codes render brighter than they should") {
     // full cycle, against the exact product:
     //
     //   premixed  value  emitted/ideal
-    //   255       1      11 / 8    (+37.5%)
-    //   255       2      19 / 16   (+18.8%)
-    //   16        1       1 / 0    (unbounded: the ideal is 0.5 codes)
+    //   255       1      11 / 8      (+37.5%)
+    //   255       2      19 / 16     (+18.8%)
+    //   16        1       1 / 0.502  (+99%)
     //
     // This is not a rounding artefact of the measurement -- the sum is over a
     // whole cycle, so it is the time-averaged light. It is the reason R8 says
@@ -127,14 +132,20 @@ FL_TEST_CASE("Dither - the lowest codes render brighter than they should") {
     // 8-bit reference these all match, and compared against the light they
     // are asking for they do not.
     FL_CHECK_EQ(cycleSum(1, 255), 11);
-    FL_CHECK_EQ(idealSum(1, 255), 8);
+    FL_CHECK_EQ(idealSum(1, 255), 8.0);
     FL_CHECK_EQ(cycleSum(2, 255), 19);
-    FL_CHECK_EQ(idealSum(2, 255), 16);
+    FL_CHECK_EQ(idealSum(2, 255), 16.0);
+
+    // And the low-brightness row the table quotes, where the ideal is a
+    // fraction of a code rather than a whole one.
+    FL_CHECK_EQ(cycleSum(1, 16), 1);
+    FL_CHECK_GT(idealSum(1, 16), 0.50);
+    FL_CHECK_LT(idealSum(1, 16), 0.51);
 
     // The bias shrinks as a fraction as the value grows, which is why it is
     // invisible anywhere but the bottom.
-    FL_CHECK_GT(cycleSum(1, 255) * 100, idealSum(1, 255) * 130);
-    FL_CHECK_LT(cycleSum(64, 255) * 100, idealSum(64, 255) * 102);
+    FL_CHECK_GT(cycleSum(1, 255), idealSum(1, 255) * 1.30);
+    FL_CHECK_LT(cycleSum(64, 255), idealSum(64, 255) * 1.02);
 }
 
 FL_TEST_CASE("Dither - at full scale the correction has nothing to correct") {

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -45,4 +45,116 @@ FL_TEST_CASE("PixelController advances temporal dither phase per frame") {
     FL_CHECK_EQ(pixels.d[0], frame_start);
 }
 
+// ---------------------------------------------------------------------------
+// The black floor and the low-code bias (#4156 R8, P8 #4042)
+//
+// R8 asks for the black floor, the luminance-error denominator and the
+// unsupported low-light region to be defined rather than inferred from wider
+// arithmetic. These measure the shipped path instead of arguing about it.
+//
+// Sums are taken over a full eight-frame dither cycle, which makes them
+// independent of the phase the test happens to start on.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+const int kDitherCycle = 8;
+
+// Total emitted code across one dither cycle. The mean light is this over
+// `kDitherCycle * 255` of full scale.
+int cycleSum(fl::u8 value, fl::u8 premixed) {
+    int sum = 0;
+    for (int frame = 0; frame < kDitherCycle; ++frame) {
+        CRGB pixel(value, value, value);
+        ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+        adjustment.premixed = CRGB(premixed, premixed, premixed);
+        fl::detail::advanceDitherFrame();
+        PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
+        sum += pixels.loadAndScale0();
+    }
+    return sum;
+}
+
+// What the cycle should sum to if the path were exact.
+int idealSum(fl::u8 value, fl::u8 premixed) {
+    return kDitherCycle * static_cast<int>(value) * static_cast<int>(premixed) / 255;
+}
+
+} // namespace
+
+FL_TEST_CASE("Dither - a source code of zero is never lifted off the floor") {
+    // `dither()` is `b ? qadd8(b, d) : 0`, so black is excluded by
+    // construction. The consequence is the black floor R8 asks to have
+    // defined: nothing below one source code is reachable at any brightness,
+    // any refresh rate, or any dither cycle length. R8's example -- an
+    // identity linear16 input of 1/65535, which is 0.0039 of an 8-bit code --
+    // emits zero forever, and its 100% luminance error is not a cadence
+    // problem that a longer cycle could fix.
+    const fl::u8 premixed[] = {255, 128, 64, 32, 16, 4, 1};
+    for (fl::u8 scale : premixed) {
+        FL_CHECK_EQ(cycleSum(0, scale), 0);
+    }
+    // And one source code above the floor is reachable, so the floor is the
+    // quantization of the source and not a dead zone above it.
+    FL_CHECK_GT(cycleSum(1, 255), 0);
+    FL_CHECK_GT(cycleSum(1, 16), 0);
+}
+
+FL_TEST_CASE("Dither - sub-code precision is recovered above the floor") {
+    // The thing dithering is for: at 1/16 brightness a source code of 1 wants
+    // an output of 0.06 codes, which no single frame can emit. The cycle emits
+    // code 1 on one frame of eight and zero on the rest, so the mean lands
+    // between two output codes.
+    const int sum = cycleSum(1, 16);
+    FL_CHECK_GT(sum, 0);
+    FL_CHECK_LT(sum, kDitherCycle);
+}
+
+FL_TEST_CASE("Dither - the lowest codes render brighter than they should") {
+    // The correction that makes scale8's truncation round-to-nearest is a
+    // constant addition of about half a dither quantum, and at the bottom of
+    // the range that is a large fraction of the value itself. Measured over a
+    // full cycle, against the exact product:
+    //
+    //   premixed  value  emitted/ideal
+    //   255       1      11 / 8    (+37.5%)
+    //   255       2      19 / 16   (+18.8%)
+    //   16        1       1 / 0    (unbounded: the ideal is 0.5 codes)
+    //
+    // This is not a rounding artefact of the measurement -- the sum is over a
+    // whole cycle, so it is the time-averaged light. It is the reason R8 says
+    // a quantized reference can conceal optical error: compared against an
+    // 8-bit reference these all match, and compared against the light they
+    // are asking for they do not.
+    FL_CHECK_EQ(cycleSum(1, 255), 11);
+    FL_CHECK_EQ(idealSum(1, 255), 8);
+    FL_CHECK_EQ(cycleSum(2, 255), 19);
+    FL_CHECK_EQ(idealSum(2, 255), 16);
+
+    // The bias shrinks as a fraction as the value grows, which is why it is
+    // invisible anywhere but the bottom.
+    FL_CHECK_GT(cycleSum(1, 255) * 100, idealSum(1, 255) * 130);
+    FL_CHECK_LT(cycleSum(64, 255) * 100, idealSum(64, 255) * 102);
+}
+
+FL_TEST_CASE("Dither - at full scale the correction has nothing to correct") {
+    // `scale8(i, 255)` is exact under FASTLED_SCALE8_FIXED: `(i * 256) >> 8`
+    // is `i`. So at premixed 255 no fractional precision is lost, there is
+    // nothing for a rounding correction to recover, and every code the dither
+    // adds is pure gain. The cycle sum is above the exact product rather than
+    // equal to it, for every low code.
+    for (fl::u8 value = 1; value <= 8; ++value) {
+        FL_CHECK_EQ(fl::scale8(value, 255), value);
+        FL_CHECK_GT(cycleSum(value, 255), idealSum(value, 255));
+    }
+    // Disabling the dither is what makes the path exact there.
+    for (fl::u8 value = 1; value <= 8; ++value) {
+        CRGB pixel(value, value, value);
+        ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+        adjustment.premixed = CRGB(255, 255, 255);
+        PixelController<RGB> pixels(&pixel, 1, adjustment, DISABLE_DITHER);
+        FL_CHECK_EQ(pixels.loadAndScale0(), value);
+    }
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
Refs #4156 (R8), #4042.

R8 was one of the three findings the triage left unchecked. This is R8. It asks for the black floor, the luminance-error denominator and the unsupported low-light region to be **defined** rather than inferred from wider arithmetic.

## R8's arithmetic is right; its conclusion understates the problem

An identity linear16 input of `1/65535` is 0.0039 of an 8-bit code, its nearest 8-bit output is zero, and matching it by alternating codes 0 and 1 needs one code-1 frame in 257 — about **4.28 s at 60 Hz**, not a cadence anything can display.

But the cadence is not the obstacle. `PixelController::dither()` is:

```cpp
return b ? fl::qadd8(b, pc.d[RO(SLOT)]) : 0;
```

A source code of zero is excluded from dithering **by construction**. Nothing below one source code is reachable at any brightness, any refresh rate, or any cycle length — the mechanism never runs on the value in question.

**That is the answer to R8's question.** The black floor is the quantization of the source, and the unsupported low-light region is, for an identity mapping, every source value that quantizes to 8-bit zero. It is not a dead zone above the floor either: one code up, the cycle emits light.

## Above the floor, dithering does what it claims

At 1/16 brightness a source code of 1 asks for 0.06 output codes, which no single frame can emit. The eight-frame cycle emits code 1 once and zero seven times, so the mean lands between two output codes. Sub-output-code precision is real.

## Two things measured on the way that were not in R8

Summed over a full dither cycle, so these are **time-averaged light**, not single-frame rounding:

| premixed | source code | emitted | exact | error |
|---|---|---|---|---|
| 255 | 1 | 11 | 8 | **+37.5%** |
| 255 | 2 | 19 | 16 | +18.8% |
| 255 | 64 | — | — | under +2% |

- **The lowest codes render brighter than they ask for.** The correction that turns `scale8`'s truncation into round-to-nearest is a constant addition of about half a dither quantum, which at the bottom of the range is a large fraction of the value. Being a constant in absolute terms, it is invisible above the first few codes.
- **At `premixed = 255` the correction has nothing to correct.** `scale8(i, 255)` is exact under `FASTLED_SCALE8_FIXED` — `(i * 256) >> 8` is `i` — so no fractional precision is lost there and every code the dither adds is gain. `DISABLE_DITHER` makes that path exact. (`premixed` is brightness × colour correction, so this is `UncorrectedColor` at full brightness rather than the common default.)

This is what R8 means by a quantized reference concealing optical error: against an 8-bit reference every one of these matches; against the light they are asking for they do not. The denominator has to be emitted light.

## Not proposed: a change to the dither

R8 asks for the contract to be **defined**. Shifting the low-code rendering of every existing sketch is a decision, not a cleanup, and it is not mine to make here.

## Verification

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `bash lint` — 0 errors
- Sums are over a full eight-frame cycle, so they are independent of the phase a test starts on
- Mutation-tested: dithering black, dropping the `+1` from the dither range, and removing the centring of `Q` each fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on the source quantization floor, unsupported low-light values, luminance-error calculations, and dithering precision.
  - Documented how rounding affects brightness at the lowest source values and how full-scale output behaves with dithering enabled or disabled.

- **Tests**
  - Added coverage for black-floor behavior, sub-code precision, low-level brightness bias, fractional values, and full-scale dithering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->