### PR TITLE
feat(gfx): float-free s16.16 3x3 inverse, the first half of P9 item 2 (#4043)

### DIFF
--- a/ci/tests/test_fixed_point_headers_are_self_contained.py
+++ b/ci/tests/test_fixed_point_headers_are_self_contained.py
@@ -36,6 +36,10 @@ kSelfContainedHeaders = [
     "fl/math/fixed_point/s0x32x4.h",
     "fl/math/fixed_point/s16x16.h",
     "fl/math/fixed_point/s0x32.h",
+    # Same defect, different cause: `device_solve.h` spelled `EmitterProfile`
+    # unqualified, which only resolves once some *other* header has pulled in
+    # the `using` from `fl/channels/color_profile.h`. FastLED#4043.
+    "fl/gfx/device_solve.h",
 ]
 
 

--- a/ci/tests/test_q16_inverse_is_float_free.py
+++ b/ci/tests/test_q16_inverse_is_float_free.py
@@ -1,0 +1,171 @@
+"""`invert3x3Q16` links no floating-point runtime.
+
+P9 (FastLED#4043) asks for a colorimetric build and solve that no float
+symbol reaches, on tiers where float is soft. Saying so is easy and checking
+it on the host is worthless: x86 has hardware float, so a float operation
+leaves no call behind to find.
+
+So this compiles the implementation for a Cortex-M0+ -- no FPU, every float
+operation a call into `libgcc` -- and reads the calls out of the two
+functions' disassembly. On that target the difference is not subtle.
+
+The positive control matters as much as the assertion: `buildRgbSolveMatrixQ16`
+is the existing float path in the same translation unit, and it must show the
+helpers this test says `invert3x3Q16` does not. Without it, a typo in a symbol
+name would make the check pass by disassembling nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from typeguard import typechecked
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Soft-float entry points in libgcc's ARM EABI naming: `__aeabi_f*` for
+# float, `__aeabi_d*` for double, plus the generic `__*sf3` / `__*df3` names
+# a non-EABI build would emit. Deliberately not `__aeabi_l*`, which is 64-bit
+# *integer* -- `invert3x3Q16` uses `__aeabi_ldivmod` and `__aeabi_lmul` and is
+# meant to.
+kFloatHelper = re.compile(r"__aeabi_[fd][a-z0-9]*|__[a-z]+(?:sf|df)3")
+
+kQ16Symbol = "_ZN2fl12invert3x3Q16ERA3_A3_KlRA3_A3_l"
+kFloatPathSymbol = (
+    "_ZN2fl22buildRgbSolveMatrixQ16ERKNS_"
+    "21colorimetric_response14EmitterProfileEPNS_21EmitterSolveMatrixQ16E"
+)
+
+
+@dataclass(frozen=True)
+class ArmTools:
+    """A cross compiler and the objdump that goes with it."""
+
+    compiler: str
+    objdump: str
+
+
+@typechecked
+def _arm_tools() -> ArmTools | None:
+    found = shutil.which("arm-none-eabi-g++")
+    if found is not None:
+        dump = shutil.which("arm-none-eabi-objdump")
+        return ArmTools(compiler=found, objdump=dump) if dump else None
+    for root in (Path.home() / ".platformio" / "packages", Path.home() / ".fbuild"):
+        if not root.is_dir():
+            continue
+        for candidate in root.rglob("bin/arm-none-eabi-g++"):
+            dump = candidate.with_name("arm-none-eabi-objdump")
+            if dump.exists():
+                return ArmTools(compiler=str(candidate), objdump=str(dump))
+    return None
+
+
+@typechecked
+def _helpers_called(objdump: str, obj: Path, symbol: str) -> set[str]:
+    """Soft-float helpers named inside one function's disassembly.
+
+    Raises if the symbol is absent, so a rename cannot turn this into a test
+    that passes by reading an empty body.
+    """
+
+    # `subprocess.run` and not `RunningProcess.run`: the latter merges stderr
+    # into stdout, which would put objdump's warnings into the disassembly
+    # this parses.
+    completed = subprocess.run(  # noqa: SRC001
+        [objdump, "-d", "--no-show-raw-insn", str(obj)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    body: list[str] = []
+    inside = False
+    for line in completed.stdout.splitlines():
+        if line.endswith(f"<{symbol}>:"):
+            inside = True
+            continue
+        if inside:
+            if not line.strip():
+                break
+            body.append(line)
+    if not body:
+        raise AssertionError(f"{symbol} not found in {obj.name}")
+    return set(kFloatHelper.findall("\n".join(body)))
+
+
+@pytest.fixture(scope="module")
+@typechecked
+def compiled(tmp_path_factory: pytest.TempPathFactory) -> tuple[ArmTools, Path]:
+    tools = _arm_tools()
+    if tools is None:
+        pytest.skip("no arm-none-eabi cross compiler on this machine")
+
+    tmp_path = tmp_path_factory.mktemp("q16_float_free")
+    source = tmp_path / "device_solve_tu.cpp"
+    source.write_text('#include "fl/gfx/device_solve.cpp.hpp"\n', encoding="utf-8")
+    obj = tmp_path / "device_solve_tu.o"
+    subprocess.run(  # noqa: SRC001
+        [
+            tools.compiler,
+            "-c",
+            str(source),
+            "-o",
+            str(obj),
+            "-I",
+            str(PROJECT_ROOT / "src"),
+            # Cortex-M0+: ARMv6-M, no FPU, so every float operation becomes a
+            # call. RP2040 and Teensy LC are this core.
+            "-mcpu=cortex-m0plus",
+            "-march=armv6-m",
+            "-mthumb",
+            "-Os",
+            "-std=gnu++17",
+            "-ffreestanding",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-DARDUINO_ARCH_RP2040",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return tools, obj
+
+
+@typechecked
+def test_q16_inverse_calls_no_float_runtime(
+    compiled: tuple[ArmTools, Path],
+) -> None:
+    tools, obj = compiled
+    helpers = _helpers_called(tools.objdump, obj, kQ16Symbol)
+    assert helpers == set(), (
+        f"invert3x3Q16 reaches the float runtime: {sorted(helpers)}"
+    )
+
+
+@typechecked
+def test_the_float_path_alongside_it_does(compiled: tuple[ArmTools, Path]) -> None:
+    """Positive control.
+
+    `buildRgbSolveMatrixQ16` is in the same object and does its work in float.
+    If this stops finding helpers, the check above has stopped being able to
+    find them either, and its silence means nothing.
+
+    Measured on GCC 16.1 for cortex-m0plus at -Os: 11 distinct helpers.
+    """
+
+    tools, obj = compiled
+    helpers = _helpers_called(tools.objdump, obj, kFloatPathSymbol)
+    assert len(helpers) >= 8, (
+        f"expected the float path to call the soft-float runtime, found {sorted(helpers)}"
+    )

--- a/ci/tests/test_q16_inverse_is_float_free.py
+++ b/ci/tests/test_q16_inverse_is_float_free.py
@@ -53,10 +53,17 @@ class ArmTools:
 
 @typechecked
 def _arm_tools() -> ArmTools | None:
+    """A complete pair, from PATH if it has one and the caches otherwise.
+
+    Both halves are needed, so a `PATH` carrying only the compiler falls
+    through to the caches rather than reporting no toolchain -- which would
+    skip this test on a machine that has a usable one.
+    """
+
     found = shutil.which("arm-none-eabi-g++")
-    if found is not None:
-        dump = shutil.which("arm-none-eabi-objdump")
-        return ArmTools(compiler=found, objdump=dump) if dump else None
+    dump = shutil.which("arm-none-eabi-objdump")
+    if found is not None and dump is not None:
+        return ArmTools(compiler=found, objdump=dump)
     for root in (Path.home() / ".platformio" / "packages", Path.home() / ".fbuild"):
         if not root.is_dir():
             continue

--- a/src/fl/gfx/device_solve.cpp.hpp
+++ b/src/fl/gfx/device_solve.cpp.hpp
@@ -70,7 +70,7 @@ bool productFitsI64(i64 a, i64 b) FL_NO_EXCEPT {
 ///
 /// It is reachable, not theoretical. A single term cannot be the minimum
 /// because `productFitsI64` rejects any product that large, but a sum can:
-/// 2^63 - 1 factors as 7 * 73 * 127 * 337 * 92737 * 649657, so one term can
+/// 2^63 - 1 factors as 7^2 * 73 * 127 * 337 * 92737 * 649657, so one term can
 /// be made exactly -(2^63 - 1) from i32 entries and a second can contribute
 /// the remaining -1. `tests/fl/gfx/device_solve.cpp` carries the matrix.
 bool sumFitsI64(i64 a, i64 b) FL_NO_EXCEPT {

--- a/src/fl/gfx/device_solve.cpp.hpp
+++ b/src/fl/gfx/device_solve.cpp.hpp
@@ -44,6 +44,99 @@ i32 quantizeSolveQ16(float v) FL_NO_EXCEPT {
 /// while still being a proof rather than an assumption.
 constexpr i32 kMaxCoefficient = 21845;  // floor(2^32 / 3) >> 16
 
+constexpr i64 kI64Max = 9223372036854775807LL;
+
+/// Does `a * b` fit an i64?
+///
+/// By division rather than by bounding the inputs, because the inputs cannot
+/// usefully be bounded here -- see `invert3x3Q16`. Division is exact on every
+/// target and needs no builtin; `__builtin_mul_overflow` would be cheaper but
+/// MSVC does not have it and the host suite builds there.
+bool productFitsI64(i64 a, i64 b) FL_NO_EXCEPT {
+    if (a == 0 || b == 0) {
+        return true;
+    }
+    const i64 lhs = a < 0 ? -a : a;
+    const i64 rhs = b < 0 ? -b : b;
+    return rhs <= kI64Max / lhs;
+}
+
+/// Does `a + b` fit an i64, for operands already known to be in range?
+bool sumFitsI64(i64 a, i64 b) FL_NO_EXCEPT {
+    if (b > 0) {
+        return a <= kI64Max - b;
+    }
+    if (b < 0) {
+        return a >= -kI64Max - 1 - b;
+    }
+    return true;
+}
+
+/// `e * i - f * h`, or false if any part of it leaves i64.
+bool cofactorQ32(i32 e, i32 i_, i32 f, i32 h, i64* out) FL_NO_EXCEPT {
+    const i64 left = static_cast<i64>(e) * static_cast<i64>(i_);
+    const i64 right = static_cast<i64>(f) * static_cast<i64>(h);
+    // Two i32 products always fit; their difference need not.
+    if (!sumFitsI64(left, -right)) {
+        return false;
+    }
+    *out = left - right;
+    return true;
+}
+
+/// Nearest integer, halves away from zero. Truncating would bias every
+/// coefficient toward zero, and the bias does not cancel across a row --
+/// a solve is a sum of three of them.
+i64 roundedDivI64(i64 numerator, i64 denominator) FL_NO_EXCEPT {
+    if (denominator < 0) {
+        numerator = -numerator;
+        denominator = -denominator;
+    }
+    const i64 half = denominator / 2;
+    if (numerator >= 0) {
+        return (numerator + half) / denominator;
+    }
+    return -((-numerator + half) / denominator);
+}
+
+/// `round(cofactor_q32 * 2^32 / determinant_q48)`, in s16.16, without a
+/// 128-bit intermediate.
+///
+/// The obvious form is `(cofactor << 32) / determinant`, which is what the
+/// host study computes with unbounded integers. A target without `__int128`
+/// cannot form that numerator: the cofactor is already Q32, and 32 more bits
+/// puts it past i64 for any matrix that matters.
+///
+/// So each of the 32 doublings is spent where there is room -- on the
+/// numerator while it still fits, on the denominator otherwise. Both raise
+/// the quotient by the same factor, so the only loss is what halving the
+/// denominator rounds away, and the determinant carries far more bits than a
+/// s16.16 answer needs.
+///
+/// Checked against the exact divide over `ci/color_fixed_inverse_study.py`'s
+/// corpus, six degrees of primary collapse, and 20,000 random primary sets:
+/// **zero** disagreement, and 72% of coefficients needed at least one
+/// denominator halving, up to 11 -- so the staged path is the one being
+/// exercised, not a branch nothing reaches.
+i64 divideCoefficientQ16(i64 cofactor_q32, i64 determinant_q48) FL_NO_EXCEPT {
+    i64 numerator = cofactor_q32;
+    i64 denominator = determinant_q48;
+    if (denominator < 0) {
+        numerator = -numerator;
+        denominator = -denominator;
+    }
+    constexpr i64 kHalfMax = kI64Max / 2;
+    for (int spent = 0; spent < 32; ++spent) {
+        const i64 magnitude = numerator < 0 ? -numerator : numerator;
+        if (magnitude <= kHalfMax) {
+            numerator *= 2;
+        } else {
+            denominator = (denominator + 1) / 2;
+        }
+    }
+    return roundedDivI64(numerator, denominator);
+}
+
 i32 dotSolveRowQ16(const i32 (&row)[3], const i32 (&v)[3]) FL_NO_EXCEPT {
     const i64 acc = static_cast<i64>(row[0]) * static_cast<i64>(v[0])
                   + static_cast<i64>(row[1]) * static_cast<i64>(v[1])
@@ -67,7 +160,60 @@ i32 dotSolveRowQ16(const i32 (&row)[3], const i32 (&v)[3]) FL_NO_EXCEPT {
 
 }  // namespace
 
-bool buildRgbSolveMatrixQ16(const EmitterProfile& profile,
+bool invert3x3Q16(const i32 (&in)[3][3], i32 (&out)[3][3]) FL_NO_EXCEPT {
+    const i32 a = in[0][0], b = in[0][1], c = in[0][2];
+    const i32 d = in[1][0], e = in[1][1], f = in[1][2];
+    const i32 g = in[2][0], h = in[2][1], i_ = in[2][2];
+
+    // Cofactors are differences of two Q16 products, so Q32.
+    i64 cof[3][3];
+    if (!cofactorQ32(e, i_, f, h, &cof[0][0]) ||
+        !cofactorQ32(c, h, b, i_, &cof[0][1]) ||
+        !cofactorQ32(b, f, c, e, &cof[0][2]) ||
+        !cofactorQ32(f, g, d, i_, &cof[1][0]) ||
+        !cofactorQ32(a, i_, c, g, &cof[1][1]) ||
+        !cofactorQ32(c, d, a, f, &cof[1][2]) ||
+        !cofactorQ32(d, h, e, g, &cof[2][0]) ||
+        !cofactorQ32(b, g, a, h, &cof[2][1]) ||
+        !cofactorQ32(a, e, b, d, &cof[2][2])) {
+        return false;
+    }
+
+    // Determinant is a Q16 times a Q32, so Q48.
+    const i32 first_row[3] = {a, b, c};
+    i64 determinant = 0;
+    for (int col = 0; col < 3; ++col) {
+        const i64 term_lhs = static_cast<i64>(first_row[col]);
+        if (!productFitsI64(term_lhs, cof[col][0])) {
+            return false;
+        }
+        const i64 term = term_lhs * cof[col][0];
+        if (!sumFitsI64(determinant, term)) {
+            return false;
+        }
+        determinant += term;
+    }
+    if (determinant == 0) {
+        return false;
+    }
+
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            const i64 value = divideCoefficientQ16(cof[row][col], determinant);
+            // The same bound the float path applies to its own result, and
+            // for the same reason: past it the solve's accumulator can
+            // overflow for an in-range XYZ input.
+            const i64 limit = static_cast<i64>(kMaxCoefficient) << 16;
+            if (value > limit || value < -limit) {
+                return false;
+            }
+            out[row][col] = static_cast<i32>(value);
+        }
+    }
+    return true;
+}
+
+bool buildRgbSolveMatrixQ16(const colorimetric_response::EmitterProfile& profile,
                             EmitterSolveMatrixQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
         return false;

--- a/src/fl/gfx/device_solve.cpp.hpp
+++ b/src/fl/gfx/device_solve.cpp.hpp
@@ -62,12 +62,23 @@ bool productFitsI64(i64 a, i64 b) FL_NO_EXCEPT {
 }
 
 /// Does `a + b` fit an i64, for operands already known to be in range?
+///
+/// The negative bound stops one short of i64's minimum, deliberately.
+/// `divideCoefficientQ16` and `roundedDivI64` both negate the determinant,
+/// and negating the minimum is undefined behaviour -- so this is what
+/// guarantees they never see it.
+///
+/// It is reachable, not theoretical. A single term cannot be the minimum
+/// because `productFitsI64` rejects any product that large, but a sum can:
+/// 2^63 - 1 factors as 7 * 73 * 127 * 337 * 92737 * 649657, so one term can
+/// be made exactly -(2^63 - 1) from i32 entries and a second can contribute
+/// the remaining -1. `tests/fl/gfx/device_solve.cpp` carries the matrix.
 bool sumFitsI64(i64 a, i64 b) FL_NO_EXCEPT {
     if (b > 0) {
         return a <= kI64Max - b;
     }
     if (b < 0) {
-        return a >= -kI64Max - 1 - b;
+        return a >= -kI64Max - b;
     }
     return true;
 }
@@ -121,6 +132,8 @@ i64 roundedDivI64(i64 numerator, i64 denominator) FL_NO_EXCEPT {
 i64 divideCoefficientQ16(i64 cofactor_q32, i64 determinant_q48) FL_NO_EXCEPT {
     i64 numerator = cofactor_q32;
     i64 denominator = determinant_q48;
+    // Safe to negate: `sumFitsI64` refuses a determinant of i64's minimum, so
+    // the caller cannot pass the one value this would be undefined for.
     if (denominator < 0) {
         numerator = -numerator;
         denominator = -denominator;

--- a/src/fl/gfx/device_solve.h
+++ b/src/fl/gfx/device_solve.h
@@ -32,12 +32,25 @@ struct EmitterSolveMatrixQ16 {
     i32 m[3][3];
 };
 
+/// Inverse of an s16.16 3x3 matrix, in s16.16, computed without floats.
+///
+/// The float-free half of P9 item 2 (FastLED#4043). `buildRgbSolveMatrixQ16`
+/// still reaches this through `invert3x3`; a bind path that never touches
+/// float calls it directly.
+///
+/// False on a singular matrix, on a coefficient too large for s16.16, and on
+/// any input whose exact cofactors or determinant do not fit an i64. That
+/// last case is detected rather than bounded away: a deep-blue emitter at
+/// xy = (0.14, 0.03) already has a Z column near 28, so a fixed input limit
+/// generous enough to be safe would reject real parts.
+bool invert3x3Q16(const i32 (&in)[3][3], i32 (&out)[3][3]) FL_NO_EXCEPT;
+
 /// Invert the emitter matrix for a three-emitter profile.
 ///
 /// False when the emitter chromaticities are non-finite, degenerate, or
 /// collinear, any of which makes the matrix singular and the solve
 /// meaningless.
-bool buildRgbSolveMatrixQ16(const EmitterProfile& profile,
+bool buildRgbSolveMatrixQ16(const colorimetric_response::EmitterProfile& profile,
                             EmitterSolveMatrixQ16* out) FL_NO_EXCEPT;
 
 /// One pixel: XYZ in s16.16 to three emitter drives in s16.16.

--- a/tests/fl/gfx/device_solve.cpp
+++ b/tests/fl/gfx/device_solve.cpp
@@ -324,6 +324,22 @@ FL_TEST_CASE("Q16 inverse refuses input whose determinant leaves i64") {
     FL_CHECK_EQ(out[0][1], 0);
 }
 
+FL_TEST_CASE("Q16 inverse refuses a determinant of exactly i64's minimum") {
+    // Every product below fits an i64 on its own and every cofactor is a
+    // valid difference of two i32 products, but the three terms sum to
+    // exactly -2^63 -- and negating that, which both the staged divide and
+    // its rounding helper do, is undefined behaviour.
+    //
+    // Constructed rather than found: 2^63 - 1 factors as
+    // 7 * 73 * 127 * 337 * 92737 * 649657, so one term can be made exactly
+    // -(2^63 - 1) with i32 entries, and a second contributes the remaining
+    // -1. Reported by review on FastLED#4305.
+    i32 out[3][3];
+    const i32 int64_min_determinant[3][3] = {
+        {-92737, 64896, 1}, {0, 64897, 1}, {1, 0, 1532540863}};
+    FL_CHECK(!invert3x3Q16(int64_min_determinant, out));
+}
+
 FL_TEST_CASE("Q16 inverse rounds rather than truncates") {
     // Truncation biases every coefficient toward zero, and a solve sums three
     // of them, so the bias does not cancel across a row. 3/2 inverts to 2/3,

--- a/tests/fl/gfx/device_solve.cpp
+++ b/tests/fl/gfx/device_solve.cpp
@@ -331,13 +331,31 @@ FL_TEST_CASE("Q16 inverse refuses a determinant of exactly i64's minimum") {
     // its rounding helper do, is undefined behaviour.
     //
     // Constructed rather than found: 2^63 - 1 factors as
-    // 7 * 73 * 127 * 337 * 92737 * 649657, so one term can be made exactly
+    // 7^2 * 73 * 127 * 337 * 92737 * 649657, so one term can be made exactly
     // -(2^63 - 1) with i32 entries, and a second contributes the remaining
     // -1. Reported by review on FastLED#4305.
     i32 out[3][3];
     const i32 int64_min_determinant[3][3] = {
         {-92737, 64896, 1}, {0, 64897, 1}, {1, 0, 1532540863}};
     FL_CHECK(!invert3x3Q16(int64_min_determinant, out));
+
+    // The determinant really is the minimum, computed here the way
+    // `invert3x3Q16` computes it. Without this the case would still pass if
+    // the matrix stopped being the witness and started being refused for
+    // some unrelated reason -- review caught the factorisation above being
+    // wrong by a factor of 7, which is exactly the kind of drift that leaves
+    // a comment describing a matrix the test no longer contains.
+    const i32 (&m)[3][3] = int64_min_determinant;
+    const i64 cofactor0 = static_cast<i64>(m[1][1]) * static_cast<i64>(m[2][2]) -
+                          static_cast<i64>(m[1][2]) * static_cast<i64>(m[2][1]);
+    const i64 cofactor1 = static_cast<i64>(m[1][2]) * static_cast<i64>(m[2][0]) -
+                          static_cast<i64>(m[1][0]) * static_cast<i64>(m[2][2]);
+    const i64 cofactor2 = static_cast<i64>(m[1][0]) * static_cast<i64>(m[2][1]) -
+                          static_cast<i64>(m[1][1]) * static_cast<i64>(m[2][0]);
+    const i64 determinant = static_cast<i64>(m[0][0]) * cofactor0 +
+                            static_cast<i64>(m[0][1]) * cofactor1 +
+                            static_cast<i64>(m[0][2]) * cofactor2;
+    FL_CHECK_EQ(determinant, -9223372036854775807LL - 1);
 }
 
 FL_TEST_CASE("Q16 inverse rounds rather than truncates") {

--- a/tests/fl/gfx/device_solve.cpp
+++ b/tests/fl/gfx/device_solve.cpp
@@ -179,4 +179,162 @@ FL_TEST_CASE("Degenerate and non-finite emitter profiles are rejected") {
     FL_CHECK(buildRgbSolveMatrixQ16(rgbDevice(), &matrix));
 }
 
+namespace {
+
+/// The four profiles `ci/color_fixed_inverse_study.py` prices P9 item 2
+/// against, quantised to s16.16 exactly as its `quantize_rows` does, with the
+/// inverse its `invert3x3_q16` produces using Python's unbounded integers.
+///
+/// These are a reference, not a recording of this implementation's output.
+/// The study computes `(cofactor << 32) / determinant` exactly; that is the
+/// thing `invert3x3Q16` claims to reproduce without a 128-bit intermediate,
+/// and a table written from C++ output could not tell the two apart.
+struct StudyInverse {
+    i32 forward[3][3];
+    i32 inverse[3][3];
+};
+
+const StudyInverse kStudyInverses[] = {
+    // srgb
+    {{{127100, 32768, 163840}, {65536, 65536, 65536}, {5958, 10923, 862891}},
+     {{45165, -21424, -6948}, {-45428, 87925, 1948}, {263, -965, 5001}}},
+    // bt2020
+    {{{158902, 13979, 186635}, {65536, 65536, 65536}, {0, 2714, 1172525}},
+     {{29555, -6123, -4362}, {-29623, 71826, 701}, {69, -166, 3661}}},
+    // display_p3
+    {{{139264, 25170, 163840}, {65536, 65536, 65536}, {0, 4274, 862891}},
+     {{37418, -13977, -6043}, {-37604, 79908, 1071}, {186, -396, 4972}}},
+    // narrow -- the near-degenerate set, where the determinant is smallest
+    {{{127100, 78019, 72090}, {65536, 65536, 65536}, {5958, 12483, 26214}},
+     {{92837, -118156, 40087}, {-136953, 299419, -371929}, {44116, -115727, 331843}}},
+};
+
+/// The (0,0) cofactor, which is what `cofactor << 32` would have to hold.
+i64 leadCofactor(const i32 (&m)[3][3]) {
+    return static_cast<i64>(m[1][1]) * static_cast<i64>(m[2][2]) -
+           static_cast<i64>(m[1][2]) * static_cast<i64>(m[2][1]);
+}
+
+}  // namespace
+
+FL_TEST_CASE("Q16 inverse reproduces the host study exactly") {
+    for (const auto& item : kStudyInverses) {
+        i32 out[3][3];
+        FL_REQUIRE(invert3x3Q16(item.forward, out));
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                FL_CHECK_EQ(out[row][col], item.inverse[row][col]);
+            }
+        }
+    }
+}
+
+FL_TEST_CASE("the wide numerator the staged divide avoids really is needed") {
+    // Vacuity guard for the case above. If every cofactor fitted in the 31
+    // bits that `cofactor << 32` leaves, the staged divide would be an
+    // elaborate way to write one division and the agreement above would say
+    // nothing about it.
+    //
+    // Lead cofactors, in bits: srgb 2^35.7, bt2020 2^36.2, display_p3 2^35.7,
+    // narrow 2^29.7. Three of the four need more than the 31 bits available,
+    // and narrow -- the near-degenerate set -- is the one that does not.
+    int needing_wide = 0;
+    for (const auto& item : kStudyInverses) {
+        const i64 cofactor = leadCofactor(item.forward);
+        const i64 magnitude = cofactor < 0 ? -cofactor : cofactor;
+        if (magnitude >= (static_cast<i64>(1) << 31)) {
+            ++needing_wide;
+        }
+    }
+    FL_CHECK_EQ(needing_wide, 3);
+}
+
+FL_TEST_CASE("Q16 inverse round-trips to the identity") {
+    // Independent of the study: M . M^-1 must be I, which no transcription
+    // error in the table above could satisfy by accident.
+    for (const auto& item : kStudyInverses) {
+        i32 inverse[3][3];
+        FL_REQUIRE(invert3x3Q16(item.forward, inverse));
+        i32 worst_diagonal = 0;
+        i32 worst_off_diagonal = 0;
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                i64 acc = 0;
+                for (int k = 0; k < 3; ++k) {
+                    acc += static_cast<i64>(item.forward[row][k]) *
+                           static_cast<i64>(inverse[k][col]);
+                }
+                const i32 value = static_cast<i32>((acc + 32768) >> 16);
+                const i32 expected = row == col ? 65536 : 0;
+                i32 error = value - expected;
+                if (error < 0) {
+                    error = -error;
+                }
+                if (row == col) {
+                    if (error > worst_diagonal) {
+                        worst_diagonal = error;
+                    }
+                } else if (error > worst_off_diagonal) {
+                    worst_off_diagonal = error;
+                }
+            }
+        }
+        // Measured worst across the four: 7 raw units on the diagonal and 8
+        // off it, both on bt2020 -- about 1e-4 of a unit, which is the
+        // inputs' own quantisation rather than anything the inversion adds.
+        // display_p3 and narrow are inside 3.
+        FL_CHECK_LT(worst_diagonal, 16);
+        FL_CHECK_LT(worst_off_diagonal, 16);
+    }
+}
+
+FL_TEST_CASE("Q16 inverse refuses a singular matrix") {
+    i32 out[3][3];
+    // Two identical columns: determinant exactly zero.
+    const i32 repeated_column[3][3] = {
+        {65536, 65536, 32768}, {65536, 65536, 16384}, {13107, 13107, 65536}};
+    FL_CHECK(!invert3x3Q16(repeated_column, out));
+
+    // Singular by a different route, and the one a zero-initialised profile
+    // would produce.
+    const i32 zero[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+    FL_CHECK(!invert3x3Q16(zero, out));
+}
+
+FL_TEST_CASE("Q16 inverse refuses input whose determinant leaves i64") {
+    // Why the guard is a check and not a bound on the input: this is refused
+    // for arithmetic reasons, not because the entries are implausible. A
+    // fixed input limit safe enough to make the determinant fit would have to
+    // sit near 16.0, and a deep-blue emitter at xy = (0.14, 0.03) already has
+    // a Z column near 28.
+    i32 out[3][3];
+    const i32 huge[3][3] = {
+        {2000000000, 3, 5}, {7, 2000000000, 11}, {13, 17, 2000000000}};
+    FL_CHECK(!invert3x3Q16(huge, out));
+
+    // And it refuses rather than wrapping. A wrapped determinant would hand
+    // back a plausible-looking inverse for a matrix that has none in s16.16,
+    // so the identity is checked alongside to show refusal is not the only
+    // thing this function does.
+    const i32 identity[3][3] = {{65536, 0, 0}, {0, 65536, 0}, {0, 0, 65536}};
+    FL_REQUIRE(invert3x3Q16(identity, out));
+    FL_CHECK_EQ(out[0][0], 65536);
+    FL_CHECK_EQ(out[1][1], 65536);
+    FL_CHECK_EQ(out[2][2], 65536);
+    FL_CHECK_EQ(out[0][1], 0);
+}
+
+FL_TEST_CASE("Q16 inverse rounds rather than truncates") {
+    // Truncation biases every coefficient toward zero, and a solve sums three
+    // of them, so the bias does not cancel across a row. 3/2 inverts to 2/3,
+    // which is 43690.667 in s16.16 -- rounding gives 43691 and truncation
+    // 43690, so the two are distinguishable. `diag(3)` would not do: 1/3 is
+    // 21845.33 and both give 21845.
+    i32 out[3][3];
+    const i32 three_halves[3][3] = {
+        {98304, 0, 0}, {0, 98304, 0}, {0, 0, 98304}};
+    FL_REQUIRE(invert3x3Q16(three_halves, out));
+    FL_CHECK_EQ(out[0][0], 43691);
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
First half of P9 item 2 (#4043). The other half is measured but not written — see the end.

## What was missing

P9 asks for a colorimetric build and solve that no float symbol reaches.
`buildRgbSolveMatrixQ16` inverts in **float** and quantises afterwards, so the inverse was
the piece standing in the way. `ci/color_fixed_inverse_study.py` priced it at 0.0064
dE2000 (#4275) and deliberately left the arithmetic unwritten.

## The obstacle, and what it cost

The inverse is `(cofactor << 32) / determinant`. The cofactor is already Q32, so 32 more
bits puts the numerator past i64 for any matrix that matters. The study computes it with
Python's unbounded integers and says out loud that a C++ version needs "a staged or
128-bit divide". AVR has no `__int128`.

So it is staged: each of the 32 doublings is spent on the numerator while it still fits,
and on the denominator otherwise. Both raise the quotient by the same factor, and the
determinant carries far more bits than a s16.16 answer needs.

**Validated before any C++ was written**, against the exact divide:

| corpus | disagreement |
|---|---|
| the study's four profiles | 0 ULP |
| six degrees of primary collapse (to 0.99999 collinear) | 0 ULP |
| 20,000 random primary sets | 0 ULP |

And it is not passing by never staging: **72%** of coefficients need at least one
denominator halving, up to 11. A C++ case pins the same thing from the other side — three
of the four profiles' lead cofactors exceed the 31 bits a naive shift would leave.

## Input is checked, not bounded

A fixed input limit safe enough to keep the determinant inside i64 would sit near **16.0**,
and a deep-blue emitter at xy = (0.14, 0.03) already has a Z column near **28**. So every
cofactor, and each of the determinant's products and sums, is overflow-checked by
division — exact on every target, and no `__builtin_mul_overflow`, which MSVC lacks and
the host suite builds there.

## Float-freeness, checked where it can be

Claiming this on the host is worthless: x86 has hardware float, so a float operation leaves
no call behind to find. `ci/tests/test_q16_inverse_is_float_free.py` compiles the
translation unit for a **Cortex-M0+** — ARMv6-M, no FPU — and reads the calls out of each
function's disassembly. GCC 16.1, `-Os`:

| function | instructions | float-runtime calls |
|---|---:|---|
| `invert3x3Q16` | 383 | **none** — `__aeabi_ldivmod` and `__aeabi_lmul` are 64-bit *integer* |
| `buildRgbSolveMatrixQ16` | 503 | **11** distinct `__aeabi_f*` / `__aeabi_d*` |

The second row is a positive control, not decoration. Without it a mistyped symbol name
would make the first row pass by disassembling nothing — which is exactly what happened to
me on the first run, and is why the helper raises when the symbol is absent.

Mutation-checked both directions: a float divide inside `invert3x3Q16` fails the assertion;
renaming the control's symbol fails the control.

## A defect that blocked the cross-compile

`device_solve.h` spelled `EmitterProfile` unqualified, which only resolves once some *other*
header has pulled in the `using` from `fl/channels/color_profile.h`. It did not compile
standalone on host or cross. Qualified, and added to the self-containment test #4300 landed
— mutation-checked by reverting the qualification.

## Coverage

Six C++ cases: exact agreement with the study for all four profiles; the vacuity guard
above; an identity round-trip that no transcription error in the reference table could
satisfy by accident (worst 7 raw units on the diagonal, 8 off it, both on bt2020); singular
refusal by two routes; i64-overflow refusal alongside a working identity so refusal is not
all it does; and that it rounds rather than truncates (3/2 → 43691, not 43690 — `diag(3)`
would not separate them).

303/303 unit + 84/84 examples, `bash lint` clean.

## Not done

`buildRgbSolveMatrixQ16` still builds its forward matrix in float, and `EmitterProfile`
still stores float chromaticities. #4292 measured that half at **0.1085 dE2000** worst
against A1's 0.5 — seventeen times this half's figure, and where item 2's error budget
actually goes. It is feasible, it is cross-cutting with P2 because the legacy RGBW stack
consumes the same type, and it wants its own change rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fixed-point 3×3 matrix inversion for color-processing workflows.
  * Added safeguards for singular matrices, arithmetic overflow, and coefficients outside supported bounds.
  * Matrix inversion operates without floating-point runtime dependencies, improving compatibility with constrained embedded targets.

* **Tests**
  * Added coverage for inversion accuracy, rounding, identity round-trips, and invalid inputs.
  * Added checks confirming required headers compile independently and validating floating-point runtime usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->