### PR TITLE
fix(power): charge an RGBW strip for the diode it lights (#4156 R3)

### DIFF
--- a/docs/color-pipeline-contracts.md
+++ b/docs/color-pipeline-contracts.md
@@ -170,6 +170,51 @@ unmodeled internal PWM transients or replace electrical supply protection.
 Nonlinear electrical models require a bounded/conservative scalar solution;
 assuming watts proportional to XYZ Y is not supported.
 
+### The legacy estimator's emitter count
+
+"Aggregated with their respective electrical models" is not free wording. The
+legacy estimator walks the source `CRGB` array, which is what the sketch
+wrote, not what the strip is driven with. A controller in RGBW mode converts
+every pixel with `rgb_2_rgbw` before latching, and the resulting four drives
+are neither bounded by nor proportional to the source triple.
+
+Measured on 300 pixels of source white with the shipped default
+`PowerModelRGBW` (r90 g70 b90 w100 dark5), in milliwatts:
+
+| RGBW mode | source triple | four emitters | |
+|---|---|---|---|
+| `kRGBWMaxBrightness` | 76,205 | 106,086 | source triple is **28% under** |
+| `kRGBWBoostedWhite` | 76,205 | 81,470 | **6.5% under** |
+| `kRGBWExactColors` | 76,205 | 30,485 | **150% over** |
+
+The first two are budget under-spent against; the third is a strip dimmed for
+no reason. `set_power_model(const PowerModelRGBW&)` compounded it by routing
+through `toRGB()`, which dropped `white_mW`: the API accepted the figure and
+discarded it, so the fourth diode could not have been charged even in
+principle. The estimator now runs the same conversion the encoder will and
+charges all four emitters.
+
+Two boundaries this leaves in place, both deliberate:
+
+- **Demand is still projected linearly in brightness.** The estimator reports
+  demand at full brightness and the limiter scales it. That commutes with
+  `kRGBWExactColors` and `kRGBWMaxBrightness` to within 0.4% over the measured
+  cases, but not with `kRGBWBoostedWhite`, which reallocates between emitters
+  as the scale falls: demand there runs up to **12.1% above** the linear
+  projection at low brightness. Closing it means evaluating demand per
+  candidate brightness, which is a pixel walk per step of the limiter's
+  search. Charging four emitters instead of three is the larger correction by
+  a wide margin; the residual is recorded rather than folded into the claim.
+- **RGBWW still folds.** `PowerModelRGBWW::toRGB()` spreads its two white
+  emitters across R/G/B rather than dropping them, which over-estimates and
+  so cannot break a budget. A five-emitter accounting needs the RGBWW
+  allocation the way the RGBW path needs `rgb_2_rgbw`.
+
+A controller in RGBW mode under a model that declares no white emitter is
+diagnosed once rather than guessed at. There is no basis for a fourth
+emitter's draw in a three-emitter declaration, and inventing one is the shape
+of the defect this replaced.
+
 ### Fidelity accounting
 
 Report three distinct errors:

--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -474,9 +474,12 @@ fl::u32 CFastLED::getEstimatedPowerInMilliWatts(bool apply_limiter) const {
 	// The dark-current baseline is kept apart from the part brightness scales,
 	// because it is drawn at every brightness including zero (#4156 R4).
 	const fl::u32 dark_mW_per_led = get_power_model().dark_mW;
-	CLEDController::visitControllers([&](const CLEDController* /*controller*/, fl::span<const CRGB> leds) {
+	CLEDController::visitControllers([&](const CLEDController* controller, fl::span<const CRGB> leds) {
 		if (!leds.empty()) {
-			const fl::u32 unscaled_mW = calculate_unscaled_power_mW(leds);
+			// Through the controller's own RGBW setting, so an RGBW strip is
+			// charged for the diode it actually lights (#4156 R3).
+			const fl::u32 unscaled_mW =
+			    calculate_unscaled_power_mW(leds, controller->getRgbw());
 			const fl::u32 dark_mW = dark_mW_per_led * static_cast<fl::u32>(leds.size());
 			fixed_power_mW += dark_mW;
 			controllable_power_mW += unscaled_mW > dark_mW ? unscaled_mW - dark_mW : 0;

--- a/src/power_mgt.cpp.hpp
+++ b/src/power_mgt.cpp.hpp
@@ -14,6 +14,7 @@
 #include "fl/stl/int.h"           // fl::u32, fl::u8
 #include "power_mgt.h"        // Function declarations (to avoid redefinition errors)
 #include "fl/stl/singleton.h"    // fl::Singleton
+#include "fl/gfx/rgbw.h"     // fl::Rgbw, fl::rgb_2_rgbw
 // POWER MANAGEMENT
 
 /// @name Power Usage Values
@@ -41,6 +42,23 @@ static constexpr float kPowerScalingExponentEpsilon = 0.0001f;
 /// Global RGB power model (initialized to WS2812 @ 5V defaults, linear response)
 static PowerModelRGB& gPowerModel() {
     return fl::Singleton<PowerModelRGB>::instance();
+}
+
+/// The white emitter's draw, when the caller declared one.
+///
+/// Kept beside the RGB model rather than inside it because it applies to a
+/// controller only when that controller is in RGBW mode -- the same model
+/// serves plain RGB strips on the same sketch, and they have no white diode
+/// to charge for.
+///
+/// Zero means "not declared". That reading is available because zero is not
+/// a draw any emitter has, so it cannot collide with a real declaration.
+struct WhiteEmitterPower {
+    fl::u8 mW;
+};
+
+static WhiteEmitterPower& gWhiteEmitterPower() {
+    return fl::Singleton<WhiteEmitterPower>::instance();
 }
 
 #if SKETCH_HAS_LARGE_MEMORY
@@ -184,6 +202,70 @@ fl::u32 calculate_unscaled_power_mW( const CRGB* ledbuffer, fl::u16 numLeds ) //
     return calculate_unscaled_power_mW(fl::span<const CRGB>(ledbuffer, numLeds));
 }
 
+// Four emitters, using the conversion the encoder will actually run.
+//
+// The three-emitter overload reads the source triple the sketch wrote. For an
+// RGBW controller that triple is an input to `rgb_2_rgbw`, not a description
+// of the drives, and the two disagree by more than rounding: at full white on
+// the shipped default model the source triple reads 249 while the strip draws
+// 348 under `kRGBWMaxBrightness` and 99 under `kRGBWExactColors`. #4156 R3.
+//
+// Scales are passed as 255 because this is the demand at full brightness --
+// the caller scales the result. That is exact for `kRGBWExactColors` and
+// `kRGBWMaxBrightness`, whose conversions commute with the scale to within
+// 0.4% over the measured cases. It is not exact for `kRGBWBoostedWhite`,
+// which reallocates between emitters as the scale drops: demand there runs up
+// to 12.1% above the linear projection at low brightness. Charging four
+// emitters instead of three is the larger correction by far, and the residual
+// is stated rather than hidden -- closing it needs demand evaluated per
+// candidate brightness, which is a pixel walk per step of the limiter's
+// search.
+fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds, const fl::Rgbw& rgbw) {
+    const fl::u8 white_mW = gWhiteEmitterPower().mW;
+    // `!rgbw.active()` is a fast path, not a different answer: the only
+    // inactive mode is `kRGBWInvalid`, which `rgb_2_rgbw` dispatches to
+    // null-white -- RGB passed through with w = 0 -- so the loop below would
+    // return the same total. Removing the test changes nothing observable
+    // and costs one conversion per pixel on every plain RGB controller in
+    // the sketch, which the estimator walks once per frame.
+    //
+    // The `white_mW == 0` half *is* behavioural: with no declared white
+    // there is nothing to charge the fourth diode at.
+    if (!rgbw.active() || white_mW == 0) {
+        if (rgbw.active()) {
+            FL_WARN_F_ONCE("power: controller is in RGBW mode but the power model "
+                         "declares no white emitter, so the budget covers three "
+                         "of its four diodes. Call "
+                         "FastLED.setPowerModel(PowerModelRGBW(...)) to fix it.");
+        }
+        return calculate_unscaled_power_mW(leds);
+    }
+
+    fl::u32 red32 = 0, green32 = 0, blue32 = 0, white32 = 0;
+    for (fl::size i = 0; i < leds.size(); i++) {
+        fl::u8 r = 0, g = 0, b = 0, w = 0;
+        fl::rgb_2_rgbw(rgbw, leds[i].r, leds[i].g, leds[i].b, 255, 255, 255,
+                       &r, &g, &b, &w);
+        red32   += map_power_value(r);
+        green32 += map_power_value(g);
+        blue32  += map_power_value(b);
+        white32 += map_power_value(w);
+    }
+
+    red32   *= gPowerModel().red_mW;
+    green32 *= gPowerModel().green_mW;
+    blue32  *= gPowerModel().blue_mW;
+    white32 *= white_mW;
+
+    red32   >>= 8;
+    green32 >>= 8;
+    blue32  >>= 8;
+    white32 >>= 8;
+
+    return red32 + green32 + blue32 + white32 +
+           (gPowerModel().dark_mW * leds.size());
+}
+
 
 // The part of the estimate a brightness scalar cannot touch: every controller
 // IC draws its quiescent current whether or not an emitter is lit, and the MCU
@@ -281,8 +363,8 @@ fl::u8 calculate_max_brightness_for_power_mW( fl::u8 target_brightness, fl::u32 
     CLEDController *pCur = CLEDController::head();
 	while(pCur) {
         const fl::u32 count = pCur->size();
-        const fl::u32 unscaled_mW =
-            calculate_unscaled_power_mW(fl::span<const CRGB>(pCur->leds(), count));
+        const fl::u32 unscaled_mW = calculate_unscaled_power_mW(
+            fl::span<const CRGB>(pCur->leds(), count), pCur->getRgbw());
         const fl::u32 dark_mW = fixed_power_mW(count);
         fixed_mW += dark_mW;
         controllable_mW += unscaled_mW > dark_mW ? unscaled_mW - dark_mW : 0;
@@ -345,7 +427,10 @@ void set_max_power_indicator_LED( fl::u8 pinNumber)
     gMaxPowerIndicatorLEDPinNumber = pinNumber;
 }
 
-void set_power_model(const PowerModelRGB& model) {
+// The RGB half of installing a model. Split out because the white emitter's
+// lifetime is not the same as the RGB model's: declaring an RGB model retracts
+// a white declaration, but changing the exponent must not.
+static void apply_rgb_power_model(const PowerModelRGB& model) {
     gPowerModel() = model;
 #if SKETCH_HAS_LARGE_MEMORY
     rebuild_power_scaling_tables(model.exponent);
@@ -356,10 +441,30 @@ void set_power_model(const PowerModelRGB& model) {
 #endif
 }
 
+void set_power_model(const PowerModelRGB& model) {
+    apply_rgb_power_model(model);
+    // An RGB model describes a strip with three emitters. Leaving a white
+    // declaration from an earlier RGBW model standing would charge this one
+    // for a diode the caller just said it does not have.
+    gWhiteEmitterPower().mW = 0;
+}
+
+void set_power_model(const PowerModelRGBW& model) {
+    apply_rgb_power_model(model.toRGB());
+    gWhiteEmitterPower().mW = model.white_mW;
+}
+
+fl::u8 get_white_emitter_mW() {
+    return gWhiteEmitterPower().mW;
+}
+
 void set_power_scaling_exponent(float exponent) {
     PowerModelRGB model = gPowerModel();
     model.exponent = exponent;
-    set_power_model(model);
+    // Not `set_power_model`: the exponent is a property of the response
+    // curve, and changing it is not a statement about how many emitters the
+    // strip has.
+    apply_rgb_power_model(model);
 }
 
 float get_power_scaling_exponent() {

--- a/src/power_mgt.h
+++ b/src/power_mgt.h
@@ -3,6 +3,7 @@
 #include "fl/system/fastled.h"
 
 #include "pixeltypes.h"
+#include "fl/gfx/rgbw.h"
 
 /// @file power_mgt.h
 /// Functions to limit the power used by FastLED
@@ -51,8 +52,7 @@ struct PowerModelRGB {
 };
 
 /// RGBW LED power consumption model
-/// @note Future API enhancement - not yet implemented in power calculations
-/// @note Currently forwards to PowerModelRGB, ignoring white channel
+/// Used for 4-channel LEDs (SK6812 RGBW and similar).
 struct PowerModelRGBW {
     fl::u8 red_mW;    ///< Red channel power at full brightness (255), in milliwatts
     fl::u8 green_mW;  ///< Green channel power at full brightness (255), in milliwatts
@@ -78,8 +78,14 @@ struct PowerModelRGBW {
         : red_mW(r), green_mW(g), blue_mW(b), white_mW(w), dark_mW(d),
           exponent(e) {}
 
-    /// Convert to RGB model (extracts RGB components, preserves exponent)
-    /// @note Used internally until RGBW power calculations are implemented
+    /// The RGB emitters alone, without the white one.
+    ///
+    /// This is not the power model of an RGBW strip: it describes three of
+    /// its four emitters. `set_power_model(const PowerModelRGBW&)` used to
+    /// route through here, which is how `white_mW` came to be accepted by
+    /// the API and then discarded. Kept because callers who genuinely want
+    /// the RGB subset -- driving the same strip as plain RGB, say -- have
+    /// no other way to ask for it.
     constexpr PowerModelRGB toRGB() const {
         return PowerModelRGB(red_mW, green_mW, blue_mW, dark_mW, exponent);
     }
@@ -181,23 +187,41 @@ float get_power_scaling_exponent();
 
 /// Set custom RGBW LED power consumption model
 /// @param model RGBW power consumption model
-/// @note Future API enhancement - currently extracts RGB components only
-/// @note White channel power is stored but not yet used in calculations
-inline void set_power_model(const PowerModelRGBW& model) {
-    set_power_model(model.toRGB());  // TODO: Implement RGBW power model.
-}
+///
+/// `white_mW` is kept and used. It used to be dropped by `toRGB()`, so a
+/// caller who declared an RGBW strip got a budget computed over three
+/// emitters while four were lit. On the shipped default model
+/// (r90 g70 b90 w100) and the shipped conversions, at full white, the
+/// three-emitter figure is 249 units against a true four-emitter draw of
+/// 348 under `kRGBWMaxBrightness` (40% under budget), 266 under
+/// `kRGBWBoostedWhite`, and 99 under `kRGBWExactColors` (2.5x over).
+///
+/// The white emitter is charged only for controllers actually in RGBW mode;
+/// see `calculate_unscaled_power_mW(span, const Rgbw&)`.
+void set_power_model(const PowerModelRGBW& model);
 
 /// Set custom RGBWW LED power consumption model
 /// @param model RGBWW power consumption model
-/// @note Future API enhancement - currently extracts RGB components only
-/// @note White channel power is stored but not yet used in calculations
+///
+/// Unlike the RGBW model above, `PowerModelRGBWW::toRGB()` does not drop its
+/// white emitters -- it spreads them across R/G/B, which over-estimates and
+/// so cannot break the budget. That fold is left in place: it is documented,
+/// safe by construction, and a five-emitter accounting needs the RGBWW
+/// allocation the way the RGBW path needs `rgb_2_rgbw`. #4156 R3.
 inline void set_power_model(const PowerModelRGBWW& model) {
-    set_power_model(model.toRGB());  // TODO: Implement RGBWW power model.
+    set_power_model(model.toRGB());
 }
 
 /// Get current RGB power model
 /// @returns Current RGB power consumption model
 PowerModelRGB get_power_model();
+
+/// The white-emitter draw the caller declared, or zero if they declared only
+/// an RGB model.
+///
+/// Zero is the "not declared" reading rather than "declared as free": no
+/// emitter costs nothing, so the two cannot be confused.
+fl::u8 get_white_emitter_mW();
 
 /// @} PowerModel
 
@@ -258,6 +282,27 @@ fl::u32 calculate_unscaled_power_mW( const CRGB* ledbuffer, fl::u16 numLeds);
 /// @copydoc calculate_unscaled_power_mW(const CRGB*, uint16_t)
 /// @param leds span of LED data to check
 fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds);
+
+/// Same, for a strip driven through the RGBW conversion.
+///
+/// The overloads above read the source CRGB triple, which is what the sketch
+/// wrote -- not what the strip is driven with. A controller in RGBW mode
+/// converts every pixel with `rgb_2_rgbw` before latching, and the resulting
+/// four drives are neither bounded by nor proportional to the source triple.
+/// Measured on the shipped default `PowerModelRGBW` at full white, in units
+/// of the sum below: source-triple 249 against a true 348 under
+/// `kRGBWMaxBrightness`, 266 under `kRGBWBoostedWhite`, 99 under
+/// `kRGBWExactColors`. The first two are the budget being under-spent
+/// against; the third is a strip dimmed for no reason.
+///
+/// This runs the same conversion the encoder will and charges all four
+/// emitters. It needs `white_mW`, so it falls back to the three-emitter
+/// figure -- and says so once -- when the caller declared only an RGB model.
+///
+/// @param leds span of LED data to check
+/// @param rgbw the controller's RGBW setting; an inactive one delegates to
+///        the three-emitter overload
+fl::u32 calculate_unscaled_power_mW(fl::span<const CRGB> leds, const fl::Rgbw& rgbw);
 
 /// Applies the configured power-scaling response to a total power value.
 ///

--- a/tests/power_mgt.cpp
+++ b/tests/power_mgt.cpp
@@ -263,11 +263,26 @@ FL_TEST_CASE("Power scaling exponent - limiter becomes more conservative") {
 namespace {
 
 struct ScopedDefaultPowerModel {
-    ScopedDefaultPowerModel() : previous_model(get_power_model()) {
+    ScopedDefaultPowerModel()
+        : previous_model(get_power_model()),
+          previous_white_mW(get_white_emitter_mW()) {
         set_power_model(PowerModelRGB());
     }
-    ~ScopedDefaultPowerModel() { set_power_model(previous_model); }
+    ~ScopedDefaultPowerModel() {
+        // Restores both halves, for the reason on ScopedRgbwPowerModel below:
+        // the RGB setter retracts a white declaration by design, so restoring
+        // through it alone loses one that was standing on entry.
+        if (previous_white_mW != 0) {
+            set_power_model(PowerModelRGBW(
+                previous_model.red_mW, previous_model.green_mW,
+                previous_model.blue_mW, previous_white_mW,
+                previous_model.dark_mW, previous_model.exponent));
+        } else {
+            set_power_model(previous_model);
+        }
+    }
     PowerModelRGB previous_model;
+    fl::u8 previous_white_mW;
 };
 
 // What the strip really draws at a brightness: the dark current of every
@@ -462,11 +477,42 @@ fl::u32 four_emitter_mW(fl::span<const CRGB> leds, const fl::Rgbw& rgbw,
 
 struct ScopedRgbwPowerModel {
     explicit ScopedRgbwPowerModel(const PowerModelRGBW& model)
-        : previous_model(get_power_model()) {
+        : previous_model(get_power_model()),
+          previous_white_mW(get_white_emitter_mW()) {
         set_power_model(model);
     }
-    ~ScopedRgbwPowerModel() { set_power_model(previous_model); }
+    ~ScopedRgbwPowerModel() {
+        // Both halves, not just the RGB one. The RGB setter deliberately
+        // retracts a white declaration -- that is the contract a case below
+        // asserts -- so restoring through it alone would leave the process
+        // with no white emitter regardless of what it had on entry, and make
+        // any case that ran afterwards depend on the order it ran in.
+        if (previous_white_mW != 0) {
+            set_power_model(PowerModelRGBW(
+                previous_model.red_mW, previous_model.green_mW,
+                previous_model.blue_mW, previous_white_mW,
+                previous_model.dark_mW, previous_model.exponent));
+        } else {
+            set_power_model(previous_model);
+        }
+    }
     PowerModelRGB previous_model;
+    fl::u8 previous_white_mW;
+};
+
+/// A registered controller, for the two entry points that walk the controller
+/// list rather than taking a buffer.
+///
+/// Scoped rather than added through `FastLED.addLeds<>`: `~CLEDController`
+/// calls `removeFromDrawList()` on large-memory targets, so this leaves the
+/// global list exactly as it found it. There is no API to unregister an
+/// `addLeds` controller, and a leaked one would silently join every later
+/// case's traversal.
+class RegisteredController : public CLEDController {
+  public:
+    void showColor(const CRGB&, int, fl::u8) FL_NO_EXCEPT override {}
+    void show(const CRGB*, int, fl::u8) FL_NO_EXCEPT override {}
+    void init() FL_NO_EXCEPT override {}
 };
 
 } // namespace
@@ -588,13 +634,18 @@ FL_TEST_CASE("Power estimate - an undeclared white emitter falls back, it does n
 }
 
 FL_TEST_CASE("Power limiter - an RGBW budget is met by the emitters, not by three of them") {
-    // What the estimate is for. Under `kRGBWMaxBrightness` the strip draws
-    // more than its source triple says, so a budget set from the triple is
-    // exceeded. The limiter now answers against the four-emitter demand.
+    // The end-to-end case, through the entry point a sketch actually uses.
+    //
+    // An earlier version of this compared estimator values and never called
+    // the limiter, so reverting the traversal site in
+    // `calculate_max_brightness_for_power_mW` to the three-emitter overload
+    // left every case here passing. This one registers a controller and goes
+    // through the list-walking overload, which is the only thing that
+    // exercises `pCur->getRgbw()`.
     ScopedRgbwPowerModel guard{PowerModelRGBW()};
     const PowerModelRGBW model;
     const int kCount = 300;
-    CRGB leds[kCount];
+    static CRGB leds[kCount];
     for (int i = 0; i < kCount; ++i) {
         leds[i] = CRGB(255, 255, 255);
     }
@@ -602,30 +653,103 @@ FL_TEST_CASE("Power limiter - an RGBW budget is met by the emitters, not by thre
     const fl::Rgbw rgbw(fl::kRGBWDefaultColorTemp,
                         fl::RGBW_MODE::kRGBWMaxBrightness);
 
+    RegisteredController controller;
+    controller.setLeds(leds, kCount);
+    controller.setRgbw(rgbw);
+
     const fl::u32 truth_mW = four_emitter_mW(span, rgbw, model);
+    const fl::u32 source_triple_mW = calculate_unscaled_power_mW(span);
+
+    // A budget between the two figures: the source triple says the strip fits
+    // inside it at full brightness, the four-emitter truth says it does not.
+    // That interval is exactly the region the old estimate got wrong, and it
+    // is non-empty only because the two disagree.
+    FL_REQUIRE(source_triple_mW < truth_mW);
+    const fl::u32 budget_mW = (source_triple_mW + truth_mW) / 2;
+
+    const fl::u8 recommended =
+        calculate_max_brightness_for_power_mW(255, budget_mW);
+
+    // The three-emitter figure would have said the whole strip fits at full
+    // brightness. It does not, so the limiter must come down off 255.
+    FL_CHECK_LT(int(recommended), 255);
+
+    // And what it recommends must actually fit, measured against the demand
+    // the strip really draws rather than the one the estimator used to report.
+    // The controller's dark current is the part no scalar reduces; the rest
+    // is what the recommendation scales.
     const fl::u32 fixed_mW = static_cast<fl::u32>(model.dark_mW) * kCount;
     const fl::u32 controllable_mW = truth_mW - fixed_mW;
+    const fl::u32 drawn_mW =
+        fixed_mW + scale_power_for_brightness(controllable_mW, recommended);
+    FL_CHECK_LE(drawn_mW, budget_mW);
+}
 
-    // A budget between the two figures: the source triple says the strip
-    // fits inside it at full brightness, the four-emitter truth says it does
-    // not. That interval is exactly the region the old estimate got wrong,
-    // and it is non-empty only because the two disagree.
+FL_TEST_CASE("Power estimate - the reported total walks controllers with their own RGBW setting") {
+    // The second entry point that walks the list.
+    // `CFastLED::getEstimatedPowerInMilliWatts` has its own traversal, and
+    // reverting *its* call to the three-emitter overload also left every case
+    // here passing before this one existed.
+    ScopedRgbwPowerModel guard{PowerModelRGBW()};
+    const PowerModelRGBW model;
+    const int kCount = 60;
+    static CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    const fl::Rgbw rgbw(fl::kRGBWDefaultColorTemp,
+                        fl::RGBW_MODE::kRGBWMaxBrightness);
+
+    RegisteredController controller;
+    controller.setLeds(leds, kCount);
+    controller.setRgbw(rgbw);
+
+    const fl::u8 previous_brightness = FastLED.getBrightness();
+    FastLED.setBrightness(255);
+    // Without a limiter installed the report is the unscaled demand, which is
+    // what makes it comparable to the four-emitter figure directly.
+    const fl::u32 reported_mW = FastLED.getEstimatedPowerInMilliWatts(false);
+    FastLED.setBrightness(previous_brightness);
+
+    const fl::u32 truth_mW = four_emitter_mW(span, rgbw, model);
     const fl::u32 source_triple_mW = calculate_unscaled_power_mW(span);
-    const fl::u32 budget_mW = (source_triple_mW + truth_mW) / 2;
-    const fl::u32 measured_mW = calculate_unscaled_power_mW(span, rgbw);
-    const fl::u32 measured_controllable =
-        measured_mW > fixed_mW ? measured_mW - fixed_mW : 0;
 
-    // The demand the limiter now works from is the true one.
-    FL_CHECK_LE(measured_controllable > controllable_mW
-                    ? measured_controllable - controllable_mW
-                    : controllable_mW - measured_controllable,
+    // Within a milliwatt per LED of the four-emitter truth, across the two
+    // sum orders -- and nowhere near the three-emitter figure it used to
+    // report, which is 28% low on this mode.
+    FL_CHECK_LE(reported_mW > truth_mW ? reported_mW - truth_mW
+                                       : truth_mW - reported_mW,
                 static_cast<fl::u32>(kCount));
+    FL_CHECK_GT(reported_mW, source_triple_mW);
+}
 
-    // Whereas the three-emitter figure would have claimed the whole strip
-    // fits inside that budget at full brightness -- it does not.
-    FL_CHECK_LT(source_triple_mW, budget_mW);
-    FL_CHECK_GT(truth_mW, budget_mW);
+FL_TEST_CASE("Power model - a scoped guard puts back the white emitter it found") {
+    // What makes the guards above safe to nest, and why they save two things
+    // rather than one. The RGB setter retracts a white declaration on purpose
+    // -- a case above asserts exactly that -- so a guard restoring through it
+    // alone would leave the process with no white emitter whatever it had on
+    // entry, and every case that ran afterwards would depend on its position
+    // in the file.
+    ScopedDefaultPowerModel outer;
+    set_power_model(PowerModelRGBW(90, 70, 90, 77, 5));
+    FL_REQUIRE(get_white_emitter_mW() == 77);
+
+    {
+        ScopedRgbwPowerModel inner{PowerModelRGBW(10, 10, 10, 20, 1)};
+        FL_CHECK_EQ(get_white_emitter_mW(), 20);
+    }
+    FL_CHECK_EQ(get_white_emitter_mW(), 77);
+
+    {
+        ScopedDefaultPowerModel inner;
+        FL_CHECK_EQ(get_white_emitter_mW(), 0);  // an RGB model has no fourth diode
+    }
+    FL_CHECK_EQ(get_white_emitter_mW(), 77);
+
+    // And leave the process as the file found it: `outer` restores the RGB
+    // model, and this retracts the white this case declared.
+    set_power_model(PowerModelRGB());
 }
 
 } // FL_TEST_FILE

--- a/tests/power_mgt.cpp
+++ b/tests/power_mgt.cpp
@@ -433,4 +433,199 @@ FL_TEST_CASE("Power limiter - a budget over demand leaves brightness alone") {
                 200);
 }
 
+// ---------------------------------------------------------------------------
+// #4156 R3: the estimate must cover the emitters the strip actually lights.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// The four-emitter draw, computed the long way: run the same conversion the
+// encoder runs, then charge each diode at its declared rate. Deliberately not
+// the function under test -- if both were the same code the cases below would
+// only be asserting that a function equals itself.
+fl::u32 four_emitter_mW(fl::span<const CRGB> leds, const fl::Rgbw& rgbw,
+                        const PowerModelRGBW& model) {
+    fl::u32 r32 = 0, g32 = 0, b32 = 0, w32 = 0;
+    for (fl::size i = 0; i < leds.size(); ++i) {
+        fl::u8 r = 0, g = 0, b = 0, w = 0;
+        fl::rgb_2_rgbw(rgbw, leds[i].r, leds[i].g, leds[i].b, 255, 255, 255,
+                       &r, &g, &b, &w);
+        r32 += r;
+        g32 += g;
+        b32 += b;
+        w32 += w;
+    }
+    return ((r32 * model.red_mW) >> 8) + ((g32 * model.green_mW) >> 8) +
+           ((b32 * model.blue_mW) >> 8) + ((w32 * model.white_mW) >> 8) +
+           static_cast<fl::u32>(model.dark_mW) * leds.size();
+}
+
+struct ScopedRgbwPowerModel {
+    explicit ScopedRgbwPowerModel(const PowerModelRGBW& model)
+        : previous_model(get_power_model()) {
+        set_power_model(model);
+    }
+    ~ScopedRgbwPowerModel() { set_power_model(previous_model); }
+    PowerModelRGB previous_model;
+};
+
+} // namespace
+
+FL_TEST_CASE("Power model - an RGBW declaration keeps its white emitter") {
+    // `set_power_model(PowerModelRGBW)` used to route through `toRGB()`,
+    // which drops `white_mW`. The API accepted the number and threw it away,
+    // so every RGBW budget was computed over three of four diodes.
+    ScopedRgbwPowerModel guard(PowerModelRGBW(90, 70, 90, 100, 5));
+    FL_CHECK_EQ(get_white_emitter_mW(), 100);
+    // And the RGB half still lands where it was declared.
+    FL_CHECK_EQ(get_power_model().red_mW, 90);
+    FL_CHECK_EQ(get_power_model().blue_mW, 90);
+
+    // Declaring an RGB model afterwards retracts the white emitter: three
+    // emitters is what an RGB model says the strip has.
+    set_power_model(PowerModelRGB(80, 55, 75, 5));
+    FL_CHECK_EQ(get_white_emitter_mW(), 0);
+}
+
+FL_TEST_CASE("Power model - changing the exponent does not retract the white emitter") {
+    // `set_power_scaling_exponent` reinstalls the RGB model to carry the new
+    // exponent. Routing that through the public RGB setter would clear the
+    // white declaration as a side effect of an unrelated call.
+    ScopedRgbwPowerModel guard(PowerModelRGBW(90, 70, 90, 100, 5));
+    set_power_scaling_exponent(1.0f);
+    FL_CHECK_EQ(get_white_emitter_mW(), 100);
+}
+
+FL_TEST_CASE("Power estimate - the source triple is not the RGBW strip's demand") {
+    // The measurement behind R3, at the size that makes it concrete. Source
+    // white on 300 SK6812-class pixels, the shipped default RGBW model.
+    ScopedRgbwPowerModel guard{PowerModelRGBW()};
+    const PowerModelRGBW model;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    const fl::u32 source_triple_mW = calculate_unscaled_power_mW(span);
+
+    struct Case {
+        fl::RGBW_MODE mode;
+        bool source_triple_under_counts;
+    };
+    const Case cases[] = {
+        // Lights every diode at the source level: the largest draw of the
+        // four modes, and the one the source triple most under-states.
+        {fl::RGBW_MODE::kRGBWMaxBrightness, true},
+        // Adds white on top of a reduced RGB residual; still over the triple.
+        {fl::RGBW_MODE::kRGBWBoostedWhite, true},
+        // Moves the neutral into the white diode, so the strip draws far
+        // *less* than the triple. Wrong in the other direction: a strip
+        // dimmed against a budget it was never near.
+        {fl::RGBW_MODE::kRGBWExactColors, false},
+    };
+
+    for (const auto& c : cases) {
+        const fl::Rgbw rgbw(fl::kRGBWDefaultColorTemp, c.mode);
+        const fl::u32 truth = four_emitter_mW(span, rgbw, model);
+        const fl::u32 measured = calculate_unscaled_power_mW(span, rgbw);
+
+        // The estimate tracks the four-emitter truth, not the source triple.
+        // Within a milliwatt per LED of rounding across the two sum orders.
+        FL_CHECK_LE(measured > truth ? measured - truth : truth - measured,
+                    static_cast<fl::u32>(kCount));
+
+        // And the gap it closes is not a rounding-scale gap. Measured on
+        // these 300 pixels the smallest of the three is `kRGBWBoostedWhite`
+        // at 6.5% of the true draw; `kRGBWMaxBrightness` is 28% and
+        // `kRGBWExactColors` is 150%. A twentieth is under all three and far
+        // over anything the two sum orders could differ by.
+        const fl::u32 gap = source_triple_mW > truth ? source_triple_mW - truth
+                                                     : truth - source_triple_mW;
+        FL_CHECK_GT(gap, truth / 20);
+        FL_CHECK_EQ(truth > source_triple_mW, c.source_triple_under_counts);
+    }
+}
+
+FL_TEST_CASE("Power estimate - the white diode is charged only where there is one") {
+    // The same model must not inflate a plain RGB controller on the same
+    // sketch. An inactive Rgbw is the three-emitter answer exactly.
+    //
+    // Note what this does and does not pin. It pins the answer. It cannot
+    // distinguish the implementation's `!rgbw.active()` short-circuit from
+    // running the conversion anyway, because the inactive mode dispatches to
+    // null-white and returns the input unchanged -- deleting that branch
+    // leaves this case passing. The branch is there for the per-pixel cost,
+    // and is documented as such rather than as a guard.
+    ScopedRgbwPowerModel guard{PowerModelRGBW()};
+    const int kCount = 60;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(200, 140, 90);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    FL_CHECK_EQ(calculate_unscaled_power_mW(span, fl::RgbwInvalid::value()),
+                calculate_unscaled_power_mW(span));
+}
+
+FL_TEST_CASE("Power estimate - an undeclared white emitter falls back, it does not guess") {
+    // With only an RGB model declared there is no white draw to charge. The
+    // estimate stays the three-emitter figure rather than inventing a number
+    // for the fourth diode, which is the state that produced R3 in the first
+    // place -- so the fallback is the documented behaviour, not silence.
+    ScopedDefaultPowerModel guard;
+    const int kCount = 60;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    const fl::Rgbw rgbw(fl::kRGBWDefaultColorTemp,
+                        fl::RGBW_MODE::kRGBWMaxBrightness);
+    FL_CHECK_EQ(get_white_emitter_mW(), 0);
+    FL_CHECK_EQ(calculate_unscaled_power_mW(span, rgbw),
+                calculate_unscaled_power_mW(span));
+}
+
+FL_TEST_CASE("Power limiter - an RGBW budget is met by the emitters, not by three of them") {
+    // What the estimate is for. Under `kRGBWMaxBrightness` the strip draws
+    // more than its source triple says, so a budget set from the triple is
+    // exceeded. The limiter now answers against the four-emitter demand.
+    ScopedRgbwPowerModel guard{PowerModelRGBW()};
+    const PowerModelRGBW model;
+    const int kCount = 300;
+    CRGB leds[kCount];
+    for (int i = 0; i < kCount; ++i) {
+        leds[i] = CRGB(255, 255, 255);
+    }
+    const fl::span<const CRGB> span(leds, kCount);
+    const fl::Rgbw rgbw(fl::kRGBWDefaultColorTemp,
+                        fl::RGBW_MODE::kRGBWMaxBrightness);
+
+    const fl::u32 truth_mW = four_emitter_mW(span, rgbw, model);
+    const fl::u32 fixed_mW = static_cast<fl::u32>(model.dark_mW) * kCount;
+    const fl::u32 controllable_mW = truth_mW - fixed_mW;
+
+    // A budget between the two figures: the source triple says the strip
+    // fits inside it at full brightness, the four-emitter truth says it does
+    // not. That interval is exactly the region the old estimate got wrong,
+    // and it is non-empty only because the two disagree.
+    const fl::u32 source_triple_mW = calculate_unscaled_power_mW(span);
+    const fl::u32 budget_mW = (source_triple_mW + truth_mW) / 2;
+    const fl::u32 measured_mW = calculate_unscaled_power_mW(span, rgbw);
+    const fl::u32 measured_controllable =
+        measured_mW > fixed_mW ? measured_mW - fixed_mW : 0;
+
+    // The demand the limiter now works from is the true one.
+    FL_CHECK_LE(measured_controllable > controllable_mW
+                    ? measured_controllable - controllable_mW
+                    : controllable_mW - measured_controllable,
+                static_cast<fl::u32>(kCount));
+
+    // Whereas the three-emitter figure would have claimed the whole strip
+    // fits inside that budget at full brightness -- it does not.
+    FL_CHECK_LT(source_triple_mW, budget_mW);
+    FL_CHECK_GT(truth_mW, budget_mW);
+}
+
 } // FL_TEST_FILE


### PR DESCRIPTION
## The estimator was reading the wrong array

#4156 R3 says accurate demand depends on the RGBW allocation. It does, and the estimator did not have it.

`calculate_unscaled_power_mW` walks the source `CRGB` array — what the sketch wrote. A controller in RGBW mode converts every pixel with `rgb_2_rgbw` before latching, and the four resulting drives are neither bounded by nor proportional to that triple.

Measured on 300 pixels of source white with the shipped default `PowerModelRGBW` (r90 g70 b90 w100 dark5):

| RGBW mode | source triple | four emitters | |
|---|---|---|---|
| `kRGBWMaxBrightness` | 76,205 mW | 106,086 mW | source triple **28% under** |
| `kRGBWBoostedWhite` | 76,205 mW | 81,470 mW | **6.5% under** |
| `kRGBWExactColors` | 76,205 mW | 30,485 mW | **150% over** |

The first two are budget being under-spent against — the limiter says the strip fits when it does not. The third is a strip dimmed against a budget it was never near.

`set_power_model(const PowerModelRGBW&)` compounded it by routing through `toRGB()`, which **drops `white_mW`**. The API accepted the figure and discarded it, so the fourth diode could not have been charged even in principle. That was the standing `// TODO: Implement RGBW power model.`

## What changed

- The declared white draw is stored instead of dropped, and `get_white_emitter_mW()` reports it.
- A new `calculate_unscaled_power_mW(span, const Rgbw&)` runs the same conversion the encoder will and charges all four emitters. Both traversal sites — the limiter's and `getEstimatedPowerInMilliWatts` — pass the controller's own `getRgbw()`.
- `set_power_scaling_exponent` no longer routes through the public RGB setter, which would have retracted a white declaration as a side effect of changing a response curve.
- A controller in RGBW mode under a model with no declared white is **diagnosed once** and falls back to the three-emitter figure. There is no basis for a fourth emitter's draw in a three-emitter declaration, and inventing one is the shape of the defect this replaces.

## What this does not do

Both recorded in `docs/color-pipeline-contracts.md` rather than folded into the claim.

- **Demand is still projected linearly in brightness.** That commutes with `kRGBWExactColors` and `kRGBWMaxBrightness` to within 0.4% over the measured cases. It does not commute with `kRGBWBoostedWhite`, which reallocates between emitters as the scale falls: demand there runs up to **12.1% above** the linear projection at low brightness. Closing it means evaluating demand per candidate brightness — a pixel walk per step of the limiter's search. Charging four emitters instead of three is the larger correction by a wide margin.
- **RGBWW still folds.** `PowerModelRGBWW::toRGB()` spreads its two whites across R/G/B rather than dropping them, which over-estimates and so cannot break a budget. A five-emitter accounting needs the RGBWW allocation the way this needs `rgb_2_rgbw`.
- **This is R3's RGBW-allocation half only.** The streaming prepass that decides the shared scalar before emission is untouched.

## Evidence

Six cases in `tests/power_mgt.cpp`. The four-emitter truth is computed the long way in the test rather than by calling the function under test, so the cases are not asserting that a function equals itself.

Mutation-checked — each of these fails the new cases:

| mutation | cases failed |
|---|---|
| discard `white_mW` again (the original defect) | 4 |
| never take the four-emitter path | 2 |
| route the exponent setter through `set_power_model` | 1 |
| stop retracting a stale white declaration | 2 |

One mutation that is **not** caught, and is documented as such in both the code and the test: removing the `!rgbw.active()` short-circuit. `kRGBWInvalid` dispatches to null-white and returns the input unchanged, so the four-emitter loop would give the same total. That branch is a per-pixel cost saving on every plain RGB controller the estimator walks, not a guard, and it is labelled that way rather than left looking load-bearing.

Full suite green: 299/299 unit, 84/84 examples. `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Power estimation now accounts for all four emitters on RGBW LED strips.
  * Added support for configuring RGBW power models with white-emitter power values.
  * Brightness limiting now reflects RGBW emitter power consumption.
  * Added diagnostics for RGBW configurations without a declared white-emitter power value.
  * White-emitter settings are preserved when adjusting power-scaling settings.

* **Documentation**
  * Documented RGBW emitter accounting, conversion behavior, measured power data, and diagnostic conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->