### PR TITLE
study(color): price P9 item 2's other half — building in Q16, not just inverting (#4043)

### DIFF
--- a/ci/color_fixed_profile_study.py
+++ b/ci/color_fixed_profile_study.py
@@ -1,0 +1,233 @@
+"""Can the emitter matrix be *built* in fixed point, not just inverted?
+
+FastLED#4043 (P9) item 2 is "fixed-point `EmitterProfile` + bind-time
+derivation". #4275 measured one half of its precondition -- that a Q16 3x3
+inverse is accurate enough to replace the float one -- and it is: worst
+0.0064 dE2000 across the shipped primaries, against A1's 0.5.
+
+That measurement kept the *forward* matrix float. It quantised a matrix that
+float had already built from float chromaticities. The half it did not price
+is the one item 2 actually needs: `EmitterProfile` stores `float xy_r[2]`,
+and a float-free bind path has to hold those as Q16 and run `xyY_to_XYZ` in
+Q16 too.
+
+That is not the same question, and there is a specific reason to doubt it.
+`xyY_to_XYZ` is `X = Y*x/y`, `Z = Y*(1-x-y)/y` -- a division by `y`, and blue's
+`y` is about 0.06. One Q16 step is 1/65536, so quantising `y` there is a
+relative perturbation of 2.5e-04 on the divisor, and it lands on the column
+the inverse is least able to absorb. Measuring it before anyone converts the
+profile is the same discipline #4275 applied to the inverse: if it does not
+hold, item 2 as scoped is not effort, it is impossible, and that is worth
+knowing first.
+
+    uv run python ci/color_fixed_profile_study.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+from typeguard import typechecked
+
+from ci.color_fixed_inverse_study import (
+    D65_WHITE,
+    Primaries,
+    _matvec,
+    clamp_drives,
+    corpus_primaries,
+    delta_e2000,
+    emitter_matrix,
+    emitter_matrix_f32,
+    f32,
+    from_q16,
+    invert3x3_f32,
+    invert3x3_q16,
+    lab_safe,
+    quantize_rows,
+    rounded_div,
+    solve_q16,
+    sweep_drives,
+    to_q16,
+    xyz_to_lab,
+)
+
+
+kQ16One = 1 << 16
+
+
+@typechecked
+@dataclass(frozen=True, slots=True)
+class ProfileError:
+    """What one device costs when its profile is held in Q16.
+
+    `coefficient_ulps` is on the inverse the solve uses; `drive_error` is in
+    normalized drive units; `delta_e` is the perceptual figure A1 is written
+    in and the one that decides the question.
+    """
+
+    name: str
+    delta_e: float
+    drive_error: float
+    coefficient_ulps: int
+
+
+@typechecked
+def emitter_matrix_q16(primaries: Primaries) -> list[list[int]] | None:
+    """The emitter columns built entirely in Q16, from Q16 chromaticities.
+
+    Mirrors `xyY_to_XYZ`'s operation order -- divide by `y`, then scale --
+    because that order is what decides where a fixed-point path rounds. Unit
+    luminance per emitter, as `EmitterProfile`'s defaults carry.
+
+    Returns None when a `y` quantises to zero, which is the degenerate case
+    the shipped `isUsableSolveChromaticity` already refuses.
+    """
+
+    columns: list[list[int]] = []
+    for x_float, y_float in primaries:
+        x = to_q16(x_float)
+        y = to_q16(y_float)
+        if y <= 0:
+            return None
+        # z = 1 - x - y, in Q16, from the *quantised* x and y rather than
+        # from the floats: a fixed-point profile has no float to go back to.
+        z = kQ16One - x - y
+        # X = x / y and Z = z / y at unit Y, both in Q16.
+        columns.append(
+            [rounded_div(x * kQ16One, y), kQ16One, rounded_div(z * kQ16One, y)]
+        )
+    return [
+        [columns[0][0], columns[1][0], columns[2][0]],
+        [columns[0][1], columns[1][1], columns[2][1]],
+        [columns[0][2], columns[1][2], columns[2][2]],
+    ]
+
+
+@typechecked
+def compare_profile_quantization(
+    name: str, primaries: Primaries, steps: int
+) -> ProfileError:
+    """Worst dE2000, drive error and coefficient ULPs for one device.
+
+    The baseline is the shipped derivation at its own precision -- float32
+    forward, float32 inverse, quantised at the end -- exactly as #4275
+    models it. The candidate quantises the chromaticities first and never
+    reaches float again.
+    """
+
+    forward_f32 = emitter_matrix_f32(primaries)
+    inverse_f32 = invert3x3_f32(forward_f32)
+    if inverse_f32 is None:
+        raise ValueError(f"{name}: float32 inverse reported singular")
+    shipped = quantize_rows(inverse_f32)
+
+    forward_q16 = emitter_matrix_q16(primaries)
+    if forward_q16 is None:
+        raise ValueError(f"{name}: a chromaticity quantised to an unusable y")
+    proposed = invert3x3_q16(forward_q16)
+    if proposed is None:
+        raise ValueError(f"{name}: fixed-point inverse reported singular")
+
+    worst_ulps = 0
+    for row in range(3):
+        for col in range(3):
+            difference = abs(shipped[row][col] - proposed[row][col])
+            if difference > worst_ulps:
+                worst_ulps = difference
+
+    # Rendering stays float64: it stands in for the device, and modelling it
+    # at either candidate's precision would credit one of them with the
+    # emulator's rounding.
+    forward = emitter_matrix(primaries)
+
+    worst_delta_e = 0.0
+    worst_drive_error = 0.0
+    for drives in sweep_drives(steps):
+        xyz = _matvec(forward, drives)
+        shipped_drives = solve_q16(shipped, xyz)
+        proposed_drives = solve_q16(proposed, xyz)
+
+        for index in range(3):
+            error = abs(shipped_drives[index] - proposed_drives[index])
+            if error > worst_drive_error:
+                worst_drive_error = error
+
+        shipped_xyz = lab_safe(_matvec(forward, clamp_drives(shipped_drives)))
+        proposed_xyz = lab_safe(_matvec(forward, clamp_drives(proposed_drives)))
+        difference = delta_e2000(
+            xyz_to_lab(shipped_xyz, D65_WHITE), xyz_to_lab(proposed_xyz, D65_WHITE)
+        )
+        if difference > worst_delta_e:
+            worst_delta_e = difference
+
+    return ProfileError(name, worst_delta_e, worst_drive_error, worst_ulps)
+
+
+@typechecked
+def quantization_residual(primaries: Primaries) -> float:
+    """Largest relative error the Q16 grid puts on a chromaticity itself.
+
+    Reported alongside the dE2000, because it is the input to everything
+    above and it is where the divisor sensitivity shows: blue's `y` is the
+    smallest number in the profile and so the most perturbed in relative
+    terms.
+    """
+
+    worst = 0.0
+    for x_float, y_float in primaries:
+        for value in (x_float, y_float):
+            if value == 0.0:
+                continue
+            residual = abs(from_q16(to_q16(value)) - value) / abs(value)
+            if residual > worst:
+                worst = residual
+    return worst
+
+
+@typechecked
+def main(argv: list[str]) -> int:
+    """Print the table and return non-zero when A1 would be breached."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=9,
+        help="drive sweep resolution per axis (default 9, i.e. 729 targets)",
+    )
+    args = parser.parse_args(argv)
+
+    print("Building the emitter matrix in Q16, from Q16 chromaticities.")
+    print("Baseline: the shipped float32 forward + float32 inverse.")
+    print()
+    print(
+        f"{'primaries':<14}{'chroma q16 err':>16}{'coef ULP':>10}"
+        f"{'drive err':>12}{'worst dE2000':>14}"
+    )
+
+    worst_overall = 0.0
+    for name, primaries in corpus_primaries():
+        measured = compare_profile_quantization(name, primaries, args.steps)
+        residual = quantization_residual(primaries)
+        print(
+            f"{name:<14}{residual:>16.2e}{measured.coefficient_ulps:>10d}"
+            f"{measured.drive_error:>12.2e}{measured.delta_e:>14.4f}"
+        )
+        if measured.delta_e > worst_overall:
+            worst_overall = measured.delta_e
+
+    print()
+    # A1 allows 0.5 dE2000 end to end, and the gamut mapper already spends
+    # about 0.15 of it, so a derivation change has roughly 0.35 to work in.
+    print(f"worst across the corpus: {worst_overall:.4f} dE2000 (A1 budget 0.5)")
+    if worst_overall > 0.35:
+        print("OVER the derivation's share of the budget")
+        return 1
+    print("inside the derivation's share of the budget")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ci/tests/test_color_fixed_profile_study.py
+++ b/ci/tests/test_color_fixed_profile_study.py
@@ -66,12 +66,17 @@ class TestQuantizedProfileStudy(unittest.TestCase):
             if measured.delta_e > worst:
                 worst = measured.delta_e
         self.assertLess(worst, 0.35)
-        # And the measured value, so a regression that stays inside the
-        # budget still fails rather than sliding by.
-        self.assertLess(worst, 0.15)
-        # Not zero: that would mean the arms converged, which the case above
-        # checks structurally and this checks in the metric.
-        self.assertGreater(worst, 0.01)
+        # And a band around the measured 0.1085, tight enough that the
+        # figure the issue comment reports is the figure this checks. A
+        # single `assertLess(worst, 0.15)` admitted 0.149 -- materially worse
+        # than what was reported, and passing.
+        #
+        # The band is +/- 5%, which is far outside anything the arithmetic
+        # can drift by (both arms are deterministic integer paths over a
+        # fixed corpus and a fixed sweep) and far inside the 38% headroom to
+        # the budget. A change that moves this at all should say so.
+        self.assertGreater(worst, 0.1031)
+        self.assertLess(worst, 0.1139)
 
     def test_bt2020_is_the_worst_and_its_smallest_y_is_why(self) -> None:
         """The mechanism the study claims, checked rather than asserted.

--- a/ci/tests/test_color_fixed_profile_study.py
+++ b/ci/tests/test_color_fixed_profile_study.py
@@ -1,0 +1,124 @@
+"""The quantised-profile study measures what it claims to.
+
+`ci/color_fixed_profile_study.py` prices FastLED#4043 (P9) item 2's
+precondition: whether the emitter matrix can be *built* in fixed point from
+Q16 chromaticities, not merely inverted in fixed point from a float-built
+one. These cases guard the parts of that claim a reader would otherwise have
+to take on trust -- above all that the candidate really differs from the
+baseline, since a study whose two arms have silently converged reports a
+budget it never tested.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from ci.color_fixed_inverse_study import (
+    corpus_primaries,
+    emitter_matrix_f32,
+    from_q16,
+    quantize_rows,
+    to_q16,
+)
+from ci.color_fixed_profile_study import (
+    compare_profile_quantization,
+    emitter_matrix_q16,
+    main,
+    quantization_residual,
+)
+
+
+class TestQuantizedProfileStudy(unittest.TestCase):
+    """The measurement, and the reasons to believe it."""
+
+    def test_the_two_arms_actually_differ(self) -> None:
+        """Vacuity guard, and the most important case here.
+
+        If quantising the chromaticities first produced the same matrix the
+        float path builds, every dE2000 in the table would be zero and the
+        study would be reporting "inside budget" without having measured
+        anything.
+        """
+
+        differing = 0
+        for _name, primaries in corpus_primaries():
+            float_built = quantize_rows(emitter_matrix_f32(primaries))
+            q16_built = emitter_matrix_q16(primaries)
+            self.assertIsNotNone(q16_built)
+            assert q16_built is not None
+            for row in range(3):
+                for col in range(3):
+                    if float_built[row][col] != q16_built[row][col]:
+                        differing += 1
+        self.assertGreater(differing, 0, "the Q16 build matched float exactly")
+
+    def test_the_headline_figure_is_inside_a1(self) -> None:
+        """The result the issue comment reports, pinned.
+
+        Measured worst is 0.1085 dE2000 on BT.2020 against A1's 0.5, of
+        which the derivation has roughly 0.35 once the gamut mapper's 0.15
+        is accounted for.
+        """
+
+        worst = 0.0
+        for name, primaries in corpus_primaries():
+            measured = compare_profile_quantization(name, primaries, 9)
+            if measured.delta_e > worst:
+                worst = measured.delta_e
+        self.assertLess(worst, 0.35)
+        # And the measured value, so a regression that stays inside the
+        # budget still fails rather than sliding by.
+        self.assertLess(worst, 0.15)
+        # Not zero: that would mean the arms converged, which the case above
+        # checks structurally and this checks in the metric.
+        self.assertGreater(worst, 0.01)
+
+    def test_bt2020_is_the_worst_and_its_smallest_y_is_why(self) -> None:
+        """The mechanism the study claims, checked rather than asserted.
+
+        `xyY_to_XYZ` divides by `y`, so the profile with the smallest `y`
+        takes the largest relative perturbation from a Q16 grid. BT.2020's
+        blue sits at y = 0.046, the smallest number in the corpus.
+        """
+
+        by_name = dict(corpus_primaries())
+        residuals = {}
+        for name, primaries in by_name.items():
+            residuals[name] = quantization_residual(primaries)
+        shipped = ("srgb", "bt2020", "display_p3")
+        worst_shipped = max(shipped, key=lambda name: residuals[name])
+        self.assertEqual(worst_shipped, "bt2020")
+
+        smallest_y = min(y for _x, y in by_name["bt2020"])
+        self.assertLess(smallest_y, 0.05)
+
+    def test_a_chromaticity_that_quantises_to_zero_y_is_refused(self) -> None:
+        """The degenerate case the shipped guard already rejects.
+
+        `isUsableSolveChromaticity` refuses a non-positive `y`; a fixed-point
+        build has a second way to reach it, since a `y` below half a Q16 step
+        quantises to zero and would divide by it.
+        """
+
+        degenerate = ((0.64, 0.33), (0.30, 0.60), (0.15, 1.0 / 200000.0))
+        self.assertEqual(to_q16(1.0 / 200000.0), 0)
+        self.assertIsNone(emitter_matrix_q16(degenerate))
+
+    def test_q16_round_trip_is_within_one_step(self) -> None:
+        """The residual the table reports is a quantisation residual."""
+
+        for _name, primaries in corpus_primaries():
+            for x, y in primaries:
+                for value in (x, y):
+                    self.assertLessEqual(
+                        abs(from_q16(to_q16(value)) - value), 1.0 / 65536.0
+                    )
+
+    def test_the_entry_point_reports_success(self) -> None:
+        """`main` returns zero while the corpus stays inside the budget."""
+
+        self.assertEqual(main(["--steps", "5"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #4275 measured half the precondition; this is the other half

P9's survey calls item 2 — "fixed-point `EmitterProfile` + bind-time derivation" — the piece "genuinely blocked on nothing but effort". #4275 then measured its precondition: a Q16 3×3 inverse can replace the float one, at **0.0064 dE2000** against A1's 0.5.

But that measurement kept the **forward** matrix float. It quantised a matrix float had already built from float chromaticities — which is not what item 2 needs. `EmitterProfile` stores `float xy_r[2]`, and a float-free bind path has to hold those as Q16 and run `xyY_to_XYZ` in Q16 too.

There was a specific reason to doubt that half. `xyY_to_XYZ` is `X = Y·x/y` — a **division by `y`**, and BT.2020's blue sits at `y = 0.046`. One Q16 step there is a relative perturbation of `2.5e-04` on a divisor, landing on the column an inverse is least able to absorb.

## It holds — and the cost is 17× the inverse-only figure

| primaries | chroma q16 err | coef ULP | drive err | worst dE2000 |
|---|---:|---:|---:|---:|
| srgb | 4.07e-05 | 1 | 2.14e-04 | 0.0172 |
| **bt2020** | **1.14e-04** | 2 | 3.66e-04 | **0.1085** |
| display_p3 | 4.07e-05 | 1 | 7.63e-05 | 0.0037 |
| narrow | 1.53e-05 | 34 | 9.16e-05 | 0.0025 |

Worst **0.1085** against A1's 0.5, of which the derivation has roughly 0.35 once the gamut mapper's 0.15 is accounted for.

So **item 2 is feasible** — but the profile quantisation, not the inverse, is where its error budget goes: 0.109 against #4275's 0.0064 on the same corpus. Anyone doing item 2 should size it against 0.109, not 0.0064.

## The predicted mechanism is the one that shows up

BT.2020 carries both the worst chromaticity residual and the worst dE2000, and it is the profile with the smallest `y`. `narrow`, which is near-degenerate, takes **34 coefficient ULP and still only 0.0025 dE2000** — conditioning moves the coefficients, the small divisor moves the colour, and they are not the same failure. Worth stating because #4275's degeneracy walk found the opposite ordering, and it is easy to assume one figure predicts the other.

## Checked rather than assumed

**Undersampling.** The figure is stable from a 9-step drive sweep upward — 0.1085 at 9, 0.1093 at 17, 0.1000 at 25 — and only a 5-step sweep understates it, at 0.0423. The default is 9.

**Vacuity.** The most important case in the test file checks the two arms actually differ. A study whose candidate silently converged on its baseline reports "inside budget" having measured nothing.

| mutation | result |
|---|---|
| build the candidate from float chromaticities (arms converge) | headline case fails |
| remove the zero-`y` guard | degenerate case fails |

`bash lint` clean; 6 cases pass.

## What this does not do

It does not convert anything. `buildRgbSolveMatrixQ16` still builds and inverts in float, and `EmitterProfile` still stores floats — that is item 2, and it stays cross-cutting with P2 because the legacy RGBW stack consumes the same type. This says the effort is worth spending and what it has to fit inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Tools**
  - Added a fixed-point color profile study comparing quantized Q16 calculations with the existing floating-point approach.
  - Reports color accuracy, drive error, coefficient precision, and chromaticity quantization results across supported primary profiles.
  - Returns a failure status when measured color error exceeds the defined accuracy budget.

- **Tests**
  - Added coverage for quantization behavior, accuracy thresholds, edge cases, and successful study execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->