### PR TITLE
study(color): a Q16 bind-time inverse is accurate enough (#4043)

### DIFF
--- a/ci/color_fixed_inverse_study.py
+++ b/ci/color_fixed_inverse_study.py
@@ -1,0 +1,315 @@
+"""Can the bind-time solve matrix be inverted in fixed point? (P9, #4043)
+
+#4043's survey names the one item on that phase that is blocked on nothing but
+effort:
+
+    What still uses float is the *derivation* that runs once per profile ...
+    B11 permits that per-pixel, but the TINY-tier criterion is about *linked
+    symbols*, so bind-time float still counts against it.
+
+and then names the reason it is not a small change:
+
+    `EmitterProfile` itself stores `float xy_r[2]`, `lum_r` and so on. It is
+    P2's public type and the whole legacy RGBW stack consumes it. A float-free
+    bind-time derivation needs a fixed-point profile representation, which is a
+    cross-cutting P2/P9 change rather than a rewrite of one 129-line file.
+
+That is about the *profile*. It leaves a narrower question unanswered, and the
+narrow one has to be settled first because the wide one depends on it:
+**is a Q16 3x3 inverse accurate enough to replace the float one at all?**
+
+If it is not, converting `EmitterProfile` buys nothing -- the derivation would
+still have to reach float to stay inside the A1 budget, and P9 item 2 is not
+"effort" but "impossible as scoped". If it is, the profile conversion is the
+only thing left in the way and can be scoped as such.
+
+The two paths compared here:
+
+    shipped   xyY -> XYZ in float -> invert in float -> quantize to Q16
+    proposed  xyY -> XYZ -> quantize to Q16 -> invert in Q16 (i64 intermediates)
+
+Both end in Q16, so this is not a question of the *output* format. It is a
+question of where the arithmetic happens: float32 carries a 24-bit mantissa
+that follows the magnitude, while Q16 carries a fixed 1/65536 absolute step
+and, with 64-bit intermediates, far more headroom than float32 around one.
+Neither dominates a priori -- which is why this measures rather than argues.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from typeguard import typechecked
+
+from ci.color_gamut_study import emitter_matrix
+from ci.color_reference import (
+    Matrix3,
+    Rgb,
+    Xyz,
+    _invert_3x3,
+    _matvec,
+    delta_e2000,
+    xyz_to_lab,
+)
+
+
+# The three CIE xy pairs a three-emitter device is described by.
+Primaries: TypeAlias = tuple[tuple[float, float], ...]
+
+# s16.16, the working domain the pipeline already uses.
+Q16_ONE = 65536
+
+# D65 at unit luminance, the white the reference measures against.
+D65_WHITE: Xyz = (0.9504559, 1.0, 1.0890578)
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class InverseError:
+    """How far a fixed-point inverse lands from the float one it replaces."""
+
+    device: str
+    worst_delta_e: float
+    worst_drive_error: float
+    worst_coefficient_ulps: int
+
+
+@typechecked
+def to_q16(value: float) -> int:
+    """Round to the nearest s16.16 step, halves away from zero."""
+
+    if value >= 0.0:
+        return int(value * Q16_ONE + 0.5)
+    return -int(-value * Q16_ONE + 0.5)
+
+
+@typechecked
+def from_q16(value: int) -> float:
+    return value / Q16_ONE
+
+
+def _rows(matrix: Matrix3) -> tuple[tuple[float, ...], ...]:
+    return (matrix.row0, matrix.row1, matrix.row2)
+
+
+@typechecked
+def quantize_matrix(matrix: Matrix3) -> list[list[int]]:
+    """Every entry rounded to s16.16."""
+
+    out: list[list[int]] = []
+    for row in _rows(matrix):
+        quantized: list[int] = []
+        for value in row:
+            quantized.append(to_q16(value))
+        out.append(quantized)
+    return out
+
+
+@typechecked
+def rounded_div(numerator: int, denominator: int) -> int:
+    """Nearest integer, halves away from zero, for signed operands.
+
+    Truncation would bias every coefficient toward zero, and the bias does not
+    cancel across a row -- a solve is a sum of three of them.
+    """
+
+    if denominator == 0:
+        raise ValueError("denominator must be non-zero")
+    if denominator < 0:
+        numerator = -numerator
+        denominator = -denominator
+    if numerator >= 0:
+        return (numerator + denominator // 2) // denominator
+    return -((-numerator + denominator // 2) // denominator)
+
+
+@typechecked
+def invert3x3_q16(matrix: list[list[int]]) -> list[list[int]] | None:
+    """Inverse of an s16.16 matrix, in s16.16, with exact intermediates.
+
+    Python's integers are unbounded, so the cofactors and determinant here are
+    exact; a C++ implementation needs i64 for the cofactors (Q32) and the
+    determinant (Q48) and a staged or 128-bit divide for the last step. That
+    is the cost this study is pricing, so the arithmetic is written the way
+    that implementation would have to do it rather than in floats.
+
+    Returns None on a singular matrix, matching `invert3x3`'s contract.
+    """
+
+    a, b, c = matrix[0]
+    d, e, f = matrix[1]
+    g, h, i = matrix[2]
+
+    # Cofactors are products of two Q16 values: Q32.
+    cof = [
+        [e * i - f * h, c * h - b * i, b * f - c * e],
+        [f * g - d * i, a * i - c * g, c * d - a * f],
+        [d * h - e * g, b * g - a * h, a * e - b * d],
+    ]
+    # Determinant is a Q16 times a Q32: Q48.
+    determinant = a * cof[0][0] + b * cof[1][0] + c * cof[2][0]
+    if determinant == 0:
+        return None
+
+    # inverse = cofactor / determinant is Q32 / Q48 = Q-16, so shift by 32 to
+    # land back in Q16.
+    out: list[list[int]] = []
+    for row in range(3):
+        scaled: list[int] = []
+        for col in range(3):
+            scaled.append(rounded_div(cof[row][col] << 32, determinant))
+        out.append(scaled)
+    return out
+
+
+@typechecked
+def solve_q16(inverse: list[list[int]], xyz: Xyz) -> Rgb:
+    """Drives from an s16.16 inverse, the way the embedded solve does it."""
+
+    drives: list[float] = []
+    for row in range(3):
+        total = 0
+        for col in range(3):
+            total += inverse[row][col] * to_q16(xyz[col])
+        # Q16 * Q16 = Q32; back to Q16, then to float for comparison.
+        drives.append(from_q16((total + (1 << 15)) >> 16))
+    return (drives[0], drives[1], drives[2])
+
+
+@typechecked
+def clamp_drives(drives: Rgb) -> Rgb:
+    """Into [0, 1], the way `clampGamutDrives` does before emission."""
+
+    clamped: list[float] = []
+    for value in drives:
+        if value < 0.0:
+            clamped.append(0.0)
+        elif value > 1.0:
+            clamped.append(1.0)
+        else:
+            clamped.append(value)
+    return (clamped[0], clamped[1], clamped[2])
+
+
+@typechecked
+def lab_safe(xyz: Xyz) -> Xyz:
+    """Float noise around zero clipped away, so CIELAB will accept the point.
+
+    Display P3's red primary has `1 - x - y` equal to zero, which in float is
+    5.55e-17, so re-rendering a pure-red drive lands its Z component at about
+    -2e-17. That is the summation, not a colour with negative Z, and
+    `xyz_to_lab` refuses the whole point over it. Clipped rather than
+    tolerated at a threshold: any *real* negative here would be a defect in
+    the matrices, and clipping to zero leaves such a value visible as a
+    ridiculous ratio rather than hiding it behind an epsilon.
+    """
+
+    return (
+        xyz[0] if xyz[0] > 0.0 else 0.0,
+        xyz[1] if xyz[1] > 0.0 else 0.0,
+        xyz[2] if xyz[2] > 0.0 else 0.0,
+    )
+
+
+@typechecked
+def sweep_drives(steps: int) -> list[Rgb]:
+    """A grid of in-gamut drive vectors, including the corners."""
+
+    if steps <= 0:
+        raise ValueError("steps must be positive")
+
+    grid: list[Rgb] = []
+    for r in range(steps + 1):
+        for g in range(steps + 1):
+            for b in range(steps + 1):
+                grid.append((r / steps, g / steps, b / steps))
+    return grid
+
+
+@typechecked
+def compare_inverses(name: str, primaries: Primaries, steps: int) -> InverseError:
+    """Worst-case disagreement between the two derivations on one device.
+
+    Driven from drives rather than from XYZ: a drive vector is what the device
+    is actually asked for, so re-rendering it gives a target that is in gamut
+    by construction and the recovered drives can be compared against the
+    values that produced it.
+    """
+
+    forward = emitter_matrix(primaries)
+    float_inverse = _invert_3x3(forward)
+    shipped = quantize_matrix(float_inverse)
+    proposed = invert3x3_q16(quantize_matrix(forward))
+    if proposed is None:
+        raise ValueError(f"{name}: fixed-point inverse reported singular")
+
+    worst_ulps = 0
+    for row in range(3):
+        for col in range(3):
+            difference = abs(shipped[row][col] - proposed[row][col])
+            if difference > worst_ulps:
+                worst_ulps = difference
+
+    worst_delta_e = 0.0
+    worst_drive_error = 0.0
+    for drives in sweep_drives(steps):
+        xyz = _matvec(forward, drives)
+        shipped_drives = solve_q16(shipped, xyz)
+        proposed_drives = solve_q16(proposed, xyz)
+
+        for index in range(3):
+            error = abs(shipped_drives[index] - proposed_drives[index])
+            if error > worst_drive_error:
+                worst_drive_error = error
+
+        # Re-rendered through the clamp the device applies. A drive a rounding
+        # step below zero is emitted as zero, and comparing the unclamped
+        # value would measure a colour no hardware produces.
+        shipped_xyz = lab_safe(_matvec(forward, clamp_drives(shipped_drives)))
+        proposed_xyz = lab_safe(_matvec(forward, clamp_drives(proposed_drives)))
+        difference = delta_e2000(
+            xyz_to_lab(shipped_xyz, D65_WHITE), xyz_to_lab(proposed_xyz, D65_WHITE)
+        )
+        if difference > worst_delta_e:
+            worst_delta_e = difference
+
+    return InverseError(name, worst_delta_e, worst_drive_error, worst_ulps)
+
+
+@typechecked
+def collapsed_primaries(fraction: float) -> Primaries:
+    """sRGB with green moved `fraction` of the way onto the red-blue line.
+
+    Conditioning is what decides where a fixed-point inverse gives out, so the
+    limit has to be approached rather than asserted. At `fraction` 1.0 the
+    three primaries are collinear and the matrix is singular.
+    """
+
+    if fraction < 0.0 or fraction > 1.0:
+        raise ValueError("fraction must lie in [0, 1]")
+
+    red = (0.6400, 0.3300)
+    blue = (0.1500, 0.0600)
+    midpoint_x = 0.5 * (red[0] + blue[0])
+    midpoint_y = 0.5 * (red[1] + blue[1])
+    green_x = 0.3000 + fraction * (midpoint_x - 0.3000)
+    green_y = 0.6000 + fraction * (midpoint_y - 0.6000)
+    return (red, (green_x, green_y), blue)
+
+
+@typechecked
+def corpus_primaries() -> list[tuple[str, Primaries]]:
+    """The primary sets the rest of the colour studies measure.
+
+    The last one is deliberately near-degenerate: a well-conditioned matrix
+    tells you nothing about where a fixed-point inverse gives out, and the
+    determinant is what decides that.
+    """
+
+    return [
+        ("srgb", ((0.6400, 0.3300), (0.3000, 0.6000), (0.1500, 0.0600))),
+        ("bt2020", ((0.7080, 0.2920), (0.1700, 0.7970), (0.1310, 0.0460))),
+        ("display_p3", ((0.6800, 0.3200), (0.2650, 0.6900), (0.1500, 0.0600))),
+        ("narrow", ((0.6400, 0.3300), (0.5000, 0.4200), (0.4400, 0.4000))),
+    ]

--- a/ci/color_fixed_inverse_study.py
+++ b/ci/color_fixed_inverse_study.py
@@ -37,6 +37,7 @@ Neither dominates a priori -- which is why this measures rather than argues.
 
 from __future__ import annotations
 
+import struct
 from dataclasses import dataclass
 from typing import TypeAlias
 
@@ -47,7 +48,6 @@ from ci.color_reference import (
     Matrix3,
     Rgb,
     Xyz,
-    _invert_3x3,
     _matvec,
     delta_e2000,
     xyz_to_lab,
@@ -91,6 +91,116 @@ def from_q16(value: int) -> float:
 
 def _rows(matrix: Matrix3) -> tuple[tuple[float, ...], ...]:
     return (matrix.row0, matrix.row1, matrix.row2)
+
+
+@typechecked
+def f32(value: float) -> float:
+    """Rounded to float32, the precision the shipped derivation actually has.
+
+    Python floats are float64, so a study written in them models a derivation
+    twice as precise as the one it is pricing. `buildRgbSolveMatrixQ16` builds
+    and inverts in `float`, and only then quantises -- so the baseline this
+    compares against has to be rounded at every step, not just at the end.
+    """
+
+    return struct.unpack("<f", struct.pack("<f", value))[0]
+
+
+@typechecked
+def emitter_matrix_f32(primaries: Primaries) -> list[list[float]]:
+    """The emitter columns, built the way `xyY_to_XYZ` builds them.
+
+    Same operation order as the shipped code -- `1/y` once, then two
+    multiplies -- because the order is what decides where float32 rounds.
+    """
+
+    columns: list[list[float]] = []
+    for x, y in primaries:
+        inv_y = f32(1.0 / f32(y))
+        columns.append(
+            [
+                f32(f32(f32(x) * 1.0) * inv_y),
+                1.0,
+                f32(f32(f32(1.0 - f32(x) - f32(y)) * 1.0) * inv_y),
+            ]
+        )
+    return [
+        [columns[0][0], columns[1][0], columns[2][0]],
+        [columns[0][1], columns[1][1], columns[2][1]],
+        [columns[0][2], columns[1][2], columns[2][2]],
+    ]
+
+
+@typechecked
+def invert3x3_f32(matrix: list[list[float]]) -> list[list[float]] | None:
+    """`colorimetric_response::invert3x3`, rounded to float32 at every step.
+
+    Mirrors the shipped body rather than the mathematics: cofactors, then one
+    reciprocal of the determinant, then nine multiplies. Computing `1/det`
+    once and multiplying is not the same as nine divisions in float32, and the
+    difference is exactly what this study is trying to see.
+    """
+
+    a, b, c = matrix[0]
+    d, e, f = matrix[1]
+    g, h, i = matrix[2]
+
+    def mul(left: float, right: float) -> float:
+        return f32(left * right)
+
+    def sub(left: float, right: float) -> float:
+        return f32(left - right)
+
+    def add(left: float, right: float) -> float:
+        return f32(left + right)
+
+    # a*(ei - fh) - b*(di - fg) + c*(dh - eg), associated left to right as
+    # the shipped expression is.
+    determinant = add(
+        sub(
+            mul(a, sub(mul(e, i), mul(f, h))),
+            mul(b, sub(mul(d, i), mul(f, g))),
+        ),
+        mul(c, sub(mul(d, h), mul(e, g))),
+    )
+    if determinant == 0.0:
+        return None
+
+    inv_det = f32(1.0 / determinant)
+    cof = [
+        [
+            sub(mul(e, i), mul(f, h)),
+            sub(mul(c, h), mul(b, i)),
+            sub(mul(b, f), mul(c, e)),
+        ],
+        [
+            sub(mul(f, g), mul(d, i)),
+            sub(mul(a, i), mul(c, g)),
+            sub(mul(c, d), mul(a, f)),
+        ],
+        [
+            sub(mul(d, h), mul(e, g)),
+            sub(mul(b, g), mul(a, h)),
+            sub(mul(a, e), mul(b, d)),
+        ],
+    ]
+    out: list[list[float]] = []
+    for row in range(3):
+        scaled: list[float] = []
+        for col in range(3):
+            scaled.append(mul(cof[row][col], inv_det))
+        out.append(scaled)
+    return out
+
+
+@typechecked
+def quantize_rows(rows: list[list[float]]) -> list[list[int]]:
+    """Every entry of a plain 3x3 rounded to s16.16."""
+
+    out: list[list[int]] = []
+    for row in rows:
+        out.append([to_q16(value) for value in row])
+    return out
 
 
 @typechecked
@@ -237,12 +347,26 @@ def compare_inverses(name: str, primaries: Primaries, steps: int) -> InverseErro
     values that produced it.
     """
 
-    forward = emitter_matrix(primaries)
-    float_inverse = _invert_3x3(forward)
-    shipped = quantize_matrix(float_inverse)
-    proposed = invert3x3_q16(quantize_matrix(forward))
+    # The baseline is the shipped derivation, modelled at its own precision:
+    # float32 throughout, quantised at the end. An earlier revision inverted
+    # in float64 and called it "the float path", which prices a derivation
+    # twice as precise as the one being replaced.
+    forward_f32 = emitter_matrix_f32(primaries)
+    inverse_f32 = invert3x3_f32(forward_f32)
+    if inverse_f32 is None:
+        raise ValueError(f"{name}: float32 inverse reported singular")
+    shipped = quantize_rows(inverse_f32)
+
+    # And the forward matrix the fixed-point path quantises is the same one
+    # the shipped path builds, so the two differ only in the inversion.
+    proposed = invert3x3_q16(quantize_rows(forward_f32))
     if proposed is None:
         raise ValueError(f"{name}: fixed-point inverse reported singular")
+
+    # Rendering stays in float64: it stands in for the physical device, and
+    # modelling it at float32 would attribute the emulator's rounding to one
+    # of the two candidates.
+    forward = emitter_matrix(primaries)
 
     worst_ulps = 0
     for row in range(3):

--- a/ci/tests/test_color_fixed_inverse.py
+++ b/ci/tests/test_color_fixed_inverse.py
@@ -1,0 +1,148 @@
+"""A Q16 bind-time inverse is accurate enough; the profile is what is left.
+
+#4043's survey calls the fixed-point bind-time derivation "the one that is
+genuinely blocked on nothing but effort", and gives the reason it is not small:
+`EmitterProfile` stores floats, is P2's public type, and the legacy RGBW stack
+consumes it.
+
+That is a statement about the *profile*. It assumes the narrower question --
+whether a Q16 3x3 inverse is accurate enough to replace the float one at all --
+is already answered yes. It was not measured. If the answer were no, the
+profile conversion would buy nothing, because the derivation would still have
+to reach float to stay inside A1.
+
+These measure it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ci.color_fixed_inverse_study import (
+    collapsed_primaries,
+    compare_inverses,
+    corpus_primaries,
+    invert3x3_q16,
+    quantize_matrix,
+    rounded_div,
+    to_q16,
+)
+from ci.color_gamut_study import emitter_matrix
+
+
+# A1's implementation-fidelity budget. The shipped mapper scores 0.15 of it
+# with eight halvings, so this is the room the whole pipeline has, not the room
+# this one step may take.
+DELTA_E_BUDGET = 0.5
+
+
+class TestTheFixedPointInverseIsAccurateEnough(unittest.TestCase):
+    def test_real_primary_sets_agree_to_a_ulp(
+        self: "TestTheFixedPointInverseIsAccurateEnough",
+    ) -> None:
+        # sRGB, BT.2020 and Display P3. The two derivations end in the same
+        # format, so a disagreement here is the arithmetic in between and
+        # nothing else.
+        for name, primaries in corpus_primaries()[:3]:
+            with self.subTest(device=name):
+                result = compare_inverses(name, primaries, 8)
+                self.assertLessEqual(result.worst_coefficient_ulps, 1)
+                self.assertLess(result.worst_delta_e, 0.01)
+
+    def test_the_error_stays_far_inside_the_budget(
+        self: "TestTheFixedPointInverseIsAccurateEnough",
+    ) -> None:
+        for name, primaries in corpus_primaries():
+            with self.subTest(device=name):
+                result = compare_inverses(name, primaries, 8)
+                self.assertLess(result.worst_delta_e, DELTA_E_BUDGET / 10.0)
+
+
+class TestWhereItGivesOut(unittest.TestCase):
+    def test_coefficient_error_explodes_as_the_matrix_collapses(
+        self: "TestWhereItGivesOut",
+    ) -> None:
+        # The limit has to be approached rather than asserted, and this is the
+        # half that behaves as expected: a shrinking determinant costs the
+        # coefficients their precision, by four orders of magnitude.
+        gentle = compare_inverses("gentle", collapsed_primaries(0.3), 4)
+        severe = compare_inverses("severe", collapsed_primaries(0.999), 4)
+        self.assertLessEqual(gentle.worst_coefficient_ulps, 1)
+        self.assertGreater(severe.worst_coefficient_ulps, 1000)
+
+    def test_but_the_colour_error_does_not(self: "TestWhereItGivesOut") -> None:
+        # And this is the half that does not, which is the finding. Those
+        # thousands of ULPs sit in directions a near-collinear device can
+        # barely produce, so they do not become visible error: even at the
+        # edge of singularity the disagreement stays an order of magnitude
+        # inside A1.
+        for fraction in (0.9, 0.99, 0.999):
+            with self.subTest(fraction=fraction):
+                result = compare_inverses(
+                    "collapsing", collapsed_primaries(fraction), 4
+                )
+                self.assertLess(result.worst_delta_e, DELTA_E_BUDGET / 5.0)
+
+
+class TestTheArithmetic(unittest.TestCase):
+    def test_a_singular_matrix_is_refused(self: "TestTheArithmetic") -> None:
+        # Two identical primaries: the columns are equal, so the determinant
+        # is zero in Q16 as well as in float, and the caller gets None rather
+        # than a division by zero.
+        duplicated = ((0.6400, 0.3300), (0.6400, 0.3300), (0.1500, 0.0600))
+        quantized = quantize_matrix(emitter_matrix(duplicated))
+        self.assertIsNone(invert3x3_q16(quantized))
+
+    def test_the_inverse_reproduces_the_identity(self: "TestTheArithmetic") -> None:
+        # Independent of the float path: multiplying the Q16 inverse by the
+        # Q16 forward matrix must give the identity, which catches a
+        # transposed cofactor that comparing against float cannot -- the float
+        # path would be transposed the same way.
+        #
+        # The bound is a measurement, not a target. Across the corpus the
+        # worst residual is 7 ULP (BT.2020), which is 1.07e-04 of unity and is
+        # the Q16 rounding of a three-term dot product with coefficients of
+        # magnitude three to five. 16 leaves room without letting a real
+        # transposition through: swapping two cofactors moves an off-diagonal
+        # entry by order unity, which is 65536 ULP.
+        for name, primaries in corpus_primaries():
+            with self.subTest(device=name):
+                forward = quantize_matrix(emitter_matrix(primaries))
+                inverse = invert3x3_q16(forward)
+                assert inverse is not None
+                for row in range(3):
+                    for col in range(3):
+                        total = 0
+                        for k in range(3):
+                            total += inverse[row][k] * forward[k][col]
+                        product = (total + (1 << 15)) >> 16
+                        expected = to_q16(1.0) if row == col else 0
+                        self.assertLess(abs(product - expected), 16)
+
+    def test_rounding_is_symmetric_about_zero(self: "TestTheArithmetic") -> None:
+        # Truncating would bias every coefficient toward zero, and a solve
+        # sums three of them, so the bias would not cancel.
+        self.assertEqual(rounded_div(7, 2), 4)
+        self.assertEqual(rounded_div(-7, 2), -4)
+        self.assertEqual(rounded_div(7, -2), -4)
+        self.assertEqual(rounded_div(-7, -2), 4)
+        self.assertEqual(rounded_div(5, 10), 1)
+        self.assertEqual(rounded_div(-5, 10), -1)
+        with self.assertRaises(ValueError):
+            rounded_div(1, 0)
+
+
+class TestInputValidation(unittest.TestCase):
+    def test_degenerate_arguments_are_refused(self: "TestInputValidation") -> None:
+        from ci.color_fixed_inverse_study import sweep_drives
+
+        with self.assertRaises(ValueError):
+            sweep_drives(0)
+        with self.assertRaises(ValueError):
+            collapsed_primaries(-0.1)
+        with self.assertRaises(ValueError):
+            collapsed_primaries(1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -211,6 +211,57 @@ Widening lms makes the mapper *worse*, and widening XYZ -- which the whole
 P6 working domain would have to follow -- only improves it about fourfold.
 Neither buys anything the budget needs, so the simpler implementation ships.
 
+### And the bind-time inverse could be fixed point too (P9, #4043)
+
+The section above is about the per-pixel path, which is already integer end to
+end. The derivation that runs once per profile is not: `buildRgbSolveMatrixQ16`
+builds the emitter matrix in float, inverts it in float, and quantises the
+result to s16.16. #4043 calls converting that "the one that is genuinely
+blocked on nothing but effort", and gives the reason it is not small -- the
+profile stores floats and is P2's public type.
+
+That reasoning assumes the narrow question is already settled: **is a Q16
+inverse accurate enough to replace the float one at all?** If it is not, the
+profile conversion buys nothing, because the derivation would still have to
+reach float. It had not been measured. `ci/color_fixed_inverse_study.py`
+measures it.
+
+Both paths end in s16.16, so this is not about the output format. It is about
+where the arithmetic happens: float32 carries a 24-bit mantissa that follows
+the magnitude, while Q16 with 64-bit intermediates carries a fixed 1/65536
+step and much more headroom around one. Neither dominates a priori.
+
+| primaries | worst coefficient error | worst dE2000 |
+| --- | ---: | ---: |
+| sRGB | 0 ULP | 0.0000 |
+| BT.2020 | 1 ULP | 0.0057 |
+| Display P3 | 1 ULP | 0.0064 |
+
+Against A1's 0.5 budget, of which the shipped mapper already spends 0.15.
+
+**Where it gives out is the more interesting half.** Conditioning is what
+decides a fixed-point inverse's accuracy, so green was walked onto the
+red-blue line until the matrix was nearly singular:
+
+| green collapsed | worst coefficient error | worst dE2000 |
+| --- | ---: | ---: |
+| 90% of the way | 6 ULP | 0.0421 |
+| 99% | 575 ULP | 0.0270 |
+| 99.9% | **28 487 ULP** | **0.0914** |
+
+The coefficients lose four orders of magnitude of precision and *the colour
+error does not follow*. Those ULPs sit in directions a near-collinear device
+can barely produce, so they do not become visible error: even at the edge of
+singularity the two derivations stay an order of magnitude inside A1.
+
+So the answer is yes, and P9 item 2 is effort rather than an open question.
+
+Two things this does **not** say. It compares the two derivations against each
+other, not against float64 -- the shipped path is itself Q16-quantised, and
+"can this replace that" is the question being asked. And the sweep drives are
+in `[0, 1]`, so every target is in gamut by construction; an out-of-gamut
+target goes through the mapper above, which is measured separately.
+
 ## Is the feasible chroma ray actually connected? No.
 
 Bisection assumes it is. The reference does not, so the assumption was tested

--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -231,6 +231,16 @@ where the arithmetic happens: float32 carries a 24-bit mantissa that follows
 the magnitude, while Q16 with 64-bit intermediates carries a fixed 1/65536
 step and much more headroom around one. Neither dominates a priori.
 
+The baseline is modelled at the shipped derivation's own precision --
+float32 through `xyY_to_XYZ` and `invert3x3`, in the same operation order,
+quantised at the end. An earlier revision of this study inverted in float64
+and called that "the float path", which prices a derivation twice as precise
+as the one being replaced. It turned out not to change the verdict: the real
+primary sets score identically either way, and only the near-singular sweep
+moves (569 ULP against 575, 28 848 against 28 487). Recorded because the
+answer being the same is a result, not a reason the distinction did not
+matter.
+
 | primaries | worst coefficient error | worst dE2000 |
 | --- | ---: | ---: |
 | sRGB | 0 ULP | 0.0000 |
@@ -246,8 +256,8 @@ red-blue line until the matrix was nearly singular:
 | green collapsed | worst coefficient error | worst dE2000 |
 | --- | ---: | ---: |
 | 90% of the way | 6 ULP | 0.0421 |
-| 99% | 575 ULP | 0.0270 |
-| 99.9% | **28 487 ULP** | **0.0914** |
+| 99% | 569 ULP | 0.0091 |
+| 99.9% | **28 848 ULP** | **0.0654** |
 
 The coefficients lose four orders of magnitude of precision and *the colour
 error does not follow*. Those ULPs sit in directions a near-collinear device


### PR DESCRIPTION
Refs #4043 (P9).

The survey on #4043 calls the fixed-point bind-time derivation **"the one that is genuinely blocked on nothing but effort"**, and gives the reason it is not a small change:

> `EmitterProfile` itself stores `float xy_r[2]`, `lum_r` and so on. It is P2's public type and the whole legacy RGBW stack consumes it. A float-free bind-time derivation needs a fixed-point profile representation, which is a cross-cutting P2/P9 change rather than a rewrite of one 129-line file.

That is a statement about the *profile*. It assumes the narrower question is already answered yes: **is a Q16 3×3 inverse accurate enough to replace the float one at all?** If it is not, converting the profile buys nothing — the derivation would still have to reach float to stay inside A1, and item 2 is not "effort" but "impossible as scoped".

It had not been measured. `ci/color_fixed_inverse_study.py` measures it.

## What is actually being compared

Both paths end in s16.16, so this is not a question about the output format. It is a question about where the arithmetic happens — float32 carries a 24-bit mantissa that follows the magnitude, Q16 with 64-bit intermediates carries a fixed 1/65536 step and far more headroom around one, and neither dominates a priori.

| primaries | worst coefficient error | worst ΔE2000 |
|---|---:|---:|
| sRGB | 0 ULP | 0.0000 |
| BT.2020 | 1 ULP | 0.0057 |
| Display P3 | 1 ULP | 0.0064 |

against A1's 0.5 budget, of which the shipped mapper already spends 0.15.

## Where it gives out is the more interesting half

Conditioning is what decides a fixed-point inverse's accuracy, so green was walked onto the red–blue line until the matrix was nearly singular:

| green collapsed | worst coefficient error | worst ΔE2000 |
|---|---:|---:|
| 90% of the way | 6 ULP | 0.0421 |
| 99% | 575 ULP | 0.0270 |
| 99.9% | **28 487 ULP** | **0.0914** |

The coefficients lose **four orders of magnitude** of precision and the colour error does not follow. Those ULPs sit in directions a near-collinear device can barely produce, so they never become visible error: even at the edge of singularity the two derivations stay an order of magnitude inside the budget.

**So the answer is yes**, and P9 item 2 is effort rather than an open question.

## What this does not say

Stated because it is easy to over-read: it compares the two derivations against **each other**, not against float64 — the shipped path is itself Q16-quantised, and "can this replace that" is the question. And every target is in gamut by construction, since the sweep drives are in `[0, 1]`; an out-of-gamut target goes through the mapper, which is measured separately.

## Verification

- `uv run python -m pytest ci/tests/test_color_fixed_inverse.py -q` — 8 passed, 14 subtests
- `bash lint` — 0 errors
- Mutation-tested: truncating the divide instead of rounding, transposing the cofactors, and never reporting singular each fail. The identity check is what catches the transposition — comparing against the float path cannot, because it would be transposed the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an analysis of fixed-point color-gamut matrix inversion accuracy.
  * Documented comparisons across common color spaces and near-singular conditions using the shipped numerical precision.
  * Recorded color-error findings and implementation considerations.

* **Tests**
  * Added coverage for inversion accuracy, rounding behavior, singular matrices, identity residuals, and invalid inputs.
  * Added color-error budget checks across standard and edge-case color configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->