### PR TITLE
fix(color): keep the lightness above the cap, by clamping chroma into its interval (#4245)

### DIFF
--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -304,6 +304,13 @@ converges on an infeasible answer. Every mapper here clamps into the hull --
 the OKLCh ones by first reducing lightness to the attainable neutral, as the
 reference does, and the naive ones by bounding drives to [0, 1].
 
+That is still true of the *bisection*, and it is no longer the whole story of
+the shipped mapper. "The clamp gives up more than it needs to" below shows the
+clamp discards up to 29.7% of the reachable lightness, and the mapper now
+clamps chroma into its feasible interval above the cap instead, falling back
+to this when that interval is empty. Read this section as why a bracket at
+zero cannot work there, not as a description of what happens.
+
 The corpus contains no over-bright target, so this had to be constructed to
 be tested. That gap has now hidden two defects in this harness: this one and
 the missing upper-bound check in `is_feasible` fixed alongside it. Worth
@@ -757,6 +764,40 @@ bounded by a count rather than by a convergence criterion, so an
 implementation fixes both and the loop count is known at compile time. An
 earlier revision of this section called the parameters themselves
 compile-time constants, which they are not.
+
+### What the embedded mapper does with it
+
+Shipped in `gamut_map.cpp.hpp` for all three mappers, at
+`kGamutMapProbes = 8` and `kGamutMapHalvings = 8`, so the above-cap path costs
+24 feasibility tests and the loop count is known at build time. Targets at or
+below the cap never enter it, and neither does an in-gamut target, so nothing
+below the cap moved.
+
+Re-rendered through the emitters rather than read back off the mapper, it
+reproduces the table above:
+
+| target | embedded L, C |
+| --- | --- |
+| L 1.286, hue 300, C 0.30 | 1.2860, 0.3081 |
+| L 1.398, hue 300, C 0.30 | 1.3978, 0.4431 |
+| L 1.398, hue 120, C 0.50 | 1.1182, 0.0000 |
+
+**One deliberate difference from the harness.** The study probes to an
+absolute `PROBE_CEILING = 0.8`; the mapper works in factors of the request and
+reaches four times it. Both reproduce every row above, and they differ only on
+targets the table does not contain: a bright *near-neutral*, which is
+infeasible precisely because it is not saturated enough. An absolute ceiling
+answers that with a saturated colour; a relative one finds no seed and falls
+back to the clamp, keeping a near-neutral request near-neutral. An over-bright
+grey has no chroma to scale at all and clamps under either.
+
+**A note for whoever tests the wide mappers.** A hull with a white emitter
+swallows a *saturated* target a little above the cap outright -- the
+allocation succeeds and the mapper returns before the clamp is reached -- so
+a case written at chroma 0.30 exercises none of this and passes with the whole
+path disabled. The reachable-but-outside region above the cap is at low
+chroma, which is the finding restating itself. The tests assert the target is
+outside the hull before they assert anything else.
 
 The lower edge is not optional: clamping to the upper edge alone produces
 *infeasible* output on exactly the targets this is meant to fix, which the

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -144,6 +144,85 @@ i32 largestFeasibleChroma(const i32 (&lab)[3], i32 lightness,
     return low;
 }
 
+/// The feasible chroma interval at the target's *own* lightness, as factors of
+/// the target's chroma.
+///
+/// Above the brightest neutral the interval is still one run -- that much is
+/// measured, on this device and on the wide ones -- but it no longer contains
+/// zero (#4245). `largestFeasibleChroma` cannot find it: its bracket assumes a
+/// feasible low end, and starting infeasible it walks down to zero, which is
+/// the clamp this exists to avoid.
+///
+/// So the seed comes first, by a linear scan, and only then are the two edges
+/// bisected. Returns false when no probe lands inside, which is the caller's
+/// signal to keep the shipped clamp-then-bisect path -- the reason this is
+/// never worse than what it replaces.
+template <typename Feasible>
+bool feasibleChromaInterval(const i32 (&lab)[3], i32 lightness,
+                            Feasible feasible, i32* out_low,
+                            i32* out_high) FL_NO_EXCEPT {
+    i32 seed = 0;
+    bool found = false;
+    for (int probe = 1; probe <= kGamutMapProbes; ++probe) {
+        const i32 factor = static_cast<i32>(
+            (static_cast<i64>(kGamutProbeCeilingQ16) * probe) / kGamutMapProbes);
+        i32 candidate_xyz[3];
+        chromaCandidateXyz(lab, lightness, factor, candidate_xyz);
+        if (feasible(candidate_xyz)) {
+            seed = factor;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        return false;
+    }
+
+    // Lower edge: the smallest feasible factor. `high` is feasible throughout,
+    // `low` is not, which is the mirror of the usual invariant.
+    i32 low = 0;
+    i32 high = seed;
+    for (int step = 0; step < kGamutMapHalvings; ++step) {
+        const i32 factor = low + ((high - low) >> 1);
+        i32 candidate_xyz[3];
+        chromaCandidateXyz(lab, lightness, factor, candidate_xyz);
+        if (feasible(candidate_xyz)) {
+            high = factor;
+        } else {
+            low = factor;
+        }
+    }
+    *out_low = high;
+
+    // Upper edge: the largest feasible factor, the usual invariant again.
+    low = seed;
+    high = kGamutProbeCeilingQ16;
+    for (int step = 0; step < kGamutMapHalvings; ++step) {
+        const i32 factor = low + ((high - low) >> 1);
+        i32 candidate_xyz[3];
+        chromaCandidateXyz(lab, lightness, factor, candidate_xyz);
+        if (feasible(candidate_xyz)) {
+            low = factor;
+        } else {
+            high = factor;
+        }
+    }
+    *out_high = low;
+    return true;
+}
+
+/// The target's chroma clamped into `[low, high]`, in factor space.
+i32 clampChromaFactor(i32 low, i32 high) FL_NO_EXCEPT {
+    i32 factor = kGamutFullDrive;
+    if (factor < low) {
+        factor = low;
+    }
+    if (factor > high) {
+        factor = high;
+    }
+    return factor;
+}
+
 }  // namespace
 
 bool buildGamutMapQ16(const EmitterProfile& profile, GamutMapQ16* out) FL_NO_EXCEPT {
@@ -217,15 +296,37 @@ void mapAndSolveDrivesQ16(const GamutMapQ16& map, const i32 (&xyz)[3],
     i32 lab[3];
     xyzToOklabQ16(xyz, lab);
 
-    // Lightness first. Reducing chroma cannot bring an over-bright target
-    // back into the hull -- at zero chroma it is still outside -- so without
-    // this the halvings below converge on an infeasible answer.
     i32 lightness = lab[0];
-    if (lightness > map.max_neutral_lightness) {
-        lightness = map.max_neutral_lightness;
-    }
     if (lightness < 0) {
         lightness = 0;
+    }
+
+    // Above the brightest neutral, try keeping the lightness (#4245). The
+    // feasible chroma there is an interval that does not contain zero, so it
+    // has to be located before either edge can be bisected; when it is found,
+    // clamping the target's chroma into it holds the requested lightness
+    // instead of discarding up to 29.7% of what the hull reaches.
+    if (lightness > map.max_neutral_lightness) {
+        i32 low_edge = 0;
+        i32 high_edge = 0;
+        if (feasibleChromaInterval(lab, lightness, RgbFeasible{map.solve},
+                                   &low_edge, &high_edge)) {
+            i32 candidate_xyz[3];
+            chromaCandidateXyz(lab, lightness, clampChromaFactor(low_edge, high_edge),
+                               candidate_xyz);
+            i32 candidate[3];
+            solveRgbDrivesQ16(map.solve, candidate_xyz, candidate);
+            if (gamutDrivesAreInRange(candidate, kGamutFeasibilitySlack)) {
+                for (int i = 0; i < 3; ++i) {
+                    drives[i] = candidate[i];
+                }
+                clampGamutDrives(drives);
+                return;
+            }
+        }
+        // No seed, or the accepted candidate fell outside on the re-solve.
+        // Fall through to the clamp, which is what shipped before this.
+        lightness = map.max_neutral_lightness;
     }
 
     // Then chroma, by scaling (a, b) toward zero.
@@ -355,11 +456,26 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
     i32 lab[3];
     xyzToOklabQ16(xyz, lab);
     i32 lightness = lab[0];
-    if (lightness > map.max_neutral_lightness) {
-        lightness = map.max_neutral_lightness;
-    }
     if (lightness < 0) {
         lightness = 0;
+    }
+
+    // Same above-cap interval clamp as the RGB path (#4245). The white
+    // emitter moves the cap but does not change the shape: above it the
+    // feasible chroma still misses zero.
+    if (lightness > map.max_neutral_lightness) {
+        i32 low_edge = 0;
+        i32 high_edge = 0;
+        if (feasibleChromaInterval(lab, lightness, RgbwFeasible{map.allocation},
+                                   &low_edge, &high_edge)) {
+            i32 candidate_xyz[3];
+            chromaCandidateXyz(lab, lightness, clampChromaFactor(low_edge, high_edge),
+                               candidate_xyz);
+            if (allocateEmitterDrivesQ16(map.allocation, candidate_xyz, drives)) {
+                return;
+            }
+        }
+        lightness = map.max_neutral_lightness;
     }
 
     const i32 factor =
@@ -505,11 +621,24 @@ void mapAndAllocateRgbwwQ16(const GamutMapRgbwwQ16& map, const i32 (&xyz)[3],
     i32 lab[3];
     xyzToOklabQ16(xyz, lab);
     i32 lightness = lab[0];
-    if (lightness > map.max_neutral_lightness) {
-        lightness = map.max_neutral_lightness;
-    }
     if (lightness < 0) {
         lightness = 0;
+    }
+
+    // And again for two whites (#4245).
+    if (lightness > map.max_neutral_lightness) {
+        i32 low_edge = 0;
+        i32 high_edge = 0;
+        if (feasibleChromaInterval(lab, lightness, RgbwwFeasible{map.allocation},
+                                   &low_edge, &high_edge)) {
+            i32 candidate_xyz[3];
+            chromaCandidateXyz(lab, lightness, clampChromaFactor(low_edge, high_edge),
+                               candidate_xyz);
+            if (allocateTwoWhiteDrivesQ16(map.allocation, candidate_xyz, drives)) {
+                return;
+            }
+        }
+        lightness = map.max_neutral_lightness;
     }
 
     const i32 factor =

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -11,6 +11,32 @@ namespace {
 /// Full drive, as an s16.16 raw value.
 constexpr i32 kGamutFullDrive = 65536;
 
+/// Probes used to find a seed inside the feasible chroma interval when the
+/// target is brighter than the device's brightest neutral (#4245).
+///
+/// Above that lightness the feasible chroma is still a single interval, but it
+/// no longer contains zero -- so the halving bracket `[0, target]`, whose whole
+/// invariant is that the low end is feasible, starts infeasible and converges
+/// on zero. That is the clamp this replaces: it discards up to 29.7% of the
+/// lightness the hull can actually reach on this device.
+///
+/// A linear scan rather than a search because there is nothing to search on:
+/// the interval's location is what is unknown. Bounded like the halvings and
+/// for the same reason (A3/B11) -- the cost of the above-cap path is
+/// `kGamutMapProbes + 2 * kGamutMapHalvings` feasibility tests, fixed when the
+/// firmware is built. Targets at or below the cap never run it.
+constexpr int kGamutMapProbes = 8;
+
+/// How far above the target's own chroma the probes reach, in Q16.
+///
+/// The interval above the cap can start *above* the requested chroma -- a
+/// bright near-neutral is infeasible precisely because it is not saturated
+/// enough -- so a ceiling of one would find no seed on exactly the targets
+/// this is for. Four is a factor of the request rather than an absolute
+/// chroma, which keeps a near-neutral request near-neutral instead of
+/// answering it with a saturated colour.
+constexpr i32 kGamutProbeCeilingQ16 = 4 << 16;
+
 /// D65 in s16.16, the white the working domain is normalized to.
 constexpr i32 kGamutD65Q16[3] = {62289, 65536, 71372};
 

--- a/src/fl/gfx/gamut_map.h
+++ b/src/fl/gfx/gamut_map.h
@@ -39,32 +39,6 @@ namespace fl {
 /// that runs until a convergence criterion is met.
 constexpr int kGamutMapHalvings = 8;
 
-/// Probes used to find a seed inside the feasible chroma interval when the
-/// target is brighter than the device's brightest neutral (#4245).
-///
-/// Above that lightness the feasible chroma is still a single interval, but it
-/// no longer contains zero -- so the halving bracket `[0, target]`, whose whole
-/// invariant is that the low end is feasible, starts infeasible and converges
-/// on zero. That is the clamp this replaces: it discards up to 29.7% of the
-/// lightness the hull can actually reach on this device.
-///
-/// A linear scan rather than a search because there is nothing to search on:
-/// the interval's location is what is unknown. Bounded like the halvings and
-/// for the same reason (A3/B11) -- the cost of the above-cap path is
-/// `kGamutMapProbes + 2 * kGamutMapHalvings` feasibility tests, fixed when the
-/// firmware is built. Targets at or below the cap never run it.
-constexpr int kGamutMapProbes = 8;
-
-/// How far above the target's own chroma the probes reach, in Q16.
-///
-/// The interval above the cap can start *above* the requested chroma -- a
-/// bright near-neutral is infeasible precisely because it is not saturated
-/// enough -- so a ceiling of one would find no seed on exactly the targets
-/// this is for. Four is a factor of the request rather than an absolute
-/// chroma, which keeps a near-neutral request near-neutral instead of
-/// answering it with a saturated colour.
-constexpr i32 kGamutProbeCeilingQ16 = 4 << 16;
-
 /// Everything the per-pixel mapper needs, derived once when a profile binds.
 struct GamutMapQ16 {
     EmitterSolveMatrixQ16 solve;

--- a/src/fl/gfx/gamut_map.h
+++ b/src/fl/gfx/gamut_map.h
@@ -39,6 +39,32 @@ namespace fl {
 /// that runs until a convergence criterion is met.
 constexpr int kGamutMapHalvings = 8;
 
+/// Probes used to find a seed inside the feasible chroma interval when the
+/// target is brighter than the device's brightest neutral (#4245).
+///
+/// Above that lightness the feasible chroma is still a single interval, but it
+/// no longer contains zero -- so the halving bracket `[0, target]`, whose whole
+/// invariant is that the low end is feasible, starts infeasible and converges
+/// on zero. That is the clamp this replaces: it discards up to 29.7% of the
+/// lightness the hull can actually reach on this device.
+///
+/// A linear scan rather than a search because there is nothing to search on:
+/// the interval's location is what is unknown. Bounded like the halvings and
+/// for the same reason (A3/B11) -- the cost of the above-cap path is
+/// `kGamutMapProbes + 2 * kGamutMapHalvings` feasibility tests, fixed when the
+/// firmware is built. Targets at or below the cap never run it.
+constexpr int kGamutMapProbes = 8;
+
+/// How far above the target's own chroma the probes reach, in Q16.
+///
+/// The interval above the cap can start *above* the requested chroma -- a
+/// bright near-neutral is infeasible precisely because it is not saturated
+/// enough -- so a ceiling of one would find no seed on exactly the targets
+/// this is for. Four is a factor of the request rather than an absolute
+/// chroma, which keeps a near-neutral request near-neutral instead of
+/// answering it with a saturated colour.
+constexpr i32 kGamutProbeCeilingQ16 = 4 << 16;
+
 /// Everything the per-pixel mapper needs, derived once when a profile binds.
 struct GamutMapQ16 {
     EmitterSolveMatrixQ16 solve;

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1538,6 +1538,13 @@ FL_TEST_CASE("RGBW keeps the lightness above its own, higher cap") {
     // what this path claims to do.
     FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - requested), 0.01f);
     FL_CHECK_GT(toFloat(emitted[0]), cap + 0.05f);
+
+    // And on the hue it was asked for. Lightness alone would accept a colour
+    // of the right brightness on any ray at all, which is not what a
+    // hue-preserving mapper promises. `hueDivergence` returns 1.0 for a
+    // neutral result and for an anti-parallel one, so this bound catches a
+    // collapse to grey and a 180-degree rotation as well as a drift.
+    FL_CHECK_LT(hueDivergence(lab, emitted), 0.01f);
 }
 
 FL_TEST_CASE("RGBW falls back to its cap when no chroma is feasible there") {
@@ -1593,6 +1600,8 @@ FL_TEST_CASE("RGBWW keeps the lightness above its own cap") {
     emittedLabWide<5>(drives, kWhiteD65, kWhiteD50Map, emitted);
     FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - requested), 0.01f);
     FL_CHECK_GT(toFloat(emitted[0]), cap + 0.05f);
+
+    FL_CHECK_LT(hueDivergence(lab, emitted), 0.01f);
 }
 
 FL_TEST_CASE("RGBWW falls back to its cap when no chroma is feasible there") {

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1472,45 +1472,151 @@ FL_TEST_CASE("An over-bright neutral still clamps, because it has no chroma") {
     }
 }
 
+namespace {
+
+/// OKLab of a four- or five-emitter drive vector, re-rendered through the
+/// device rather than read back off the mapper.
+template <int N>
+void emittedLabWide(const i32 (&drives)[N], const i32 (&white1)[3],
+                    const i32 (&white2)[3], i32 (&out_lab)[3]) {
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    float xyz[3] = {0.0f, 0.0f, 0.0f};
+    for (int e = 0; e < 3; ++e) {
+        float emitter[3];
+        colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                          emitter);
+        for (int i = 0; i < 3; ++i) {
+            xyz[i] += toFloat(drives[e]) * emitter[i];
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        xyz[i] += toFloat(drives[3]) * toFloat(white1[i]);
+        if (N > 4) {
+            xyz[i] += toFloat(drives[4]) * toFloat(white2[i]);
+        }
+    }
+    const i32 emitted[3] = {q16(xyz[0]), q16(xyz[1]), q16(xyz[2])};
+    xyzToOklabQ16(emitted, out_lab);
+}
+
+}  // namespace
+
 FL_TEST_CASE("RGBW keeps the lightness above its own, higher cap") {
     // The white emitter moves the cap; it does not change the shape of the
     // problem, so the same interval clamp has to run there too.
+    //
+    // Low chroma on purpose, and asserted outside the hull before anything
+    // else. A wide hull swallows most *saturated* targets a little above the
+    // cap outright -- `allocateEmitterDrivesQ16` succeeds and the mapper
+    // returns before the clamp is reached -- so a test written at chroma 0.30
+    // measures nothing and passes with the whole path disabled. That is the
+    // shape of test this guard exists to stop, having written one.
     GamutMapRgbwQ16 rgbw;
     FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
                                      WhiteAllocationPolicy::WhitePreferred, &rgbw));
     const float cap = toFloat(rgbw.max_neutral_lightness);
+    const float requested = cap + 0.15f;
 
-    // Just above the RGBW cap, on the hue that has headroom there.
-    const i32 lab[3] = {q16(cap + 0.06f), q16(0.15f), q16(-0.2598076f)};
+    const i32 lab[3] = {q16(requested), q16(0.05f), q16(-0.0866025f)};
     i32 xyz[3];
     oklabToXyzQ16(lab, xyz);
     i32 drives[4];
+    FL_REQUIRE_FALSE(allocateEmitterDrivesQ16(rgbw.allocation, xyz, drives));
+
     mapAndAllocateRgbwQ16(rgbw, xyz, drives);
     for (int i = 0; i < 4; ++i) {
         FL_CHECK_GE(drives[i], 0);
         FL_CHECK_LE(drives[i], kFullDrive);
     }
 
-    // Re-render through the four emitters, white included.
-    const float emitters[3][2] = {
-        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
-    float out[3] = {0.0f, 0.0f, 0.0f};
-    for (int e = 0; e < 3; ++e) {
-        float emitter[3];
-        colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
-                                          emitter);
-        for (int i = 0; i < 3; ++i) {
-            out[i] += toFloat(drives[e]) * emitter[i];
-        }
-    }
-    for (int i = 0; i < 3; ++i) {
-        out[i] += toFloat(drives[3]) * toFloat(kWhiteD65[i]);
-    }
-    const i32 emitted_xyz[3] = {q16(out[0]), q16(out[1]), q16(out[2])};
     i32 emitted[3];
-    xyzToOklabQ16(emitted_xyz, emitted);
+    emittedLabWide<4>(drives, kWhiteD65, kWhiteD65, emitted);
 
-    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.02f);
+    // The requested lightness itself, not merely something above the cap.
+    // "Above the cap" is satisfied by any improvement at all, which is not
+    // what this path claims to do.
+    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - requested), 0.01f);
+    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.05f);
+}
+
+FL_TEST_CASE("RGBW falls back to its cap when no chroma is feasible there") {
+    // The other half of the contract, and the one that keeps this from ever
+    // being worse: a lightness far past what any hue can reach must still
+    // come back clamped rather than wrong.
+    GamutMapRgbwQ16 rgbw;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
+    const float cap = toFloat(rgbw.max_neutral_lightness);
+
+    const i32 lab[3] = {q16(cap + 0.60f), q16(0.05f), q16(-0.0866025f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[4];
+    FL_REQUIRE_FALSE(allocateEmitterDrivesQ16(rgbw.allocation, xyz, drives));
+
+    mapAndAllocateRgbwQ16(rgbw, xyz, drives);
+    for (int i = 0; i < 4; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+
+    i32 emitted[3];
+    emittedLabWide<4>(drives, kWhiteD65, kWhiteD65, emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - cap), 0.02f);
+}
+
+FL_TEST_CASE("RGBWW keeps the lightness above its own cap") {
+    // Two whites raise the cap again, and the same clamp is wired into that
+    // mapper. Wiring it without testing it would have left the third path
+    // asserted only by the fact that it compiles.
+    GamutMapRgbwwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+    const float cap = toFloat(map.max_neutral_lightness);
+    const float requested = cap + 0.15f;
+
+    const i32 lab[3] = {q16(requested), q16(0.05f), q16(-0.0866025f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[5];
+    FL_REQUIRE_FALSE(allocateTwoWhiteDrivesQ16(map.allocation, xyz, drives));
+
+    mapAndAllocateRgbwwQ16(map, xyz, drives);
+    for (int i = 0; i < 5; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+
+    i32 emitted[3];
+    emittedLabWide<5>(drives, kWhiteD65, kWhiteD50Map, emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - requested), 0.01f);
+    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.05f);
+}
+
+FL_TEST_CASE("RGBWW falls back to its cap when no chroma is feasible there") {
+    GamutMapRgbwwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+    const float cap = toFloat(map.max_neutral_lightness);
+
+    const i32 lab[3] = {q16(cap + 0.60f), q16(0.05f), q16(-0.0866025f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[5];
+    FL_REQUIRE_FALSE(allocateTwoWhiteDrivesQ16(map.allocation, xyz, drives));
+
+    mapAndAllocateRgbwwQ16(map, xyz, drives);
+    for (int i = 0; i < 5; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+
+    i32 emitted[3];
+    emittedLabWide<5>(drives, kWhiteD65, kWhiteD50Map, emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - cap), 0.02f);
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1316,4 +1316,201 @@ FL_TEST_CASE("RGBWW mapper preserves hue while compressing chroma") {
     FL_CHECK_GT(compressed, 0);
 }
 
+// ---------------------------------------------------------------------------
+// Above the brightest neutral (#4245)
+//
+// The clamp to `max_neutral_lightness` throws away lightness the hull can
+// reach off the neutral axis -- up to 29.7% of the headroom on this device.
+// `ci/color_lightness_headroom_study.py` established why the obvious repairs
+// fail and what works: above the cap the feasible chroma is still one
+// interval, it simply stops containing zero, so a seed has to be found before
+// either edge can be bisected. These check the embedded mapper against the
+// numbers that study published.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Re-render mapped drives through the emitters and read back OKLab.
+///
+/// Re-rendered rather than assumed: the point of the change is what the
+/// device actually emits, and a mapper that reported a lightness it did not
+/// produce would pass a test built on its own arithmetic.
+void emittedLab(const i32 (&drives)[3], i32 (&out_lab)[3]) {
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    float xyz[3] = {0.0f, 0.0f, 0.0f};
+    for (int e = 0; e < 3; ++e) {
+        float emitter[3];
+        colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                          emitter);
+        for (int i = 0; i < 3; ++i) {
+            xyz[i] += toFloat(drives[e]) * emitter[i];
+        }
+    }
+    const i32 emitted[3] = {q16(xyz[0]), q16(xyz[1]), q16(xyz[2])};
+    xyzToOklabQ16(emitted, out_lab);
+}
+
+float chromaOf(const i32 (&lab)[3]) {
+    const float a = toFloat(lab[1]);
+    const float b = toFloat(lab[2]);
+    return fl::sqrtf(a * a + b * b);
+}
+
+}  // namespace
+
+FL_TEST_CASE("Above the cap the mapper keeps the lightness it was asked for") {
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+    const float cap = toFloat(map.max_neutral_lightness);
+
+    // Hue 300 degrees at chroma 0.30, at two lightnesses above the cap. The
+    // study reports 1.2860 / 0.3081 and 1.3978 / 0.4431 for these against the
+    // shipped 1.1182 for both.
+    struct Case {
+        float lightness;
+        float expect_chroma;
+    };
+    const Case cases[] = {{1.286f, 0.3081f}, {1.398f, 0.4431f}};
+    for (const auto& c : cases) {
+        const i32 lab[3] = {q16(c.lightness), q16(0.15f), q16(-0.2598076f)};
+        i32 xyz[3];
+        oklabToXyzQ16(lab, xyz);
+        i32 drives[3];
+        mapAndSolveDrivesQ16(map, xyz, drives);
+
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_GE(drives[i], 0);
+            FL_CHECK_LE(drives[i], kFullDrive);
+        }
+
+        i32 emitted[3];
+        emittedLab(drives, emitted);
+        // The requested lightness, not the cap.
+        FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - c.lightness), 0.01f);
+        FL_CHECK_GT(toFloat(emitted[0]), cap + 0.05f);
+        FL_CHECK_LT(fl::fabsf(chromaOf(emitted) - c.expect_chroma), 0.01f);
+    }
+}
+
+FL_TEST_CASE("The lower edge is not optional above the cap") {
+    // At lightness 1.398 on hue 300 the feasible chroma is about
+    // [0.4432, 0.6000] -- it starts *above* the requested 0.30. Clamping to
+    // the upper edge alone would be a search that never looks below the seed,
+    // and clamping to the request would return something infeasible: the
+    // answer has to move chroma *up* into the interval.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+
+    const float requested_chroma = 0.30f;
+    const i32 lab[3] = {q16(1.398f), q16(0.15f), q16(-0.2598076f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[3];
+    mapAndSolveDrivesQ16(map, xyz, drives);
+
+    i32 emitted[3];
+    emittedLab(drives, emitted);
+    FL_CHECK_GT(chromaOf(emitted), requested_chroma * 1.3f);
+
+    // Hue is still exact -- raising chroma along the same ray is what makes
+    // that true, and is why this is not simply "return any feasible colour".
+    const float ax = toFloat(lab[1]), ay = toFloat(lab[2]);
+    const float bx = toFloat(emitted[1]), by = toFloat(emitted[2]);
+    const float scale = fl::sqrtf((ax * ax + ay * ay) * (bx * bx + by * by));
+    FL_REQUIRE_GT(scale, 1e-4f);
+    FL_CHECK_GT(ax * bx + ay * by, 0.0f);
+    FL_CHECK_LT(fl::fabsf(ax * by - ay * bx) / scale, 0.005f);
+}
+
+FL_TEST_CASE("It falls back to the clamp when no chroma is feasible there") {
+    // Lightness 1.398 on hue 120 has no feasible chroma at all -- the study
+    // records `(none)` for that row. The interval search finds no seed and the
+    // shipped clamp-then-bisect answers instead, which is what makes this
+    // never worse than what it replaces.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+
+    const i32 lab[3] = {q16(1.398f), q16(-0.25f), q16(0.4330127f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[3];
+    mapAndSolveDrivesQ16(map, xyz, drives);
+
+    for (int i = 0; i < 3; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+    i32 emitted[3];
+    emittedLab(drives, emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) -
+                          toFloat(map.max_neutral_lightness)),
+                0.01f);
+}
+
+FL_TEST_CASE("An over-bright neutral still clamps, because it has no chroma") {
+    // The regression this could most easily cause. A neutral has no chroma to
+    // scale, so scaling it by any factor leaves it neutral and infeasible; the
+    // probes find no seed and the lightness clamp still runs. Without this the
+    // change could quietly turn every over-bright grey into a saturated
+    // colour and the existing neutral test would not see it, since it checks
+    // ratios rather than chroma.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+
+    for (float luminance : {2.0f, 5.0f, 30.0f}) {
+        i32 xyz[3];
+        xyzAt(0.3127f, 0.3290f, luminance, xyz);
+        i32 drives[3];
+        mapAndSolveDrivesQ16(map, xyz, drives);
+        i32 emitted[3];
+        emittedLab(drives, emitted);
+        FL_CHECK_LT(chromaOf(emitted), 0.01f);
+        FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) -
+                              toFloat(map.max_neutral_lightness)),
+                    0.01f);
+    }
+}
+
+FL_TEST_CASE("RGBW keeps the lightness above its own, higher cap") {
+    // The white emitter moves the cap; it does not change the shape of the
+    // problem, so the same interval clamp has to run there too.
+    GamutMapRgbwQ16 rgbw;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &rgbw));
+    const float cap = toFloat(rgbw.max_neutral_lightness);
+
+    // Just above the RGBW cap, on the hue that has headroom there.
+    const i32 lab[3] = {q16(cap + 0.06f), q16(0.15f), q16(-0.2598076f)};
+    i32 xyz[3];
+    oklabToXyzQ16(lab, xyz);
+    i32 drives[4];
+    mapAndAllocateRgbwQ16(rgbw, xyz, drives);
+    for (int i = 0; i < 4; ++i) {
+        FL_CHECK_GE(drives[i], 0);
+        FL_CHECK_LE(drives[i], kFullDrive);
+    }
+
+    // Re-render through the four emitters, white included.
+    const float emitters[3][2] = {
+        {0.6400f, 0.3300f}, {0.3000f, 0.6000f}, {0.1500f, 0.0600f}};
+    float out[3] = {0.0f, 0.0f, 0.0f};
+    for (int e = 0; e < 3; ++e) {
+        float emitter[3];
+        colorimetric_response::xyY_to_XYZ(emitters[e][0], emitters[e][1], 1.0f,
+                                          emitter);
+        for (int i = 0; i < 3; ++i) {
+            out[i] += toFloat(drives[e]) * emitter[i];
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        out[i] += toFloat(drives[3]) * toFloat(kWhiteD65[i]);
+    }
+    const i32 emitted_xyz[3] = {q16(out[0]), q16(out[1]), q16(out[2])};
+    i32 emitted[3];
+    xyzToOklabQ16(emitted_xyz, emitted);
+
+    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.02f);
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
Closes #4245. Refs #4041 (P7).

The last comment on #4245 settled the algorithm and left the implementation open:

> This is host-side. The embedded mapper still clamps, and converting it means a probe loop plus a second bisection in `gamut_map.cpp.hpp` for rgb/rgbw/rgbww, with the s16.16 accuracy work that implies. The algorithm choice is settled; the implementation is not.

This is that implementation, for all three mappers.

## Why the shipped search cannot find it

Above the brightest neutral the feasible chroma is still a single interval — measured, on this device and on the four wide ones — but it no longer contains zero. `largestFeasibleChroma`'s bracket `[0, target]` has exactly one invariant, that the low end is feasible; starting infeasible it walks down to zero. That *is* the clamp, and on this device it discards up to **29.7%** of the lightness the hull actually reaches.

So the seed comes first, by a bounded linear scan, and only then are both edges bisected.

## Against the study's numbers

Re-rendered through the emitters rather than read back off the mapper, because what matters is what the device emits:

| target | shipped | now |
|---|---|---|
| L 1.286, hue 300, C 0.30 | 1.1182, 0.2988 | **1.2860, 0.3081** |
| L 1.398, hue 300, C 0.30 | 1.1182, 0.2988 | **1.3978, 0.4431** |
| L 1.398, hue 120, C 0.50 | 1.1182, 0.0000 | 1.1182, 0.0000 *(no seed)* |

The second row is the one that needs the **lower** edge. The interval there is about `[0.4432, 0.6000]` — it starts *above* the requested 0.30, so the answer has to move chroma **up** into it. Clamping to the upper edge alone, or to the request, returns something infeasible.

## Never worse, by construction

No seed found, or a candidate that falls outside on the re-solve, falls through to the clamp that shipped before. Targets at or below the cap never enter the new path, so in-gamut and below-cap behaviour is untouched — the existing suite passes unchanged.

## Two design points worth stating

- **The probe ceiling is four times the request, not an absolute chroma.** A bright near-neutral is infeasible precisely because it is not saturated enough; an absolute ceiling would answer it with a saturated colour. A relative one keeps a near-neutral request near-neutral and falls back instead.
- **An over-bright grey still clamps**, because it has no chroma to scale. There is a case pinning that, since the existing neutral test checks drive *ratios* and would not have noticed the change turning every over-bright grey into a colour.

Cost is `kGamutMapProbes + 2 * kGamutMapHalvings` feasibility tests, on the above-cap path only and fixed at build time, so A3/B11 hold.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: suppressing the seed, dropping the lower-edge clamp, and setting the probe ceiling to one each fail their cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color gamut mapping for targets above the brightest neutral-lightness limit.
  * Preserves requested lightness when a feasible chroma range exists across RGB, RGBW, and RGBWW outputs.
  * Falls back to neutral-lightness clamping when no feasible chroma is available.

* **Tests**
  * Added hue-preservation checks for RGBW and RGBWW outputs above the lightness limit.

* **Documentation**
  * Updated gamut-mapping guidance to describe revised chroma and lightness handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->