### PR TITLE
fix(screenmap): stop writing a fabricated pin into every v2 segment (#3322)

### DIFF
--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -427,8 +427,12 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
     // Emits the v2 screenmap shape (issue ledmapper#143):
     //   { "version": 2,
     //     "groups": { "<name>": { "color": "#hex" } },
-    //     "segments": [ { "id": "<name>", "pin": "pin1", "group": "<name>",
+    //     "segments": [ { "id": "<name>", "group": "<name>",
     //                     "x": [...], "y": [...], "diameter": ... } ] }
+    //
+    // `pin` is part of the v2 shape but is not emitted here -- see the note
+    // at the segment object below. Writing the example value from a comment
+    // as data is how it came to be there.
     // Bilingual readers (`ScreenMap::ParseJson`, ledmapper) accept both v1
     // and v2, so any existing on-disk v1 JSON keeps loading. v1 emission
     // is no longer supported.
@@ -471,7 +475,23 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
 
         fl::json segmentObj = fl::json::object();
         segmentObj.set("id", fl::json(fl::string(name)));
-        segmentObj.set("pin", fl::json(fl::string("pin1")));
+        // No `pin`. The v2 shape carries one and the parser above drops it --
+        // it is wiring metadata with nowhere to live on this side -- so there
+        // is nothing here to write. What used to be written was the literal
+        // `"pin1"` from the shape example in the comment above, copied into
+        // the emitter as data.
+        //
+        // That is worse than omitting it, because it is wrong rather than
+        // absent. A three-segment file wired to pin1/pin2/pin3 came back with
+        // all three on pin1, and a numeric `"pin": 7` came back as the string
+        // `"pin1"`. A consumer reading that mis-wires a strip and has no way
+        // to tell; a consumer reading a missing optional key can see that it
+        // is missing.
+        //
+        // Carrying the value through instead is FastLED #3322, which needs
+        // somewhere on `ScreenMap` to put it and a decision about the
+        // `<int|str>` union. Until then this loses the field visibly rather
+        // than rewriting it silently.
         segmentObj.set("group", fl::json(fl::string(name)));
         segmentObj.set("x", xArray);
         segmentObj.set("y", yArray);

--- a/tests/fl/math/screenmap.cpp
+++ b/tests/fl/math/screenmap.cpp
@@ -314,4 +314,55 @@ FL_TEST_CASE("ScreenMap v2 JSON parsing — EL geometry remains shape-native") {
 
 FL_TEST_FILE(FL_FILEPATH) {
 
-} // FL_TEST_FILE
+
+FL_TEST_CASE("ScreenMap v2 emission does not invent a pin") {
+    // `toJson` used to write the literal `"pin1"` into every segment -- the
+    // example value from the shape comment above the emitter, copied in as
+    // data. The parser drops `pin` (it is wiring metadata with nowhere to
+    // live on this side), so the round trip did not preserve the field, it
+    // *rewrote* it: a file wired to pin1/pin2/pin3 came back with all three
+    // on pin1, and a numeric `"pin": 7` came back as the string `"pin1"`.
+    //
+    // Wrong is worse than absent here. A consumer reading a rewritten pin
+    // mis-wires a strip with no way to tell; a consumer reading a missing
+    // optional key can see it is missing. Carrying the value through is
+    // #3322, which needs a place to store it and a decision about the
+    // `<int|str>` union.
+    const char *kThreePins = R"({
+      "version": 2,
+      "segments": [
+        { "id": "a", "pin": "pin1", "x": [0, 1], "y": [0, 1] },
+        { "id": "b", "pin": "pin2", "x": [0, 1], "y": [0, 1] },
+        { "id": "c", "pin": 7,      "x": [0, 1], "y": [0, 1] }
+      ]
+    })";
+    fl::flat_map<fl::string, ScreenMap> maps;
+    fl::string err;
+    FL_REQUIRE(ScreenMap::ParseJson(kThreePins, &maps, &err));
+    FL_REQUIRE_EQ(maps.size(), fl::size(3));
+
+    fl::string out;
+    ScreenMap::toJsonStr(maps, &out);
+
+    // Not one pin, and not three: none. Checking the count rather than the
+    // absence of "pin1" specifically, so re-introducing a different constant
+    // fails this too.
+    int pins = 0;
+    const fl::string needle("\"pin\"");
+    fl::size at = out.find(needle);
+    while (at != fl::string::npos) {
+        ++pins;
+        at = out.find(needle, at + needle.size());
+    }
+    FL_CHECK_EQ(pins, 0);
+
+    // And the geometry still round-trips, so this removed a field rather
+    // than the emitter's output.
+    fl::flat_map<fl::string, ScreenMap> again;
+    FL_REQUIRE(ScreenMap::ParseJson(out.c_str(), &again, &err));
+    FL_CHECK_EQ(again.size(), fl::size(3));
+    FL_CHECK_EQ(again["b"].getLength(), fl::u32(2));
+    FL_CHECK(again["b"][1].x == 1.0f);
+}
+
+}


### PR DESCRIPTION
Refs #3322.

#3322's first complaint is that `pin` is documented in the screen-map envelope and never read:

> A user who writes `"pin": "D0"` in their JSON gets it silently dropped.

That is true, and deliberate — the parser says as much. What the issue does not say, and what turns this from a missing feature into a defect, is what the **emitter** does with it.

## The emitter was writing a comment's example value as data

`ScreenMap::toJson` wrote the literal `"pin1"` into every segment. That string is the example from the shape comment directly above the emitter, copied into the code; the commit that added it (#3100) does not mention `pin` anywhere in its message.

So the round trip did not *drop* the field — it **rewrote** it. Measured on a three-segment file before touching anything:

| segment | in | out |
|---|---|---|
| a | `"pin1"` | `"pin1"` |
| b | `"pin2"` | **`"pin1"`** |
| c | `7` | **`"pin1"`** |

Two of three segments come back on the wrong pin, and a numeric pin comes back as a string. `examples/hydropack/data/el-shapes-triangles-wire.json` is exactly that shape — pin1/pin2/pin3 — so this is a file in the tree, not a hypothetical.

## Nothing is emitted now

**Wrong is worse than absent here.** A consumer reading a rewritten pin mis-wires a strip and has no way to tell; a consumer reading a missing optional key can see that it is missing. FastLED's own parser ignores the key either way, so nothing on this side changes.

Carrying the value through is the real fix and is **#3322 proper** — it needs somewhere on `ScreenMap` to put it and a decision about the `<int|str>` union, which is what that issue exists to settle. This stops making it worse in the meantime, without pre-empting that design.

The test counts `"pin"` occurrences rather than looking for `"pin1"` specifically, so re-introducing a *different* constant fails it too — both mutations do.

## Left alone, and recorded

The emitter also writes `"diameter":-1.000` for a map with no diameter set, while the field's own comment says *"Only serialized if it's not > 0.0f"*. Same shape of problem, different field, and changing it moves what the parser reads back — so it is flagged rather than folded in.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: restoring `"pin1"`, and emitting a different constant, each fail the case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen map JSON output no longer adds an incorrect hardcoded pin value to segments.
  * Segment geometry remains intact when JSON is parsed and serialized again.

* **Tests**
  * Added coverage confirming pin metadata is omitted from emitted v2 JSON while segment geometry round-trips correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->