### PR TITLE
study(color): section 5's last candidate does not need the cadence to be scored (#4042)

### DIFF
--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -331,11 +331,21 @@ The static worst sits at a different target from the 2% one quoted above,
 which is why it reads 0.0466 rather than 0.0382: at 1% luminance no single
 frame improves on rounding at all.
 
-At the 2% target specifically -- rounding 0.0605, the distance-optimal single
-frame 0.0382 -- the distance-optimal eight-frame cycle sits at **0.0016**. The
-remaining candidate is not in the same class as the static ones: it does not
-close the last third, it closes almost all of it. Eight frames is also the
-cycle `BINARY_DITHER` already runs, so the cadence question is not a new one.
+At the 2% target, all three against the same baseline of per-channel rounding:
+
+| | chroma | reduction against rounding |
+| --- | ---: | ---: |
+| per-channel rounding | 0.0605 | -- |
+| best value-only shaping | 0.0530 | 12% |
+| distance-optimal single frame | 0.0382 | 37% |
+| **distance-optimal eight-frame cycle** | **0.0016** | **97%** |
+
+The section above framed this candidate as the one that "could close the other
+two thirds", meaning the part of the static ceiling's 37% that value-only
+shaping leaves behind. That framing understates it: the cycle is not competing
+for the remainder of a 37% budget, it removes 97% of the error outright.
+Eight frames is also the cycle `BINARY_DITHER` already runs, so the cadence
+question is not a new one.
 
 The one-frame row is a control rather than a second measurement: at `N = 1`
 the grid collapses to the integer codes over the same window the static search

--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -307,7 +307,17 @@ perceptual coordinates do not -- the same assumption the dither guide in
 `pixel_controller.h` makes when it says the eye integrates the cycle above
 ~50 Hz.
 
-Worst case over the same 40 targets:
+**What is tabulated is the chroma of the *distance-optimal* cycle**, not the
+lowest chroma a cycle could reach. The distinction is the one recorded above
+under "Distance is not chroma": the search minimises OKLab distance to the
+ideal and the table reports that candidate's neutral-axis error. Minimising
+chroma directly would be meaningless here -- a cycle drives chroma to zero by
+going to black, so an unconstrained chroma minimum answers "emit nothing" at
+every target. What a strategy picks is the closest reproduction, and this is
+what that costs on the axis.
+
+Worst case over the same 40 targets, all searches over the same `[-2, 2]`
+window:
 
 | | worst chroma |
 | --- | ---: |
@@ -321,14 +331,20 @@ The static worst sits at a different target from the 2% one quoted above,
 which is why it reads 0.0466 rather than 0.0382: at 1% luminance no single
 frame improves on rounding at all.
 
-At the 2% target specifically -- rounding 0.0605, best single frame 0.0382 --
-an eight-frame cycle reaches **0.0016**. The remaining candidate is not in the
-same class as the static ones: it does not close the last third, it closes
-almost all of it. Eight frames is also the cycle `BINARY_DITHER` already runs,
-so the cadence question is not a new one.
+At the 2% target specifically -- rounding 0.0605, the distance-optimal single
+frame 0.0382 -- the distance-optimal eight-frame cycle sits at **0.0016**. The
+remaining candidate is not in the same class as the static ones: it does not
+close the last third, it closes almost all of it. Eight frames is also the
+cycle `BINARY_DITHER` already runs, so the cadence question is not a new one.
 
-Three things this does not say. It is a **ceiling**, like the static one -- the
-best an N-frame cycle could do, not what an algorithm achieves. It says
+The one-frame row is a control rather than a second measurement: at `N = 1`
+the grid collapses to the integer codes over the same window the static search
+uses, so it must reproduce the static answer exactly. It does, to within a
+float ULP.
+
+Three things this does not say. It is a **ceiling**, like the static one -- what
+a distance-optimal N-frame cycle costs on the axis, not what an algorithm
+achieves. It says
 nothing about flicker; a cycle that reaches the floor by toggling the bottom
 codes is exactly the trade #4156 R8 asks to have declared. And it assumes a
 pipeline dither that can choose sub-code average drives, which is a different

--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -293,12 +293,54 @@ single frame has.** Across the sweep it lands at or below the distance-optimal
 code's chroma at 36 of 40 targets; the four exceptions are the distance-versus-
 chroma disagreement recorded above, not a failure of the strategy.
 
+### And the remaining candidate, which does not need the cadence to be scored
+
+Linear-light temporal dithering was left as "waiting on the frame cadence P6
+wires up". The cadence is needed to *ship* it. It is not needed to *score* it:
+an N-frame cycle's time-averaged light is arithmetic, and the static ceiling
+above is the same construction with N = 1.
+
+A cycle that spends `k` of its `N` frames one code higher averages to a drive
+of `base + k/N`, per channel, so the reachable averages are a grid. Averaging
+is done in linear XYZ rather than in OKLab, because light averages and
+perceptual coordinates do not -- the same assumption the dither guide in
+`pixel_controller.h` makes when it says the eye integrates the cycle above
+~50 Hz.
+
+Worst case over the same 40 targets:
+
+| | worst chroma |
+| --- | ---: |
+| per-channel rounding | 0.0605 |
+| static ceiling | 0.0466 |
+| temporal, 2 frames | 0.0304 |
+| temporal, 4 frames | 0.0109 |
+| **temporal, 8 frames** | **0.0086** |
+
+The static worst sits at a different target from the 2% one quoted above,
+which is why it reads 0.0466 rather than 0.0382: at 1% luminance no single
+frame improves on rounding at all.
+
+At the 2% target specifically -- rounding 0.0605, best single frame 0.0382 --
+an eight-frame cycle reaches **0.0016**. The remaining candidate is not in the
+same class as the static ones: it does not close the last third, it closes
+almost all of it. Eight frames is also the cycle `BINARY_DITHER` already runs,
+so the cadence question is not a new one.
+
+Three things this does not say. It is a **ceiling**, like the static one -- the
+best an N-frame cycle could do, not what an algorithm achieves. It says
+nothing about flicker; a cycle that reaches the floor by toggling the bottom
+codes is exactly the trade #4156 R8 asks to have declared. And it assumes a
+pipeline dither that can choose sub-code average drives, which is a different
+mechanism from `BINARY_DITHER` -- that one is gated on a nonzero source and
+recovers precision lost in the brightness multiply, as the black-floor section
+above records.
+
 ### What that leaves
 
-Linear-light temporal dithering, which is the only remaining candidate that
-could close the other two thirds, and which is stateful and waits on the frame
-cadence P6 wires up. The static half of section 5 is answered: one candidate
-is out, one survives and is worth having, and neither reaches the ceiling.
+Building it. Section 5's comparison is answered: independent RGB gamma is out,
+value-only shaping survives and takes about a third, and temporal dithering is
+worth the state it costs.
 
 ## Not covered
 

--- a/tests/fl/gfx/hsv16.cpp
+++ b/tests/fl/gfx/hsv16.cpp
@@ -1154,10 +1154,17 @@ FL_TEST_CASE("Section 5 can be scored without the frame cadence") {
 }
 
 FL_TEST_CASE("At the worst target the cycle closes what a frame cannot") {
-    // 2% luminance: rounding 0.0605, the best single frame 0.0382, and an
-    // eight-frame cycle 0.0016. Section 5's remaining candidate is not in the
-    // same class as the static ones -- it does not close the last third, it
-    // closes almost all of it.
+    // 2% luminance, everything measured against the same baseline of
+    // per-channel rounding at 0.0605:
+    //
+    //   best value-only shaping         0.0530   12% lower
+    //   distance-optimal single frame   0.0382   37% lower
+    //   distance-optimal 8-frame cycle  0.0016   97% lower
+    //
+    // #4277 framed this candidate as the one that "could close the other two
+    // thirds" -- the part of the static ceiling's 37% that value-only shaping
+    // leaves. That understates it: the cycle is not competing for the
+    // remainder of a 37% budget, it removes almost all of the error.
     const float luminance = 0.02f;
     const Oklab ideal = idealNeutralLight(luminance);
     const float rounded_chroma = chromaOf(lightOf(neutralCodes(luminance)));

--- a/tests/fl/gfx/hsv16.cpp
+++ b/tests/fl/gfx/hsv16.cpp
@@ -1050,22 +1050,42 @@ FL_TEST_CASE("At the worst target it takes a third of the room there is") {
 
 namespace {
 
-/// Best chroma reachable by averaging an N-frame cycle's emitted light.
+/// Chroma of the *distance-optimal* N-frame cycle.
+///
+/// Not "the best chroma an N-frame cycle can reach", which is what an earlier
+/// revision called it. The search minimises OKLab distance to the ideal and
+/// then reports that candidate's chroma, and #4265 established in this same
+/// file that the two objectives can disagree -- so naming it after chroma
+/// described a quantity it does not compute.
+///
+/// Distance is the right objective anyway, and the reason is worth stating:
+/// minimising chroma on its own is degenerate. A cycle can drive chroma to
+/// zero by going to black, so an unconstrained chroma minimum answers "emit
+/// nothing" at every target. What a strategy actually picks is the closest
+/// reproduction, and its neutral-axis error is what this reports.
 ///
 /// A cycle that spends `k` of its `N` frames one code higher averages to a
 /// drive of `base + k/N`, and the choice is per channel, so the reachable
-/// averages are a grid. `frames == 1` collapses that grid to the integer
-/// codes, which is what makes it a control rather than a second measurement.
-float bestTemporalChroma(float luminance, const Oklab& ideal, int frames) {
+/// averages are a grid. Base offsets run -2..1 so that `base + k/N` covers
+/// [-2, 2] for every cycle length -- the same window the static search uses,
+/// which is what lets `frames == 1` be compared against it directly.
+///
+/// That widening is an argument, not a measurement: no target in the sweep
+/// has a static optimum at a -2 offset, so narrowing the window back to -1..1
+/// changes no number here. It is done anyway because the control's claim is
+/// "the same domain", and a control whose domain merely happens to suffice is
+/// one nobody can check.
+float distanceOptimalCycleChroma(float luminance, const Oklab& ideal,
+                                 int frames) {
     const RgbColorimetricCache cache = ws2812Cache();
     const CRGB rounded = neutralCodes(luminance);
     float best_distance = 1e9f;
     float best_chroma = 0.0f;
-    for (int base_r = -1; base_r <= 1; ++base_r)
+    for (int base_r = -2; base_r <= 1; ++base_r)
     for (int step_r = 0; step_r <= frames; ++step_r)
-    for (int base_g = -1; base_g <= 1; ++base_g)
+    for (int base_g = -2; base_g <= 1; ++base_g)
     for (int step_g = 0; step_g <= frames; ++step_g)
-    for (int base_b = -1; base_b <= 1; ++base_b)
+    for (int base_b = -2; base_b <= 1; ++base_b)
     for (int step_b = 0; step_b <= frames; ++step_b) {
         const float dr =
             (rounded.r + base_r + static_cast<float>(step_r) / frames) / 255.0f;
@@ -1118,7 +1138,7 @@ FL_TEST_CASE("Section 5 can be scored without the frame cadence") {
         const float luminance = static_cast<float>(step) / 100.0f;
         const Oklab ideal = idealNeutralLight(luminance);
         const float rounded_chroma = chromaOf(lightOf(neutralCodes(luminance)));
-        const float temporal = bestTemporalChroma(luminance, ideal, 8);
+        const float temporal = distanceOptimalCycleChroma(luminance, ideal, 8);
         if (rounded_chroma > worst_rounding) {
             worst_rounding = rounded_chroma;
         }
@@ -1141,7 +1161,7 @@ FL_TEST_CASE("At the worst target the cycle closes what a frame cannot") {
     const float luminance = 0.02f;
     const Oklab ideal = idealNeutralLight(luminance);
     const float rounded_chroma = chromaOf(lightOf(neutralCodes(luminance)));
-    const float temporal = bestTemporalChroma(luminance, ideal, 8);
+    const float temporal = distanceOptimalCycleChroma(luminance, ideal, 8);
 
     FL_CHECK_LT(fl::fabsf(rounded_chroma - 0.0605f), 0.001f);
     FL_CHECK_LT(temporal, 0.003f);
@@ -1151,27 +1171,51 @@ FL_TEST_CASE("At the worst target the cycle closes what a frame cannot") {
 FL_TEST_CASE("A longer cycle never does worse, and one frame is the static case") {
     // The reachable averages nest -- every k/2 is a k/4 is a k/8 -- so a
     // longer cycle cannot lose. A search that violated that would be finding
-    // something other than the best average, which is the failure mode this
-    // construction is most exposed to.
+    // something other than the distance-optimal average, which is the failure
+    // mode this construction is most exposed to.
     //
-    // And at one frame the grid collapses to the integer codes, so the result
-    // must be an ordinary static answer rather than a sub-code one. Without
-    // this the whole measurement could be an artefact of the search.
+    // And at one frame the grid collapses to the integer codes over the same
+    // [-2, 2] window the static search uses, so it must reproduce the static
+    // answer exactly. An earlier revision searched [-1, 2] here and asserted
+    // only a lower bound, which could not have shown that. Without this the
+    // whole measurement could be an artefact of the search.
     const float luminance = 0.02f;
     const Oklab ideal = idealNeutralLight(luminance);
 
-    const float one = bestTemporalChroma(luminance, ideal, 1);
-    const float two = bestTemporalChroma(luminance, ideal, 2);
-    const float four = bestTemporalChroma(luminance, ideal, 4);
-    const float eight = bestTemporalChroma(luminance, ideal, 8);
+    const float one = distanceOptimalCycleChroma(luminance, ideal, 1);
+    const float two = distanceOptimalCycleChroma(luminance, ideal, 2);
+    const float four = distanceOptimalCycleChroma(luminance, ideal, 4);
+    const float eight = distanceOptimalCycleChroma(luminance, ideal, 8);
 
     FL_CHECK_LE(two, one + 1e-6f);
     FL_CHECK_LE(four, two + 1e-6f);
     FL_CHECK_LE(eight, four + 1e-6f);
 
-    // One frame reaches no further than the static ceiling the ±2 search
-    // finds, and no better than it: the same mechanism, without the cycle.
-    FL_CHECK_GE(one, 0.0382f - 0.001f);
+    // The static reference, computed here the way #4265 computes it.
+    const CRGB rounded = neutralCodes(luminance);
+    float best_distance = oklabDistance(lightOf(rounded), ideal);
+    float static_chroma = chromaOf(lightOf(rounded));
+    for (int dr = -2; dr <= 2; ++dr) {
+        for (int dg = -2; dg <= 2; ++dg) {
+            for (int db = -2; db <= 2; ++db) {
+                const int r = static_cast<int>(rounded.r) + dr;
+                const int g = static_cast<int>(rounded.g) + dg;
+                const int b = static_cast<int>(rounded.b) + db;
+                if (r < 0 || g < 0 || b < 0) continue;
+                if (r > 255 || g > 255 || b > 255) continue;
+                const CRGB candidate(static_cast<u8>(r), static_cast<u8>(g),
+                                     static_cast<u8>(b));
+                const Oklab light = lightOf(candidate);
+                const float distance = oklabDistance(light, ideal);
+                if (distance < best_distance) {
+                    best_distance = distance;
+                    static_chroma = chromaOf(light);
+                }
+            }
+        }
+    }
+    // Same domain, same objective, so the same answer -- not merely a bound.
+    FL_CHECK_LT(fl::fabsf(one - static_chroma), 1e-6f);
 }
 
 }  // namespace ws2812_shaping

--- a/tests/fl/gfx/hsv16.cpp
+++ b/tests/fl/gfx/hsv16.cpp
@@ -1030,4 +1030,148 @@ FL_TEST_CASE("At the worst target it takes a third of the room there is") {
     FL_CHECK_LT(fraction, 0.45f);
 }
 
+// ---------------------------------------------------------------------------
+// The temporal ceiling (#4042 section 5)
+//
+// #4277 left one candidate: linear-light temporal dithering, described as
+// waiting on the frame cadence P6 wires up. The cadence is needed to *ship*
+// it. It is not needed to *score* it -- an N-frame cycle's time-averaged
+// light is arithmetic, and #4265's static ceiling is the same construction
+// with N = 1.
+//
+// Averaging is done in linear XYZ rather than in OKLab, because light
+// averages and perceptual coordinates do not. That is the modelling choice
+// this rests on, and it is the one the dither guide in `pixel_controller.h`
+// already assumes when it says the eye integrates the cycle above ~50 Hz.
+//
+// What is measured is a ceiling, like #4265's: the best an N-frame cycle
+// could do, not what any particular algorithm achieves.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Best chroma reachable by averaging an N-frame cycle's emitted light.
+///
+/// A cycle that spends `k` of its `N` frames one code higher averages to a
+/// drive of `base + k/N`, and the choice is per channel, so the reachable
+/// averages are a grid. `frames == 1` collapses that grid to the integer
+/// codes, which is what makes it a control rather than a second measurement.
+float bestTemporalChroma(float luminance, const Oklab& ideal, int frames) {
+    const RgbColorimetricCache cache = ws2812Cache();
+    const CRGB rounded = neutralCodes(luminance);
+    float best_distance = 1e9f;
+    float best_chroma = 0.0f;
+    for (int base_r = -1; base_r <= 1; ++base_r)
+    for (int step_r = 0; step_r <= frames; ++step_r)
+    for (int base_g = -1; base_g <= 1; ++base_g)
+    for (int step_g = 0; step_g <= frames; ++step_g)
+    for (int base_b = -1; base_b <= 1; ++base_b)
+    for (int step_b = 0; step_b <= frames; ++step_b) {
+        const float dr =
+            (rounded.r + base_r + static_cast<float>(step_r) / frames) / 255.0f;
+        const float dg =
+            (rounded.g + base_g + static_cast<float>(step_g) / frames) / 255.0f;
+        const float db =
+            (rounded.b + base_b + static_cast<float>(step_b) / frames) / 255.0f;
+        if (dr < 0.0f || dg < 0.0f || db < 0.0f) continue;
+        if (dr > 1.0f || dg > 1.0f || db > 1.0f) continue;
+
+        float xyz[3];
+        rgb_source_to_XYZ(cache, dr, dg, db, xyz);
+        const i32 q16[3] = {static_cast<i32>(xyz[0] * kQ16 + 0.5f),
+                            static_cast<i32>(xyz[1] * kQ16 + 0.5f),
+                            static_cast<i32>(xyz[2] * kQ16 + 0.5f)};
+        i32 lab[3];
+        xyzToOklabQ16(q16, lab);
+        const Oklab light{static_cast<float>(lab[0]) / kQ16,
+                          static_cast<float>(lab[1]) / kQ16,
+                          static_cast<float>(lab[2]) / kQ16};
+        const float distance = oklabDistance(light, ideal);
+        if (distance < best_distance) {
+            best_distance = distance;
+            best_chroma = chromaOf(light);
+        }
+    }
+    return best_chroma;
+}
+
+}  // namespace
+
+FL_TEST_CASE("Section 5 can be scored without the frame cadence") {
+    // The whole point. A cycle's average light is arithmetic; only shipping
+    // one needs P6.
+    //
+    // Worst case over the same 40 targets the static study uses:
+    //
+    //   per-channel rounding   0.0605
+    //   static ceiling         0.0466
+    //   temporal, 2 frames     0.0304
+    //   temporal, 4 frames     0.0109
+    //   temporal, 8 frames     0.0086
+    //
+    // The static worst is at a different target from the 2% one #4265 quotes,
+    // which is why it reads 0.0466 rather than 0.0382: at 1% luminance no
+    // single frame improves on rounding at all.
+    float worst_rounding = 0.0f;
+    float worst_temporal = 0.0f;
+    for (int step = 1; step <= 40; ++step) {
+        const float luminance = static_cast<float>(step) / 100.0f;
+        const Oklab ideal = idealNeutralLight(luminance);
+        const float rounded_chroma = chromaOf(lightOf(neutralCodes(luminance)));
+        const float temporal = bestTemporalChroma(luminance, ideal, 8);
+        if (rounded_chroma > worst_rounding) {
+            worst_rounding = rounded_chroma;
+        }
+        if (temporal > worst_temporal) {
+            worst_temporal = temporal;
+        }
+    }
+    FL_CHECK_LT(fl::fabsf(worst_rounding - 0.0605f), 0.001f);
+    FL_CHECK_LT(worst_temporal, 0.010f);
+    // An 86% reduction in the worst case, against a static ceiling that
+    // manages 23%.
+    FL_CHECK_LT(worst_temporal, worst_rounding * 0.2f);
+}
+
+FL_TEST_CASE("At the worst target the cycle closes what a frame cannot") {
+    // 2% luminance: rounding 0.0605, the best single frame 0.0382, and an
+    // eight-frame cycle 0.0016. Section 5's remaining candidate is not in the
+    // same class as the static ones -- it does not close the last third, it
+    // closes almost all of it.
+    const float luminance = 0.02f;
+    const Oklab ideal = idealNeutralLight(luminance);
+    const float rounded_chroma = chromaOf(lightOf(neutralCodes(luminance)));
+    const float temporal = bestTemporalChroma(luminance, ideal, 8);
+
+    FL_CHECK_LT(fl::fabsf(rounded_chroma - 0.0605f), 0.001f);
+    FL_CHECK_LT(temporal, 0.003f);
+    FL_CHECK_LT(temporal, 0.0382f * 0.2f);
+}
+
+FL_TEST_CASE("A longer cycle never does worse, and one frame is the static case") {
+    // The reachable averages nest -- every k/2 is a k/4 is a k/8 -- so a
+    // longer cycle cannot lose. A search that violated that would be finding
+    // something other than the best average, which is the failure mode this
+    // construction is most exposed to.
+    //
+    // And at one frame the grid collapses to the integer codes, so the result
+    // must be an ordinary static answer rather than a sub-code one. Without
+    // this the whole measurement could be an artefact of the search.
+    const float luminance = 0.02f;
+    const Oklab ideal = idealNeutralLight(luminance);
+
+    const float one = bestTemporalChroma(luminance, ideal, 1);
+    const float two = bestTemporalChroma(luminance, ideal, 2);
+    const float four = bestTemporalChroma(luminance, ideal, 4);
+    const float eight = bestTemporalChroma(luminance, ideal, 8);
+
+    FL_CHECK_LE(two, one + 1e-6f);
+    FL_CHECK_LE(four, two + 1e-6f);
+    FL_CHECK_LE(eight, four + 1e-6f);
+
+    // One frame reaches no further than the static ceiling the ±2 search
+    // finds, and no better than it: the same mechanism, without the cycle.
+    FL_CHECK_GE(one, 0.0382f - 0.001f);
+}
+
 }  // namespace ws2812_shaping


### PR DESCRIPTION
Refs #4042 (P8, section 5).

#4277 left linear-light temporal dithering as the remaining candidate and described it as waiting on the frame cadence P6 wires up. **The cadence is needed to ship it. It is not needed to score it** — an N-frame cycle's time-averaged light is arithmetic, and #4265's static ceiling is the same construction with N = 1.

## The construction

A cycle that spends `k` of its `N` frames one code higher averages to a drive of `base + k/N`, per channel, so the reachable averages are a grid. **Averaging is done in linear XYZ, not in OKLab**, because light averages and perceptual coordinates do not — the same assumption `pixel_controller.h`'s dither guide already makes when it says the eye integrates the cycle above ~50 Hz.

## Worst case over the same 40 targets

| | worst chroma |
|---|---:|
| per-channel rounding | 0.0605 |
| static ceiling | 0.0466 |
| temporal, 2 frames | 0.0304 |
| temporal, 4 frames | 0.0109 |
| **temporal, 8 frames** | **0.0086** |

The static worst sits at a different target from the 2% one #4265 quotes, which is why it reads 0.0466 rather than 0.0382: at 1% luminance no single frame improves on rounding at all.

At the **2% target** — rounding 0.0605, best single frame 0.0382 — eight frames reach **0.0016**. The remaining candidate is not in the same class as the static ones: it does not close the last third, it closes almost all of it. Eight frames is also the cycle `BINARY_DITHER` already runs, so the cadence question is not a new one.

## Three things this does not say

Stated in the doc rather than left to be assumed:

- it is a **ceiling**, like the static one — the best an N-frame cycle could do, not what an algorithm achieves;
- it says **nothing about flicker**. A cycle that reaches the floor by toggling the bottom codes is exactly the trade #4156 R8 asks to have declared;
- it assumes a **pipeline dither** that can choose sub-code average drives, which is a different mechanism from `BINARY_DITHER` — that one is gated on a nonzero source and recovers precision lost in the brightness multiply, as the black-floor section records.

## The control is the load-bearing part

At one frame the grid collapses to the integer codes, so the result must be an ordinary static answer. Without that check the whole measurement could be an artefact of the search. Nesting is checked too — every `k/2` is a `k/4` is a `k/8`, so a longer cycle cannot lose, and a search that violated it would be finding something other than the best average.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: collapsing the sub-code step to a whole code, and scoring the worst target at one frame instead of eight, each fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that temporal-dithering results represent distance-optimal cycles rather than minimum chroma.
  - Documented the shared search window, 2% target terminology, and one-frame control matching static results.
  - Refined guidance on cycle quality, chroma ceilings, and the conclusions of the comparison.

- **Tests**
  - Added coverage for temporal-dithering ceilings across cycle lengths.
  - Verified improved worst-case color accuracy with eight-frame cycles and monotonic behavior for longer cycles.
  - Confirmed consistency with static behavior and near-complete closure of the 2% target gap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->