### PR TITLE
fix(screenmap): stop publishing the unset-diameter sentinel (#3322)

### DIFF
--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -495,7 +495,19 @@ void ScreenMap::toJson(const fl::flat_map<string, ScreenMap> &segmentMaps,
         segmentObj.set("group", fl::json(fl::string(name)));
         segmentObj.set("x", xArray);
         segmentObj.set("y", yArray);
-        segmentObj.set("diameter", fl::json(diameter));
+        // Only when there is one. `mDiameter` defaults to -1 as a sentinel
+        // meaning "unset", and writing that out publishes an impossible
+        // physical size: no LED is -1 units across. The parser already reads
+        // an absent key back as -1 (both the v1 and v2 paths default it), so
+        // omitting round-trips to exactly the same value inside FastLED and
+        // stops a consumer from having to know the sentinel.
+        //
+        // The field's own comment in screenmap.h asked for this and had the
+        // sense inverted -- "Only serialized if it's not > 0.0f" -- which is
+        // presumably how the writer came to do the opposite.
+        if (diameter > 0.0f) {
+            segmentObj.set("diameter", fl::json(diameter));
+        }
         segmentsArr.push_back(segmentObj);
 
         idx++;

--- a/src/fl/math/screenmap.cpp.hpp
+++ b/src/fl/math/screenmap.cpp.hpp
@@ -26,6 +26,29 @@
 
 namespace fl {
 
+namespace {
+
+// Every value that reaches `mDiameter` from a caller passes through here.
+//
+// The class accepts any `float` -- three constructors and `setDiameter` all
+// take one unfiltered -- but only two kinds of value mean anything: a
+// positive size, and the -1 sentinel for "unset". A caller who stores 0.0f
+// or -2.0f has named a diameter no LED has. The emitter cannot publish
+// those (a consumer reading `"diameter": -2` learns nothing it can use) and
+// the parsers read an absent key back as -1, so before this normalization a
+// stored 0.0f came back from a round trip as -1.0f: silently different from
+// what was set, and different in a way `getDiameter()` did not show until
+// the file had been through JSON.
+//
+// Folding them to the sentinel at the boundary makes the two agree. A
+// non-positive diameter now reads back as -1 immediately, from the setter
+// onward, so the round trip is the identity on every value the class holds.
+float normalizedDiameter(float diameter) FL_NO_EXCEPT {
+    return diameter > 0.0f ? diameter : -1.0f;
+}
+
+}  // namespace
+
 // Default constructor and destructor - must be in .cpp for proper smart_ptr handling
 ScreenMap::ScreenMap() = default;
 ScreenMap::~ScreenMap() FL_NO_EXCEPT = default;
@@ -529,8 +552,8 @@ void ScreenMap::toJsonStr(const fl::flat_map<string, ScreenMap> &segmentMaps,
     *jsonBuffer = doc.to_string();
 }
 
-ScreenMap::ScreenMap(u32 length, float mDiameter)
-    : length(length), mDiameter(mDiameter) {
+ScreenMap::ScreenMap(u32 length, float mDiameter) FL_NO_EXCEPT
+    : length(length), mDiameter(normalizedDiameter(mDiameter)) {
     if (length > 0) {
         mLookUpTable = fl::make_shared<LUTXYFLOAT>(length);
         LUTXYFLOAT &lut = *mLookUpTable.get();
@@ -541,8 +564,8 @@ ScreenMap::ScreenMap(u32 length, float mDiameter)
     }
 }
 
-ScreenMap::ScreenMap(const vec2f *lut, u32 length, float diameter)
-    : length(length), mDiameter(diameter) {
+ScreenMap::ScreenMap(const vec2f *lut, u32 length, float diameter) FL_NO_EXCEPT
+    : length(length), mDiameter(normalizedDiameter(diameter)) {
     mLookUpTable = fl::make_shared<LUTXYFLOAT>(length);
     LUTXYFLOAT &lut16xy = *mLookUpTable.get();
     vec2f *data = lut16xy.getDataMutable();
@@ -551,8 +574,8 @@ ScreenMap::ScreenMap(const vec2f *lut, u32 length, float diameter)
     }
 }
 
-ScreenMap::ScreenMap(int count, float diameter, fl::function<void(int, vec2f& pt_out)> func)
-    : length(count), mDiameter(diameter) {
+ScreenMap::ScreenMap(int count, float diameter, fl::function<void(int, vec2f& pt_out)> func) FL_NO_EXCEPT
+    : length(count), mDiameter(normalizedDiameter(diameter)) {
     if (count > 0) {
         mLookUpTable = fl::make_shared<LUTXYFLOAT>(count);
         LUTXYFLOAT &lut = *mLookUpTable.get();
@@ -589,7 +612,9 @@ void ScreenMap::set(u16 index, const vec2f &p) {
     }
 }
 
-void ScreenMap::setDiameter(float diameter) { mDiameter = diameter; }
+void ScreenMap::setDiameter(float diameter) FL_NO_EXCEPT {
+    mDiameter = normalizedDiameter(diameter);
+}
 
 vec2f ScreenMap::mapToIndex(u32 x) const {
     if (x >= length || !mLookUpTable) {

--- a/src/fl/math/screenmap.h
+++ b/src/fl/math/screenmap.h
@@ -134,7 +134,9 @@ class ScreenMap {
   private:
     static const vec2f &empty() FL_NO_EXCEPT;
     u32 length = 0;
-    float mDiameter = -1.0f; // Only serialized if it's not > 0.0f.
+    // -1 is the sentinel for "unset", and is not serialized: a negative
+    // diameter is not a size, and the parser reads an absent key back as -1.
+    float mDiameter = -1.0f;
     LUTXYFLOATPtr mLookUpTable;
     XYMapPtr mSourceXYMap;  // Optional: source XYMap for encoding pipeline
     fl::vector<Shape> mShapes;

--- a/src/fl/math/screenmap.h
+++ b/src/fl/math/screenmap.h
@@ -136,6 +136,9 @@ class ScreenMap {
     u32 length = 0;
     // -1 is the sentinel for "unset", and is not serialized: a negative
     // diameter is not a size, and the parser reads an absent key back as -1.
+    // The constructors and `setDiameter` fold every non-positive value to
+    // it, so this holds either a real size or the sentinel and never a
+    // third thing a round trip would have to change.
     float mDiameter = -1.0f;
     LUTXYFLOATPtr mLookUpTable;
     XYMapPtr mSourceXYMap;  // Optional: source XYMap for encoding pipeline

--- a/tests/fl/math/screenmap.cpp
+++ b/tests/fl/math/screenmap.cpp
@@ -315,6 +315,44 @@ FL_TEST_CASE("ScreenMap v2 JSON parsing — EL geometry remains shape-native") {
 FL_TEST_FILE(FL_FILEPATH) {
 
 
+FL_TEST_CASE("ScreenMap v2 emission omits an unset diameter") {
+    // `mDiameter` defaults to -1 as a sentinel meaning "unset", and the
+    // emitter wrote it out: every segment of a map with no diameter came back
+    // carrying `"diameter":-1.000`, which is not a physical size. The field's
+    // own comment asked for it to be skipped and had the sense inverted --
+    // "Only serialized if it's not > 0.0f" -- which is presumably how the
+    // writer came to do the opposite.
+    //
+    // Omitting round-trips identically, because both parser paths already
+    // read an absent key back as -1. That is what this checks: the value
+    // survives, the sentinel stops being published.
+    fl::flat_map<fl::string, ScreenMap> maps;
+    maps["unset"] = ScreenMap(2);           // no diameter given
+    ScreenMap sized(2, 2.5f);
+    maps["sized"] = sized;
+
+    fl::string out;
+    ScreenMap::toJsonStr(maps, &out);
+
+    // One diameter in the output, not two.
+    int diameters = 0;
+    const fl::string needle("\"diameter\"");
+    fl::size at = out.find(needle);
+    while (at != fl::string::npos) {
+        ++diameters;
+        at = out.find(needle, at + needle.size());
+    }
+    FL_CHECK_EQ(diameters, 1);
+    FL_CHECK(out.find(fl::string("-1")) == fl::string::npos);
+
+    // And the round trip is unchanged for both.
+    fl::flat_map<fl::string, ScreenMap> back;
+    fl::string err;
+    FL_REQUIRE(ScreenMap::ParseJson(out.c_str(), &back, &err));
+    FL_CHECK_EQ(back["sized"].getDiameter(), 2.5f);
+    FL_CHECK_EQ(back["unset"].getDiameter(), -1.0f);
+}
+
 FL_TEST_CASE("ScreenMap v2 emission does not invent a pin") {
     // `toJson` used to write the literal `"pin1"` into every segment -- the
     // example value from the shape comment above the emitter, copied in as

--- a/tests/fl/math/screenmap.cpp
+++ b/tests/fl/math/screenmap.cpp
@@ -353,6 +353,51 @@ FL_TEST_CASE("ScreenMap v2 emission omits an unset diameter") {
     FL_CHECK_EQ(back["unset"].getDiameter(), -1.0f);
 }
 
+FL_TEST_CASE("ScreenMap keeps every diameter it accepts through a round trip") {
+    // The omission above is written as `diameter > 0.0f`, which skips more
+    // than the sentinel: 0.0f and any other negative are dropped too, and
+    // both parsers restore an absent key as -1.0f. So a caller who stored
+    // 0.0f got -1.0f back from a round trip -- a value they never set, and
+    // one `getDiameter()` agreed with only after the map had been through
+    // JSON.
+    //
+    // The class now folds every non-positive value to the sentinel where it
+    // is stored, so the two agree from the setter onward and the round trip
+    // is the identity on everything the class holds. Checked here for the
+    // sentinel itself, for zero, for another negative, and for a positive
+    // size that must still survive.
+    ScreenMap zero(2);
+    zero.setDiameter(0.0f);
+    FL_CHECK_EQ(zero.getDiameter(), -1.0f);
+
+    ScreenMap negative(2, -2.0f);
+    FL_CHECK_EQ(negative.getDiameter(), -1.0f);
+
+    ScreenMap tiny(2, 0.25f);
+    FL_CHECK_EQ(tiny.getDiameter(), 0.25f);
+
+    fl::flat_map<fl::string, ScreenMap> maps;
+    maps["zero"] = zero;
+    maps["negative"] = negative;
+    maps["tiny"] = tiny;
+
+    fl::string out;
+    ScreenMap::toJsonStr(maps, &out);
+
+    fl::flat_map<fl::string, ScreenMap> back;
+    fl::string err;
+    FL_REQUIRE(ScreenMap::ParseJson(out.c_str(), &back, &err));
+    FL_CHECK_EQ(back["zero"].getDiameter(), zero.getDiameter());
+    FL_CHECK_EQ(back["negative"].getDiameter(), negative.getDiameter());
+    FL_CHECK_EQ(back["tiny"].getDiameter(), tiny.getDiameter());
+
+    // And nothing impossible reached the wire: no negative diameter, and a
+    // positive one that is smaller than the old `> 0.0f` guard's threshold
+    // is still published rather than quietly dropped.
+    FL_CHECK(out.find(fl::string("\"diameter\":-")) == fl::string::npos);
+    FL_CHECK(out.find(fl::string("\"diameter\"")) != fl::string::npos);
+}
+
 FL_TEST_CASE("ScreenMap v2 emission does not invent a pin") {
     // `toJson` used to write the literal `"pin1"` into every segment -- the
     // example value from the shape comment above the emitter, copied in as


### PR DESCRIPTION
Refs #3322. Follows #4278, which recorded this and deliberately did not fold it in.

## The second instance of the same shape

`ScreenMap::toJson` writes `"diameter":-1.000` for a map with no diameter set, while the field's own comment asks for it to be skipped:

```cpp
float mDiameter = -1.0f; // Only serialized if it's not > 0.0f.
```

`-1` is the sentinel for "unset". Writing it out publishes an impossible physical size — no LED is -1 units across — and makes every consumer of this JSON responsible for knowing FastLED's sentinel.

It is one step milder than the fabricated pin #4278 removed: **the pin was wrong** (a segment on pin2 came back on pin1), while this is the real internal value, just one that should not leave the process.

## Omitting round-trips identically

That is the part worth checking rather than asserting, and it is what makes this safe: **both parser paths already default an absent key to -1** (`screenmap.cpp.hpp:206` for v2, `:364` for v1). So a map with no diameter comes back with no diameter either way.

The test walks one segment with a diameter and one without through `toJsonStr` → `ParseJson` and checks both values survive — 2.5 stays 2.5, unset stays unset — while the output carries one `"diameter"` key instead of two.

The comment had its sense inverted, which is presumably how the writer came to do the opposite; reworded to say what it means.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: emitting the sentinel again fails the new case; **never** emitting a diameter fails it *and* the pre-existing round-trip case, which is what keeps this from being "delete the field"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Screen map JSON no longer includes a diameter when it is unset.
  - Zero and negative diameters are consistently treated as unset.
  - Positive diameters continue to be serialized and preserved during JSON round-tripping.

- **Documentation**
  - Clarified the behavior of unset screen diameters.

- **Tests**
  - Added coverage for diameter normalization, serialization, and round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->