### PR TITLE
docs(color): state the black floor the fidelity contract asks for (#4034)

### DIFF
--- a/docs/color-pipeline-contracts.md
+++ b/docs/color-pipeline-contracts.md
@@ -256,15 +256,34 @@ Its effect on A1, over all 57 vectors the corpus holds for that device:
 | every vector | 1.3055, at `bt2020-rgb-03` -- source code (0,0,1) in BT.2020, whose reference drives are (0, 5.242e-05, **1.447e-05**) |
 | vectors with no sub-ULP drive (49 of 57) | **0.3951** |
 
-So A1's 0.5 is met everywhere the arithmetic can represent the target, and the
-two vectors above it are unreachable by any fixed-point implementation of this
-width rather than by this one. Eight of the 57 carry a sub-ULP drive.
+So A1's 0.5 is met everywhere the arithmetic can represent the target **in a
+single frame**, which is what these figures measure: `processPixelQ16` returns
+one `i32` triple per pixel and the corpus is compared frame by frame. The
+vectors above 0.5 are out of reach of a one-frame fixed-point answer of this
+width -- by any implementation of it, not just this one. They are not thereby
+unreachable altogether, because a cycle can average to a sub-ULP drive; see
+the note below on the unsupported low-light region, which is the same
+distinction from the other side. Eight of the 57 carry a sub-ULP drive.
 
-Both figures are asserted in `tests/fl/gfx/pipeline.cpp`, so neither the
-floored result nor the unfloored miss can drift while the other passes. This
-does not silently exclude difficult vectors: the excluded set is defined by a
-property of the arithmetic, counted, and the unfloored number is published
-beside the floored one.
+What `tests/fl/gfx/pipeline.cpp` asserts, stated exactly rather than as "both
+figures are pinned", which they are not:
+
+* the corpus size and the excluded count are pinned exactly -- `kVectorCount
+  == 57` and `below_floor == 8` -- so a shrunken corpus, or a floor that
+  swallowed it, cannot satisfy the bounds below;
+* the floored worst is bounded above twice, at A1's `0.5` and again at `0.45`,
+  so a regression that stays inside A1 still fails;
+* the unfloored worst is bounded above at `1.4`, so the low-light miss cannot
+  quietly grow while the floored bound keeps passing.
+
+Those are upper bounds and not equalities: a floored worst of 0.44 would pass.
+The measured values, 0.3951 and 1.3055, are recorded in the comments beside
+those assertions and here, and are what a change should be read against. The
+count of vectors above 0.5 is not asserted at all -- `below_floor` is.
+
+This does not silently exclude difficult vectors: the excluded set is defined
+by a property of the arithmetic, its size is asserted, and the unfloored
+number is published beside the floored one.
 
 What this floor does **not** settle is the *unsupported low-light region* the
 same paragraph asks for -- that is a statement about what a device is allowed

--- a/docs/color-pipeline-contracts.md
+++ b/docs/color-pipeline-contracts.md
@@ -231,6 +231,46 @@ but cannot prove ideal-light accuracy. Publish luminance normalization,
 relative-error denominators, black-floor treatment, and the exact corpus.
 Do not silently exclude difficult vectors to satisfy the issue's budgets.
 
+#### The black floor, stated
+
+The paragraph above requires a black-floor treatment to be published. This is
+it, measured rather than chosen.
+
+**A reference drive below one s16.16 unit is outside the budget's scope.** One
+unit is `1/65536` = `1.5259e-05` in normalized emitter flux. Below that the
+fixed-point path can only answer zero or a whole unit where the reference asks
+for a fraction of one, and CIELAB's kappa branch turns that into a whole unit
+of L*.
+
+The floor is the arithmetic's resolution and **not** a luminance threshold,
+which is the part worth being exact about because the obvious form does not
+work. Measured on the P5 corpus's `rgb` device, `bt2020-rgb-02` misses at
+Y = 5.4e-04 while `srgb_bt709-rgb-00` passes at Y = 3.0e-04 -- a *darker*
+vector inside the budget and a brighter one outside it. What separates them is
+that the first has a sub-ULP drive and the second does not.
+
+Its effect on A1, over all 57 vectors the corpus holds for that device:
+
+| | worst dE2000 |
+|---|---:|
+| every vector | 1.3055, at `bt2020-rgb-03` -- source code (0,0,1) in BT.2020, whose reference drives are (0, 5.242e-05, **1.447e-05**) |
+| vectors with no sub-ULP drive (49 of 57) | **0.3951** |
+
+So A1's 0.5 is met everywhere the arithmetic can represent the target, and the
+two vectors above it are unreachable by any fixed-point implementation of this
+width rather than by this one. Eight of the 57 carry a sub-ULP drive.
+
+Both figures are asserted in `tests/fl/gfx/pipeline.cpp`, so neither the
+floored result nor the unfloored miss can drift while the other passes. This
+does not silently exclude difficult vectors: the excluded set is defined by a
+property of the arithmetic, counted, and the unfloored number is published
+beside the floored one.
+
+What this floor does **not** settle is the *unsupported low-light region* the
+same paragraph asks for -- that is a statement about what a device is allowed
+to render, and it needs P8's dithering answer, since a sub-ULP average drive is
+reachable over a cycle even though it is not reachable in one frame.
+
 Dither accuracy is based on time-weighted emitted XYZ over a declared cadence
 and observation window, followed by perceptual error calculation. It is not
 an unweighted mean of frame codes or frame Delta E values. State advances on


### PR DESCRIPTION
## The contract requires a black floor and did not contain one

`docs/color-pipeline-contracts.md` says:

> Publish luminance normalization, relative-error denominators, **black-floor treatment**, and the exact corpus. Do not silently exclude difficult vectors to satisfy the issue's budgets.

It published none. #4156 R8 asked for the same thing. #4287 measured it, and this writes it down where the contract lives rather than leaving it in a test comment and an issue thread.

## The floor

**A reference drive below one s16.16 unit** — `1/65536` = `1.5259e-05` in normalized emitter flux. Below that the fixed-point path can only answer zero or a whole unit where the reference asks for a fraction of one, and CIELAB's kappa branch turns that into a whole unit of L*.

**It is not a luminance threshold**, and that is the part worth being exact about, because the obvious form does not separate the cases:

| vector | Y | verdict |
|---|---:|---|
| `bt2020-rgb-02` | 5.4e-04 | **misses** |
| `srgb_bt709-rgb-00` | 3.0e-04 | passes |

A darker vector inside the budget and a brighter one outside it. What distinguishes them is a sub-ULP drive.

## Both figures, not just the flattering one

| | worst dE2000 |
|---|---:|
| all 57 vectors | 1.3055 |
| the 49 with no sub-ULP drive | **0.3951** |

Publishing only the second would be the *"silently exclude difficult vectors"* the same paragraph forbids. So the excluded set is defined by a property of the arithmetic, counted at eight, and the unfloored number is stated beside the floored one — as both already are in `tests/fl/gfx/pipeline.cpp`, so neither can drift while the other passes.

## What it does not settle

The **unsupported low-light region** the same paragraph asks for. That is a statement about what a device may render, and it waits on P8's dithering answer — a sub-ULP *average* drive is reachable over a cycle even though it is not reachable in one frame. Said in the doc rather than left for a reader to assume this closed it.

## Checked

Every figure was cross-checked against the assertions in `tests/fl/gfx/pipeline.cpp` rather than carried over from #4287's description — `kQ16Unit`, `below_floor == 8`, `kVectorCount == 57`, and the two worst-case bounds.

Docs only; `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the fixed-point resolution floor is an arithmetic limit, not a luminance threshold.
  * Documented measured color-difference results and upper bounds for supported test vectors.
  * Clarified frame-by-frame comparison, excluded-vector criteria, and pinned corpus counts.
  * Noted that cycle-averaged sub-floor output may still be possible.
  * Recorded that unsupported low-light behavior remains unresolved pending dithering support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->