### PR TITLE
feat(fs): let the host back getEmbeddedFs() with a real directory (#4007)

### DIFF
--- a/src/fl/fs/testing.h
+++ b/src/fl/fs/testing.h
@@ -22,6 +22,21 @@ void setTestFileSystemRoot(const char *root_path) FL_NO_EXCEPT;
 /// The directory most recently passed to `setTestFileSystemRoot`.
 const char *getTestFileSystemRoot() FL_NO_EXCEPT;
 
+/// Point `fl::getEmbeddedFs()` at `root_path` on the host's real disk.
+///
+/// Separate from the SD root above on purpose: on a device those are two
+/// media, so a test that wrote to on-chip flash and read it back from a card
+/// would pass here and fail on hardware if they shared a directory
+/// (FastLED #4007).
+///
+/// Until this is called, `fl::getEmbeddedFs()` returns null on the host
+/// exactly as it does on a platform with no embedded storage, so the
+/// null-fallback contract stays testable.
+void setTestEmbeddedFileSystemRoot(const char *root_path) FL_NO_EXCEPT;
+
+/// The directory most recently passed to `setTestEmbeddedFileSystemRoot`.
+const char *getTestEmbeddedFileSystemRoot() FL_NO_EXCEPT;
+
 } // namespace fl
 
 #endif // FASTLED_TESTING

--- a/src/platforms/embedded_fs.h
+++ b/src/platforms/embedded_fs.h
@@ -32,8 +32,14 @@
 // The browser VFS stands in for on-chip flash so a LittleFS sketch runs
 // unmodified in the web preview.
 #include "platforms/wasm/fs/embedded_fs_wasm.hpp"
+#elif defined(FL_IS_STUB) && defined(FASTLED_TESTING)
+// The host has no on-chip flash. It does have a directory, which is the
+// concept this API names, so a unit test can point at one and exercise the
+// real read path instead of only the null fallback (#4007 question 3). Null
+// until a test asks, so nothing that does not ask changes behaviour.
+#include "platforms/stub/fs/embedded_fs_stub.hpp"
 #else
-// No embedded storage on this platform (host/stub, AVR, Teensy, ARM).
+// No embedded storage on this platform (AVR, Teensy, ARM).
 // RP2040 also ships LittleFS and should gain a fragment here.
 #include "platforms/shared/embedded_fs_noop.hpp"
 #endif

--- a/src/platforms/embedded_fs.h
+++ b/src/platforms/embedded_fs.h
@@ -32,11 +32,13 @@
 // The browser VFS stands in for on-chip flash so a LittleFS sketch runs
 // unmodified in the web preview.
 #include "platforms/wasm/fs/embedded_fs_wasm.hpp"
-#elif defined(FL_IS_STUB) && defined(FASTLED_TESTING)
+#elif defined(FL_IS_STUB)
 // The host has no on-chip flash. It does have a directory, which is the
 // concept this API names, so a unit test can point at one and exercise the
 // real read path instead of only the null fallback (#4007 question 3). Null
-// until a test asks, so nothing that does not ask changes behaviour.
+// until a test asks, so nothing that does not ask changes behaviour -- and
+// null unconditionally in a host build that is not a test build, which the
+// fragment decides for itself rather than making this dispatcher care.
 #include "platforms/stub/fs/embedded_fs_stub.hpp"
 #else
 // No embedded storage on this platform (AVR, Teensy, ARM).

--- a/src/platforms/stub/fs/embedded_fs_stub.hpp
+++ b/src/platforms/stub/fs/embedded_fs_stub.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+// IWYU pragma: private
+
+/// @file platforms/stub/fs/embedded_fs_stub.hpp
+/// @brief Host fragment backing `fl::getEmbeddedFs()` under FASTLED_TESTING.
+///
+/// FastLED #4007 asked, as its third open question:
+///
+///     Should the stub implement it? Mapping it to a scratch directory would
+///     let host tests exercise real read paths instead of only the
+///     null-fallback contract.
+///
+/// It would, and this is that. Without it the only host coverage of embedded
+/// storage is the no-op fragment -- a genuine contract, and one the tests do
+/// cover, but it exercises none of the read path a sketch actually runs.
+///
+/// **Opt-in, and null until asked.** `fl::getEmbeddedFs()` returns null here
+/// exactly as the no-op fragment does until a test calls
+/// `fl::setTestEmbeddedFileSystemRoot()`. Nothing that does not ask changes
+/// behaviour, and the null-fallback tests keep testing the null fallback.
+///
+/// **A separate root from the SD stub, deliberately.** On a device these are
+/// two media -- on-chip flash and a card -- and a sketch that writes to one
+/// and reads from the other must not find the same bytes. Sharing
+/// `setTestFileSystemRoot`'s directory would make a test pass on the host
+/// that fails on hardware, so the two roots are set independently.
+
+#include "fl/stl/compiler_control.h"
+#include "fl/fs/fs.h"
+
+#ifdef FASTLED_TESTING
+
+#include "fl/stl/memory.h"
+#include "fl/stl/string.h"
+#include "platforms/stub/fs_stub.hpp"
+
+namespace fl {
+namespace platforms {
+
+inline FsImplPtr makeEmbeddedFs(bool format_on_fail) FL_NO_EXCEPT {
+    // Nothing to format: the backing store is a directory that either
+    // exists or does not, and creating one behind a sketch's back is not
+    // what the flag means on a device either.
+    FASTLED_UNUSED(format_on_fail);
+
+    const char *root = getTestEmbeddedFileSystemRoot();
+    if (root == nullptr || *root == '\0') {
+        return FsImplPtr();
+    }
+    fl::shared_ptr<StubFileSystem> ptr = fl::make_shared<StubFileSystem>();
+    ptr->setRootPath(fl::string(root));
+    return ptr;
+}
+
+} // namespace platforms
+} // namespace fl
+
+#else
+
+namespace fl {
+namespace platforms {
+
+inline FsImplPtr makeEmbeddedFs(bool format_on_fail) FL_NO_EXCEPT {
+    FASTLED_UNUSED(format_on_fail);
+    return FsImplPtr();
+}
+
+} // namespace platforms
+} // namespace fl
+
+#endif // FASTLED_TESTING

--- a/src/platforms/stub/fs_stub.cpp.hpp
+++ b/src/platforms/stub/fs_stub.cpp.hpp
@@ -24,6 +24,24 @@ const char* getTestFileSystemRoot() FL_NO_EXCEPT {
     return g_stub_fs_root_path.c_str();
 }
 
+// Root for `fl::getEmbeddedFs()`, kept separate from the SD root above.
+// On a device those are two media, and a test that wrote to one and read
+// from the other would pass here and fail on hardware if they shared a
+// directory. Empty by default, which keeps the host result null (#4007).
+fl::string g_stub_embedded_fs_root_path;
+
+void setTestEmbeddedFileSystemRoot(const char* root_path) FL_NO_EXCEPT {
+    if (root_path) {
+        g_stub_embedded_fs_root_path = root_path;
+    } else {
+        g_stub_embedded_fs_root_path.clear();
+    }
+}
+
+const char* getTestEmbeddedFileSystemRoot() FL_NO_EXCEPT {
+    return g_stub_embedded_fs_root_path.c_str();
+}
+
 // Stub platform implementation that maps to real hard drive
 FsImplPtr make_sdcard_filesystem(int cs_pin) FL_NO_EXCEPT {
     FASTLED_UNUSED(cs_pin);

--- a/src/platforms/stub/fs_stub.hpp
+++ b/src/platforms/stub/fs_stub.hpp
@@ -299,6 +299,8 @@ public:
 FsImplPtr make_sdcard_filesystem(int cs_pin) FL_NO_EXCEPT;
 void setTestFileSystemRoot(const char* root_path) FL_NO_EXCEPT;
 const char* getTestFileSystemRoot() FL_NO_EXCEPT;
+void setTestEmbeddedFileSystemRoot(const char* root_path) FL_NO_EXCEPT;
+const char* getTestEmbeddedFileSystemRoot() FL_NO_EXCEPT;
 
 } // namespace fl
 

--- a/tests/fl/fs/embedded/embedded_fs.cpp
+++ b/tests/fl/fs/embedded/embedded_fs.cpp
@@ -74,6 +74,14 @@ struct ScopedEmbeddedRoot {
     ~ScopedEmbeddedRoot() { fl::setTestEmbeddedFileSystemRoot(nullptr); }
 };
 
+// The SD root is global too, and a failed FL_REQUIRE leaves the rest of the
+// case unrun -- so clearing it on the way out has to be the destructor's job
+// rather than a line at the bottom.
+struct ScopedSdRoot {
+    explicit ScopedSdRoot(const char *root) { fl::setTestFileSystemRoot(root); }
+    ~ScopedSdRoot() { fl::setTestFileSystemRoot(nullptr); }
+};
+
 } // namespace
 
 FL_TEST_CASE("the host backend stays null until a test asks for it") {
@@ -119,7 +127,7 @@ FL_TEST_CASE("embedded storage and the SD card are separate stores") {
     // read it back from a card must not pass, so the two roots are set
     // independently and pointing one somewhere does not move the other.
     ScopedEmbeddedRoot root("tests/data/audio");
-    fl::setTestFileSystemRoot("tests/data/codec");
+    ScopedSdRoot card_root("tests/data/codec");
 
     fl::FileSystem embedded;
     FL_REQUIRE(embedded.begin(fl::getEmbeddedFs()));
@@ -137,7 +145,6 @@ FL_TEST_CASE("embedded storage and the SD card are separate stores") {
 
     embedded.end();
     card.end();
-    fl::setTestFileSystemRoot(nullptr);
 }
 
 } // FL_TEST_FILE

--- a/tests/fl/fs/embedded/embedded_fs.cpp
+++ b/tests/fl/fs/embedded/embedded_fs.cpp
@@ -12,6 +12,7 @@
 #include "test.h"
 
 #include "fl/fs/embedded/embedded_fs.h"
+#include "fl/fs/testing.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -46,6 +47,97 @@ FL_TEST_CASE("a failed mount leaves the FileSystem safe to use") {
 
     // And tearing down an unmounted filesystem is harmless.
     fs.end();
+}
+
+// ---------------------------------------------------------------------------
+// The host backend (#4007 question 3)
+//
+// #4007 asked whether the stub should implement this, and answered its own
+// question: "Mapping it to a scratch directory would let host tests exercise
+// real read paths instead of only the null-fallback contract." Everything
+// above tests the null fallback. These test the read path.
+//
+// The root is opt-in, so the cases above still see null and still mean what
+// they meant.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// A file that exists under tests/data and is not going anywhere.
+const char *kEmbeddedRoot = "tests/data";
+const char *kExistingFile = "audio/README.md";
+
+struct ScopedEmbeddedRoot {
+    explicit ScopedEmbeddedRoot(const char *root) {
+        fl::setTestEmbeddedFileSystemRoot(root);
+    }
+    ~ScopedEmbeddedRoot() { fl::setTestEmbeddedFileSystemRoot(nullptr); }
+};
+
+} // namespace
+
+FL_TEST_CASE("the host backend stays null until a test asks for it") {
+    // Every case above depends on this. If pointing the host at a directory
+    // became the default, they would stop testing the no-embedded-storage
+    // contract and nothing would say so.
+    fl::setTestEmbeddedFileSystemRoot(nullptr);
+    FL_CHECK(!fl::getEmbeddedFs());
+}
+
+FL_TEST_CASE("the host backend reads a real file once a root is set") {
+    ScopedEmbeddedRoot root(kEmbeddedRoot);
+
+    fl::FsImplPtr impl = fl::getEmbeddedFs();
+    FL_REQUIRE(impl);
+
+    fl::FileSystem fs;
+    FL_REQUIRE(fs.begin(impl));
+
+    fl::ifstream handle = fs.openRead(kExistingFile);
+    FL_REQUIRE(handle.is_open());
+
+    // Reading, not just opening: the null fallback can fake an open, and it
+    // is the bytes that the ESP backend has to match.
+    char first = 0;
+    handle.read(&first, 1);
+    FL_CHECK_NE(first, 0);
+
+    fs.end();
+}
+
+FL_TEST_CASE("a missing file still fails closed with a root set") {
+    ScopedEmbeddedRoot root(kEmbeddedRoot);
+
+    fl::FileSystem fs;
+    FL_REQUIRE(fs.begin(fl::getEmbeddedFs()));
+    FL_CHECK(!fs.openRead("no/such/file.bin").is_open());
+    fs.end();
+}
+
+FL_TEST_CASE("embedded storage and the SD card are separate stores") {
+    // On a device these are two media. A test that wrote to on-chip flash and
+    // read it back from a card must not pass, so the two roots are set
+    // independently and pointing one somewhere does not move the other.
+    ScopedEmbeddedRoot root("tests/data/audio");
+    fl::setTestFileSystemRoot("tests/data/codec");
+
+    fl::FileSystem embedded;
+    FL_REQUIRE(embedded.begin(fl::getEmbeddedFs()));
+
+    fl::FileSystem card;
+    FL_REQUIRE(card.begin(fl::make_sdcard_filesystem(0)));
+
+    // README.md is under the embedded root only.
+    FL_CHECK(embedded.openRead("README.md").is_open());
+    FL_CHECK(!card.openRead("README.md").is_open());
+
+    // file.gif is under the card root only.
+    FL_CHECK(!embedded.openRead("file.gif").is_open());
+    FL_CHECK(card.openRead("file.gif").is_open());
+
+    embedded.end();
+    card.end();
+    fl::setTestFileSystemRoot(nullptr);
 }
 
 } // FL_TEST_FILE


### PR DESCRIPTION
Refs #4007.

The triage on #4007 establishes point by point that #4006 satisfied the design. What it does not cover is the issue's **third open question**, which #4006 answered by omission rather than by decision:

> **Should the stub implement it?** Mapping it to a scratch directory would let host tests exercise real read paths instead of only the null-fallback contract. That is a genuine testability win and the strongest argument for the generic name.

It is, so this does it. Before this, the only host coverage of embedded storage was the no-op fragment — a real contract, and one the existing cases do test, but one that exercises none of the read path a sketch runs.

## Two things make it safe to add

**Opt-in, and null until asked.** `getEmbeddedFs()` returns null on the host exactly as the no-op fragment does, until a test calls `setTestEmbeddedFileSystemRoot()`. The four existing cases keep testing the null fallback and keep meaning what they meant — and there is now a case pinning *that*, because if pointing the host at a directory ever became the default those cases would silently stop testing it and nothing would say so.

**A separate root from the SD stub.** On a device these are two media, so a test that wrote to on-chip flash and read it back off a card must not pass. Sharing `setTestFileSystemRoot`'s directory would make such a test green here and red on hardware, so the roots are set independently and a case asserts a file under one is not visible through the other.

## Shape

The fragment follows what `platforms/embedded_fs.h` already documents — a plain header composed into `fl.fs.embedded+.cpp`, so it is dropped together with the entry point when a sketch never asks — and is selected by `FL_IS_STUB && FASTLED_TESTING`, which cannot reach a device build.

## Not addressed here

RP2040/RP2350 still take the no-op branch, so on-chip storage returns null there. That is correct under this design and is unimplemented work rather than a defect; the triage on #4007 already flagged it and I have left it flagged rather than folding it in.

## Verification

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: ignoring the root, dropping the opt-in gate, and aliasing the embedded root to the SD one each fail their cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a separate embedded filesystem location in host testing environments.
  - Embedded filesystem access now reads files from the configured location when available.

- **Bug Fixes**
  - Prevented embedded filesystem data from being confused with SD-card filesystem data.
  - Preserved safe null behavior when no location is configured or requested files are missing.

- **Tests**
  - Added coverage for configuration, file reading, missing files, and filesystem isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->