### PR TITLE
fix(stl): stop printing every large float as -21474836.48

### DIFF
--- a/src/fl/stl/stdio.cpp.hpp
+++ b/src/fl/stl/stdio.cpp.hpp
@@ -2,6 +2,47 @@
 
 namespace fl { namespace printf_detail {
 
+bool float_is_finite(float value) FL_NO_EXCEPT {
+    if (value != value) {
+        return false;
+    }
+    return value > -3.5e38f && value < 3.5e38f;
+}
+
+fl::string format_float_scientific(float value, int precision) FL_NO_EXCEPT {
+    const bool negative = value < 0.0f;
+    float magnitude = negative ? -value : value;
+    int exponent = 0;
+    while (magnitude >= 10.0f) {
+        magnitude /= 10.0f;
+        ++exponent;
+    }
+    while (magnitude > 0.0f && magnitude < 1.0f) {
+        magnitude *= 10.0f;
+        --exponent;
+    }
+
+    sstream stream;
+    if (negative) {
+        stream << "-";
+    }
+    // The mantissa is in [1, 10) now, so the ordinary path renders it.
+    stream << format_float(magnitude, precision);
+    stream << "e";
+    if (exponent < 0) {
+        stream << "-";
+        exponent = -exponent;
+    } else {
+        stream << "+";
+    }
+    if (exponent < 10) {
+        stream << "0";
+    }
+    stream << exponent;
+    return stream.str();
+}
+
+
 void format_arg(sstream& stream, const FormatSpec& spec, const fl::string& arg) FL_NO_EXCEPT {
     format_arg(stream, spec, arg.c_str());
 }

--- a/src/fl/stl/stdio.cpp.hpp
+++ b/src/fl/stl/stdio.cpp.hpp
@@ -22,6 +22,20 @@ fl::string format_float_scientific(float value, int precision) FL_NO_EXCEPT {
         --exponent;
     }
 
+    // Normalising put the mantissa in [1, 10), but *rounding* it to the
+    // requested precision can carry it back out: 9.999e18 at precision 2
+    // rounds to 10.00, and "10.00e+18" is not scientific notation. Checked
+    // before formatting rather than patched after, so there is one place
+    // where the exponent is decided.
+    float half_step = 0.5f;
+    for (int digit = 0; digit < precision; ++digit) {
+        half_step /= 10.0f;
+    }
+    if (magnitude >= 10.0f - half_step) {
+        magnitude /= 10.0f;
+        ++exponent;
+    }
+
     sstream stream;
     if (negative) {
         stream << "-";

--- a/src/fl/stl/stdio.h
+++ b/src/fl/stl/stdio.h
@@ -318,51 +318,146 @@ inline fl::string apply_width(const fl::string& str, const FormatSpec& spec, boo
     return result;
 }
 
+// Largest magnitude whose scaled form still fits an i64 with room for the
+// rounding step. Anything past this cannot be rendered digit-by-digit from an
+// integer, so it goes to the scientific path below.
+constexpr float kFloatDecimalLimit = 4.0e18f;
+
+// True for a value that is neither NaN nor an infinity.
+//
+// Written without <cmath> because this header is reachable from every
+// platform: `v != v` is the definition of NaN, and the magnitude bound catches
+// both infinities. 1e38 is inside the float range, so a finite value can
+// exceed it -- which is why the caller must handle large finites separately
+// rather than treating this as "printable".
+inline bool float_is_finite(float value) FL_NO_EXCEPT {
+    if (value != value) {
+        return false;
+    }
+    return value > -3.5e38f && value < 3.5e38f;
+}
+
+inline fl::string format_float(float value, int precision) FL_NO_EXCEPT;
+
+// `d.ddde+NN` for a magnitude no integer accumulator can hold.
+//
+// The alternative is to print such a value as though it were small, which is
+// what this file used to do: every magnitude at or above 2^31 / 10^precision
+// came out as `-21474836.48`, because `static_cast<int>` of an out-of-range
+// float is undefined behaviour and lands on INT_MIN on the common targets.
+// A number that is wrong without saying so is worse than one in a shape the
+// reader has to decode (FastLED #4156).
+//
+// Precondition: `value` is finite. The normalisation loop below divides while
+// the magnitude is at or above ten, which never terminates for an infinity --
+// removing the caller's non-finite check hangs rather than mis-prints, which
+// is how that ordering was confirmed to be load-bearing.
+inline fl::string format_float_scientific(float value, int precision) FL_NO_EXCEPT {
+    const bool negative = value < 0.0f;
+    float magnitude = negative ? -value : value;
+    int exponent = 0;
+    while (magnitude >= 10.0f) {
+        magnitude /= 10.0f;
+        ++exponent;
+    }
+    while (magnitude > 0.0f && magnitude < 1.0f) {
+        magnitude *= 10.0f;
+        --exponent;
+    }
+
+    sstream stream;
+    if (negative) {
+        stream << "-";
+    }
+    // The mantissa is in [1, 10) now, so the ordinary path renders it.
+    stream << format_float(magnitude, precision);
+    stream << "e";
+    if (exponent < 0) {
+        stream << "-";
+        exponent = -exponent;
+    } else {
+        stream << "+";
+    }
+    if (exponent < 10) {
+        stream << "0";
+    }
+    stream << exponent;
+    return stream.str();
+}
+
 // Format floating point with specified precision
 inline fl::string format_float(float value, int precision) FL_NO_EXCEPT {
+    // Non-finite first. These used to reach the integer cast below and print
+    // as `-21474836.48` -- a plausible-looking number for a value that is not
+    // a number at all.
+    if (value != value) {
+        return fl::string("nan");
+    }
+    if (!float_is_finite(value)) {
+        return fl::string(value < 0.0f ? "-inf" : "inf");
+    }
+
     if (precision < 0) {
         // Default precision - use sstream's default behavior
         sstream stream;
         stream << value;
         return stream.str();
     }
-    
-    // Simple precision formatting
-    // This is a basic implementation - could be enhanced
+
+    // Past what an integer accumulator can hold, digit-by-digit rendering is
+    // not available at all, so say so in a different shape rather than
+    // printing a wrong number.
+    if (value >= kFloatDecimalLimit || value <= -kFloatDecimalLimit) {
+        return format_float_scientific(value, precision > 0 ? precision : 6);
+    }
+
+    const bool negative = value < 0.0f;
+    const float magnitude = negative ? -value : value;
+
+    // Split before scaling, not after. Multiplying the whole value by the
+    // multiplier in float loses the low digits of a large integer part -- 1e9
+    // at precision 2 came out as 999999979.52, because 1e11 is not
+    // representable in a float. Only the fractional residue is scaled; the
+    // integer part goes through as an integer.
+    //
+    // Above 2^24 a float has no fractional part, so the residue is exactly
+    // zero there and the clamp below is for the rounding of the cast back,
+    // not for a value that genuinely has digits to lose.
+    fl::i64 int_part = static_cast<fl::i64>(magnitude);
+    float residue = magnitude - static_cast<float>(int_part);
+    if (residue < 0.0f) {
+        residue = 0.0f;
+    }
+
     if (precision == 0) {
-        int int_part = static_cast<int>(value + 0.5f); // Round
+        if (residue >= 0.5f) {
+            ++int_part;
+        }
         sstream stream;
+        if (negative && int_part != 0) {
+            stream << "-";
+        }
         stream << int_part;
         return stream.str();
     }
-    
-    // For non-zero precision, use basic rounding
-    int multiplier = 1;
+
+    fl::i64 multiplier = 1;
     for (int i = 0; i < precision; ++i) {
         multiplier *= 10;
     }
 
-    // Handle rounding correctly for both positive and negative numbers
-    float scaled_float = value * multiplier;
-    int scaled;
-    if (scaled_float >= 0) {
-        scaled = static_cast<int>(scaled_float + 0.5f);
-    } else {
-        scaled = static_cast<int>(scaled_float - 0.5f);
-    }
-
-    int int_part = scaled / multiplier;
-    int frac_part = scaled % multiplier;
-
-    // For negative numbers, frac_part will be negative, so take absolute value
-    if (frac_part < 0) {
-        frac_part = -frac_part;
+    fl::i64 frac_part =
+        static_cast<fl::i64>(residue * static_cast<float>(multiplier) + 0.5f);
+    if (frac_part >= multiplier) {
+        // Rounded up through the next whole unit.
+        frac_part -= multiplier;
+        ++int_part;
     }
 
     sstream stream;
-    // Preserve sign for values like -0.5 that round to int_part=0 (printed
-    // without sign by the integer write below).
-    if (value < 0 && int_part == 0) {
+    // The sign is printed from the sign of the input, not recovered from the
+    // integer part, so -0.5 keeps its sign at precision 1.
+    if (negative && (int_part != 0 || frac_part != 0)) {
         stream << "-";
     }
     stream << int_part;
@@ -373,10 +468,10 @@ inline fl::string format_float(float value, int precision) FL_NO_EXCEPT {
     // to 1, which produced "0.0"/"1.0" instead of "0.00"/"1.00" for any
     // integer-valued input. It also omitted the digits entirely when
     // frac_part == 0.
-    int temp_multiplier = multiplier / 10;
+    fl::i64 temp_multiplier = multiplier / 10;
     while (temp_multiplier > 0) {
-        int digit = (frac_part / temp_multiplier) % 10;
-        stream << static_cast<char>('0' + digit);
+        const fl::i64 digit = (frac_part / temp_multiplier) % 10;
+        stream << static_cast<char>('0' + static_cast<int>(digit));
         temp_multiplier /= 10;
     }
 

--- a/src/fl/stl/stdio.h
+++ b/src/fl/stl/stdio.h
@@ -330,14 +330,7 @@ constexpr float kFloatDecimalLimit = 4.0e18f;
 // both infinities. 1e38 is inside the float range, so a finite value can
 // exceed it -- which is why the caller must handle large finites separately
 // rather than treating this as "printable".
-inline bool float_is_finite(float value) FL_NO_EXCEPT {
-    if (value != value) {
-        return false;
-    }
-    return value > -3.5e38f && value < 3.5e38f;
-}
-
-inline fl::string format_float(float value, int precision) FL_NO_EXCEPT;
+bool float_is_finite(float value) FL_NO_EXCEPT;
 
 // `d.ddde+NN` for a magnitude no integer accumulator can hold.
 //
@@ -348,42 +341,14 @@ inline fl::string format_float(float value, int precision) FL_NO_EXCEPT;
 // A number that is wrong without saying so is worse than one in a shape the
 // reader has to decode (FastLED #4156).
 //
-// Precondition: `value` is finite. The normalisation loop below divides while
-// the magnitude is at or above ten, which never terminates for an infinity --
+// Precondition: `value` is finite. The normalisation loop divides while the
+// magnitude is at or above ten, which never terminates for an infinity --
 // removing the caller's non-finite check hangs rather than mis-prints, which
 // is how that ordering was confirmed to be load-bearing.
-inline fl::string format_float_scientific(float value, int precision) FL_NO_EXCEPT {
-    const bool negative = value < 0.0f;
-    float magnitude = negative ? -value : value;
-    int exponent = 0;
-    while (magnitude >= 10.0f) {
-        magnitude /= 10.0f;
-        ++exponent;
-    }
-    while (magnitude > 0.0f && magnitude < 1.0f) {
-        magnitude *= 10.0f;
-        --exponent;
-    }
-
-    sstream stream;
-    if (negative) {
-        stream << "-";
-    }
-    // The mantissa is in [1, 10) now, so the ordinary path renders it.
-    stream << format_float(magnitude, precision);
-    stream << "e";
-    if (exponent < 0) {
-        stream << "-";
-        exponent = -exponent;
-    } else {
-        stream << "+";
-    }
-    if (exponent < 10) {
-        stream << "0";
-    }
-    stream << exponent;
-    return stream.str();
-}
+//
+// Defined in `stdio.cpp.hpp` rather than here: `src/**/*.h` carries
+// declarations, and these two need no template visibility.
+fl::string format_float_scientific(float value, int precision) FL_NO_EXCEPT;
 
 // Format floating point with specified precision
 inline fl::string format_float(float value, int precision) FL_NO_EXCEPT {

--- a/tests/fl/stl/charconv.cpp
+++ b/tests/fl/stl/charconv.cpp
@@ -147,4 +147,94 @@ FL_TEST_CASE("fl::to_hex - case sensitivity") {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ftoa over the whole float range
+//
+// Recorded as an aside on #4156, where it nearly caused a live finite check to
+// be deleted as dead code: `FL_WARN` printed *every* over-range float as
+// `-21474836.48`. The cause is `static_cast<int>` of an out-of-range float,
+// which is undefined behaviour and lands on INT_MIN on the common targets.
+// The old boundary was about 2.1e7 at the default precision of two -- 21.5
+// million, which a microsecond count, a byte total or a raw s16.16 value
+// passes without being unusual.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+fl::string ftoaOf(float value, int precision) {
+    char buf[64] = {0};
+    fl::ftoa(value, buf, precision);
+    return fl::string(buf);
+}
+
+float positiveInfinity() {
+    float zero = 0.0f;
+    return 1.0f / zero;
+}
+
+}  // namespace
+
+FL_TEST_CASE("ftoa - magnitudes past the old int boundary print correctly") {
+    // 21 million was fine before, 22 million was not. Both are ordinary.
+    FL_CHECK_EQ(ftoaOf(21000000.0f, 2), fl::string("21000000.00"));
+    FL_CHECK_EQ(ftoaOf(22000000.0f, 2), fl::string("22000000.00"));
+    FL_CHECK_EQ(ftoaOf(-22000000.0f, 2), fl::string("-22000000.00"));
+    FL_CHECK_EQ(ftoaOf(1000000000.0f, 2), fl::string("1000000000.00"));
+}
+
+FL_TEST_CASE("ftoa - the integer part is not lost to the scaling") {
+    // Scaling the whole value by the multiplier in float is what cost the low
+    // digits: 1e9 * 100 is 1e11, which no float represents, so this used to
+    // read 999999979.52 even once the integer overflow was gone. Only the
+    // fractional residue is scaled now.
+    FL_CHECK_EQ(ftoaOf(1000000000.0f, 2), fl::string("1000000000.00"));
+    FL_CHECK_EQ(ftoaOf(16777216.0f, 3), fl::string("16777216.000"));
+}
+
+FL_TEST_CASE("ftoa - the whole 64-bit band renders as digits") {
+    // The band between 2^31 and the scientific threshold is where an `int`
+    // accumulator is still undefined and an `i64` one is still exact. Powers
+    // of two because they are exact in both a float and an i64, so the
+    // expected string is not itself an approximation.
+    FL_CHECK_EQ(ftoaOf(8589934592.0f, 2), fl::string("8589934592.00"));         // 2^33
+    FL_CHECK_EQ(ftoaOf(1125899906842624.0f, 2),
+                fl::string("1125899906842624.00"));                            // 2^50
+    FL_CHECK_EQ(ftoaOf(-8589934592.0f, 2), fl::string("-8589934592.00"));
+    FL_CHECK_EQ(ftoaOf(8589934592.0f, 0), fl::string("8589934592"));
+}
+
+FL_TEST_CASE("ftoa - a magnitude beyond any integer goes to scientific") {
+    // Not representable digit by digit at all, so it is printed in a shape the
+    // reader has to decode rather than as a wrong decimal.
+    FL_CHECK_EQ(ftoaOf(1e30f, 2), fl::string("1.00e+30"));
+    FL_CHECK_EQ(ftoaOf(-1e30f, 2), fl::string("-1.00e+30"));
+    FL_CHECK_EQ(ftoaOf(3.0e38f, 2), fl::string("3.00e+38"));
+    // Two-digit exponents are zero padded so the width is stable in a log.
+    FL_CHECK_EQ(ftoaOf(5e19f, 1), fl::string("5.0e+19"));
+}
+
+FL_TEST_CASE("ftoa - non-finite values say what they are") {
+    const float inf = positiveInfinity();
+    FL_CHECK_EQ(ftoaOf(inf, 2), fl::string("inf"));
+    FL_CHECK_EQ(ftoaOf(-inf, 2), fl::string("-inf"));
+    FL_CHECK_EQ(ftoaOf(inf - inf, 2), fl::string("nan"));
+    // And at every precision, including the two special paths.
+    FL_CHECK_EQ(ftoaOf(inf, 0), fl::string("inf"));
+    FL_CHECK_EQ(ftoaOf(inf, -1), fl::string("inf"));
+}
+
+FL_TEST_CASE("ftoa - the ordinary cases are untouched") {
+    // The regression guard. Everything above is about the tail of the range;
+    // none of it may move what the common path prints.
+    FL_CHECK_EQ(ftoaOf(0.0f, 2), fl::string("0.00"));
+    FL_CHECK_EQ(ftoaOf(1.5f, 2), fl::string("1.50"));
+    FL_CHECK_EQ(ftoaOf(-1.5f, 2), fl::string("-1.50"));
+    FL_CHECK_EQ(ftoaOf(1.0f, 2), fl::string("1.00"));
+    FL_CHECK_EQ(ftoaOf(0.125f, 3), fl::string("0.125"));
+    FL_CHECK_EQ(ftoaOf(-0.5f, 1), fl::string("-0.5"));
+    FL_CHECK_EQ(ftoaOf(2.5f, 0), fl::string("3"));
+    FL_CHECK_EQ(ftoaOf(-2.5f, 0), fl::string("-3"));
+    FL_CHECK_EQ(ftoaOf(0.0f, 0), fl::string("0"));
+}
+
 } // FL_TEST_FILE

--- a/tests/fl/stl/charconv.cpp
+++ b/tests/fl/stl/charconv.cpp
@@ -237,4 +237,24 @@ FL_TEST_CASE("ftoa - the ordinary cases are untouched") {
     FL_CHECK_EQ(ftoaOf(0.0f, 0), fl::string("0"));
 }
 
+FL_TEST_CASE("ftoa - a mantissa that rounds to ten carries the exponent") {
+    // Normalising puts the mantissa in [1, 10), but rounding it to the
+    // requested precision can carry it back out. 9.999e18 at precision 2
+    // rounded to 10.00 and printed `10.00e+18`, which is not scientific
+    // notation and reads as a different number at a glance.
+    FL_CHECK_EQ(ftoaOf(9.999e18f, 2), fl::string("1.00e+19"));
+    FL_CHECK_EQ(ftoaOf(9.9999e30f, 2), fl::string("1.00e+31"));
+    FL_CHECK_EQ(ftoaOf(-9.999e18f, 2), fl::string("-1.00e+19"));
+
+    // The carry is precision-dependent, which is why the threshold is
+    // computed from the precision rather than fixed: 9.99e19 stays at 9.99
+    // with two digits and becomes 1.0e+20 with one.
+    FL_CHECK_EQ(ftoaOf(9.99e19f, 2), fl::string("9.99e+19"));
+    FL_CHECK_EQ(ftoaOf(9.99e19f, 1), fl::string("1.0e+20"));
+
+    // And a mantissa that was never near ten is left alone.
+    FL_CHECK_EQ(ftoaOf(1.0e19f, 2), fl::string("1.00e+19"));
+    FL_CHECK_EQ(ftoaOf(5.0e19f, 1), fl::string("5.0e+19"));
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
Refs #4156.

This was recorded as an aside on #4156, where it nearly cost a live check:

> `FL_WARN` printed every over-range float as `-21474836.48` … Read literally it says "the number is finite and small", which would have led me to delete the check as dead code.

It was left as a note for whoever debugs numerics through it. A diagnostic that prints a confident, wrong, plausible-looking number is worth fixing rather than knowing about.

## Reproduced first

At precision 2, before any change:

| input | printed |
|---|---|
| 21 000 000 | `21000000.00` |
| **22 000 000** | **`-21474836.48`** |
| 1e9 | `-21474836.48` |
| 1e30 | `-21474836.48` |
| +inf | `-21474836.48` |
| -inf | `-21474836.48` |
| nan | `-21474836.48` |

The boundary is `2^31 / 10^precision` — about **21.5 million** by default, which a microsecond count, a byte total or a raw s16.16 value passes without being unusual. `static_cast<int>` of an out-of-range float is undefined behaviour and lands on `INT_MIN` on the common targets; `-2147483648 / 100` and its remainder are exactly where those digits come from.

## Three fixes, in the order they were found

- **Non-finite values are named** — `nan`, `inf`, `-inf`. They reached the same cast, and a NaN printed as a number is the worst of these.
- **The accumulator is 64-bit**, covering the whole band up to the scientific threshold. The tests walk that band with powers of two, which are exact in both a float and an `i64`, so the expected string is not itself an approximation. My first pass tested only up to 1e9 — below 2^31 — and the mutation narrowing the accumulator back to `int` **passed**, which is how that gap was found.
- **The split happens before the scaling.** Multiplying the whole value by the multiplier in float loses the low digits of a large integer part: with the overflow gone, 1e9 still read `999999979.52`, because 1e11 is not representable in a float. Only the fractional residue is scaled now; above 2^24 a float has no fractional part, so the residue is exactly zero there.

Past what any integer can hold, the value goes out as `d.ffe+NN`. A shape the reader has to decode beats a decimal that is wrong.

## Verification

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: restoring the whole-value scaling, narrowing the accumulator back to `int`, and removing the non-finite check each fail. The last one **hangs** rather than mis-printing — the scientific path's normalisation loop never terminates on an infinity — so that ordering is load-bearing and the comment now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point formatting for very large and very small values.
  * Prevented precision loss when formatting large whole-number portions.
  * Added scientific notation for values beyond supported formatting ranges.
  * Corrected display of special values, including “NaN” and infinity.
  * Fixed scientific-notation rounding so exponent carry produces normalized output.
  * Preserved expected formatting for ordinary floating-point values.

* **Tests**
  * Expanded coverage across extreme magnitudes, special values, precision handling, and rounding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->