### PR TITLE
perf(simd): stop the 4-lane scalar backends indexing their lanes out of memory (#4216)

### DIFF
--- a/ci/tests/test_simd_dispatch.py
+++ b/ci/tests/test_simd_dispatch.py
@@ -95,6 +95,42 @@ def _select(defines: list[str]) -> tuple[str, str]:
     return selected, fallback
 
 
+@typechecked
+def _arm_cross_compiler() -> str | None:
+    """An `arm-none-eabi-gcc`, if this machine has one."""
+
+    found = shutil.which("arm-none-eabi-gcc")
+    if found is not None:
+        return found
+    # PlatformIO and fbuild both keep one under the user's cache.
+    for root in (Path.home() / ".platformio" / "packages", Path.home() / ".fbuild"):
+        if not root.is_dir():
+            continue
+        for candidate in root.rglob("bin/arm-none-eabi-gcc"):
+            return str(candidate)
+    return None
+
+
+@typechecked
+def _predefined(compiler: str, flags: list[str], macro: str) -> str:
+    """`macro`'s value in `compiler`'s predefined set under `flags`, or ""."""
+
+    completed = subprocess.run(  # noqa: SRC001
+        [compiler, *flags, "-dM", "-E", "-x", "c", "-"],
+        input="",
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    for line in completed.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0] == "#define" and parts[1] == macro:
+            return parts[2]
+    return ""
+
+
 class TestSimdDispatch(unittest.TestCase):
     """One case per target family the chain claims to cover."""
 
@@ -112,6 +148,47 @@ class TestSimdDispatch(unittest.TestCase):
         """Teensy 3.x/4.x, SAMD51, nRF52: DSP extension, no NEON."""
 
         backend, fallback = _select(["-D__ARM_FEATURE_DSP=1"])
+        self.assertEqual(backend, "platforms/arm/teensy/simd_arm_dsp.hpp")
+        self.assertEqual(fallback, "0")
+
+    def test_cortex_m33_with_the_dsp_extension_takes_the_dsp_backend(self) -> None:
+        """RP2350, and why FastLED#4216 was filed against the wrong file.
+
+        That issue reported a 15x slowdown in the packed `s16x16x4` type on an
+        RP2350W and attributed it to `simd_noop.hpp`, on the reasoning that
+        "RP2350 is Cortex-M33 without `__ARM_FEATURE_DSP`". The Cortex-M33
+        does not have to carry the DSP extension, but the RP2350's does, and
+        the Arduino-Pico core compiles for it: its `rp2350` branch passes
+        `-mcpu=cortex-m33 -march=armv8-m.main+fp+dsp`, and GCC then defines
+        `__ARM_FEATURE_DSP` to 1. So the arm below claims the target and
+        `simd_noop.hpp` is never reached.
+
+        Two of that issue's experiments -- dropping `FL_ALIGNAS(16)`, and
+        unrolling the trip-4 lane loops -- were made in `simd_noop.hpp` and
+        measured no change, which was then read as evidence against both
+        ideas. Neither edit was in the build. The unroll in particular works:
+        it is what `FL_SIMD_LANE4` now does.
+
+        The arm this lands on is written for "Cortex-M4 / M4F / M7", which is
+        where the misreading starts; ARMv8-M parts reach it too.
+        """
+
+        compiler = _arm_cross_compiler()
+        if compiler is None:
+            raise unittest.SkipTest("no arm-none-eabi-gcc on this machine")
+
+        # Verbatim from the Arduino-Pico core's `rp2350` branch,
+        # framework-arduinopico/tools/platformio-build.py.
+        rp2350_flags = [
+            "-mcpu=cortex-m33",
+            "-mthumb",
+            "-march=armv8-m.main+fp+dsp",
+            "-mfloat-abi=softfp",
+        ]
+        dsp = _predefined(compiler, rp2350_flags, "__ARM_FEATURE_DSP")
+        self.assertEqual(dsp, "1", "an RP2350 build defines __ARM_FEATURE_DSP")
+
+        backend, fallback = _select([f"-D__ARM_FEATURE_DSP={dsp}"])
         self.assertEqual(backend, "platforms/arm/teensy/simd_arm_dsp.hpp")
         self.assertEqual(fallback, "0")
 

--- a/src/platforms/arm/teensy/simd_arm_dsp.hpp
+++ b/src/platforms/arm/teensy/simd_arm_dsp.hpp
@@ -45,6 +45,7 @@
 #include "fl/stl/compiler_control.h"  // IWYU pragma: keep
 #include "fl/stl/noexcept.h"       // IWYU pragma: keep
 #include "fl/math/math.h"          // for sqrtf (scalar f32 fallback)
+#include "platforms/shared/simd_lane4.h"  // IWYU pragma: keep
 
 // This file is only meaningful when the ARMv7E-M DSP extension is present.
 // All Teensy 3.x (Cortex-M4 / M4F) and Teensy 4.x (Cortex-M7) cores have it.
@@ -262,46 +263,46 @@ FASTLED_FORCE_INLINE FL_IRAM void store_u8_16(u8* ptr, simd_u8x16 vec) FL_NO_EXC
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4(const u32* ptr) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4_aligned(const u32* ptr) FL_NO_EXCEPT {
     const u32* p = FL_ASSUME_ALIGNED(ptr, 16);
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = p[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_u32_4(u32* ptr, simd_u32x4 vec) FL_NO_EXCEPT {
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_u32_4_aligned(u32* ptr, simd_u32x4 vec) FL_NO_EXCEPT {
     u32* p = FL_ASSUME_ALIGNED(ptr, 16);
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         p[i] = vec.data[i];
-    }
+    );
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 load_f32_4(const float* ptr) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_f32_4(float* ptr, simd_f32x4 vec) FL_NO_EXCEPT {
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 
 //==============================================================================
@@ -620,7 +621,7 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u16x8 set1_u16_8(u16 value) FL_NO_EXCEPT {
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 set1_u32_4(u32 value) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = value;
+    FL_SIMD_LANE4(result.data[i] = value;);
     return result;
 }
 
@@ -635,19 +636,19 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 set_u32_4(u32 a, u32 b, u32 c, u32 d) FL
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 xor_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] ^ b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] ^ b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 add_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] + b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] + b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sub_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] - b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] - b.data[i];);
     return result;
 }
 
@@ -668,21 +669,21 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_i32_4(simd_u32x4 a, simd_u32x4 b) 
     // SMMUL gives (i32 × i32) >> 32 in one cycle; we want >> 16, so use a wide
     // SMULL pair and shift. Scalar long-multiply lets the compiler pick SMULL.
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 a_i = static_cast<i32>(a.data[i]);
         i32 b_i = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(a_i) * static_cast<i64>(b_i);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 16));
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         u64 prod = static_cast<u64>(a.data[i]) * static_cast<u64>(b.data[i]);
         result.data[i] = static_cast<u32>(prod >> 16);
-    }
+    );
     return result;
 }
 
@@ -692,65 +693,65 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_su32_4(simd_u32x4 a, simd_u32x4 b)
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 srl_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = vec.data[i] >> shift;
+    FL_SIMD_LANE4(result.data[i] = vec.data[i] >> shift;);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sll_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = vec.data[i] << shift;
+    FL_SIMD_LANE4(result.data[i] = vec.data[i] << shift;);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sra_i32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 signed_val = static_cast<i32>(vec.data[i]);
         result.data[i] = static_cast<u32>(signed_val >> shift);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 and_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] & b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] & b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 or_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] | b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] | b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 min_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai < bi ? ai : bi);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 max_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai > bi ? ai : bi);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi32_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(ai) * static_cast<i64>(bi);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 32));
-    }
+    );
     return result;
 }
 
@@ -792,49 +793,49 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 unpackhi_u64_as_u32_4(simd_u32x4 a, simd
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 set1_f32_4(float value) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = value;
+    FL_SIMD_LANE4(result.data[i] = value;);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 add_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] + b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] + b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sub_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] - b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] - b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 mul_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] * b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] * b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 div_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = a.data[i] / b.data[i];
+    FL_SIMD_LANE4(result.data[i] = a.data[i] / b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sqrt_f32_4(simd_f32x4 vec) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = fl::sqrtf(vec.data[i]);
+    FL_SIMD_LANE4(result.data[i] = fl::sqrtf(vec.data[i]););
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 min_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = (a.data[i] < b.data[i]) ? a.data[i] : b.data[i];
+    FL_SIMD_LANE4(result.data[i] = (a.data[i] < b.data[i]) ? a.data[i] : b.data[i];);
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 max_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) result.data[i] = (a.data[i] > b.data[i]) ? a.data[i] : b.data[i];
+    FL_SIMD_LANE4(result.data[i] = (a.data[i] > b.data[i]) ? a.data[i] : b.data[i];);
     return result;
 }
 

--- a/src/platforms/esp/32/simd_riscv.hpp
+++ b/src/platforms/esp/32/simd_riscv.hpp
@@ -13,6 +13,7 @@
 
 #include "fl/stl/stdint.h"  // IWYU pragma: keep
 #include "fl/stl/align.h"  // IWYU pragma: keep
+#include "platforms/shared/simd_lane4.h"  // IWYU pragma: keep
 
 #if defined(FL_IS_ESP_32C2) || defined(FL_IS_ESP_32C3) || \
     defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32C6) || \
@@ -174,33 +175,33 @@ FASTLED_FORCE_INLINE FL_IRAM void store_u8_16(u8* ptr, simd_u8x16 vec) FL_NO_EXC
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4(const u32* ptr) FL_NO_EXCEPT {
     simd_u32x4 result;
     // RVV-ready: This loop can be replaced with vle32.v
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_u32_4(u32* ptr, simd_u32x4 vec) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vse32.v
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 load_f32_4(const float* ptr) FL_NO_EXCEPT {
     simd_f32x4 result;
     // RVV-ready: This loop can be replaced with vle32.v
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_f32_4(float* ptr, simd_f32x4 vec) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vse32.v
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 
 //==============================================================================
@@ -229,9 +230,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u8x16 scale_u8_16(simd_u8x16 vec, u8 scale) FL
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 set1_u32_4(u32 value) FL_NO_EXCEPT {
     simd_u32x4 result;
     // RVV-ready: This loop can be replaced with vmv.v.x
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = value;
-    }
+    );
     return result;
 }
 
@@ -353,72 +354,72 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u8x16 max_u8_16(simd_u8x16 a, simd_u8x16 b) FL
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 set1_f32_4(float value) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vmv.v.x
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = value;
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 add_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfadd.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] + b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sub_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfsub.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] - b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 mul_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfmul.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] * b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 div_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfdiv.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] / b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sqrt_f32_4(simd_f32x4 vec) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfsqrt.v
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = fl::sqrtf(vec.data[i]);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 min_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfmin.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = (a.data[i] < b.data[i]) ? a.data[i] : b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 max_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vfmax.vv
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = (a.data[i] > b.data[i]) ? a.data[i] : b.data[i];
-    }
+    );
     return result;
 }
 
@@ -432,9 +433,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 xor_u32_4(simd_u32x4 a, simd_u32x4 b) FL
     pie_xor_128(a.data, b.data, result.data);
 #else
     // RVV-ready: This loop can be replaced with vxor.vv
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] ^ b.data[i];
-    }
+    );
 #endif
     return result;
 }
@@ -442,22 +443,22 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 xor_u32_4(simd_u32x4 a, simd_u32x4 b) FL
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 add_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vadd.vv
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 a_i = static_cast<i32>(a.data[i]);
         i32 b_i = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(a_i + b_i);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sub_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vsub.vv
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 a_i = static_cast<i32>(a.data[i]);
         i32 b_i = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(a_i - b_i);
-    }
+    );
     return result;
 }
 
@@ -467,21 +468,21 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_i32_4(simd_u32x4 a, simd_u32x4 b) 
 #if __riscv_xlen == 32
     // RV32: Use mul+mulh inline asm to avoid 64-bit widening multiply.
     // Extracts bits [47:16] of each 64-bit product for Q16.16 fixed-point.
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 lo, hi;
         asm("mul  %0, %2, %3\n\t"
             "mulh %1, %2, %3"
             : "=&r"(lo), "=&r"(hi)
             : "r"(a.data[i]), "r"(b.data[i]));
         result.data[i] = (static_cast<u32>(lo) >> 16) | (static_cast<u32>(hi) << 16);
-    }
+    );
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 a_i = static_cast<i32>(a.data[i]);
         i32 b_i = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(a_i) * static_cast<i64>(b_i);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 16));
-    }
+    );
 #endif
     return result;
 }
@@ -489,9 +490,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_i32_4(simd_u32x4 a, simd_u32x4 b) 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 srl_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     // RVV-ready: This loop can be replaced with vsrl.vx
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = vec.data[i] >> shift;
-    }
+    );
     return result;
 }
 
@@ -501,9 +502,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 and_u32_4(simd_u32x4 a, simd_u32x4 b) FL
     pie_and_128(a.data, b.data, result.data);
 #else
     // RVV-ready: This loop can be replaced with vand.vv
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] & b.data[i];
-    }
+    );
 #endif
     return result;
 }
@@ -514,9 +515,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4_aligned(const u32* ptr) FL_NO
 #if FL_RISCV_HAS_PIE
     pie_copy_128(p, result.data);
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = p[i];
-    }
+    );
 #endif
     return result;
 }
@@ -526,9 +527,9 @@ FASTLED_FORCE_INLINE FL_IRAM void store_u32_4_aligned(u32* ptr, simd_u32x4 vec) 
 #if FL_RISCV_HAS_PIE
     pie_copy_128(vec.data, p);
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         p[i] = vec.data[i];
-    }
+    );
 #endif
 }
 
@@ -546,27 +547,27 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 or_u32_4(simd_u32x4 a, simd_u32x4 b) FL_
 #if FL_RISCV_HAS_PIE
     pie_or_128(a.data, b.data, result.data);
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] | b.data[i];
-    }
+    );
 #endif
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sll_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = vec.data[i] << shift;
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sra_i32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 signed_val = static_cast<i32>(vec.data[i]);
         result.data[i] = static_cast<u32>(signed_val >> shift);
-    }
+    );
     return result;
 }
 
@@ -574,19 +575,19 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_u32_4(simd_u32x4 a, simd_u32x4 b) 
     simd_u32x4 result;
 #if __riscv_xlen == 32
     // RV32: Use mul+mulhu inline asm to avoid 64-bit widening multiply.
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         u32 lo, hi;
         asm("mul   %0, %2, %3\n\t"
             "mulhu %1, %2, %3"
             : "=&r"(lo), "=&r"(hi)
             : "r"(a.data[i]), "r"(b.data[i]));
         result.data[i] = (lo >> 16) | (hi << 16);
-    }
+    );
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         u64 prod = static_cast<u64>(a.data[i]) * static_cast<u64>(b.data[i]);
         result.data[i] = static_cast<u32>(prod >> 16);
-    }
+    );
 #endif
     return result;
 }
@@ -599,41 +600,41 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi32_i32_4(simd_u32x4 a, simd_u32x4 b
     simd_u32x4 result;
 #if __riscv_xlen == 32
     // RV32: >> 32 means we only need the high word — single mulh instruction.
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 hi;
         asm("mulh %0, %1, %2"
             : "=r"(hi)
             : "r"(a.data[i]), "r"(b.data[i]));
         result.data[i] = static_cast<u32>(hi);
-    }
+    );
 #else
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(ai) * static_cast<i64>(bi);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 32));
-    }
+    );
 #endif
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 min_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai < bi ? ai : bi);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 max_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai > bi ? ai : bi);
-    }
+    );
     return result;
 }
 

--- a/src/platforms/shared/simd_lane4.h
+++ b/src/platforms/shared/simd_lane4.h
@@ -1,0 +1,52 @@
+// ok no namespace fl
+#pragma once
+
+// IWYU pragma: private
+
+/// @file simd_lane4.h
+/// Four-lane loop replacement for the scalar SIMD backends.
+
+/// Run @p ... once per lane of a 4-lane vector, with `i` bound to the lane
+/// index as a compile-time constant.
+///
+/// This exists to keep the scalar backends from writing
+/// `for (int i = 0; i < 4; ++i)`, which looks equivalent and is not.
+///
+/// Those backends hold their lanes in a `u32 data[4]` member. A trip-4 loop
+/// indexes that array with a runtime induction variable, so the vector has to
+/// live in memory: every lane costs a load and a store, and a four-lane
+/// operation never reaches registers at all. Once the index is a constant the
+/// subscripts fold away, the register allocator keeps the whole vector live,
+/// and the stack traffic disappears.
+///
+/// Measured on one packed multiply-add -- `mulhi_i32_4` then `add_i32_4`, the
+/// pair `fl::s16x16x4`'s operators reduce to -- compiled at each backend's
+/// shipping optimisation level and counted over the whole function:
+///
+/// | backend | target | before | after |
+/// |---|---|---|---|
+/// | `simd_arm_dsp.hpp` | Cortex-M33, `-Os -march=armv8-m.main+fp+dsp` | 67 insns, 60 B frame | 41 insns, no frame |
+/// | `simd_noop.hpp` | Cortex-M0+, `-Os -march=armv6-m` | 107 insns, 84 B frame | 82 insns, 28 B frame |
+/// | `simd_riscv.hpp` | RV32IMAC, `-Os` | 21 insns, 64 B frame | 14 insns, no frame |
+///
+/// Cortex-M0+ keeps a frame because eight low registers cannot hold twelve
+/// live lanes; it still loses a quarter of its instructions.
+///
+/// Nothing here needs a macro to work -- four hand-written statements with
+/// literal subscripts generate the same code. The macro is how the bodies stay
+/// single copies, and it is what stops the loops growing back: a future reader
+/// who sees four near-identical statements will fold them into a `for`, and
+/// this file is the note explaining why that undoes the fix.
+///
+/// The `constexpr int i` shadows nothing, because the loops this replaces used
+/// `i` for exactly the same thing -- which is why their bodies transplanted
+/// verbatim. Each lane gets its own scope so a body may declare locals.
+///
+/// FastLED#4216.
+#define FL_SIMD_LANE4(...)                                                     \
+    do {                                                                       \
+        { constexpr int i = 0; __VA_ARGS__ }                                   \
+        { constexpr int i = 1; __VA_ARGS__ }                                   \
+        { constexpr int i = 2; __VA_ARGS__ }                                   \
+        { constexpr int i = 3; __VA_ARGS__ }                                   \
+    } while (0)

--- a/src/platforms/shared/simd_noop.hpp
+++ b/src/platforms/shared/simd_noop.hpp
@@ -10,6 +10,7 @@
 
 #include "fl/stl/stdint.h"
 #include "fl/stl/compiler_control.h"
+#include "platforms/shared/simd_lane4.h"
 #include "fl/stl/align.h"
 #include "fl/math/math.h"  // for sqrtf
 #include "fl/stl/align.h"
@@ -82,9 +83,9 @@ FASTLED_FORCE_INLINE FL_IRAM void store_u8_16(u8* ptr, simd_u8x16 vec) FL_NO_EXC
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4(const u32* ptr) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
@@ -93,38 +94,38 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4(const u32* ptr) FL_NO_EXCEPT 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 load_u32_4_aligned(const u32* ptr) FL_NO_EXCEPT {
     const u32* p = FL_ASSUME_ALIGNED(ptr, 16);
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = p[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_u32_4(u32* ptr, simd_u32x4 vec) FL_NO_EXCEPT {
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 /// Aligned store scalar fallback: FL_ASSUME_ALIGNED propagates the alignment hint
 /// to surrounding loop code, matching the behaviour of _mm_store_si128 on SSE2.
 FASTLED_FORCE_INLINE FL_IRAM void store_u32_4_aligned(u32* ptr, simd_u32x4 vec) FL_NO_EXCEPT {
     u32* p = FL_ASSUME_ALIGNED(ptr, 16);
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         p[i] = vec.data[i];
-    }
+    );
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 load_f32_4(const float* ptr) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = ptr[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM void store_f32_4(float* ptr, simd_f32x4 vec) FL_NO_EXCEPT {
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         ptr[i] = vec.data[i];
-    }
+    );
 }
 
 //==============================================================================
@@ -150,9 +151,9 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u8x16 scale_u8_16(simd_u8x16 vec, u8 scale) FL
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 set1_u32_4(u32 value) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = value;
-    }
+    );
     return result;
 }
 
@@ -262,65 +263,65 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u8x16 andnot_u8_16(simd_u8x16 a, simd_u8x16 b)
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 set1_f32_4(float value) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = value;
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 add_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] + b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sub_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] - b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 mul_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] * b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 div_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] / b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 sqrt_f32_4(simd_f32x4 vec) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = fl::sqrtf(vec.data[i]);
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 min_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = (a.data[i] < b.data[i]) ? a.data[i] : b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 max_f32_4(simd_f32x4 a, simd_f32x4 b) FL_NO_EXCEPT {
     simd_f32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = (a.data[i] > b.data[i]) ? a.data[i] : b.data[i];
-    }
+    );
     return result;
 }
 
@@ -330,47 +331,47 @@ FASTLED_FORCE_INLINE FL_IRAM simd_f32x4 max_f32_4(simd_f32x4 a, simd_f32x4 b) FL
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 xor_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] ^ b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 add_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] + b.data[i];
-    }
+    );
     return result;
 }
 
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sub_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] - b.data[i];
-    }
+    );
     return result;
 }
 
 // Multiply i32 and return high 32 bits (for fixed-point Q16.16 math)
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 a_i = static_cast<i32>(a.data[i]);
         i32 b_i = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(a_i) * static_cast<i64>(b_i);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 16));
-    }
+    );
     return result;
 }
 
 // Multiply u32 and return high 32 bits (for fixed-point Q16.16 math, unsigned)
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         u64 prod = static_cast<u64>(a.data[i]) * static_cast<u64>(b.data[i]);
         result.data[i] = static_cast<u32>(prod >> 16);
-    }
+    );
     return result;
 }
 
@@ -383,68 +384,68 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi_su32_4(simd_u32x4 a, simd_u32x4 b)
 // Shift right logical (zero-fill) - for unsigned angle decomposition
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 srl_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = vec.data[i] >> shift;
-    }
+    );
     return result;
 }
 
 // Shift left logical (zero-fill) - for fixed-point format conversion
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sll_u32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = vec.data[i] << shift;
-    }
+    );
     return result;
 }
 
 // Shift right arithmetic (sign-extend) - for signed fixed-point math
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 sra_i32_4(simd_u32x4 vec, int shift) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 signed_val = static_cast<i32>(vec.data[i]);
         result.data[i] = static_cast<u32>(signed_val >> shift);
-    }
+    );
     return result;
 }
 
 // Bitwise AND of two u32 vectors
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 and_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] & b.data[i];
-    }
+    );
     return result;
 }
 
 // Bitwise OR of two u32 vectors
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 or_u32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         result.data[i] = a.data[i] | b.data[i];
-    }
+    );
     return result;
 }
 
 // Signed min of two i32 vectors
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 min_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai < bi ? ai : bi);
-    }
+    );
     return result;
 }
 
 // Signed max of two i32 vectors
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 max_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         result.data[i] = static_cast<u32>(ai > bi ? ai : bi);
-    }
+    );
     return result;
 }
 
@@ -454,12 +455,12 @@ FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 max_i32_4(simd_u32x4 a, simd_u32x4 b) FL
 // Used for (Q31 × Q16.16) >> 31 as: mulhi32_i32_4(a, b) << 1
 FASTLED_FORCE_INLINE FL_IRAM simd_u32x4 mulhi32_i32_4(simd_u32x4 a, simd_u32x4 b) FL_NO_EXCEPT {
     simd_u32x4 result;
-    for (int i = 0; i < 4; ++i) {
+    FL_SIMD_LANE4(
         i32 ai = static_cast<i32>(a.data[i]);
         i32 bi = static_cast<i32>(b.data[i]);
         i64 prod = static_cast<i64>(ai) * static_cast<i64>(bi);
         result.data[i] = static_cast<u32>(static_cast<i32>(prod >> 32));
-    }
+    );
     return result;
 }
 

--- a/src/platforms/simd.h
+++ b/src/platforms/simd.h
@@ -23,9 +23,18 @@
     // ESP32 platforms (Xtensa PIE or RISC-V scalar)
     #include "platforms/esp/32/simd_esp32.hpp"  // IWYU pragma: keep
 #elif defined(__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP + 0) == 1
-    // ARMv7E-M DSP extension: Cortex-M4 / M4F / M7 (Teensy 3.x and 4.x,
-    // Apollo3, SAMD51, nRF52, STM32F4/F7, ...). Packed-byte and packed-half
-    // arithmetic via UQADD8 / UQSUB8 / UADD16 / etc. See issue #2628.
+    // The DSP extension: ARMv7E-M Cortex-M4 / M4F / M7 (Teensy 3.x and 4.x,
+    // Apollo3, SAMD51, nRF52, STM32F4/F7, ...) and ARMv8-M Cortex-M33 parts
+    // that carry it, which includes the RP2350 -- the Arduino-Pico core
+    // builds it with `-march=armv8-m.main+fp+dsp`. Packed-byte and
+    // packed-half arithmetic via UQADD8 / UQSUB8 / UADD16 / etc. See issue
+    // #2628.
+    //
+    // The M33 is spelled out because leaving it implied has already cost
+    // once: FastLED#4216 read this arm as ARMv7E-M only, concluded an RP2350
+    // took the scalar fallback, and tuned `simd_noop.hpp` for two rounds
+    // against a build that never included it. The header's path says
+    // `teensy/` for the same historical reason and is just as misleading.
     #include "platforms/arm/teensy/simd_arm_dsp.hpp"  // IWYU pragma: keep
 #elif defined(__ARM_NEON) || defined(__ARM_NEON__)
     // ARM Advanced SIMD, on compilers that advertise it the GNU way:


### PR DESCRIPTION
Closes #4216.

## What the measurement was actually of

#4216 reported `fl::s16x16x4` running ~15x slower than four scalar `fl::s16x16`
ops on an RP2350W, and attributed it to `simd_noop.hpp` on the reasoning that
"RP2350 is Cortex-M33 without `__ARM_FEATURE_DSP`".

The M33 does not have to carry the DSP extension. The RP2350's does, and the
Arduino-Pico core compiles for it — `framework-arduinopico/tools/platformio-build.py`
passes `-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp`
for `chip == "rp2350"` — so GCC defines `__ARM_FEATURE_DSP` to 1 and
`src/platforms/simd.h` selects **`simd_arm_dsp.hpp`**. `simd_noop.hpp` is never
compiled into that firmware.

That matters because two of the issue's four "refuted" hypotheses were tested by
editing `simd_noop.hpp` and re-measuring:

- removing `FL_ALIGNAS(16)` — "no change (11568 → 11659)"
- unrolling the trip-4 lane loops — "identical … the compiler re-rolled it … this
  avenue is closed"

Neither edit was in the build, so neither number says anything about the idea.
The unroll in particular is the fix.

## The defect

Both files hold a 4-lane vector as `u32 data[4]` and operate on it with
`for (int i = 0; i < 4; ++i)`. At `-Os` the loop stays rolled, and because the
index is a runtime value the lanes have to live in memory. Reproduced locally
with the core's own toolchain and flags, one `mulhi_i32_4`:

```
60:  ldr.w  r2, [r8], #4     ; lane a, from the stack
64:  ldr.w  r6, [lr], #4     ; lane b, from the stack
6c:  smull  r2, r6, r2, r6   ; the arithmetic — one instruction of six
7a:  str.w  r2, [r9], #4     ; lane back to the stack
7e:  bne.n  60               ; not unrolled
```

Bind the index as a compile-time constant and the subscripts fold away, the
register allocator keeps all four lanes live, and the frame disappears.

## The change

`FL_SIMD_LANE4` in the new `src/platforms/shared/simd_lane4.h`, applied to the
28 / 28 / 31 trip-4 loops in `simd_noop.hpp`, `simd_arm_dsp.hpp` and
`simd_riscv.hpp`. Nothing about the representation or the API changes, and no
caller is touched — `.data[i]` still works.

Four hand-written statements generate the same code; the macro is how the bodies
stay single copies, and it is what stops a future reader folding them back into a
`for` without seeing why that undoes the fix.

## Numbers

One packed multiply-add — `mulhi_i32_4` then `add_i32_4`, what `fl::s16x16x4`'s
operators reduce to — counted over the whole function at each backend's shipping
optimisation level:

| backend | target | before | after |
|---|---|---|---|
| `simd_arm_dsp.hpp` | Cortex-M33, `-Os -march=armv8-m.main+fp+dsp` | 67 insns, 60 B frame | **41 insns, no frame** |
| `simd_noop.hpp` | Cortex-M0+, `-Os -march=armv6-m` | 107 insns, 84 B frame | **82 insns, 28 B frame** |
| `simd_riscv.hpp` | RV32IMAC, `-Os` | 21 insns, 64 B frame | **14 insns, no frame** |

Cortex-M0+ keeps a frame because eight low registers cannot hold twelve live
lanes. It still loses a quarter of its instructions.

## Verification

- **The rewrite carries nothing but the loop form.** A re-roller that turns every
  `FL_SIMD_LANE4(...)` back into its `for` reproduces all three pre-change files
  byte for byte, and no lane body contains `break`/`continue`/`goto`/`return`.
- **Runtime, `simd_noop.hpp`:** `tests/fl/math/simd_fallback.cpp` compares the
  fallback against the host's real backend lane by lane. Mutation-checked —
  zeroing lane 2 of `add_i32_4` fails `fl_math_simd_fallback`.
- **Compile, all three:** each backend compiles standalone for its target
  (`arm-none-eabi-g++` M33 and M0+, `riscv32-esp-elf-g++` RV32IMAC).
- 303/303 unit + 84/84 examples, `bash lint` clean.

`simd_arm_dsp.hpp` and `simd_riscv.hpp` have no host runtime coverage — they are
guarded by target macros and carry inline asm — so for those the evidence is the
byte-for-byte inversion plus the codegen, not execution. **The on-device
re-measurement (`bash autoresearch rp2350w --simd`) is still worth doing by
whoever has the board**; I do not have one, and I am not claiming the µs figures
in #4216 have been re-taken.

## Also

`simd.h`'s comment for the DSP arm said "Cortex-M4 / M4F / M7", which is where
the misreading starts; it now names the ARMv8-M M33 and the RP2350. A dispatch
case pins the premise by asking a real `arm-none-eabi-gcc` what the core's own
flags define, rather than asserting it — it fails if that stops being true, and
skips where no ARM cross compiler exists.

The header's path still says `teensy/` for the same historical reason and is just
as misleading; moving it is a separate change.

### Reproducing the codegen numbers

```
g++ -c tu.cpp -Isrc -Os -std=gnu++17 -ffreestanding -fno-exceptions -fno-rtti \
    <target flags>
objdump -d --no-show-raw-insn tu.o | sed -n '/<bench_packed_mul>:/,/^$/p'
```
where `tu.cpp` calls `mulhi_i32_4` / `add_i32_4` in a dependent loop, and the
target flags are the three rows above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved four-lane SIMD processing across ARM, RISC-V, and scalar backends, preserving existing behavior while enabling more efficient compiled code.
  * Added support verification for DSP-optimized builds on Cortex-M33/RP2350 platforms.

* **Documentation**
  * Updated SIMD dispatch documentation to clarify ARM Cortex-M33 and RP2350 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->