### PR TITLE
fix(dither): name the enable threshold, so the test reads it rather than a copy (#4042)

### DIFF
--- a/src/FastLED.cpp.hpp
+++ b/src/FastLED.cpp.hpp
@@ -315,7 +315,7 @@ FL_KEEP_ALIVE void CFastLED::show(fl::u8 scale) {
 			gControllersData[length] = nullptr;
 		}
 		length++;
-		if (mNFPS < 100) { pCur->setDither(0); }
+		if (mNFPS < FL_DITHER_ENABLE_MIN_REFRESH_HZ) { pCur->setDither(0); }
 		pCur = pCur->next();
 	}
 
@@ -392,7 +392,7 @@ void CFastLED::showColor(const CRGB & color, fl::u8 scale) {
 
 	pCur = CLEDController::head();
 	while(pCur && length < MAX_CLED_CONTROLLERS) {
-		if(mNFPS < 100) { pCur->setDither(0); }
+		if (mNFPS < FL_DITHER_ENABLE_MIN_REFRESH_HZ) { pCur->setDither(0); }
 		if (pCur->getEnabled()) {
 			pCur->showColorInternal(color, scale);
 		}

--- a/src/FastLED.h
+++ b/src/FastLED.h
@@ -683,6 +683,31 @@ inline ClearFlags& operator|=(ClearFlags& a, ClearFlags b) {
 
 /// High level controller interface for FastLED.
 /// This class manages controllers, global settings, and trackings such as brightness
+/// Refresh rate below which `show()` and `showColor()` turn temporal
+/// dithering off, in Hertz.
+///
+/// Named because it was a bare `100` at both call sites, which meant the case
+/// in `tests/pixel_controller.cpp` that records the resulting cadence had to
+/// carry its own copy of the number -- so changing the threshold moved the
+/// behaviour without failing anything.
+///
+/// **This does not agree with the constants the cycle length comes from**, and
+/// the gap is the point of naming it. `pixel_controller.h` derives
+/// `UPDATES_PER_FULL_DITHER_CYCLE` as `MAX_LIKELY_UPDATE_RATE_HZ /
+/// MIN_ACCEPTABLE_DITHER_RATE_HZ` = 400 / 50 = 8, so eight frames is the
+/// number that makes a 400 Hz refresh complete a cycle at 50 Hz. At *this*
+/// threshold an eight-frame cycle completes at 12.5 Hz -- a quarter of that
+/// floor, and near the peak of human flicker sensitivity rather than above
+/// it.
+///
+/// The refresh that would actually reach the floor is
+/// `MAX_LIKELY_UPDATE_RATE_HZ`. Raising this to it would disable dithering
+/// for most sketches, so it is a decision rather than a cleanup, and it is
+/// left as it was. FastLED#4042 owns the flicker budget that settles it;
+/// FastLED#4156 R8 asked for the cadence to be written down, and this is
+/// where it now is.
+#define FL_DITHER_ENABLE_MIN_REFRESH_HZ 100
+
 /// and refresh rates, and provides access functions for driving led data to controllers
 /// via the show() / showColor() / clear() methods.
 /// This is instantiated as a global object with the name FastLED.

--- a/tests/pixel_controller.cpp
+++ b/tests/pixel_controller.cpp
@@ -1,3 +1,4 @@
+#include "FastLED.h"  // FL_DITHER_ENABLE_MIN_REFRESH_HZ
 #include "pixel_controller.h"
 #include "fl/math/math.h"
 #include "test.h"
@@ -209,9 +210,16 @@ FL_TEST_CASE("Dither - the cycle rate at the enable threshold is below the file'
     FL_CHECK_EQ(MIN_ACCEPTABLE_DITHER_RATE_HZ, 50);
     FL_CHECK_EQ(MAX_LIKELY_UPDATE_RATE_HZ, 400);
 
-    // The threshold `show()` actually applies, repeated here because it is a
-    // literal there rather than a named constant.
-    const int kDitherEnableFps = 100;
+    // The threshold `show()` actually applies -- the shipped constant, not a
+    // copy of it. It used to be a bare `100` at both call sites and a second
+    // bare `100` here, so changing the threshold moved the behaviour and
+    // failed nothing. That is the defect FastLED#4279 fixed elsewhere: a
+    // test that reads a copy is not reading the thing it names.
+    const int kDitherEnableFps = FL_DITHER_ENABLE_MIN_REFRESH_HZ;
+    // Pinned separately so a change to the threshold fails *here*, where the
+    // cadence consequence is written down, rather than only wherever it is
+    // next used.
+    FL_CHECK_EQ(kDitherEnableFps, 100);
 
     // In floating point, because the number is 12.5 and the point of this
     // case is to record the cadence rather than a rounded stand-in for it.


### PR DESCRIPTION
## The case that was supposed to catch a change could not

`tests/pixel_controller.cpp` records the cadence gap #4156 R8 asked to have written down. The dither cycle length is derived:

```
MAX_LIKELY_UPDATE_RATE_HZ     400
MIN_ACCEPTABLE_DITHER_RATE_HZ  50
UPDATES_PER_FULL_DITHER_CYCLE  400 / 50 = 8
```

Eight frames is the number that makes a 400 Hz refresh complete a cycle at 50 Hz. But what *enables* dithering is a refresh of 100 — at which an eight-frame cycle completes at **12.5 Hz**, a quarter of that floor and near the peak of human flicker sensitivity.

The case says it "fails if either number moves so that whoever moves it writes down why". **It did not.** `show()` and `showColor()` each carried a bare `if (mNFPS < 100)`, and the case carried its own:

```cpp
// The threshold `show()` actually applies, repeated here because it is a
// literal there rather than a named constant.
const int kDitherEnableFps = 100;
```

So changing the threshold moved the behaviour and failed nothing. That is the same defect #4279 fixed elsewhere: a test that reads a copy is not reading the thing it names.

## What changed

`FL_DITHER_ENABLE_MIN_REFRESH_HZ` exists once, both call sites use it, and the case reads it.

**Verified rather than assumed**: setting the constant to 200 now fails three assertions, including the 12.5 Hz cadence pin. Before this change that mutation passed silently.

**Behaviour is unchanged** — the value is still 100. The gap is a decision and not a cleanup: raising it to `MAX_LIKELY_UPDATE_RATE_HZ`, the refresh that would actually reach the floor, would disable dithering for most sketches. What changes is that the arithmetic now lives at the definition rather than only in a doc and a test comment, and the constant cannot drift away from the case that prices it.

## Placement

In `FastLED.h` rather than beside the cycle constants in `pixel_controller.h`, because those sit inside `#if !defined(NO_DITHERING) || (NO_DITHERING != 1)` while the `setDither(0)` calls this gates do not — putting it there would break a `NO_DITHERING=1` build.

Renamed from `FASTLED_`- to `FL_`-prefixed after `MacroPrefixChecker` flagged it; the repo requires the prefix for new macros.

303/303 unit, 84/84 examples, `bash lint` clean.

## Why this matters beyond tidiness

P8 (#4042) still owes a flicker budget, and the doc's own note is that it is "worth having before any *pipeline* dither is built, because that one modulates harder". This does not set the budget. It makes the number that the budget will have to move a named thing with the consequence attached, instead of a literal in two places that nothing was watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the public `FL_DITHER_ENABLE_MIN_REFRESH_HZ` setting to identify the minimum refresh rate at which dithering remains enabled.
  * Added documentation explaining the dithering threshold and its relationship to full dithering cycles.

* **Bug Fixes**
  * Ensured dithering behavior consistently uses the documented refresh-rate threshold.

* **Tests**
  * Updated dither cadence coverage to validate against the shipped threshold setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->