### PR TITLE
fix(rpc): report a discarded request line instead of dropping it silently

### DIFF
--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -164,11 +164,15 @@ createSerialRequestSource(const char* prefix = "") {
             // is exactly how a receive-buffer truncation presented in
             // FastLED#3956 -- 735 bytes transmitted, nothing returned, and
             // no layer saying anything.
-            if (view.size() >= kDroppedRequestWarnBytes) {
+            // Measure what arrived, not what survived normalisation: the
+            // view above has had its prefix stripped and whitespace trimmed,
+            // so a 64-byte line can fall under the threshold and stay silent,
+            // and the reported count would understate what was received.
+            if (line->size() >= kDroppedRequestWarnBytes) {
                 FL_WARN_F("[RPC] discarded a %u byte line that does not begin "
                           "with '{'; a request that arrived truncated looks "
                           "exactly like this",
-                          static_cast<unsigned>(view.size()));
+                          static_cast<unsigned>(line->size()));
             }
             return fl::nullopt;
         }

--- a/src/fl/remote/transport/serial.h
+++ b/src/fl/remote/transport/serial.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "fl/stl/json.h"
+#include "fl/log/log.h"  // IWYU pragma: keep -- FL_WARN_F
 #include "fl/system/delay.h"
 #include "fl/stl/int.h"
 #include "fl/stl/cctype.h"
@@ -109,6 +110,11 @@ struct SerialWriter {
 /// auto responseSink = fl::createSerialResponseSink("REMOTE: ");
 /// fl::Remote remote(requestSource, responseSink);
 /// @endcode
+/// Lines at least this long are reported when discarded. Below it, a
+/// non-JSON line is ordinary serial noise; above it, it is more likely a
+/// request that lost bytes on the way in.
+constexpr fl::size kDroppedRequestWarnBytes = 64;
+
 inline fl::function<fl::optional<fl::json>()>
 createSerialRequestSource(const char* prefix = "") {
     return [prefix]() -> fl::optional<fl::json> {
@@ -149,6 +155,21 @@ createSerialRequestSource(const char* prefix = "") {
 
         // Only parse if input starts with '{'
         if (view.empty() || view[0] != '{') {
+            // A short line here is ordinary serial noise -- boot banners,
+            // stray newlines -- and warning about it would drown the log.
+            // A long one is almost certainly a request that arrived damaged,
+            // and dropping that silently is expensive to debug: the caller
+            // sees no reply and no error, indistinguishable from an idle
+            // link, while the device keeps answering everything else. That
+            // is exactly how a receive-buffer truncation presented in
+            // FastLED#3956 -- 735 bytes transmitted, nothing returned, and
+            // no layer saying anything.
+            if (view.size() >= kDroppedRequestWarnBytes) {
+                FL_WARN_F("[RPC] discarded a %u byte line that does not begin "
+                          "with '{'; a request that arrived truncated looks "
+                          "exactly like this",
+                          static_cast<unsigned>(view.size()));
+            }
             return fl::nullopt;
         }
 


### PR DESCRIPTION
## The problem

`createSerialRequestSource()` returns `fl::nullopt` for any line that does not begin with `{`:

```cpp
if (view.empty() || view[0] != '{') {
    return fl::nullopt;
}
```

To `Server::pull()` that is indistinguishable from an idle link. So a request that arrives damaged is dropped with **no response, no error, and no log**, while the device carries on answering every other request normally.

## Why that is expensive

That is exactly how a receive-side truncation presents from the far end of a serial link, and it is what happened in #3956:

- the host transmitted the full request — **735 bytes out, zero bytes back**, measured from the daemon's byte counters
- the device stayed responsive throughout: `finishOtaArtifact` answered in **0.07 s** immediately after two 20 s timeouts
- no layer anywhere reported a problem

The observable was "the device stopped answering this one method", which sent that investigation through port locks, CDC re-enumeration, partition tables and firmware identity before the shape of it became clear. A single line saying "discarded a 735 byte line" would have ended it immediately.

## The change

Lines of 64 bytes or more are reported when discarded. Below that they stay silent, because a short non-JSON line is ordinary serial noise — boot banners, stray newlines — and warning on those would drown the log. A long line that is not JSON is far more likely to be a request that lost bytes on the way in, which is the case worth naming.

**Nothing about what is accepted or rejected changes** — only what is said about a rejection.

The 64-byte threshold is a judgement call rather than a measurement: it is meant to separate framing noise from a real request, and I would happily take a better-motivated number.

## Verification

The header compiles clean (`g++ -fsyntax-only -std=c++17`).

**Not yet run through the full suite.** `bash test --cpp` and a device build were both killed by host memory pressure on this bench rather than by failures, so CI is the first real exercise of this. Flagging it rather than implying more validation than I did.

Relates to #3956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for discarded serial requests by warning when non-JSON input is 64 bytes or longer.
  - Warning thresholds now reflect the full received message, including content removed during normalization.
  - Shorter invalid serial messages continue to be ignored without generating warnings.
  - Reported message sizes now accurately represent the original incoming data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->