### PR TITLE
fix(math): make s16x16x4.h compile as a translation unit's only include

### DIFF
--- a/ci/tests/test_fixed_point_headers_are_self_contained.py
+++ b/ci/tests/test_fixed_point_headers_are_self_contained.py
@@ -1,0 +1,76 @@
+"""The 4-wide fixed-point headers compile on their own.
+
+`s16x16x4.h` reaches `s0x32x4.h` through `simd_ops.h`, and that include sits
+*inside* `namespace fl` -- deliberately, because `simd_ops.h` defines
+cross-type operators that need both types complete and so does not open a
+namespace of its own.
+
+On the usual path this is harmless: something else has already included
+`s0x32x4.h`, so `#pragma once` makes it a no-op. In a translation unit that
+reaches `s16x16x4.h` first it is not, because the whole of `s0x32x4.h` -- and
+`s0x32.h`, and `fl/stl/type_traits.h` under it -- is then processed one
+namespace deeper. `fl::enable_if` becomes `fl::fl::enable_if` and the header
+does not compile.
+
+Nothing in the tree hits that order today, which is exactly why it is worth a
+test: the failure appears when someone adds the first include that does.
+
+`simd_ops.h` itself is not checked. It documents that it must be included
+inside an open `fl` namespace, so failing standalone is its contract.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from typeguard import typechecked
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+kSelfContainedHeaders = [
+    "fl/math/fixed_point/s16x16x4.h",
+    "fl/math/fixed_point/s0x32x4.h",
+    "fl/math/fixed_point/s16x16.h",
+    "fl/math/fixed_point/s0x32.h",
+]
+
+
+@typechecked
+def _compiler() -> str:
+    found = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    if found is None:
+        pytest.skip("no C++ compiler available")
+    return found
+
+
+@pytest.mark.parametrize("header", kSelfContainedHeaders)
+@typechecked
+def test_header_compiles_as_the_only_include(header: str, tmp_path: Path) -> None:
+    source = tmp_path / "only_include.cpp"
+    source.write_text(f'#include "{header}"\n', encoding="utf-8")
+
+    # `subprocess.run` and not `RunningProcess.run`: the latter merges stderr
+    # into stdout, and the diagnostics being reported here arrive on stderr.
+    completed = subprocess.run(  # noqa: SRC001
+        [
+            _compiler(),
+            "-fsyntax-only",
+            "-I",
+            str(PROJECT_ROOT / "src"),
+            "-std=gnu++17",
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"{header} does not compile as a translation unit's only include:\n"
+        f"{completed.stderr}"
+    )

--- a/src/fl/math/fixed_point/s16x16x4.h
+++ b/src/fl/math/fixed_point/s16x16x4.h
@@ -8,6 +8,10 @@
 #include "fl/math/sin32.h"
 #include "fl/stl/compiler_control.h"
 #include "fl/stl/align.h"
+// Pulled in at file scope, not through simd_ops.h below: that include sits
+// inside `namespace fl`, so reaching s0x32x4.h through it nests the whole
+// header -- and everything it includes -- one namespace too deep.
+#include "fl/math/fixed_point/s0x32x4.h"
 
 namespace fl {
 


### PR DESCRIPTION
## The defect

```
$ echo '#include "fl/math/fixed_point/s16x16x4.h"' > only.cpp
$ g++ -fsyntax-only only.cpp -Isrc -std=gnu++17
src/fl/math/fixed_point/s0x32.h:53:34: error: 'enable_if' in namespace 'fl::fl' does not name a template type
src/fl/math/fixed_point/simd_ops.h:16:62: error: invalid use of incomplete type 'struct fl::s0x32x4'
```

`s16x16x4.h` reaches `s0x32x4.h` through `simd_ops.h`, and that include sits inside
`namespace fl` — deliberately: `simd_ops.h` says so in its own header comment, because
it defines cross-type operators needing both types complete, and the include carries an
`// allow-include-after-namespace` marker.

On the usual path that is harmless. Something else has already included `s0x32x4.h`, so
`#pragma once` makes it a no-op and the nesting never happens. In a TU that reaches
`s16x16x4.h` first it does happen: the whole of `s0x32x4.h`, `s0x32.h`, and
`fl/stl/type_traits.h` under it get processed one namespace deeper, so `fl::enable_if`
resolves as `fl::fl::enable_if`.

## The fix

Include `s0x32x4.h` at file scope in `s16x16x4.h`. No cycle — `s0x32x4.h` only
forward-declares `s16x16x4`.

## Why a test for something nothing hits

Nothing in the tree uses that include order today, so this is latent rather than a live
break. That is the argument for pinning it: it appears the first time someone adds an
include that gets there first, and the diagnostic points at `type_traits.h` rather than
at the ordering, so the next person spends the time I did working out that a header was
being processed inside a namespace.

The test checks the four 4-wide/scalar fixed-point headers compile as a TU's only
include. `simd_ops.h` is deliberately excluded: failing standalone is its documented
contract, not a defect.

Mutation-checked — reverting the one-line fix fails
`test_header_compiles_as_the_only_include[fl/math/fixed_point/s16x16x4.h]` and leaves
the other three passing.

303/303 unit + 84/84 examples, `bash lint` clean.

Found while building a cross-compile harness for #4216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed compilation when including the 4-wide fixed-point headers independently.
  - Corrected namespace handling for fixed-point header dependencies.

- **Tests**
  - Added automated checks confirming each supported 4-wide fixed-point header compiles as a standalone include.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->