### PR TITLE
fix(autoresearch): apply the OTA fixture partition table exactly once

### DIFF
--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -150,6 +150,35 @@ def ota_chunk_is_deliverable(chunk_bytes: int, character_limit: int) -> bool:
     return encoded_characters <= character_limit
 
 
+def ota_largest_request_bytes(artifact_bytes: int, chunk_bytes: int) -> int:
+    """The largest slice a transfer of this artifact will actually send.
+
+    The chunk size only when the artifact is at least that big: a shorter
+    artifact sends one shorter request, and judging it against the chunk
+    would refuse a transfer that would have worked.
+    """
+
+    if artifact_bytes < chunk_bytes:
+        return artifact_bytes
+    return chunk_bytes
+
+
+def ota_transfer_is_deliverable(
+    artifact_bytes: int, chunk_bytes: int, character_limit: int
+) -> bool:
+    """Whether every request in this transfer fits the device's limit.
+
+    The preflight's whole decision, in one place a test can call. Keeping it
+    inline meant a case could only check the pieces and would pass with the
+    preflight wired to the wrong one -- which is exactly what happened on the
+    first attempt at covering this.
+    """
+
+    return ota_chunk_is_deliverable(
+        ota_largest_request_bytes(artifact_bytes, chunk_bytes), character_limit
+    )
+
+
 async def run_ota_peer_autoresearch(
     upload_port: str,
     peer_upload_port: str,
@@ -253,12 +282,20 @@ async def run_ota_peer_autoresearch(
         # image -- about 21 minutes against a 12 minute run budget. So both
         # candidate values fail today, one quickly and one slowly, and the
         # real fix is device-side. FastLED#3956.
-        if not ota_chunk_is_deliverable(
-            kOtaChunkBytes, kOtaLargestAnsweredRequestCharacters
+        # The largest slice this transfer will actually send, which is the
+        # chunk size only when the artifact is at least that big. An artifact
+        # shorter than one chunk sends one shorter request, and rejecting it
+        # against `kOtaChunkBytes` would refuse a transfer that would have
+        # worked -- a 321-byte artifact is one 428-character request, inside
+        # the measured limit.
+        largest_slice = ota_largest_request_bytes(len(artifact), kOtaChunkBytes)
+        if not ota_transfer_is_deliverable(
+            len(artifact), kOtaChunkBytes, kOtaLargestAnsweredRequestCharacters
         ):
             raise RuntimeError(
-                f"OTA artifact transfer cannot run: a {kOtaChunkBytes}-byte "
-                f"chunk base64-expands past the measured "
+                f"OTA artifact transfer cannot run: the largest request this "
+                f"{len(artifact)}-byte artifact sends is {largest_slice} bytes, "
+                f"which base64-expands past the measured "
                 f"{kOtaLargestAnsweredRequestCharacters}-character request limit, so "
                 f"writeOtaArtifact will not be answered. This is FastLED#3956 "
                 f"and is device-side; lowering the chunk to 256 transfers "

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -106,6 +106,27 @@ async def _settle_link(
     )
 
 
+# Raw bytes per writeOtaArtifact call.
+#
+# Base64 expands this by 4/3, and the device's RPC receive path stops
+# answering above ~512 characters of request payload: measured on an
+# ESP32-C6, 428 characters answer in 0.33 s and 512 never answer at all.
+# The request is delivered in full -- the daemon transmits all 735 bytes and
+# receives nothing back -- so the drop is device-side, and there is no error
+# response to key off. See FastLED#3956.
+#
+# That makes 512 raw bytes (684 characters) dead today. 256 raw bytes (344
+# characters) does transfer correctly, verified end to end, but per-RPC
+# latency is ~318 ms and size-independent, so a 1,034,444-byte image would
+# need 4,041 round trips -- about 21 minutes against a 12 minute run budget.
+# Halving the chunk trades a fast failure for a slow one.
+#
+# So this stays at 512 until the device-side limit is raised. Once it is,
+# this is the lever that matters: 4 KB chunks move the same image in ~1.3
+# minutes.
+kOtaChunkBytes = 512
+
+
 async def run_ota_peer_autoresearch(
     upload_port: str,
     peer_upload_port: str,
@@ -194,8 +215,18 @@ async def run_ota_peer_autoresearch(
         )
         if not begin.get("success"):
             raise RuntimeError(f"C6 refused OTA artifact: {begin}")
-        for offset in range(0, len(artifact), 512):
-            encoded = base64.b64encode(artifact[offset : offset + 512]).decode("ascii")
+        # 512 raw bytes base64-expand to 684 characters, and the device stops
+        # answering writeOtaArtifact above ~512 characters of payload: measured
+        # on an ESP32-C6, 428 characters answer in 0.33 s and 512 time out,
+        # with nothing stored and the next RPC answering instantly. So every
+        # artifact write failed and the transfer could never progress.
+        # 256 raw bytes -> 344 characters, comfortably inside the limit.
+        # The underlying request-size limit is tracked in FastLED#3956; this
+        # keeps the chunk under it rather than working around it silently.
+        for offset in range(0, len(artifact), kOtaChunkBytes):
+            encoded = base64.b64encode(
+                artifact[offset : offset + kOtaChunkBytes]
+            ).decode("ascii")
             written = await rpc_data(peer, "writeOtaArtifact", encoded)
             if not written.get("success"):
                 raise RuntimeError(

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -126,6 +126,29 @@ async def _settle_link(
 # minutes.
 kOtaChunkBytes = 512
 
+# The largest request payload measured to be *answered*, in base64
+# characters. On an ESP32-C6, 428 characters answer in 0.33 s while 512 time
+# out with nothing stored and the next RPC answering instantly.
+#
+# 428 and not 512: the true ceiling is somewhere between the two and was
+# never bisected, so the only defensible constant is the largest size known
+# to work. Taking 512 as the limit would call a 384-byte chunk deliverable,
+# and 384 bytes is exactly 512 characters -- the size measured to time out.
+#
+# Written down rather than left in prose so the preflight below can check
+# against it. FastLED#3956 is the device-side fix.
+kOtaLargestAnsweredRequestCharacters = 428
+
+
+def ota_chunk_is_deliverable(chunk_bytes: int, character_limit: int) -> bool:
+    """Whether a full chunk survives base64 expansion into one request.
+
+    Base64 is four characters per three bytes, rounded up to a whole group.
+    """
+
+    encoded_characters = ((chunk_bytes + 2) // 3) * 4
+    return encoded_characters <= character_limit
+
 
 async def run_ota_peer_autoresearch(
     upload_port: str,
@@ -215,14 +238,32 @@ async def run_ota_peer_autoresearch(
         )
         if not begin.get("success"):
             raise RuntimeError(f"C6 refused OTA artifact: {begin}")
-        # 512 raw bytes base64-expand to 684 characters, and the device stops
-        # answering writeOtaArtifact above ~512 characters of payload: measured
-        # on an ESP32-C6, 428 characters answer in 0.33 s and 512 time out,
-        # with nothing stored and the next RPC answering instantly. So every
-        # artifact write failed and the transfer could never progress.
-        # 256 raw bytes -> 344 characters, comfortably inside the limit.
-        # The underlying request-size limit is tracked in FastLED#3956; this
-        # keeps the chunk under it rather than working around it silently.
+        # Fail here rather than at the first write, and say why.
+        #
+        # `kOtaChunkBytes` is 512, which base64-expands to 684 characters and
+        # is over the measured device limit -- so the first full write is not
+        # answered, and what that looks like from outside is a hang partway
+        # into an OTA rather than a refusal. An earlier revision of this
+        # comment described 256 as being what the loop sent, which the
+        # constant has not said for some time; a reader had two numbers to
+        # choose from and no way to tell which was live.
+        #
+        # 256 does transfer, verified end to end, but at ~318 ms per RPC and
+        # size-independent it needs 4,041 round trips for a 1,034,444-byte
+        # image -- about 21 minutes against a 12 minute run budget. So both
+        # candidate values fail today, one quickly and one slowly, and the
+        # real fix is device-side. FastLED#3956.
+        if not ota_chunk_is_deliverable(
+            kOtaChunkBytes, kOtaLargestAnsweredRequestCharacters
+        ):
+            raise RuntimeError(
+                f"OTA artifact transfer cannot run: a {kOtaChunkBytes}-byte "
+                f"chunk base64-expands past the measured "
+                f"{kOtaLargestAnsweredRequestCharacters}-character request limit, so "
+                f"writeOtaArtifact will not be answered. This is FastLED#3956 "
+                f"and is device-side; lowering the chunk to 256 transfers "
+                f"correctly but needs ~21 minutes against a 12 minute budget."
+            )
         for offset in range(0, len(artifact), kOtaChunkBytes):
             encoded = base64.b64encode(
                 artifact[offset : offset + kOtaChunkBytes]

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -46,16 +46,32 @@ def apply_ota_fixture_partitions(ini: "Path") -> None:
     """
     replacement = "board_build.partitions = src/sketch/esp32c6_ota_fixture.csv"
     lines = ini.read_text(encoding="utf-8").splitlines()
+
+    matches: list[int] = []
     for index, line in enumerate(lines):
         if line.split("=", 1)[0].strip() == "board_build.partitions":
-            lines[index] = replacement
-            break
-    else:
+            matches.append(index)
+
+    if not matches:
         raise RuntimeError(
             f"No board_build.partitions key to replace in {ini}; the generated "
             f"project layout has changed and the OTA fixture partition table "
             f"would not be applied"
         )
+
+    # Every match, not the first. Replacing one and leaving another is the
+    # same defect this function exists to fix, one layer down: the parser
+    # would still be choosing between two keys, and the choice would still
+    # not be ours. Applies whether the duplicate was already there or a
+    # future generator adds one.
+    for index in matches:
+        lines[index] = replacement
+    if len(matches) > 1:
+        # Collapse them, so the file states the table once. Kept in reverse
+        # so the earlier indices stay valid as they are removed.
+        for index in reversed(matches[1:]):
+            del lines[index]
+
     ini.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/ci/autoresearch/staging.py
+++ b/ci/autoresearch/staging.py
@@ -30,6 +30,35 @@ from ci.boards import create_board
 from ci.compiler.path_manager import FastLEDPaths, resolve_project_root
 
 
+def apply_ota_fixture_partitions(ini: "Path") -> None:
+    """Point `board_build.partitions` at the OTA fixture table, exactly once.
+
+    Replaces the generated key rather than appending a second one. Appending
+    left two `board_build.partitions` entries in the same [env:esp32c6]
+    section -- the framework's huge_app.csv and this one -- and the build
+    tolerates that, so which table takes effect is decided by the ini parser
+    rather than by us. "The fixture table was silently not applied" then
+    looks identical from the outside to "it was applied". A fixture that may
+    or may not be in effect is worse than either outcome. See FastLED#3956.
+
+    Raises when there is no key to replace: a generated-layout change must
+    fail loudly, not quietly build against the wrong partition table.
+    """
+    replacement = "board_build.partitions = src/sketch/esp32c6_ota_fixture.csv"
+    lines = ini.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if line.split("=", 1)[0].strip() == "board_build.partitions":
+            lines[index] = replacement
+            break
+    else:
+        raise RuntimeError(
+            f"No board_build.partitions key to replace in {ini}; the generated "
+            f"project layout has changed and the OTA fixture partition table "
+            f"would not be applied"
+        )
+    ini.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def synthesise_autoresearch_project(
     board_name: str,
     project_root: Path | None,
@@ -108,9 +137,6 @@ def synthesise_autoresearch_project(
         if not partitions.is_file():
             raise RuntimeError(f"Missing OTA fixture partition table: {partitions}")
         ini = build_dir / "platformio.ini"
-        with ini.open("a", encoding="utf-8") as output:
-            output.write(
-                "\nboard_build.partitions = src/sketch/esp32c6_ota_fixture.csv\n"
-            )
+        apply_ota_fixture_partitions(ini)
 
     return build_dir

--- a/ci/tests/test_ota_fixture_partitions.py
+++ b/ci/tests/test_ota_fixture_partitions.py
@@ -13,6 +13,7 @@ import pytest
 
 from ci.autoresearch.staging import apply_ota_fixture_partitions
 
+
 # Measured on the bench, 2026-09-10. Both are what the flash log actually
 # wrote, not estimates: the C6 image at 0x10000 and the RP2350W update image
 # staged into spiffs. See FastLED#3956.
@@ -34,7 +35,9 @@ def _slots() -> dict[str, tuple[int, int]]:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        fields = [field.strip() for field in stripped.split(",")]
+        fields: list[str] = []
+        for field in stripped.split(","):
+            fields.append(field.strip())
         if len(fields) < 5:
             continue
         slots[fields[0]] = (int(fields[3], 0), int(fields[4], 0))
@@ -71,7 +74,9 @@ def test_partitions_do_not_overlap_or_exceed_the_flash() -> None:
     ordered = sorted(_slots().items(), key=lambda item: item[1][0])
     previous_end = 0
     for name, (offset, size) in ordered:
-        assert offset >= previous_end, f"{name} at 0x{offset:X} overlaps the slot before it"
+        assert offset >= previous_end, (
+            f"{name} at 0x{offset:X} overlaps the slot before it"
+        )
         previous_end = offset + size
     assert previous_end <= flash_bytes, (
         f"partitions end at 0x{previous_end:X}, past the {flash_bytes:#x} flash"
@@ -96,10 +101,50 @@ def test_partition_key_is_replaced_not_duplicated(tmp_path: Path) -> None:
     apply_ota_fixture_partitions(ini)
 
     text = ini.read_text(encoding="utf-8")
-    keys = [ln for ln in text.splitlines() if ln.startswith("board_build.partitions")]
+    keys: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("board_build.partitions"):
+            keys.append(line)
     assert len(keys) == 1, f"expected exactly one key, got {keys}"
     assert keys[0].endswith("esp32c6_ota_fixture.csv")
     assert "huge_app.csv" not in text
+    assert "board = esp32c6" in text
+    assert "lib_archive = true" in text
+
+
+def test_a_file_that_already_has_two_keys_ends_with_one(tmp_path: Path) -> None:
+    """Replacing the first match and stopping leaves the defect in place.
+
+    The function exists because two `board_build.partitions` keys in one
+    section mean the ini parser chooses the table rather than us. A helper
+    that replaces one of them and leaves the other has not fixed that -- it
+    has moved it one layer down, and the file still names two tables.
+
+    Reachable without a generator bug: `huge_app.csv` plus a stale fixture
+    key from an earlier staging run in the same directory.
+    """
+    ini = tmp_path / "platformio.ini"
+    ini.write_text(
+        "[env:esp32c6]\n"
+        "board = esp32c6\n"
+        "board_build.partitions = huge_app.csv\n"
+        "lib_archive = true\n"
+        "board_build.partitions = src/sketch/stale_from_last_run.csv\n",
+        encoding="utf-8",
+    )
+
+    apply_ota_fixture_partitions(ini)
+
+    text = ini.read_text(encoding="utf-8")
+    keys: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("board_build.partitions"):
+            keys.append(line)
+    assert len(keys) == 1, f"expected exactly one key, got {keys}"
+    assert keys[0].endswith("esp32c6_ota_fixture.csv")
+    assert "huge_app.csv" not in text
+    assert "stale_from_last_run.csv" not in text
+    # And nothing else was disturbed by the collapse.
     assert "board = esp32c6" in text
     assert "lib_archive = true" in text
 

--- a/ci/tests/test_ota_fixture_partitions.py
+++ b/ci/tests/test_ota_fixture_partitions.py
@@ -1,0 +1,54 @@
+"""The OTA fixture partition table must be applied unambiguously.
+
+Calls the production function directly. An earlier draft of this file
+re-implemented the replacement locally, which would have passed regardless
+of what the shipped code does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ci.autoresearch.staging import apply_ota_fixture_partitions
+
+
+def test_partition_key_is_replaced_not_duplicated(tmp_path: Path) -> None:
+    """Exactly one key, and it names the fixture table.
+
+    Appending left `huge_app.csv` and the fixture both present in
+    [env:esp32c6], so which one took effect was up to the ini parser.
+    """
+    ini = tmp_path / "platformio.ini"
+    ini.write_text(
+        "[env:esp32c6]\n"
+        "board = esp32c6\n"
+        "board_build.partitions = huge_app.csv\n"
+        "lib_archive = true\n",
+        encoding="utf-8",
+    )
+
+    apply_ota_fixture_partitions(ini)
+
+    text = ini.read_text(encoding="utf-8")
+    keys = [ln for ln in text.splitlines() if ln.startswith("board_build.partitions")]
+    assert len(keys) == 1, f"expected exactly one key, got {keys}"
+    assert keys[0].endswith("esp32c6_ota_fixture.csv")
+    assert "huge_app.csv" not in text
+    assert "board = esp32c6" in text
+    assert "lib_archive = true" in text
+
+
+def test_missing_partition_key_fails_loudly(tmp_path: Path) -> None:
+    """A layout change must not silently skip the fixture table.
+
+    Appending always "worked"; replacing can find nothing to replace, and
+    that has to be an error rather than a build that quietly uses the wrong
+    partition layout.
+    """
+    ini = tmp_path / "platformio.ini"
+    ini.write_text("[env:esp32c6]\nboard = esp32c6\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="board_build.partitions"):
+        apply_ota_fixture_partitions(ini)

--- a/ci/tests/test_ota_fixture_partitions.py
+++ b/ci/tests/test_ota_fixture_partitions.py
@@ -13,6 +13,70 @@ import pytest
 
 from ci.autoresearch.staging import apply_ota_fixture_partitions
 
+# Measured on the bench, 2026-09-10. Both are what the flash log actually
+# wrote, not estimates: the C6 image at 0x10000 and the RP2350W update image
+# staged into spiffs. See FastLED#3956.
+MEASURED_C6_APP_BYTES = 2_708_032
+MEASURED_RP2350W_IMAGE_BYTES = 1_034_444
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "AutoResearch"
+    / "esp32c6_ota_fixture.csv"
+)
+
+
+def _slots() -> dict[str, tuple[int, int]]:
+    """Parse the fixture table into {name: (offset, size)}."""
+    slots: dict[str, tuple[int, int]] = {}
+    for line in _FIXTURE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        fields = [field.strip() for field in stripped.split(",")]
+        if len(fields) < 5:
+            continue
+        slots[fields[0]] = (int(fields[3], 0), int(fields[4], 0))
+    return slots
+
+
+def test_app_slot_clears_the_measured_image() -> None:
+    """app0 must be larger than the image flashed into it.
+
+    It was not: app0 held 0x290000 (2,686,976) while the flash wrote
+    2,708,032 bytes at 0x10000, overrunning into spiffs by 20.6 KB. esptool
+    does not police partition bounds, so this reported success and the board
+    came up with no working application.
+    """
+    _, size = _slots()["app0"]
+    assert size > MEASURED_C6_APP_BYTES, (
+        f"app0 is {size:,} bytes but the measured image is "
+        f"{MEASURED_C6_APP_BYTES:,}; it would overrun into the next partition"
+    )
+
+
+def test_spiffs_clears_the_rp2350w_image() -> None:
+    """spiffs must hold the update image the fixture exists to carry."""
+    _, size = _slots()["spiffs"]
+    assert size > MEASURED_RP2350W_IMAGE_BYTES, (
+        f"spiffs is {size:,} bytes but the RP2350W image is "
+        f"{MEASURED_RP2350W_IMAGE_BYTES:,}"
+    )
+
+
+def test_partitions_do_not_overlap_or_exceed_the_flash() -> None:
+    """A 4 MB part: the slots must tile without overlapping or overflowing."""
+    flash_bytes = 0x400000
+    ordered = sorted(_slots().items(), key=lambda item: item[1][0])
+    previous_end = 0
+    for name, (offset, size) in ordered:
+        assert offset >= previous_end, f"{name} at 0x{offset:X} overlaps the slot before it"
+        previous_end = offset + size
+    assert previous_end <= flash_bytes, (
+        f"partitions end at 0x{previous_end:X}, past the {flash_bytes:#x} flash"
+    )
+
 
 def test_partition_key_is_replaced_not_duplicated(tmp_path: Path) -> None:
     """Exactly one key, and it names the fixture table.

--- a/ci/tests/test_ota_peer_hardening.py
+++ b/ci/tests/test_ota_peer_hardening.py
@@ -13,7 +13,12 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-from ci.autoresearch.ota import _served_request_count
+from ci.autoresearch.ota import (
+    _served_request_count,
+    kOtaChunkBytes,
+    kOtaLargestAnsweredRequestCharacters,
+    ota_chunk_is_deliverable,
+)
 
 
 class TestServedRequestCount(unittest.TestCase):
@@ -197,6 +202,55 @@ class TestOtaWatchdogHandling(unittest.TestCase):
         self.assertLess(update_at, rearm_at, "re-arm after it returns")
         # Requesting a long timeout instead would be silently clamped.
         self.assertNotIn("kOtaUpdateWatchdogTimeoutMs", flat)
+
+
+class TestOtaChunkDeliverability(unittest.TestCase):
+    """The chunk size has to survive base64 expansion into one request.
+
+    `kOtaChunkBytes` is 512, which expands to 684 characters and is over the
+    measured device limit, so the first full `writeOtaArtifact` is not
+    answered. What that looked like from outside was a hang partway into an
+    OTA rather than a refusal; the preflight in `run_ota_peer_autoresearch`
+    turns it into a named failure. FastLED#3956 is the device-side fix.
+    """
+
+    def test_the_shipped_chunk_is_not_deliverable_today(self) -> None:
+        """Recorded, not asserted as desirable.
+
+        This failing to be deliverable is the state of the world, and the
+        preflight exists because of it. When #3956 raises the device limit
+        this case is what says so.
+        """
+
+        self.assertFalse(
+            ota_chunk_is_deliverable(
+                kOtaChunkBytes, kOtaLargestAnsweredRequestCharacters
+            )
+        )
+
+    def test_the_boundary_is_the_largest_answered_size_not_the_first_timeout(
+        self,
+    ) -> None:
+        """384 bytes is exactly 512 characters, which is measured to time out.
+
+        Taking 512 as the limit would call that chunk deliverable. The true
+        ceiling is somewhere in (428, 512] and was never bisected, so the
+        constant is the largest size known to be answered.
+        """
+
+        limit = kOtaLargestAnsweredRequestCharacters
+        self.assertTrue(ota_chunk_is_deliverable(320, limit))  # 428 chars
+        self.assertFalse(ota_chunk_is_deliverable(384, limit))  # 512 chars
+        self.assertFalse(ota_chunk_is_deliverable(512, limit))  # 684 chars
+
+    def test_the_expansion_rounds_up_to_a_whole_base64_group(self) -> None:
+        """Three bytes to four characters, padded."""
+
+        self.assertTrue(ota_chunk_is_deliverable(3, 4))
+        self.assertFalse(ota_chunk_is_deliverable(4, 4))
+        self.assertTrue(ota_chunk_is_deliverable(4, 8))
+        self.assertTrue(ota_chunk_is_deliverable(256, 344))
+        self.assertFalse(ota_chunk_is_deliverable(256, 343))
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_ota_peer_hardening.py
+++ b/ci/tests/test_ota_peer_hardening.py
@@ -18,6 +18,8 @@ from ci.autoresearch.ota import (
     kOtaChunkBytes,
     kOtaLargestAnsweredRequestCharacters,
     ota_chunk_is_deliverable,
+    ota_largest_request_bytes,
+    ota_transfer_is_deliverable,
 )
 
 
@@ -242,6 +244,34 @@ class TestOtaChunkDeliverability(unittest.TestCase):
         self.assertTrue(ota_chunk_is_deliverable(320, limit))  # 428 chars
         self.assertFalse(ota_chunk_is_deliverable(384, limit))  # 512 chars
         self.assertFalse(ota_chunk_is_deliverable(512, limit))  # 684 chars
+
+    def test_an_artifact_shorter_than_a_chunk_is_judged_on_what_it_sends(
+        self,
+    ) -> None:
+        """The preflight prices the largest *actual* request, not the constant.
+
+        A transfer sends `min(kOtaChunkBytes, len(artifact))` in its largest
+        request. Judging a short artifact against the 512-byte chunk would
+        refuse one that would have worked: 321 bytes is a single
+        428-character request, inside the measured limit, while 512 bytes is
+        684 and outside it.
+        """
+
+        limit = kOtaLargestAnsweredRequestCharacters
+        # Through the function the preflight calls, not by recomputing the
+        # `min` here. A case that did the arithmetic itself passed with the
+        # preflight still wired to the constant -- it checked the pieces and
+        # not the decision.
+        self.assertTrue(ota_transfer_is_deliverable(321, kOtaChunkBytes, limit))
+        # And what judging the constant alone would have claimed about it.
+        self.assertFalse(ota_chunk_is_deliverable(kOtaChunkBytes, limit))
+        # An artifact at or above one chunk is judged on the chunk, which is
+        # the case that still fails today.
+        self.assertFalse(ota_transfer_is_deliverable(4096, kOtaChunkBytes, limit))
+        self.assertEqual(ota_largest_request_bytes(321, kOtaChunkBytes), 321)
+        self.assertEqual(
+            ota_largest_request_bytes(4096, kOtaChunkBytes), kOtaChunkBytes
+        )
 
     def test_the_expansion_rounds_up_to_a_whole_base64_group(self) -> None:
         """Three bytes to four characters, padded."""

--- a/examples/AutoResearch/esp32c6_ota_fixture.csv
+++ b/examples/AutoResearch/esp32c6_ota_fixture.csv
@@ -1,7 +1,23 @@
 # The C6 fixture needs room for both AutoResearch and one RP2350W update
 # image.  This is selected only for `--net-peer --ota`; ordinary C6 builds
 # retain the framework's huge_app.csv layout.
+#
+# Sizes are measured, not guessed.  The AutoResearch image for esp32c6 is
+# ~2.71 MB and the RP2350W update image ~1.01 MB, against 4 MB of flash with
+# 64 KB gone to the bootloader/partition table and nvs.  That leaves ~386 KB
+# of slack in total, so both slots are deliberately sized just above their
+# payloads rather than generously.
+#
+# The previous app0 of 0x290000 (2.56 MB) was SMALLER than the image it had
+# to hold: the flash wrote 2,708,032 bytes at 0x10000, overrunning app0 by
+# 20.6 KB into spiffs.  esptool does not police partition bounds, so the
+# flash reported success and the board then came up with no working
+# application -- the port opened and nothing answered.  See FastLED#3956.
+#
+# ci/tests/test_ota_fixture_partitions.py asserts both slots still clear
+# their payloads, so a growing image fails the test instead of silently
+# corrupting the flash layout again.
 # Name, Type, SubType, Offset, Size, Flags
 nvs, data, nvs, 0x9000, 0x5000,
-app0, app, factory, 0x10000, 0x290000,
-spiffs, data, spiffs, 0x2a0000, 0x160000,
+app0, app, factory, 0x10000, 0x2C0000,
+spiffs, data, spiffs, 0x2d0000, 0x130000,


### PR DESCRIPTION
## The defect

The OTA staging step appended `board_build.partitions` to the generated `platformio.ini` instead of replacing it, leaving two entries in the same section:

```
[env:esp32c6]
12: board_build.partitions = huge_app.csv
...
31: board_build.partitions = src/sketch/esp32c6_ota_fixture.csv
```

There is no section header after line 6, so the appended key lands inside `[env:esp32c6]` as a duplicate. The build tolerates it, so **which table takes effect is decided by the ini parser rather than by us** — and "the fixture table was silently not applied" is indistinguishable from outside from "it was applied".

## Why it matters beyond tidiness

Appending could never fail. Replacing can find nothing to replace, so a change to the generated project layout now raises instead of quietly building against the wrong partition table. That is the difference between a fixture that is definitely in effect and one that might be.

It also made an open investigation unresolvable. FastLED#3956 turns on whether the fixture table breaks the companion's serial RPC surface, and while the key was ambiguous no hardware run could answer that — both hypotheses predicted the same observable.

## Verification

With this change the staged ini carries exactly one key:

```
1:[platformio]
6:[env:esp32c6]
12:board_build.partitions = src/sketch/esp32c6_ota_fixture.csv
```

Tests call `apply_ota_fixture_partitions()` directly and were verified to **fail** against the previous append behaviour and pass against this one. An earlier draft of the test re-implemented the replacement in a local helper — it would have passed regardless of what the shipped code does, which is the failure mode `agents/docs/cpp-standards.md` warns about — so it now calls the production symbol.

Existing staging tests pass (6/6); `ty` clean.

## What this does not do

**It does not fix FastLED#3956.** Re-running the peer OTA gate with the key applied deterministically, the C6 is still mute — a timeout, not `EBUSY`, on a port verified free. That is a useful result: it rules the duplicate key out and leaves the fixture partition *layout* as the only remaining difference between a C6 that serves RPC and one that does not. Recorded on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OTA fixture builds now replace existing partition configuration without creating duplicate entries.
  * Builds now report a clear error when the required partition configuration is missing.
  * OTA transfers now validate the largest request an artifact will send against request-size limits, preventing valid short artifacts from being rejected and providing earlier errors for oversized requests.

* **Tests**
  * Added coverage for duplicate and missing partition configuration.
  * Added validation for OTA request limits and base64-expanded request boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->