### PR TITLE
study(color): the dither cadence and the enable threshold are 4x apart (#4156 R8)

### DIFF
--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -248,6 +248,47 @@ prose. No change to the dither is proposed here -- R8 asks for the contract to
 be defined, and shifting the low-code rendering of every existing sketch is a
 decision, not a cleanup.
 
+### And the cadence that decides how long a cycle may be is 4x out
+
+#4156 R8 asks for "cadence, observation window, and unsupported low-light
+region". The floor above answers the last one. This is the first, and the two
+constants that decide it disagree.
+
+The dither cycle length is *derived* from a cadence assumption, in
+`src/pixel_controller.h`:
+
+| | |
+| --- | ---: |
+| `MAX_LIKELY_UPDATE_RATE_HZ` | 400 |
+| `MIN_ACCEPTABLE_DITHER_RATE_HZ` | 50 |
+| `UPDATES_PER_FULL_DITHER_CYCLE` | 400 / 50 = **8** |
+
+Eight frames is the number that makes a 400 Hz refresh complete a cycle at
+50 Hz. That much is coherent.
+
+What *enables* dithering is not 400. `CFastLED::show()` and `showColor()` each
+carry `if (mNFPS < 100) { pCur->setDither(0); }` -- a bare literal, twice, with
+no reference to the constants above. **At 100 FPS an eight-frame cycle
+completes at 12.5 Hz**, a quarter of the file's own floor, and near the peak of
+human flicker sensitivity rather than above it.
+
+The guide in that file states two different 50 Hz conditions, and the code
+implements the weaker one:
+
+* *"At refresh rates above ~50Hz, human vision integrates these variations"* --
+  about the **refresh**;
+* *"8-frame cycle at 400Hz = 50Hz complete cycle"* -- about the **cycle**.
+
+What the eye integrates is the modulation, and the modulation is at the cycle
+rate. `tests/pixel_controller.cpp` records the arithmetic rather than asserting
+an intent: raising the threshold would disable dithering for most sketches,
+which is a decision rather than a cleanup, and the case fails if either number
+moves so that whoever moves it writes down why.
+
+Worth having before any *pipeline* dither is built, because that one modulates
+harder: reaching the bottom of the range means toggling the lowest codes, so
+the relative depth is largest exactly where the eye is most sensitive to it.
+
 ## Section 5: the two static candidates, scored
 
 The ceiling above is what makes this scoreable without settling the

--- a/docs/color-ws2812-shaping-paths.md
+++ b/docs/color-ws2812-shaping-paths.md
@@ -250,8 +250,8 @@ decision, not a cleanup.
 
 ### And the cadence that decides how long a cycle may be is 4x out
 
-#4156 R8 asks for "cadence, observation window, and unsupported low-light
-region". The floor above answers the last one. This is the first, and the two
+Issue #4156 R8 asks for "cadence, observation window, and unsupported
+low-light region". The floor above answers the last one. This is the first, and the two
 constants that decide it disagree.
 
 The dither cycle length is *derived* from a cadence assumption, in

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -168,4 +168,61 @@ FL_TEST_CASE("Dither - at full scale the correction has nothing to correct") {
     }
 }
 
+// ---------------------------------------------------------------------------
+// The cadence half of #4156 R8, which is also what P8's temporal dither waits
+// on (#4042).
+//
+// R8 asks for "cadence, observation window, and unsupported low-light region"
+// to be defined. #4269 answered the black floor. This is the cadence, and it
+// turns out the two numbers that decide it disagree with each other by 4x.
+// ---------------------------------------------------------------------------
+
+FL_TEST_CASE("Dither - the cycle rate at the enable threshold is below the file's own floor") {
+    // The cycle length is *derived* from a cadence assumption:
+    //
+    //   MAX_LIKELY_UPDATE_RATE_HZ     400
+    //   MIN_ACCEPTABLE_DITHER_RATE_HZ  50
+    //   UPDATES_PER_FULL_DITHER_CYCLE  400 / 50 = 8
+    //
+    // So eight frames is the number that makes a 400 Hz refresh complete a
+    // cycle at 50 Hz. That is coherent.
+    //
+    // What enables dithering is not 400. `CFastLED::show()` and `showColor()`
+    // each carry `if (mNFPS < 100) { pCur->setDither(0); }` -- a bare literal,
+    // twice, with no reference to the constants above. At 100 FPS an
+    // eight-frame cycle completes at 12.5 Hz, which is a quarter of the
+    // file's own MIN_ACCEPTABLE_DITHER_RATE_HZ and sits near the peak of human
+    // flicker sensitivity.
+    //
+    // The guide above states two different 50 Hz conditions and the code
+    // implements the weaker one: "at refresh rates above ~50Hz, human vision
+    // integrates these variations" is about the *refresh*, while "8-frame
+    // cycle at 400Hz = 50Hz complete cycle" is about the *cycle*. What the eye
+    // integrates is the modulation, which is at the cycle rate.
+    //
+    // This case records the arithmetic rather than asserting the intent.
+    // Raising the threshold would disable dithering for most sketches, which
+    // is a decision and not a cleanup -- so if either number moves, this fails
+    // and whoever moved it writes down why.
+    FL_CHECK_EQ(UPDATES_PER_FULL_DITHER_CYCLE, 8);
+    FL_CHECK_EQ(MIN_ACCEPTABLE_DITHER_RATE_HZ, 50);
+    FL_CHECK_EQ(MAX_LIKELY_UPDATE_RATE_HZ, 400);
+
+    // The threshold `show()` actually applies, repeated here because it is a
+    // literal there rather than a named constant.
+    const int kDitherEnableFps = 100;
+    const int cycle_hz_at_threshold =
+        kDitherEnableFps / UPDATES_PER_FULL_DITHER_CYCLE;
+    FL_CHECK_EQ(cycle_hz_at_threshold, 12);  // 12.5, truncated
+
+    // Four times short, by the file's own floor.
+    FL_CHECK_LT(cycle_hz_at_threshold, MIN_ACCEPTABLE_DITHER_RATE_HZ);
+    FL_CHECK_EQ(MAX_LIKELY_UPDATE_RATE_HZ / kDitherEnableFps, 4);
+
+    // And the refresh that would actually reach the floor is the one the
+    // cycle length was derived from.
+    FL_CHECK_EQ(MIN_ACCEPTABLE_DITHER_RATE_HZ * UPDATES_PER_FULL_DITHER_CYCLE,
+                MAX_LIKELY_UPDATE_RATE_HZ);
+}
+
 } // FL_TEST_FILE

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -1,4 +1,5 @@
 #include "pixel_controller.h"
+#include "fl/math/math.h"
 #include "test.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
@@ -211,12 +212,18 @@ FL_TEST_CASE("Dither - the cycle rate at the enable threshold is below the file'
     // The threshold `show()` actually applies, repeated here because it is a
     // literal there rather than a named constant.
     const int kDitherEnableFps = 100;
-    const int cycle_hz_at_threshold =
-        kDitherEnableFps / UPDATES_PER_FULL_DITHER_CYCLE;
-    FL_CHECK_EQ(cycle_hz_at_threshold, 12);  // 12.5, truncated
+
+    // In floating point, because the number is 12.5 and the point of this
+    // case is to record the cadence rather than a rounded stand-in for it.
+    // An integer division here reports 12, which is a different claim.
+    const float cycle_hz_at_threshold =
+        static_cast<float>(kDitherEnableFps) /
+        static_cast<float>(UPDATES_PER_FULL_DITHER_CYCLE);
+    FL_CHECK_LT(fl::fabsf(cycle_hz_at_threshold - 12.5f), 1e-6f);
 
     // Four times short, by the file's own floor.
-    FL_CHECK_LT(cycle_hz_at_threshold, MIN_ACCEPTABLE_DITHER_RATE_HZ);
+    FL_CHECK_LT(cycle_hz_at_threshold,
+                static_cast<float>(MIN_ACCEPTABLE_DITHER_RATE_HZ));
     FL_CHECK_EQ(MAX_LIKELY_UPDATE_RATE_HZ / kDitherEnableFps, 4);
 
     // And the refresh that would actually reach the floor is the one the


### PR DESCRIPTION
Refs #4156 (R8), #4042.

R8 asks for *"cadence, observation window, and unsupported low-light region"* to be defined. #4269 answered the low-light region. This is the cadence — and the two constants that decide it disagree with each other by 4×.

## The cycle length is derived from a cadence assumption

In `src/pixel_controller.h`:

| | |
|---|---:|
| `MAX_LIKELY_UPDATE_RATE_HZ` | 400 |
| `MIN_ACCEPTABLE_DITHER_RATE_HZ` | 50 |
| `UPDATES_PER_FULL_DITHER_CYCLE` | 400 / 50 = **8** |

Eight frames is the number that makes a 400 Hz refresh complete a cycle at 50 Hz. That much is coherent.

## What enables dithering is not 400

`CFastLED::show()` and `showColor()` each carry:

```cpp
if (mNFPS < 100) { pCur->setDither(0); }
```

A bare literal, twice, with no reference to those constants. **At 100 FPS an eight-frame cycle completes at 12.5 Hz** — a quarter of the file's own floor, and near the peak of human flicker sensitivity rather than above it.

## Where the confusion comes from

The guide in that file states two different 50 Hz conditions, and the code implements the weaker one:

- *"At refresh rates above ~50Hz, human vision integrates these variations"* — about the **refresh**;
- *"8-frame cycle at 400Hz = 50Hz complete cycle"* — about the **cycle**.

What the eye integrates is the modulation, and the modulation is at the cycle rate.

## Recorded, not changed

Raising the threshold to 400 would disable dithering for most sketches — few reach 400 FPS — and that is a decision rather than a cleanup, so it is not made here. The case pins the arithmetic instead, so moving either number fails it and whoever moves it writes down why.

Worth having **before** a pipeline dither is built rather than after: #4280 measures such a dither reaching 0.0016 at 2% luminance, and reaching the bottom of the range means toggling the lowest codes — so the relative modulation depth is largest exactly where the eye is most sensitive to it.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on WS2812 temporal dithering cadence, including the eight-frame cycle and its relationship to refresh rates.
  - Documented the dither cycle rate at the 100 FPS enable threshold and compared it with the documented minimum rate.

- **Tests**
  - Updated coverage to calculate and verify dither-cycle arithmetic using floating-point precision and tolerance checks.
  - Added validation of the resulting cadence at the dithering enable threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->