### PR TITLE
docs(fled): separate "mandatory" from "absent" for rgb16_linear (#4156 R10)

### DIFF
--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -220,9 +220,21 @@ tuple, so old readers degrade to reduced fidelity, never to wrong data. That is
 why adding `video.color` is not a version bump.
 
 Payloads whose color semantics are **mandatory** rather than advisory gate on a
-new `pixel_format` value instead: `rgb16_linear` is meaningless without its
-declaration, and readers that predate it already reject unknown pixel formats.
-Mandatory-ness is a property of the payload format, not a version flag.
+new `pixel_format` value instead, and readers that predate one already reject
+unknown pixel formats. Mandatory-ness is a property of the payload format, not
+a version flag.
+
+"Mandatory" is about *unresolvable* declarations, not about *absent* ones, and
+the two are easy to run together. `rgb16_linear` carries a default tuple like
+the display-encoded formats do, so an absent `video.color` resolves — the
+format value has already pinned linear-light samples, and BT.709 primaries at
+full range are the rest of the historical reading. `declared` is false on that
+result, so a consumer can still tell an inherited tuple from an author's claim.
+What `rgb16_linear` may not do is *fall back*: where an unrecognized name on
+`rgb8` may resolve to the default tuple with a diagnostic, the same name on
+`rgb16_linear` is a refusal. An earlier revision of this section said the
+format was "meaningless without its declaration", which contradicts both the
+table above and `resolveVideoColor()` (FastLED #4156 R10).
 
 ## Frame Payload
 

--- a/tests/fl/fled/fled_color.cpp
+++ b/tests/fl/fled/fled_color.cpp
@@ -180,6 +180,24 @@ FL_TEST_CASE("FLED_COLOR - rgb16_linear defaults to a linear transfer") {
     FL_CHECK(c.transfer  == ColorTransfer::Linear);
     FL_CHECK(c.primaries == ColorPrimaries::Bt709);
     FL_CHECK(c.range     == ColorRange::Full);
+    // Inherited, not claimed. #4156 R10 read the forward-compatibility prose
+    // -- which used to call this format "meaningless without its declaration"
+    // -- as saying absence is unresolvable here. It is not: the format value
+    // has already pinned linear-light samples. What makes the two states
+    // distinguishable is this flag, so it is asserted rather than assumed.
+    FL_CHECK(c.declared == false);
+}
+
+FL_TEST_CASE("FLED_COLOR - rgb16_linear refuses rather than falls back") {
+    // The half of "mandatory" that is real. On rgb8 an unrecognized name may
+    // resolve to the default tuple with a diagnostic, because the declaration
+    // is advisory there. The identical name on rgb16_linear is a refusal --
+    // and refusing is not the same as having no default, which is what the
+    // case above pins.
+    VideoColor c;
+    FL_CHECK(resolve("{\"video\":{\"color\":{\"primaries\":\"nonesuch\"}}}",
+                     kRgb16Lin, &c) != ColorStatus::Ok);
+    FL_CHECK(resolve("{}", kRgb16Lin, &c) == ColorStatus::Ok);
 }
 
 FL_TEST_CASE("FLED_COLOR - rgb16_linear accepts only a linear transfer") {


### PR DESCRIPTION
Refs #4156 (R10).

R10 was the last of the three findings the triage left unchecked. Two of its three parts have been overtaken by the tree; one is real.

## Resolved already — the fallback policy

R10 read the landed mirror as permitting fallback on unresolvable advisory RGB metadata, against #4034's strict-by-default requirement. `FLED_FORMAT.md` now says the opposite of what R10 read:

> Producers and validation tooling always take the strict reading. `resolveVideoColor()` reports every violation. FastLED playback is strict by default; an application may explicitly select best-effort only for advisory `rgb8` color metadata, and that path emits a warning.

That is #4034's contract verbatim, including the explicit opt-in.

## Resolved already — dark output on rejection

> On playback rejection, explicitly transmit/clear dark output; merely skipping `show()` can leave the preceding LED frame latched.

`Video::draw(now, leds)` writes `CRGB::Black` across the whole span when an error is recorded, before returning false. Nothing is left latched.

## Real, and fixed — the contradiction

The format table gives `rgb16_linear` a default tuple, `defaultVideoColor()` implements it, and a test pins it. Three screens down, the forward-compatibility section said the format is *"meaningless without its declaration"*. Both cannot be true.

R10's own resolution says which way to settle it — *"Keep the already implemented linear16 default tuple if absence is intended, and rewrite the contradictory prose"* — so the prose now separates the two states the old wording ran together:

- **Absent** is resolvable. The pixel-format value has already pinned linear-light samples, and BT.709 at full range is the rest of the historical reading. `declared` is false on that result, so a consumer can still tell an inherited tuple from an author's claim.
- **Unresolvable** is a refusal. Where an unrecognized name on `rgb8` may fall back to the default tuple with a diagnostic, the same name on `rgb16_linear` may not. That is what "mandatory" means here — it is about fallback, not about absence.

The `declared == false` flag is the entire distinction, so it is now asserted for `rgb16_linear` rather than only for `rgb8`, alongside a case checking that the refusal half still refuses.

## Not addressed

R10 also asks for identical contract fixtures in ledmapper. That is the other repo's half and is not something this PR can land.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: marking the inherited tuple as `declared`, and dropping the `rgb16_linear` recognition, each fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified forward-compatibility behavior for `rgb16_linear` color declarations.
  - Documented that absent color declarations use the default tuple without marking it as explicitly declared.
  - Clarified that unrecognized color names are rejected rather than silently falling back to defaults.

- **Tests**
  - Added coverage for inherited default color values.
  - Added coverage confirming invalid color names are refused while empty declarations remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->