### PR TITLE
test(audio): sweep the CQ band centres, and check the analyser answered

### DIFF
--- a/tests/fl/audio/fft/fft.cpp
+++ b/tests/fl/audio/fft/fft.cpp
@@ -863,6 +863,26 @@ FL_TEST_CASE("Binning adversarial - LOG_REBIN monotonicity sweep") {
 }
 
 FL_TEST_CASE("Binning adversarial - CQ_OCTAVE monotonicity sweep") {
+    // Rising input frequency must never drive the CQ peak bin backwards.
+    //
+    // The sweep steps the analyser's own band centres rather than an
+    // arbitrary log grid, because CQ_OCTAVE does not respond everywhere in
+    // the range it declares. Measured over 200 log-spaced probe tones across
+    // 90-14080 Hz at 16 bands / 512 samples, 49 of them (24%) produce under
+    // 20 counts in *every* band, with two wide holes at the top: 7463-9621 Hz
+    // and 10923-13383 Hz. A tone inside a hole gives no detection at all --
+    // every band reads 0-7 counts -- so `findPeakBin` returns whichever band
+    // happens to hold the most noise, and comparing two such answers measures
+    // nothing.
+    //
+    // A 30-step grid put 2 of its 30 steps inside those holes, and the peak
+    // there was decided by margins of one count (16 versus 15 at 11502 Hz).
+    // That is why this used to be able to pass or fail on an unrelated change
+    // to `fl::exp`, which moves the grid by a few percent: FastLED#4288.
+    //
+    // The holes are a real deficiency and are tracked in FastLED#4301. This case
+    // is about ordering, so it asks the question where the analyser has an
+    // answer, and checks that it really does have one.
     const int bands = 16;
     const float fmin = fl::audio::fft::Args::DefaultMinFrequency();
     const float fmax = fl::audio::fft::Args::DefaultMaxFrequency();
@@ -870,17 +890,39 @@ FL_TEST_CASE("Binning adversarial - CQ_OCTAVE monotonicity sweep") {
     fl::audio::fft::Args args(512, bands, fmin, fmax, 44100, fl::audio::fft::Mode::CQ_OCTAVE);
     fl::audio::fft::Impl fft(args);
 
-    const int numSteps = 30;
-    float logRatio = fl::logf(fmax / fmin);
+    // Same expression `_generate_center_freqs` uses, so these are the
+    // frequencies the kernels are actually built for.
+    const float logRatio = fl::logf(fmax / fmin);
     int prevPeak = -1;
     int violations = 0;
+    int weakDetections = 0;
 
-    for (int s = 0; s < numSteps; ++s) {
-        float freq = fmin * fl::expf(logRatio * static_cast<float>(s) /
-                                     static_cast<float>(numSteps - 1));
+    for (int b = 0; b < bands; ++b) {
+        float freq = fmin * fl::expf(logRatio * static_cast<float>(b) /
+                                     static_cast<float>(bands - 1));
         auto samples = makeAdversarialSine(freq);
         fl::audio::fft::Bins bins(bands);
         fft.run(samples, &bins);
+
+        // The vacuity guard. Without it this case would still "pass" if the
+        // analyser stopped responding altogether, by comparing noise -- which
+        // is exactly the failure mode the old grid had.
+        float top = 0.0f;
+        float second = 0.0f;
+        for (fl::size i = 0; i < bins.raw().size(); ++i) {
+            const float v = bins.raw()[i];
+            if (v > top) {
+                second = top;
+                top = v;
+            } else if (v > second) {
+                second = v;
+            }
+        }
+        if (top < 15.0f || top < second * 1.5f) {
+            FL_WARN("CQ weak detection at " << freq << " Hz: top " << top
+                         << ", runner-up " << second);
+            weakDetections++;
+        }
 
         int peak = findPeakBin(bins.raw());
         if (prevPeak >= 0 && peak < prevPeak) {
@@ -892,6 +934,9 @@ FL_TEST_CASE("Binning adversarial - CQ_OCTAVE monotonicity sweep") {
         prevPeak = peak;
     }
     FL_CHECK_EQ(violations, 0);
+    // Every centre detects, and by a margin: measured top 19-2410 counts
+    // against runner-ups of 2-27, the tightest ratio being 1.58 at 177 Hz.
+    FL_CHECK_EQ(weakDetections, 0);
 }
 
 // --- 4. White noise energy uniformity (catches LOG_REBIN high-bin bias) ---


### PR DESCRIPTION
Unblocks one of the three items holding up #4288. Deficiency found on the way: #4301.

## What was wrong

`Binning adversarial - CQ_OCTAVE monotonicity sweep` stepped 30 log-spaced frequencies
across 90–14080 Hz and required the peak bin never to go backwards. Two of those steps
landed where `CQ_OCTAVE` has no response at all.

Measured over 200 log-spaced tones at 16 bands / 512 samples, **49 (24%) produce under 20
counts in every band**, with holes at 7463–9621 Hz and 10923–13383 Hz. Inside a hole there
is no detection — at 8348 Hz:

```
band:    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
counts:  1  1  1  1  0  1  0  1  0  0  7  4  5  2  1  1
```

against **2410** counts for a tone on band 13's centre. `findPeakBin` returns whichever
band holds the most noise, and the case compared two such answers — at 11502 Hz the peak
was decided 16 counts to 15.

So the top third of the sweep was measuring noise ordering, and anything that moves the
grid by a few percent flips it. Making `fl::exp` accurate does exactly that, which is why
this case is one of #4288's blockers.

## What it does now

Sweeps the analyser's own band centres — the same expression `_generate_center_freqs`
uses — so the question is asked where the analyser has an answer, plus a floor that checks
it really does have one.

Measured across all 16 centres: peaks **19–2410** counts against runner-ups of **2–27**,
tightest ratio **1.58** at 177 Hz, peak bin non-decreasing throughout
(`0,0,2,3,5,5,6,7,8,9,10,11,12,13,14,15`). **Identical under both `fl::exp`
implementations**, so the case no longer depends on it.

The holes are the real deficiency and are not this case's job — filed as #4301 with the
full sweep, the mechanism, and four directions.

## Mutation-checked

| mutation | result |
|---|---|
| reverse the CQ band order | 7 monotonicity violations |
| zero the kernel window (analyser detects nothing) | 16 weak detections |

The second is the point: **the old case passed that mutation.** With every bin zero,
`findPeakBin` returns 0 at every step, so `peak < prevPeak` is never true and `violations`
stays 0. That is the vacuity the floor exists to close.

## Verification

303/303 unit + 84/84 examples, `bash lint` clean. No `src/` change — this is a test-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened audio frequency analysis validation by checking responses at actual analyzer band centers.
  * Added coverage for known response gaps and improved detection-quality checks.
  * Tests now require clear, sufficiently strong frequency detections while continuing to verify correct peak ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->