### PR TITLE
feat(simd): dispatch ARMv8-A to the NEON backend that was already there (#4286)

### DIFF
--- a/ci/tests/test_simd_dispatch.py
+++ b/ci/tests/test_simd_dispatch.py
@@ -1,0 +1,186 @@
+"""The SIMD backend dispatch table selects what it claims to.
+
+`src/platforms/simd.h` is a preprocessor chain that picks one of five SIMD
+backends from architecture macros. Nothing tested it, which is how
+FastLED#4286 happened: `platforms/arm/simd_arm_neon.hpp` -- a complete
+66-operation NEON backend -- had no arm selecting it, so every ARMv8-A
+target ran the scalar fallback and the only reference to the file outside
+itself was a comment.
+
+A missing arm is invisible: the chain still compiles, still picks *a*
+backend, and the one it picks still works. Only the performance is wrong,
+and nothing in the suite looks at that.
+
+So this evaluates the real chain with the real preprocessor. Each backend
+`#include` is rewritten to a marker first, because the backends reference
+target intrinsics (`arm_neon.h`, `emmintrin.h`) that the host does not have
+for every target being checked -- the chain's *logic* is what is under test,
+not the backends' contents.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from typeguard import typechecked
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DISPATCH_FILE = PROJECT_ROOT / "src" / "platforms" / "simd.h"
+
+kMarker = "FL_TEST_SELECTED_BACKEND"
+kFallbackProbe = "FL_TEST_FALLBACK_FLAG"
+
+
+@typechecked
+def _stub_source() -> str:
+    """`simd.h` with each backend include replaced by a marker."""
+
+    source = DISPATCH_FILE.read_text()
+    stubbed = re.sub(
+        r'#include "(platforms/[^"]*\.hpp)"[^\n]*',
+        rf"{kMarker} \1",
+        source,
+    )
+    # `is_platform.h` is a real header the chain needs for FL_IS_ESP32, but
+    # pulling it in would drag the platform tree into a -nostdinc run. The
+    # macro is supplied directly by the cases below instead.
+    stubbed = stubbed.replace('#include "platforms/is_platform.h"', "")
+    # `#define` lines do not survive preprocessing, so ask for the value.
+    return stubbed + f"\n{kFallbackProbe} FL_SIMD_BACKEND_IS_FALLBACK\n"
+
+
+@typechecked
+def _select(defines: list[str]) -> tuple[str, str]:
+    """The backend and fallback flag the chain picks for `defines`."""
+
+    compiler = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+    if compiler is None:
+        raise unittest.SkipTest("no C preprocessor on PATH")
+
+    with tempfile.NamedTemporaryFile("w", suffix=".h", delete=False) as handle:
+        handle.write(_stub_source())
+        path = Path(handle.name)
+    try:
+        # `subprocess.run` and not `RunningProcess.run`: the latter merges
+        # stderr into stdout, and the preprocessor emits a "#pragma once in
+        # main file" warning on every invocation here -- merging it would put
+        # compiler chatter into the stream this parses.
+        completed = subprocess.run(  # noqa: SRC001
+            [compiler, "-E", "-P", "-nostdinc", "-undef", *defines, str(path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    finally:
+        path.unlink()
+
+    selected = ""
+    fallback = ""
+    for raw_line in completed.stdout.splitlines():
+        # The preprocessor keeps the chain's indentation, so the marker is
+        # not at column zero.
+        line = raw_line.strip()
+        if line.startswith(kMarker):
+            selected = line.split()[-1]
+        elif line.startswith(kFallbackProbe):
+            fallback = line.split()[-1]
+    return selected, fallback
+
+
+class TestSimdDispatch(unittest.TestCase):
+    """One case per target family the chain claims to cover."""
+
+    def test_x86_takes_the_sse_backend(self) -> None:
+        backend, fallback = _select(["-D__x86_64__=1"])
+        self.assertEqual(backend, "platforms/shared/simd_x86.hpp")
+        self.assertEqual(fallback, "0")
+
+    def test_esp32_takes_its_own_backend(self) -> None:
+        backend, fallback = _select(["-DFL_IS_ESP32=1"])
+        self.assertEqual(backend, "platforms/esp/32/simd_esp32.hpp")
+        self.assertEqual(fallback, "0")
+
+    def test_cortex_m4_takes_the_dsp_backend(self) -> None:
+        """Teensy 3.x/4.x, SAMD51, nRF52: DSP extension, no NEON."""
+
+        backend, fallback = _select(["-D__ARM_FEATURE_DSP=1"])
+        self.assertEqual(backend, "platforms/arm/teensy/simd_arm_dsp.hpp")
+        self.assertEqual(fallback, "0")
+
+    def test_aarch64_takes_the_neon_backend(self) -> None:
+        """The regression FastLED#4286 was about.
+
+        Apple Silicon, Raspberry Pi 3/4/5 in 64-bit, any ARMv8-A board.
+        `__ARM_FEATURE_DSP` is a 32-bit-ARM macro these do not define, so
+        before the NEON arm existed they fell all the way through to the
+        scalar fallback.
+        """
+
+        backend, fallback = _select(["-D__ARM_NEON=1", "-D__aarch64__=1"])
+        self.assertEqual(backend, "platforms/arm/simd_arm_neon.hpp")
+        self.assertEqual(fallback, "0")
+
+    def test_the_older_neon_spelling_is_accepted(self) -> None:
+        """GCC spells it `__ARM_NEON__` on some ARM configurations."""
+
+        backend, _ = _select(["-D__ARM_NEON__=1"])
+        self.assertEqual(backend, "platforms/arm/simd_arm_neon.hpp")
+
+    def test_armv7a_with_both_macros_keeps_the_dsp_backend(self) -> None:
+        """A deliberate ordering choice, pinned so it cannot drift silently.
+
+        A 32-bit ARMv7-A part can define `__ARM_FEATURE_DSP` and `__ARM_NEON`
+        together. The NEON arm sits after the DSP arm so those keep the
+        backend they already had; moving them is a separate change with its
+        own targets to check.
+        """
+
+        backend, _ = _select(["-D__ARM_NEON=1", "-D__ARM_FEATURE_DSP=1"])
+        self.assertEqual(backend, "platforms/arm/teensy/simd_arm_dsp.hpp")
+
+    def test_an_unmatched_target_takes_the_fallback_and_says_so(self) -> None:
+        """AVR, ESP8266, Cortex-M0/M3, WASM."""
+
+        backend, fallback = _select([])
+        self.assertEqual(backend, "platforms/shared/simd_noop.hpp")
+        self.assertEqual(fallback, "1")
+
+    def test_every_backend_in_the_tree_is_reachable(self) -> None:
+        """The check that would have caught FastLED#4286 on the day.
+
+        A backend file nobody dispatches to is dead code that still compiles,
+        still looks maintained, and silently costs every target that should
+        have been using it.
+        """
+
+        backend_files: list[str] = []
+        for path in sorted((PROJECT_ROOT / "src" / "platforms").rglob("simd_*.hpp")):
+            backend_files.append(str(path.relative_to(PROJECT_ROOT / "src")))
+
+        # Reachability follows one level of indirection: `simd_esp32.hpp` is
+        # itself a dispatch, choosing between the Xtensa and RISC-V backends
+        # and the scalar fallback. A backend named by any file the top-level
+        # chain selects is reached.
+        reached_text = DISPATCH_FILE.read_text()
+        for backend in backend_files:
+            if backend in reached_text:
+                sub_dispatch = PROJECT_ROOT / "src" / backend
+                reached_text += sub_dispatch.read_text()
+
+        unreachable: list[str] = []
+        for backend in backend_files:
+            if backend not in reached_text:
+                unreachable.append(backend)
+        self.assertEqual(unreachable, [], "no arm of the dispatch selects these")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_simd_dispatch.py
+++ b/ci/tests/test_simd_dispatch.py
@@ -146,6 +146,26 @@ class TestSimdDispatch(unittest.TestCase):
         backend, _ = _select(["-D__ARM_NEON=1", "-D__ARM_FEATURE_DSP=1"])
         self.assertEqual(backend, "platforms/arm/teensy/simd_arm_dsp.hpp")
 
+    def test_msvc_arm64_is_not_covered_and_that_is_recorded(self) -> None:
+        """MSVC on ARM64 keeps the fallback, deliberately.
+
+        MSVC advertises `_M_ARM64` rather than `__ARM_NEON`, and spells the
+        NEON header `arm64_neon.h`. So the arm added for FastLED#4286 does
+        not catch it, and the `_M_ARM64` branches already inside
+        `simd_arm_neon.hpp` remain unreachable there.
+
+        That is the status quo rather than a regression -- the target took
+        the fallback before the arm existed too -- and switching a whole
+        backend on for a toolchain that nothing here can compile for, let
+        alone run, is not a thing to do on inference. Pinned so it reads as
+        a decision, and so that whoever adds MSVC ARM64 support has to
+        change this case on purpose.
+        """
+
+        backend, fallback = _select(["-D_M_ARM64=1"])
+        self.assertEqual(backend, "platforms/shared/simd_noop.hpp")
+        self.assertEqual(fallback, "1")
+
     def test_an_unmatched_target_takes_the_fallback_and_says_so(self) -> None:
         """AVR, ESP8266, Cortex-M0/M3, WASM."""
 

--- a/src/platforms/arm/simd_arm_neon.hpp
+++ b/src/platforms/arm/simd_arm_neon.hpp
@@ -135,13 +135,30 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u8x16 blend_u8_16(simd_u8x16 a, simd_u8x16 b, 
     int16x8_t diff_low = vreinterpretq_s16_u16(vsubl_u8(b_low, a_low));
     int16x8_t diff_high = vreinterpretq_s16_u16(vsubl_u8(b_high, a_high));
 
-    // Multiply by amount
-    int16x8_t scaled_low = vmulq_n_s16(diff_low, static_cast<i16>(amount));
-    int16x8_t scaled_high = vmulq_n_s16(diff_high, static_cast<i16>(amount));
-
-    // Shift right by 8 to divide by 256
-    scaled_low = vshrq_n_s16(scaled_low, 8);
-    scaled_high = vshrq_n_s16(scaled_high, 8);
+    // Multiply and shift, widening to 32 bits first.
+    //
+    // `vmulq_n_s16` here was a real bug, and the first thing macOS CI caught
+    // when this backend was finally dispatched to. `diff` spans -255..255
+    // and `amount` spans 0..255, so the product needs 17 signed bits: at
+    // a=0, b=255, amount=192 the true value is 48960, which wraps int16 to
+    // -16576, shifts to -65, and saturates to 0 where 191 was wanted. The
+    // 25% case in `tests/fl/math/simd.cpp` passed only because 255*64 fits.
+    //
+    // The scalar fallback has no such problem: `diff * amount` promotes to
+    // `int` there, so it never lost the bits in the first place.
+    //
+    // `vshrn_n_s32` keeps the arithmetic shift the fallback performs, which
+    // matters beyond overflow -- an arithmetic shift rounds toward negative
+    // infinity, so a diff of -1 at amount 1 gives -1 and not 0. Taking the
+    // absolute difference and negating afterwards would be cheaper and would
+    // disagree by one code on every darkening blend.
+    const i16 amount_s16 = static_cast<i16>(amount);
+    int16x8_t scaled_low = vcombine_s16(
+        vshrn_n_s32(vmull_n_s16(vget_low_s16(diff_low), amount_s16), 8),
+        vshrn_n_s32(vmull_n_s16(vget_high_s16(diff_low), amount_s16), 8));
+    int16x8_t scaled_high = vcombine_s16(
+        vshrn_n_s32(vmull_n_s16(vget_low_s16(diff_high), amount_s16), 8),
+        vshrn_n_s32(vmull_n_s16(vget_high_s16(diff_high), amount_s16), 8));
 
     // Widen a to 16-bit
     uint16x8_t a_low_16 = vmovl_u8(a_low);

--- a/src/platforms/simd.h
+++ b/src/platforms/simd.h
@@ -28,8 +28,18 @@
     // arithmetic via UQADD8 / UQSUB8 / UADD16 / etc. See issue #2628.
     #include "platforms/arm/teensy/simd_arm_dsp.hpp"  // IWYU pragma: keep
 #elif defined(__ARM_NEON) || defined(__ARM_NEON__)
-    // ARM Advanced SIMD: AArch64 (Apple Silicon, Raspberry Pi 3/4/5 in
+    // ARM Advanced SIMD, on compilers that advertise it the GNU way:
+    // AArch64 under clang or gcc (Apple Silicon, Raspberry Pi 3/4/5 in
     // 64-bit, any ARMv8-A board) and ARMv7-A parts with NEON.
+    //
+    // Deliberately *not* MSVC ARM64, which advertises `_M_ARM64` instead and
+    // spells the header `arm64_neon.h`. That target keeps the scalar
+    // fallback, which is what it had before this arm existed, and the
+    // `_M_ARM64` branches already inside `simd_arm_neon.hpp` stay
+    // unreachable. Adding it is a one-line guard and a different header, but
+    // it would switch a whole backend on for a toolchain nothing here can
+    // compile for, let alone run -- so it is recorded and pinned by a case
+    // in `ci/tests/test_simd_dispatch.py` rather than guessed at.
     //
     // This backend has been in the tree since before the dispatch was
     // written and nothing selected it -- the only reference to the file

--- a/src/platforms/simd.h
+++ b/src/platforms/simd.h
@@ -27,11 +27,27 @@
     // Apollo3, SAMD51, nRF52, STM32F4/F7, ...). Packed-byte and packed-half
     // arithmetic via UQADD8 / UQSUB8 / UADD16 / etc. See issue #2628.
     #include "platforms/arm/teensy/simd_arm_dsp.hpp"  // IWYU pragma: keep
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+    // ARM Advanced SIMD: AArch64 (Apple Silicon, Raspberry Pi 3/4/5 in
+    // 64-bit, any ARMv8-A board) and ARMv7-A parts with NEON.
+    //
+    // This backend has been in the tree since before the dispatch was
+    // written and nothing selected it -- the only reference to the file
+    // outside itself was a comment -- so every ARMv8-A target ran the scalar
+    // fallback with a full 128-bit implementation sitting unused beside it.
+    // FastLED#4286.
+    //
+    // Placed *after* the DSP arm rather than before it, which is the smaller
+    // change: `__ARM_FEATURE_DSP` is a 32-bit-ARM macro that AArch64 does not
+    // define, so nothing that reaches this line today was taking the DSP
+    // path. A 32-bit ARMv7-A part can define both, and those keep the
+    // backend they already had; moving them to NEON would likely be an
+    // improvement but it is a separate change with its own targets to check.
+    #include "platforms/arm/simd_arm_neon.hpp"  // IWYU pragma: keep
 #else
     // No SIMD support - use scalar fallback
-    // Covers: AVR, ESP8266, ARM Cortex-M0/M0+/M3 (no DSP ext), WASM, ARMv8-A
-    // (there is a NEON backend in `platforms/arm/simd_arm_neon.hpp`, but no
-    // arm above selects it), and anything else unmatched.
+    // Covers: AVR, ESP8266, ARM Cortex-M0/M0+/M3 (no DSP ext, no NEON),
+    // WASM, and anything else unmatched.
     #include "platforms/shared/simd_noop.hpp"  // IWYU pragma: keep
     #define FL_SIMD_BACKEND_IS_FALLBACK 1
 #endif


### PR DESCRIPTION
## A complete backend, selected by nothing

`src/platforms/arm/simd_arm_neon.hpp` implements all 66 operations of the SIMD API using `vhaddq_u8`, `vqmovn_u16` and the rest. No arm of `src/platforms/simd.h` selected it — the only reference to the file outside itself was a comment in `simd_arm_dsp.hpp`.

So every ARMv8-A target — Apple Silicon, Raspberry Pi 3/4/5 in 64-bit, any ARM64 board — ran the **scalar fallback**, with a 128-bit implementation sitting unused beside it. Filed as #4286 while working out why #4285 failed on the macOS runner.

## The arm, and where it goes

Placed **after** the DSP arm rather than before it, which is the smaller change:

- `__ARM_FEATURE_DSP` is a 32-bit-ARM macro that AArch64 does not define, so nothing reaching that line today was taking the DSP path;
- a 32-bit ARMv7-A part *can* define both, and those keep the backend they already had. Moving them to NEON is likely an improvement but has its own targets to check, and is not this.

That ordering is a decision, so it is pinned by a case rather than left to a comment.

## The dispatch table now has a test, which matters as much as the arm

A missing arm is invisible. The chain still compiles, still picks *a* backend, and the one it picks still works — only the performance is wrong, and nothing in the suite looked at that. That is how this survived.

`ci/tests/test_simd_dispatch.py` evaluates the **real chain with the real preprocessor**, one case per target family. Each backend `#include` is rewritten to a marker first, so the chain's logic can be checked without the target intrinsics (`arm_neon.h`, `emmintrin.h`) the host does not have for every target.

| target | selects |
|---|---|
| x86/x64 | `simd_x86.hpp` |
| ESP32 | `simd_esp32.hpp` |
| Cortex-M4/M7 (DSP) | `simd_arm_dsp.hpp` |
| **AArch64** | **`simd_arm_neon.hpp`** |
| ARMv7-A with both macros | `simd_arm_dsp.hpp` (the ordering decision) |
| unmatched (AVR, WASM, M0) | `simd_noop.hpp`, with `FL_SIMD_BACKEND_IS_FALLBACK 1` |

The last case is the one that would have caught this on the day: **every `simd_*.hpp` in the tree must be reachable** — named by the chain, or by a backend the chain selects (`simd_esp32.hpp` is itself a dispatch, over Xtensa, RISC-V and the fallback).

## Evidence

| mutation | result |
|---|---|
| remove the NEON arm (the #4286 state) | **3 cases fail**, including the reachability one |
| move the NEON arm before the DSP arm | the ordering case fails |

## What is validated where, stated plainly

Locally I can validate the **dispatch** and that **x86 is unchanged**: 302/302 unit, 84/84 examples, `bash lint` clean. I cannot run NEON on this host.

**The NEON backend's own correctness is validated by macOS CI**, where the runner is arm64 and now compiles it for the first time:

- `tests/fl/math/simd.cpp` (60 cases) exercises it as the platform backend;
- `tests/fl/math/simd_fallback.cpp` **turns on there for the first time** — `FL_SIMD_BACKEND_IS_FALLBACK` becomes 0, so the differential arm activates and compares all 66 operations against the scalar fallback.

That harness is #4285, and it is precisely the check #4286 said this wiring should sit behind. If NEON is wrong anywhere, CI names the operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NEON 8-bit blending for large differences to produce correct results without arithmetic overflow.
  * MSVC ARM64 targets now correctly retain the scalar fallback.

* **Tests**
  * Added coverage for SIMD backend selection across supported processor families.
  * Added verification that all available SIMD backends are reachable through dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->