### PR TITLE
perf(color): precompute the Bradford inverse instead of solving for it (#4043)

### DIFF
--- a/src/fl/gfx/chromatic_adaptation.cpp.hpp
+++ b/src/fl/gfx/chromatic_adaptation.cpp.hpp
@@ -6,12 +6,7 @@
 
 namespace fl {
 
-namespace {
-
-// Helper names carry an `adaptation` qualifier because .cpp.hpp files are
-// concatenated into one translation unit by the unity build, so an anonymous
-// namespace does not isolate them from a same-named helper in a sibling file
-// -- source_xyz.cpp.hpp defines its own quantizer.
+namespace detail {
 
 /// ICC linear Bradford cone-response matrix.
 const float kBradford[3][3] = {
@@ -38,6 +33,15 @@ const float kBradfordInverse[3][3] = {
     {0.432305276f, 0.518360257f, 0.049291227f},
     {-0.0085286675f, 0.0400428213f, 0.968486726f},
 };
+
+} // namespace detail
+
+namespace {
+
+// Helper names carry an `adaptation` qualifier because .cpp.hpp files are
+// concatenated into one translation unit by the unity build, so an anonymous
+// namespace does not isolate them from a same-named helper in a sibling file
+// -- source_xyz.cpp.hpp defines its own quantizer.
 
 /// True only for a real, usable chromaticity.
 ///
@@ -87,8 +91,9 @@ bool buildBradfordMatrixQ16(Chromaticity source_white,
 
     float source_cones[3];
     float destination_cones[3];
-    colorimetric_response::matvec3(kBradford, source_xyz, source_cones);
-    colorimetric_response::matvec3(kBradford, destination_xyz,
+    colorimetric_response::matvec3(detail::kBradford, source_xyz,
+                                   source_cones);
+    colorimetric_response::matvec3(detail::kBradford, destination_xyz,
                                    destination_cones);
 
     float scale[3];
@@ -112,7 +117,8 @@ bool buildBradfordMatrixQ16(Chromaticity source_white,
         for (int col = 0; col < 3; ++col) {
             float sum = 0.0f;
             for (int k = 0; k < 3; ++k) {
-                sum += kBradfordInverse[row][k] * scale[k] * kBradford[k][col];
+                sum += detail::kBradfordInverse[row][k] * scale[k] *
+                       detail::kBradford[k][col];
             }
             out->m[row][col] = quantizeAdaptationQ16(sum);
         }

--- a/src/fl/gfx/chromatic_adaptation.cpp.hpp
+++ b/src/fl/gfx/chromatic_adaptation.cpp.hpp
@@ -20,6 +20,25 @@ const float kBradford[3][3] = {
     {0.0389f, -0.0685f, 1.0296f},
 };
 
+/// Its inverse, precomputed.
+///
+/// This used to be `invert3x3(kBradford, ...)` on every profile bind -- a
+/// float determinant, a reciprocal, three column-scale divisions and nine
+/// multiplies, run to recompute a matrix that cannot change. The operand is a
+/// compile-time constant, so the answer is one too.
+///
+/// The values are what `invert3x3` produces from `kBradford` in float32, to
+/// the last bit, so the adaptation matrix this feeds is unchanged.
+/// `test_bradford_inverse_matches_the_general_solver` pins that against the
+/// solver rather than against a transcription, which is what catches a typo
+/// here -- a wrong digit in a plausible-looking matrix is exactly the kind of
+/// constant nothing else would notice (FastLED #4043).
+const float kBradfordInverse[3][3] = {
+    {0.986992955f, -0.14705427f, 0.159962654f},
+    {0.432305276f, 0.518360257f, 0.049291227f},
+    {-0.0085286675f, 0.0400428213f, 0.968486726f},
+};
+
 /// True only for a real, usable chromaticity.
 ///
 /// `xyY_to_XYZ` guards `y < 1e-12f`, which NaN slips past because every
@@ -82,18 +101,18 @@ bool buildBradfordMatrixQ16(Chromaticity source_white,
         scale[i] = destination_cones[i] / source_cones[i];
     }
 
-    float inverse[3][3];
-    if (!colorimetric_response::invert3x3(kBradford, inverse)) {
-        return false;
-    }
-
     // Collapse B_inv * diag(scale) * B into one matrix. Done once here so the
     // per-pixel path never sees the cone space at all.
+    //
+    // `kBradfordInverse` rather than inverting `kBradford` again: the operand
+    // is a constant, so the inverse is one, and the solver's failure return
+    // could not fire on it. Nothing that varies per profile was being
+    // computed there.
     for (int row = 0; row < 3; ++row) {
         for (int col = 0; col < 3; ++col) {
             float sum = 0.0f;
             for (int k = 0; k < 3; ++k) {
-                sum += inverse[row][k] * scale[k] * kBradford[k][col];
+                sum += kBradfordInverse[row][k] * scale[k] * kBradford[k][col];
             }
             out->m[row][col] = quantizeAdaptationQ16(sum);
         }

--- a/src/fl/gfx/chromatic_adaptation.h
+++ b/src/fl/gfx/chromatic_adaptation.h
@@ -13,6 +13,23 @@
 #include "fl/stl/noexcept.h"
 
 namespace fl {
+namespace detail {
+
+/// ICC linear Bradford cone-response matrix, and its inverse.
+///
+/// Declared here rather than kept file-local so the test can check the
+/// *shipped* constants. An earlier revision compared the solver against a
+/// copy of the numbers written into the test, which validates the copy and
+/// says nothing about the implementation -- and the inverse is precomputed
+/// precisely so that nothing recomputes it, which means nothing else would
+/// notice a wrong digit either (FastLED #4043).
+///
+/// Same reason `adaptXyzQ16` is public below: a stage that cannot be run on
+/// its own cannot be bisected when its budget misses.
+extern const float kBradford[3][3];
+extern const float kBradfordInverse[3][3];
+
+} // namespace detail
 
 /// A collapsed adaptation transform in s16.16.
 ///

--- a/tests/fl/gfx/chromatic_adaptation.cpp
+++ b/tests/fl/gfx/chromatic_adaptation.cpp
@@ -32,47 +32,31 @@ float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
 // compile-time matrix on every profile bind was float work spent recomputing
 // a known answer (#4043).
 //
-// What this case checks is the *value*: that the numbers written into
-// `chromatic_adaptation.cpp.hpp` are what `invert3x3` produces from
-// `kBradford`, and that they really invert it. It cannot see the shipped
-// constant -- that lives in the implementation's own namespace, and this file
-// re-declares `kBradford` for the same reason -- so it does not by itself
-// catch an edit there.
-//
-// The cases below do. Mutating one digit of the shipped inverse fails
-// "Adapting a white to itself is the identity"; transposing it fails that and
-// two more. Worth stating rather than implying, because a test named after a
-// constant reads like it guards the constant.
-FL_TEST_CASE("The Bradford inverse written here really is the inverse") {
-    const float kBradford[3][3] = {
-        {0.8951f, 0.2664f, -0.1614f},
-        {-0.7502f, 1.7135f, 0.0367f},
-        {0.0389f, -0.0685f, 1.0296f},
-    };
+// This reads the shipped constants. An earlier revision compared the solver
+// against a copy of the numbers written into this file, which validates the
+// copy and says nothing about the implementation -- and the whole point of
+// precomputing is that nothing recomputes it, so a wrong digit there would
+// have had nothing checking it but the behaviour cases below.
+FL_TEST_CASE("The shipped Bradford inverse is the inverse of the shipped matrix") {
     float solved[3][3];
-    FL_REQUIRE(colorimetric_response::invert3x3(kBradford, solved));
+    FL_REQUIRE(colorimetric_response::invert3x3(fl::detail::kBradford, solved));
 
-    // The shipped constant, repeated here on purpose. Reading it out of the
-    // implementation would let a wrong value agree with itself.
-    const float kExpected[3][3] = {
-        {0.986992955f, -0.14705427f, 0.159962654f},
-        {0.432305276f, 0.518360257f, 0.049291227f},
-        {-0.0085286675f, 0.0400428213f, 0.968486726f},
-    };
     for (int row = 0; row < 3; ++row) {
         for (int col = 0; col < 3; ++col) {
-            FL_CHECK_LT(fl::fabsf(solved[row][col] - kExpected[row][col]),
-                        1e-6f);
+            FL_CHECK_LT(
+                fl::fabsf(solved[row][col] - fl::detail::kBradfordInverse[row][col]),
+                1e-6f);
         }
     }
 
-    // And it really is an inverse, which a matching pair of wrong numbers
-    // would not be.
+    // And independently of the solver: the product is the identity, which a
+    // pair of numbers that merely agree with each other would not be.
     for (int row = 0; row < 3; ++row) {
         for (int col = 0; col < 3; ++col) {
             float sum = 0.0f;
             for (int k = 0; k < 3; ++k) {
-                sum += kExpected[row][k] * kBradford[k][col];
+                sum += fl::detail::kBradfordInverse[row][k] *
+                       fl::detail::kBradford[k][col];
             }
             const float want = row == col ? 1.0f : 0.0f;
             FL_CHECK_LT(fl::fabsf(sum - want), 1e-5f);

--- a/tests/fl/gfx/chromatic_adaptation.cpp
+++ b/tests/fl/gfx/chromatic_adaptation.cpp
@@ -6,6 +6,8 @@
 // corpus is generated from, ci/color_reference.py::bradford_adaptation.
 
 #include "fl/gfx/chromatic_adaptation.h"
+#include "fl/gfx/colorimetric_response.h"
+#include "fl/math/math.h"
 #include "fl/gfx/color_profile.h"
 #include "fl/gfx/source_xyz.h"
 #include "fl/stl/int.h"
@@ -25,6 +27,58 @@ i32 q16(float v) { return static_cast<i32>(v * 65536.0f + (v >= 0 ? 0.5f : -0.5f
 float toFloat(i32 v) { return static_cast<float>(v) / 65536.0f; }
 
 }  // namespace
+
+// The Bradford inverse is a precomputed constant now, because inverting a
+// compile-time matrix on every profile bind was float work spent recomputing
+// a known answer (#4043).
+//
+// What this case checks is the *value*: that the numbers written into
+// `chromatic_adaptation.cpp.hpp` are what `invert3x3` produces from
+// `kBradford`, and that they really invert it. It cannot see the shipped
+// constant -- that lives in the implementation's own namespace, and this file
+// re-declares `kBradford` for the same reason -- so it does not by itself
+// catch an edit there.
+//
+// The cases below do. Mutating one digit of the shipped inverse fails
+// "Adapting a white to itself is the identity"; transposing it fails that and
+// two more. Worth stating rather than implying, because a test named after a
+// constant reads like it guards the constant.
+FL_TEST_CASE("The Bradford inverse written here really is the inverse") {
+    const float kBradford[3][3] = {
+        {0.8951f, 0.2664f, -0.1614f},
+        {-0.7502f, 1.7135f, 0.0367f},
+        {0.0389f, -0.0685f, 1.0296f},
+    };
+    float solved[3][3];
+    FL_REQUIRE(colorimetric_response::invert3x3(kBradford, solved));
+
+    // The shipped constant, repeated here on purpose. Reading it out of the
+    // implementation would let a wrong value agree with itself.
+    const float kExpected[3][3] = {
+        {0.986992955f, -0.14705427f, 0.159962654f},
+        {0.432305276f, 0.518360257f, 0.049291227f},
+        {-0.0085286675f, 0.0400428213f, 0.968486726f},
+    };
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            FL_CHECK_LT(fl::fabsf(solved[row][col] - kExpected[row][col]),
+                        1e-6f);
+        }
+    }
+
+    // And it really is an inverse, which a matching pair of wrong numbers
+    // would not be.
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            float sum = 0.0f;
+            for (int k = 0; k < 3; ++k) {
+                sum += kExpected[row][k] * kBradford[k][col];
+            }
+            const float want = row == col ? 1.0f : 0.0f;
+            FL_CHECK_LT(fl::fabsf(sum - want), 1e-5f);
+        }
+    }
+}
 
 FL_TEST_CASE("Adapting a white to itself is the identity") {
     AdaptationMatrixQ16 matrix;


### PR DESCRIPTION
Refs #4043 (P9).

P9's remaining item is bind-time float. #4275 settled the part that needed measuring — a Q16 inverse is accurate enough, so converting the derivation is effort rather than an open question. This is a piece of that effort that needs no conversion at all.

## Inverting a constant

`buildAdaptationMatrixQ16` called `invert3x3(kBradford, inverse)` on **every profile bind**:

```cpp
const float kBradford[3][3] = {
    {0.8951f, 0.2664f, -0.1614f},
    ...
};
...
float inverse[3][3];
if (!colorimetric_response::invert3x3(kBradford, inverse)) {
    return false;
}
```

`kBradford` is a compile-time constant. That call is a float determinant, a reciprocal, three column-scale divisions and nine multiplies, run to recompute a matrix that cannot change. The inverse is now a constant beside it.

Nothing about the result moves: the values are what `invert3x3` produces from `kBradford` **in float32, to the last bit**, so the adaptation matrix this feeds is identical. The solver's failure return went with it and could not have fired — a constant is either singular always or never, and this one is not.

## On the test that checks it

A transcribed constant is only as good as the transcription, so there is a case checking these numbers are what the solver produces *and* that they invert `kBradford`.

That case reads the value it was handed rather than the shipped one — the implementation's namespace is not visible from the test, which is why the file already re-declares `kBradford` — so **it does not by itself guard against an edit in the implementation**, and its comment says so and names the cases that do. Worth being explicit about: a test named after a constant reads like it guards the constant.

Mutation-tested for exactly that: one wrong digit in the shipped inverse fails *"Adapting a white to itself is the identity"*; transposing it fails that plus two more.

## Verification

- `bash test --cpp` — 300/300 unit, 84/84 examples
- `bash lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved color adaptation calculations by using precomputed matrix values, helping reduce repeated computation during color profile processing.
* **Bug Fixes**
  * Improved consistency of color conversion results by using validated Bradford adaptation constants.
* **Tests**
  * Added verification that the adaptation matrix and its inverse produce the expected identity result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->