### PR TITLE
test(color): cover RGBW's hue objective under chroma compression (#4041)

### DIFF
--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1337,9 +1337,30 @@ FL_TEST_CASE("RGBW mapper preserves hue while compressing chroma") {
         const float divergence = hueDivergence(target_lab, mapped_lab);
         if (fl::fabsf(c[0] - 0.55f) < 1e-6f && fl::fabsf(c[1] - 0.42f) < 1e-6f) {
             FL_CHECK_LT(divergence, 0.030f);
-            // And it is genuinely worse than its neighbours: a fix that
-            // brought it into line should fail here and be looked at, not
-            // slide past a bound wide enough to cover it.
+            // Bounded from below as well, which is deliberate and is the
+            // same shape as the flash-bloat gate: that one fails on
+            // *unclaimed headroom* rather than congratulating you on it,
+            // because a ratchet with slack is not a ratchet.
+            //
+            // What makes it apply here is that 0.026 is unexplained. It is
+            // an order of magnitude above its four neighbours and above what
+            // RGBWW does on the same input, and nobody has established
+            // whether it comes from the allocation or the quantisation. If
+            // it quietly drops, something touched that path and the anomaly
+            // stopped being reproducible -- which is exactly when you want
+            // to be told rather than have the evidence absorbed.
+            //
+            // So this firing is not a defect, and the message says so,
+            // because a bound that fails on good news has to explain itself.
+            if (divergence <= 0.010f) {
+                FL_WARN_F("RGBW hue divergence at (0.55, 0.42) improved to %f "
+                          "from the 0.026 recorded here. That is good news, "
+                          "not a failure: find what changed, note it on "
+                          "FastLED#4041, and re-pin this bound. The point of "
+                          "the lower bound is that the anomaly cannot vanish "
+                          "unremarked.",
+                          static_cast<double>(divergence));
+            }
             FL_CHECK_GT(divergence, 0.010f);
         } else {
             FL_CHECK_LT(divergence, 0.005f);

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1272,6 +1272,108 @@ FL_TEST_CASE("RGBWW mapper leaves a neutral ramp neutral") {
     FL_CHECK_GT(exercised, 20);
 }
 
+FL_TEST_CASE("RGBW mapper preserves hue while compressing chroma") {
+    // The hue objective on the four-emitter hull, which was the one corner
+    // of P7's criterion still covered on only one path.
+    //
+    // RGBW's hue was checked above the neutral cap ("RGBW keeps the
+    // lightness above its own, higher cap"), where the walk-down chooses the
+    // lightness. This is the other way out of the hull: a target inside the
+    // cap whose *chroma* the four emitters cannot reach, so the halving
+    // search compresses along the hue ray and nothing else may move.
+    //
+    // Those are different code paths -- one goes through
+    // `highestReachableLightness`, this one does not -- so covering one said
+    // nothing about the other.
+    GamutMapRgbwQ16 map;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred,
+                                     &map));
+
+    const float kChroma[][2] = {
+        {0.70f, 0.28f}, {0.18f, 0.72f}, {0.10f, 0.03f},
+        {0.55f, 0.42f}, {0.08f, 0.55f},
+    };
+    int compressed = 0;
+    for (const auto& c : kChroma) {
+        i32 xyz[3];
+        xyzAt(c[0], c[1], 0.5f, xyz);
+
+        i32 probe[4];
+        const bool in_gamut = allocateEmitterDrivesQ16(map.allocation, xyz, probe);
+
+        i32 drives[4];
+        mapAndAllocateRgbwQ16(map, xyz, drives);
+        float as_float[4];
+        for (int i = 0; i < 4; ++i) {
+            as_float[i] = toFloat(drives[i]);
+        }
+        float produced[3];
+        reproduceRgbw(as_float, produced);
+        const i32 mapped_xyz[3] = {q16(produced[0]), q16(produced[1]),
+                                   q16(produced[2])};
+
+        i32 target_lab[3];
+        i32 mapped_lab[3];
+        xyzToOklabQ16(xyz, target_lab);
+        xyzToOklabQ16(mapped_xyz, mapped_lab);
+        // Bounded per target rather than by a single blanket tolerance,
+        // because the five do not behave alike and a bound loose enough for
+        // the worst would stop saying anything about the other four.
+        //
+        // Measured, in the same units `hueDivergence` returns (a sine, so
+        // 0.026 is about 1.5 degrees of OKLab hue):
+        //
+        //   (0.70, 0.28)   0.00018
+        //   (0.18, 0.72)   0.00174
+        //   (0.10, 0.03)   0.00025
+        //   (0.55, 0.42)   0.02610   <- the outlier
+        //   (0.08, 0.55)   0.00309
+        //
+        // RGBWW holds under 0.02 on the identical five, so this is a
+        // four-emitter property and not a corpus that is hard for everyone.
+        // Reported on FastLED#4041; see the note below the loop for what is
+        // and is not established about where it comes from.
+        const float divergence = hueDivergence(target_lab, mapped_lab);
+        if (fl::fabsf(c[0] - 0.55f) < 1e-6f && fl::fabsf(c[1] - 0.42f) < 1e-6f) {
+            FL_CHECK_LT(divergence, 0.030f);
+            // And it is genuinely worse than its neighbours: a fix that
+            // brought it into line should fail here and be looked at, not
+            // slide past a bound wide enough to cover it.
+            FL_CHECK_GT(divergence, 0.010f);
+        } else {
+            FL_CHECK_LT(divergence, 0.005f);
+        }
+        FL_CHECK(chromaDidNotGrow(target_lab, mapped_lab));
+        if (!in_gamut) {
+            ++compressed;
+        }
+    }
+    // Vacuity guard, and not a formality: if every target here were already
+    // inside the four-emitter hull the mapper would return them untouched
+    // and the hue check would be asserting that a copy equals itself. The
+    // white emitter makes this hull larger than the RGB one, so a target set
+    // chosen for the three-emitter case can quietly stop compressing here.
+    //
+    // Measured: all five are outside it, so all five are mapped.
+    FL_CHECK_EQ(compressed, 5);
+
+    // What is *not* established, stated rather than left to be assumed.
+    //
+    // `chromaCandidateXyz` scales `a` and `b` by one factor, which preserves
+    // hue exactly, so the mapper's own candidate is on the ray by
+    // construction. The divergence above therefore arises after it -- in the
+    // four-emitter allocation, or in the quantisation between the two. Which
+    // of those was not determined: the obvious experiment is to compare an
+    // in-gamut target, where `mapAndAllocateRgbwQ16` returns the plain
+    // allocation and any divergence is the allocator's alone, and all five
+    // targets here are out of gamut so this corpus cannot run it.
+    //
+    // The outlier is not a low-chroma artefact, which was the first
+    // explanation worth ruling out: its mapped chroma is 0.198 against a
+    // target 0.210, so the hue angle is well determined.
+}
+
 FL_TEST_CASE("RGBWW mapper preserves hue while compressing chroma") {
     // The last corner of the criterion: the hue objective on the five-emitter
     // hull.


### PR DESCRIPTION
## The one empty cell in P7's criterion grid

`tests/fl/gfx/gamut_map.cpp` already anchors a section to P7's criterion — *"In-gamut vectors preserve chromaticity; neutral ramps remain neutral; out-of-gamut mapping is continuous and meets the hue/luminance objective."* Three mappers × four parts left one cell empty.

RGBW's hue was checked only **above** the neutral cap, where the walk-down chooses the lightness. The other way out of the hull — a target inside the cap whose *chroma* the four emitters cannot reach, so the halving search compresses along the hue ray — had no hue coverage on that mapper. Those are different code paths (one goes through `highestReachableLightness`, the other does not), so covering one said nothing about the other.

## Writing it found an asymmetry

RGBWW's equivalent case uses five xy chromaticities and holds hue under 0.02. On the **identical five**, RGBW does not:

| target xy | hue divergence |
|---|---:|
| (0.70, 0.28) | 0.00018 |
| (0.18, 0.72) | 0.00174 |
| (0.10, 0.03) | 0.00025 |
| **(0.55, 0.42)** | **0.02610** |
| (0.08, 0.55) | 0.00309 |

`hueDivergence` returns a sine, so 0.026 is about **1.5° of OKLab hue**.

The case bounds each target against what it measures rather than putting one blanket tolerance over all five — at 0.03 that bound would stop saying anything about the four sitting near zero. The outlier is bounded from **below** too, so a change that brings it into line fails and gets looked at rather than sliding under a wide bound.

## What I did not establish, stated in the test

Where the 0.026 comes from. `chromaCandidateXyz` scales `a` and `b` by one factor, which preserves hue exactly, so the mapper's own candidate is on the ray *by construction* — the divergence arises after it, in the four-emitter allocation or the quantisation between them.

The experiment that would separate those is an in-gamut target, where `mapAndAllocateRgbwQ16` returns the plain allocation and any divergence is the allocator's alone. All five targets here are outside the four-emitter hull (measured — the vacuity guard asserts exactly 5 of 5 compress), so this corpus cannot run it.

**Ruled out first**, because it was the cheap explanation: it is not a low-chroma artefact. The outlier's mapped chroma is 0.198 against a target 0.210, so the hue angle is well determined rather than noise on a near-grey.

## Evidence

| mutation | result |
|---|---|
| swap `a` and `b` in the candidate (gross hue rotation) | fails this case (and 3 others) |
| nudge the candidate 400 Q16 units off the ray | fails this case (and 4 others) |

303/303 unit, 84/84 examples, `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for RGBW gamut mapping with multiple out-of-gamut chroma targets.
  - Verifies hue preservation remains within defined limits during chroma compression.
  - Confirms chroma does not increase and all tested targets are compressed.
  - Adds checks for an identified outlier case to ensure its behavior remains distinguishable and monitored.
  - Includes safeguards against vacuous or incomplete test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->