### PR TITLE
fix(color): the interval clamp must walk down to the edge, not jump (#4041)

### DIFF
--- a/docs/color-gamut-algorithm-selection.md
+++ b/docs/color-gamut-algorithm-selection.md
@@ -843,6 +843,29 @@ reproduces the table above:
 | L 1.398, hue 300, C 0.30 | 1.3978, 0.4431 |
 | L 1.398, hue 120, C 0.50 | 1.1182, 0.0000 |
 
+**The fallback had to walk, not jump.** The first version of this dropped
+straight to the neutral cap when the probes stopped landing inside the
+interval -- so the answer tracked the requested lightness up to the edge of
+the reachable region and then fell back to the cap in one step. Swept along
+hue 300 at chroma 0.10 that step measured 0.91 in summed drive, **234 eight-bit
+codes**, against the roughly one code the mapper's other paths stay inside.
+Before #4245 the same sweep was flat above the cap and therefore continuous,
+so this was a regression introduced by the fix.
+
+Bisecting lightness down to the highest reachable one instead lands on the
+edge rather than past it. Worst step over the same sweeps:
+
+| chroma | worst step |
+| --- | ---: |
+| 0.02 | 1 code |
+| 0.05 | 1 code |
+| 0.10 | 2 codes |
+| 0.20 | 3 codes |
+| 0.30 | 3 codes |
+
+It costs `kGamutMapHalvings * kGamutMapProbes` more feasibility tests, and only
+on an above-cap target whose interval was not found at its own lightness.
+
 **One deliberate difference from the harness.** The study probes to an
 absolute `PROBE_CEILING = 0.8`; the mapper works in factors of the request and
 reaches four times it. Both reproduce every row above, and they differ only on

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -237,6 +237,42 @@ bool feasibleChromaInterval(const i32 (&lab)[3], i32 lightness,
     return true;
 }
 
+/// The highest lightness at or below `requested` whose feasible chroma
+/// interval the probe scan can still find.
+///
+/// Without this the mapper is discontinuous at the top of the reachable
+/// region, and badly: holding the requested lightness works until the probes
+/// stop landing inside the interval, and the fallback then drops all the way
+/// to the neutral cap. Swept along a fixed hue at chroma 0.10 that step
+/// measured 0.91 in summed drive -- 234 eight-bit codes, against the ~1 code
+/// the rest of the mapper's paths stay inside.
+///
+/// Bisecting instead lands on the edge of the region rather than jumping past
+/// it, so the answer walks down continuously as the target rises. The neutral
+/// cap is the low end of the bracket because chroma zero is feasible there by
+/// construction, which is the invariant the search needs.
+///
+/// Costs `kGamutMapHalvings * kGamutMapProbes` feasibility tests, and only on
+/// an above-cap target whose interval was not found at its own lightness.
+template <typename Feasible>
+i32 highestReachableLightness(const i32 (&lab)[3], i32 cap, i32 requested,
+                              Feasible feasible) FL_NO_EXCEPT {
+    i32 low = cap;       // feasible: chroma zero is reachable at the cap
+    i32 high = requested; // not feasible, or the caller would not be here
+    for (int step = 0; step < kGamutMapHalvings; ++step) {
+        const i32 middle = low + ((high - low) >> 1);
+        i32 unused_low = 0;
+        i32 unused_high = 0;
+        if (feasibleChromaInterval(lab, middle, feasible, &unused_low,
+                                   &unused_high)) {
+            low = middle;
+        } else {
+            high = middle;
+        }
+    }
+    return low;
+}
+
 /// The target's chroma clamped into `[low, high]`, in factor space.
 i32 clampChromaFactor(i32 low, i32 high) FL_NO_EXCEPT {
     i32 factor = kGamutFullDrive;
@@ -350,8 +386,33 @@ void mapAndSolveDrivesQ16(const GamutMapQ16& map, const i32 (&xyz)[3],
                 return;
             }
         }
-        // No seed, or the accepted candidate fell outside on the re-solve.
-        // Fall through to the clamp, which is what shipped before this.
+        // No seed at this lightness. Walking down to the highest lightness
+        // that still has one keeps the answer continuous; dropping straight
+        // to the neutral cap does not, and that step measured 234 eight-bit
+        // codes before this search was added.
+        const i32 reachable = highestReachableLightness(
+            lab, map.max_neutral_lightness, lightness, RgbFeasible{map.solve});
+        i32 edge_low = 0;
+        i32 edge_high = 0;
+        if (reachable > map.max_neutral_lightness &&
+            feasibleChromaInterval(lab, reachable, RgbFeasible{map.solve},
+                                   &edge_low, &edge_high)) {
+            i32 candidate_xyz[3];
+            chromaCandidateXyz(lab, reachable,
+                               clampChromaFactor(edge_low, edge_high),
+                               candidate_xyz);
+            i32 candidate[3];
+            solveRgbDrivesQ16(map.solve, candidate_xyz, candidate);
+            if (gamutDrivesAreInRange(candidate, kGamutFeasibilitySlack)) {
+                for (int i = 0; i < 3; ++i) {
+                    drives[i] = candidate[i];
+                }
+                clampGamutDrives(drives);
+                return;
+            }
+        }
+        // Nothing above the cap works for this hue at all. Fall through to
+        // the clamp, which is what shipped before #4245.
         lightness = map.max_neutral_lightness;
     }
 
@@ -498,6 +559,24 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
             chromaCandidateXyz(lab, lightness, clampChromaFactor(low_edge, high_edge),
                                candidate_xyz);
             if (allocateEmitterDrivesQ16(map.allocation, candidate_xyz, drives)) {
+                return;
+            }
+        }
+
+        // Same walk-down as the RGB path: dropping straight to the cap when
+        // the probes stop landing is a step, not a mapping.
+        const i32 reachable = highestReachableLightness(
+            lab, map.max_neutral_lightness, lightness,
+            RgbwFeasible{map.allocation});
+        i32 edge_low = 0;
+        i32 edge_high = 0;
+        if (reachable > map.max_neutral_lightness &&
+            feasibleChromaInterval(lab, reachable, RgbwFeasible{map.allocation},
+                                   &edge_low, &edge_high)) {
+            i32 edge_xyz[3];
+            chromaCandidateXyz(lab, reachable,
+                               clampChromaFactor(edge_low, edge_high), edge_xyz);
+            if (allocateEmitterDrivesQ16(map.allocation, edge_xyz, drives)) {
                 return;
             }
         }
@@ -661,6 +740,24 @@ void mapAndAllocateRgbwwQ16(const GamutMapRgbwwQ16& map, const i32 (&xyz)[3],
             chromaCandidateXyz(lab, lightness, clampChromaFactor(low_edge, high_edge),
                                candidate_xyz);
             if (allocateTwoWhiteDrivesQ16(map.allocation, candidate_xyz, drives)) {
+                return;
+            }
+        }
+
+        // Same walk-down as the RGB path: dropping straight to the cap when
+        // the probes stop landing is a step, not a mapping.
+        const i32 reachable = highestReachableLightness(
+            lab, map.max_neutral_lightness, lightness,
+            RgbwwFeasible{map.allocation});
+        i32 edge_low = 0;
+        i32 edge_high = 0;
+        if (reachable > map.max_neutral_lightness &&
+            feasibleChromaInterval(lab, reachable, RgbwwFeasible{map.allocation},
+                                   &edge_low, &edge_high)) {
+            i32 edge_xyz[3];
+            chromaCandidateXyz(lab, reachable,
+                               clampChromaFactor(edge_low, edge_high), edge_xyz);
+            if (allocateTwoWhiteDrivesQ16(map.allocation, edge_xyz, drives)) {
                 return;
             }
         }

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,1 +1,14 @@
-342177
+# 2026-09-10, PR #4283 (issue #4041): +1 B, 342177 -> 342178.
+#
+# The continuity fix adds highestReachableLightness to the gamut mappers,
+# which walk down to the highest reachable lightness instead of dropping to
+# the neutral cap. None of that code links into the NEOPIXEL Blink sketch
+# this gate builds: no gamut or colour-pipeline symbol appears anywhere in
+# the run's top-25 symbol table (largest entries are fl::ClocklessIdf5<...>
+# at 45,342 B, the libc printf family, and fl::Channel::showPixels at
+# 3,296 B). The byte is layout drift, not a feature cost.
+#
+# Attribution was checked rather than assumed: master's last three runs and
+# the concurrent PR #4282 all measure 342,177 B, so the byte arrived with
+# this branch.
+342178

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1574,7 +1574,13 @@ FL_TEST_CASE("RGBW walks down to what it can reach, not to its cap") {
 
     i32 emitted[3];
     emittedLabWide<4>(drives, kWhiteD65, kWhiteD65, emitted);
-    FL_CHECK_GE(toFloat(emitted[0]), cap - 0.02f);
+    // Materially above the cap, not merely at it. The old fallback dropped
+    // straight to the cap and would satisfy any `>= cap - epsilon` floor, so
+    // that form of the assertion held with the walk-down deleted. Measured
+    // here the walk-down clears the cap by 0.22; the 0.10 bound is half of
+    // that, far enough above the noise to be a real claim and far enough
+    // below the measurement not to pin the search's exact resolution.
+    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.10f);
     FL_CHECK_LT(toFloat(emitted[0]), requested);
 
     // And asking for more gives the same answer, which is what "walks down to
@@ -1643,7 +1649,10 @@ FL_TEST_CASE("RGBWW walks down to what it can reach, not to its cap") {
 
     i32 emitted[3];
     emittedLabWide<5>(drives, kWhiteD65, kWhiteD50Map, emitted);
-    FL_CHECK_GE(toFloat(emitted[0]), cap - 0.02f);
+    // Same bound, same reason, on the two-white path: measured 0.21 above
+    // the cap here, so `cap + 0.10f` separates the walk-down from the
+    // direct-to-cap fallback it replaced.
+    FL_CHECK_GT(toFloat(emitted[0]), cap + 0.10f);
     FL_CHECK_LT(toFloat(emitted[0]), requested);
 
     const i32 higher[3] = {q16(requested + 0.20f), q16(0.05f), q16(-0.0866025f)};

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1547,16 +1547,20 @@ FL_TEST_CASE("RGBW keeps the lightness above its own, higher cap") {
     FL_CHECK_LT(hueDivergence(lab, emitted), 0.01f);
 }
 
-FL_TEST_CASE("RGBW falls back to its cap when no chroma is feasible there") {
+FL_TEST_CASE("RGBW walks down to what it can reach, not to its cap") {
     // The other half of the contract, and the one that keeps this from ever
-    // being worse: a lightness far past what any hue can reach must still
-    // come back clamped rather than wrong.
+    // being worse. It used to assert the answer landed *at* the cap, which
+    // was the old fallback -- dropping straight there is what made the mapper
+    // step by 234 eight-bit codes at the top of the reachable region on the
+    // RGB path. The answer now walks down to the highest lightness that is
+    // still reachable, so it is at or above the cap and below what was asked.
     GamutMapRgbwQ16 rgbw;
     FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
                                      WhiteAllocationPolicy::WhitePreferred, &rgbw));
     const float cap = toFloat(rgbw.max_neutral_lightness);
+    const float requested = cap + 0.60f;
 
-    const i32 lab[3] = {q16(cap + 0.60f), q16(0.05f), q16(-0.0866025f)};
+    const i32 lab[3] = {q16(requested), q16(0.05f), q16(-0.0866025f)};
     i32 xyz[3];
     oklabToXyzQ16(lab, xyz);
     i32 drives[4];
@@ -1570,7 +1574,20 @@ FL_TEST_CASE("RGBW falls back to its cap when no chroma is feasible there") {
 
     i32 emitted[3];
     emittedLabWide<4>(drives, kWhiteD65, kWhiteD65, emitted);
-    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - cap), 0.02f);
+    FL_CHECK_GE(toFloat(emitted[0]), cap - 0.02f);
+    FL_CHECK_LT(toFloat(emitted[0]), requested);
+
+    // And asking for more gives the same answer, which is what "walks down to
+    // the edge" means and what a step past it would break.
+    const i32 higher[3] = {q16(requested + 0.20f), q16(0.05f), q16(-0.0866025f)};
+    i32 higher_xyz[3];
+    oklabToXyzQ16(higher, higher_xyz);
+    i32 higher_drives[4];
+    mapAndAllocateRgbwQ16(rgbw, higher_xyz, higher_drives);
+    i32 higher_emitted[3];
+    emittedLabWide<4>(higher_drives, kWhiteD65, kWhiteD65, higher_emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(higher_emitted[0]) - toFloat(emitted[0])),
+                0.02f);
 }
 
 FL_TEST_CASE("RGBWW keeps the lightness above its own cap") {
@@ -1604,14 +1621,15 @@ FL_TEST_CASE("RGBWW keeps the lightness above its own cap") {
     FL_CHECK_LT(hueDivergence(lab, emitted), 0.01f);
 }
 
-FL_TEST_CASE("RGBWW falls back to its cap when no chroma is feasible there") {
+FL_TEST_CASE("RGBWW walks down to what it can reach, not to its cap") {
     GamutMapRgbwwQ16 map;
     FL_REQUIRE(buildGamutMapRgbwwQ16(rgbDevice(), kWhiteD65, kWhiteD50Map,
                                      WhiteAllocationPolicy::WhitePreferred,
                                      &map));
     const float cap = toFloat(map.max_neutral_lightness);
 
-    const i32 lab[3] = {q16(cap + 0.60f), q16(0.05f), q16(-0.0866025f)};
+    const float requested = cap + 0.60f;
+    const i32 lab[3] = {q16(requested), q16(0.05f), q16(-0.0866025f)};
     i32 xyz[3];
     oklabToXyzQ16(lab, xyz);
     i32 drives[5];
@@ -1625,7 +1643,84 @@ FL_TEST_CASE("RGBWW falls back to its cap when no chroma is feasible there") {
 
     i32 emitted[3];
     emittedLabWide<5>(drives, kWhiteD65, kWhiteD50Map, emitted);
-    FL_CHECK_LT(fl::fabsf(toFloat(emitted[0]) - cap), 0.02f);
+    FL_CHECK_GE(toFloat(emitted[0]), cap - 0.02f);
+    FL_CHECK_LT(toFloat(emitted[0]), requested);
+
+    const i32 higher[3] = {q16(requested + 0.20f), q16(0.05f), q16(-0.0866025f)};
+    i32 higher_xyz[3];
+    oklabToXyzQ16(higher, higher_xyz);
+    i32 higher_drives[5];
+    mapAndAllocateRgbwwQ16(map, higher_xyz, higher_drives);
+    i32 higher_emitted[3];
+    emittedLabWide<5>(higher_drives, kWhiteD65, kWhiteD50Map, higher_emitted);
+    FL_CHECK_LT(fl::fabsf(toFloat(higher_emitted[0]) - toFloat(emitted[0])),
+                0.02f);
+}
+
+FL_TEST_CASE("Crossing the cap does not step") {
+    // The defect #4271 introduced, and the reason the walk-down exists.
+    //
+    // Before that change every above-cap target clamped to the neutral cap,
+    // so a rising ramp went flat there: continuous, if dim. #4271 made the
+    // answer track the requested lightness while a feasible chroma interval
+    // could be found -- and then drop all the way back to the cap when the
+    // probes stopped landing. Swept along hue 300 at chroma 0.10 that step
+    // measured 0.91 in summed drive, **234 eight-bit codes**, against the
+    // ~1 code the mapper's other paths stay inside.
+    //
+    // Walking down to the highest reachable lightness instead lands on the
+    // edge of the region rather than past it. Worst step over the same
+    // sweeps, at the shipped eight halvings and eight probes:
+    //
+    //   chroma 0.02   1 code
+    //   chroma 0.05   1 code
+    //   chroma 0.10   2 codes
+    //   chroma 0.20   3 codes
+    //   chroma 0.30   3 codes
+    //
+    // The bound below is in drive units, and 0.02 is about five 8-bit codes:
+    // loose enough not to pin the search's exact resolution, tight enough
+    // that the 0.91 step could never pass it.
+    GamutMapQ16 map;
+    FL_REQUIRE(buildGamutMapQ16(rgbDevice(), &map));
+    const float cap = toFloat(map.max_neutral_lightness);
+
+    for (float chroma : {0.02f, 0.05f, 0.10f, 0.20f, 0.30f}) {
+        const float a = chroma * 0.5f;
+        const float b = chroma * -0.8660254f;
+        i32 previous[3] = {0, 0, 0};
+        float worst = 0.0f;
+        int above_cap = 0;
+        const int steps = 4000;
+        for (int step = 0; step <= steps; ++step) {
+            const float t = static_cast<float>(step) / steps;
+            const float lightness = cap - 0.10f + t * 0.40f;
+            if (lightness > cap) {
+                ++above_cap;
+            }
+            const i32 lab[3] = {q16(lightness), q16(a), q16(b)};
+            i32 xyz[3];
+            oklabToXyzQ16(lab, xyz);
+            i32 drives[3];
+            mapAndSolveDrivesQ16(map, xyz, drives);
+            if (step > 0) {
+                float jump = 0.0f;
+                for (int i = 0; i < 3; ++i) {
+                    jump += fl::fabsf(toFloat(drives[i] - previous[i]));
+                }
+                if (jump > worst) {
+                    worst = jump;
+                }
+            }
+            for (int i = 0; i < 3; ++i) {
+                previous[i] = drives[i];
+            }
+        }
+        // The sweep has to actually spend time above the cap, or it is
+        // measuring the ordinary path and saying nothing about this one.
+        FL_CHECK_GT(above_cap, steps / 4);
+        FL_CHECK_LT(worst, 0.02f);
+    }
 }
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Refs #4041 (P7), #4245.

**A regression I introduced in #4245**, found by checking my own change against P7's acceptance criterion rather than against the tests I wrote for it.

## What broke

#4041 asks that out-of-gamut mapping be continuous. Before #4245, every above-cap target clamped to the neutral cap, so a rising lightness ramp went flat there — continuous, if dim. #4245 made the answer track the requested lightness while a feasible chroma interval could be found, and then drop **all the way back to the cap** the moment the probes stopped landing.

Swept along hue 300 at chroma 0.10:

| requested L | emitted L | chroma | drives |
|---|---|---|---|
| 1.360 | 1.360 | 0.40 | 0.71, 1.00, 0.57 |
| 1.365 | **1.118** | **0.10** | **0.32, 0.89, 0.16** |

0.91 in summed drive — **234 eight-bit codes**. The continuity case in this file measures its worst boundary crossing at 0.80 codes and reasons explicitly about staying under one.

## The fix

The fallback now bisects lightness down to the highest one whose interval the probes can still find, so the answer lands on the *edge* of the reachable region rather than past it. Worst step over the same sweeps:

| chroma | worst step |
|---|---:|
| 0.02 | 1 code |
| 0.05 | 1 code |
| 0.10 | 2 codes |
| 0.20 | 3 codes |
| 0.30 | 3 codes |

The neutral cap is the low end of the bracket because chroma zero is feasible there by construction — that is the invariant the search needs. Cost is `kGamutMapHalvings * kGamutMapProbes` more feasibility tests, on an above-cap target whose interval was not found at its own lightness and nowhere else, so A3/B11 still hold.

Applied to all three mappers, since all three carried the same fallback.

## The two wide tests changed on purpose

"RGBW/RGBWW falls back to its cap" asserted the old behaviour. They now assert the new contract: the answer is at or above the cap, **below what was asked**, and **unchanged when the request goes higher still** — which is what "walks down to the edge" means and what a step past it would break.

## Verification

- `bash test --cpp` — 299/299 unit, 84/84 examples
- `bash lint` — 0 errors
- Mutation-tested: restoring the jump to the cap, and bracketing the walk-down at the requested lightness so it cannot walk, each fail the continuity case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color gamut mapping for above-cap colors by selecting the highest reachable lightness instead of falling directly to the neutral cap.
  * Reduced visible brightness jumps and improved continuity across gamut boundaries, including RGBW and RGBWW output paths.

* **Tests**
  * Strengthened coverage for smooth transitions across the cap and consistent results when requested lightness exceeds the reachable range.

* **Documentation**
  * Documented the updated fallback behavior and its impact on color transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->