### PR TITLE
fix(autoresearch): stop reporting an absent coroutine backend as a pass (#3832)

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -325,6 +325,20 @@
   content, not state, and
   when commits are stranded rebuild them onto current master as a fresh PR
   rather than reopening the merged one.
+- `git fetch` before starting work, not before pushing. I root-caused the
+  `s16x16x4` 15x penalty in #4216 (rolled 4-lane loops defeating
+  scalar-replacement), fixed it, and measured it on hardware -- and only when
+  the cherry-pick conflicted did I discover #4299 had landed the same root
+  cause and a better fix (`FL_SIMD_LANE4`, which also covers `simd_riscv.hpp`)
+  nine hours earlier. My local `master` was clean but stale, so every check I
+  ran agreed with me. This is the third time this session I have rebuilt work
+  the remote already had. The cheap guard is not "check before pushing" -- by
+  then the work exists -- it is `git fetch origin` plus
+  `git log --oneline <local-base>..origin/master -- <the files you are about to
+  touch>` as the first action, before reading the code. The measurement was
+  still worth posting to the issue, because #4299 argued from instruction
+  counts and I had before/after on real silicon; salvage the part that is
+  genuinely yours rather than opening a duplicate PR.
 - A diagnostic field named after the subsystem you are testing may be sourced
   from the other side of the loopback. Chasing the RP PIO capture ceiling in
   #4371 I used `rpPioWordCount` as evidence about the RX DMA and wrote on the

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -333,9 +333,19 @@
   nine hours earlier. My local `master` was clean but stale, so every check I
   ran agreed with me. This is the third time this session I have rebuilt work
   the remote already had. The cheap guard is not "check before pushing" -- by
-  then the work exists -- it is `git fetch origin` plus
-  `git log --oneline <local-base>..origin/master -- <the files you are about to
-  touch>` as the first action, before reading the code. The measurement was
+  then the work exists -- it is running this before reading the code, with the
+  paths you are about to touch spelled out:
+
+  ```bash
+  git fetch origin
+  git log --oneline HEAD..origin/master -- src/platforms/shared/simd_noop.hpp
+  ```
+
+  `HEAD..origin/master` lists what upstream has that you do not, and the
+  path filter narrows it to the files in question -- in the #4216 case that
+  one command would have printed the commit for #4299 and saved the whole
+  detour. Name real paths rather than a placeholder: without them the log is
+  the full upstream delta and you will skim past the one line that matters. The measurement was
   still worth posting to the issue, because #4299 argued from instruction
   counts and I had before/after on real silicon; salvage the part that is
   genuinely yours rather than opening a duplicate PR.

--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -39,7 +39,13 @@ from ci.autoresearch.gpio import (
 )
 from ci.autoresearch.usb_power import absent_port_error, warn_selective_suspend
 from ci.debug_attached import run_cpp_lint
-from ci.rpc_client import RpcClient, RpcCrashError, RpcError, RpcTimeoutError
+from ci.rpc_client import (
+    RpcClient,
+    RpcCrashError,
+    RpcError,
+    RpcResponse,
+    RpcTimeoutError,
+)
 from ci.util.blocker_alert import blocker_alert
 from ci.util.crash_trace_decoder import CrashTraceDecoder
 from ci.util.global_interrupt_handler import (
@@ -3997,6 +4003,39 @@ async def _run_lpc_uart_dma_tests(ctx: RunContext) -> int:
     return 0 if result.returncode == 0 else 1
 
 
+# Exit status for `--coroutine` when the device reports no real coroutine
+# backend. Distinct from 0 (every test passed) and from 1 (a test failed),
+# because "the capability is absent" is neither. Returning 0 here is what let
+# RP2xxx record a passing coroutine criterion in #3832 while running zero
+# tests -- a criterion that cannot fail is not evidence, and a regression in a
+# real backend would look identical to this. No CI workflow invokes
+# `--coroutine`; it is a bench acceptance criterion, which is exactly where a
+# vacuous pass does its damage.
+kCoroutineUnsupportedExit = 2
+
+
+def coroutine_exit_code(response: RpcResponse | dict[str, Any]) -> int:
+    """Map a ``testCoroutineAll`` RPC response to a process exit status.
+
+    Three outcomes, three codes, because collapsing the first two is the
+    defect this exists to prevent:
+
+    * ``kCoroutineUnsupportedExit`` -- the device has no real coroutine
+      backend, so it ran no test and nothing here can regress.
+    * ``1`` -- tests ran and at least one failed.
+    * ``0`` -- tests ran and all passed.
+
+    ``supported`` and ``success`` both default to the optimistic value so an
+    older firmware that omits them is read the way it was written, not
+    reported as broken.
+    """
+    if response.get("supported", True) is False:
+        return kCoroutineUnsupportedExit
+    if response.get("success", False):
+        return 0
+    return 1
+
+
 async def _run_coroutine_tests(ctx: RunContext) -> int:
     """Run coroutine test suite via RPC."""
     upload_port = ctx.upload_port
@@ -4023,11 +4062,23 @@ async def _run_coroutine_tests(ctx: RunContext) -> int:
         print(f" {Fore.GREEN}ok{Style.RESET_ALL}")
         print()
 
-        if response.get("supported", True) is False:
+        exit_code = coroutine_exit_code(response)
+
+        if exit_code == kCoroutineUnsupportedExit:
             backend = response.get("backend", "unknown")
             reason = response.get("reason", "no real coroutine backend")
-            print(f"RESULT: COROUTINE UNSUPPORTED (backend={backend}): {reason}")
-            return 0
+            print(
+                f"{Fore.YELLOW}RESULT: COROUTINE UNSUPPORTED"
+                f" (backend={backend}): {reason}{Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.YELLOW}Not a pass: the device ran no coroutine test at"
+                f" all, so nothing here can regress visibly. Exiting"
+                f" {kCoroutineUnsupportedExit}"
+                f" (unsupported), distinct from 1 (tests failed)."
+                f"{Style.RESET_ALL}"
+            )
+            return kCoroutineUnsupportedExit
 
         total = response.get("total", 0)
         passed_count = response.get("passed", 0)
@@ -4055,15 +4106,14 @@ async def _run_coroutine_tests(ctx: RunContext) -> int:
                         print(f"          {test_result['error']}")
 
         print()
-        if response.get("success", False):
+        if exit_code == 0:
             print(f"{Fore.GREEN}COROUTINE TEST PASSED ({total} tests){Style.RESET_ALL}")
-            return 0
         else:
             print(
                 f"{Fore.RED}COROUTINE TEST FAILED"
                 f" ({failed_count}/{total} failures){Style.RESET_ALL}"
             )
-            return 1
+        return exit_code
 
     except RpcTimeoutError:
         print()

--- a/ci/tests/test_autoresearch_phases.py
+++ b/ci/tests/test_autoresearch_phases.py
@@ -36,6 +36,8 @@ from ci.autoresearch.phases import (
     _run_tests_or_special_mode,
     _run_watchdog_soak,
     _validate_test_rpc_response,
+    coroutine_exit_code,
+    kCoroutineUnsupportedExit,
     stop_autoresearch_watchdog,
 )
 from ci.rpc_client import RpcError, RpcTimeoutError
@@ -2755,7 +2757,13 @@ class TestRunTestsOrSpecialMode:
         with patch(f"{_PATCH_MOD}.RpcClient", return_value=mock_client):
             rc = asyncio.run(_run_tests_or_special_mode(ctx, qctx))
 
-        assert rc == 0
+        # This asserted 0 until FastLED#3832: a null backend runs no coroutine
+        # test, so exiting 0 recorded a passing criterion on the strength of
+        # nothing having run. The code must reach the caller intact, which is
+        # what this end-to-end path proves that the unit test of
+        # coroutine_exit_code cannot.
+        assert rc == kCoroutineUnsupportedExit
+        assert rc != 0
 
     def test_rp2350_watchdog_reacquires_active_environment_and_device(self) -> None:
         ctx = _make_ctx(
@@ -3198,3 +3206,41 @@ def test_parallel_validator_rejects_an_oversized_request_error() -> None:
         }
     )
     assert not _is_valid_rp_pio_parallel_result(refusal_with_flags)
+
+
+def test_coroutine_unsupported_is_not_reported_as_a_pass() -> None:
+    """A device with no coroutine backend must not exit 0.
+
+    RP2xxx selects the generic Arduino null coroutine backend, so
+    `bash autoresearch rp2350 --coroutine` runs zero tests and the device
+    answers `supported=False`. That used to return 0, which recorded a
+    passing coroutine criterion in FastLED#3832 on the strength of no test
+    having run -- and made a genuine regression in a real backend
+    indistinguishable from the absent one.
+
+    The three outcomes must stay three distinct codes.
+    """
+    unsupported = coroutine_exit_code({"supported": False, "backend": "null"})
+    assert unsupported != 0, "an absent capability is not a pass"
+
+    failed = coroutine_exit_code({"supported": True, "success": False})
+    assert failed != 0
+
+    # Distinct from each other too: "nothing ran" and "something broke" are
+    # different findings, and a caller must be able to tell them apart.
+    assert unsupported != failed
+
+    passed = coroutine_exit_code({"supported": True, "success": True})
+    assert passed == 0
+
+
+def test_coroutine_exit_code_defaults_trust_older_firmware() -> None:
+    """Omitted keys read as the optimistic value, not as breakage.
+
+    Firmware predating the `supported` flag answers with neither key. Such a
+    response that also reports `success` is a real pass and must stay one;
+    absent `success` is a failure, matching what the caller printed before
+    this mapping was extracted.
+    """
+    assert coroutine_exit_code({"success": True}) == 0
+    assert coroutine_exit_code({}) == 1


### PR DESCRIPTION
`bash autoresearch rp2350 --coroutine` exited **0** while printing `COROUTINE UNSUPPORTED (backend=null)`.

RP2xxx selects the generic Arduino null coroutine backend, so the device runs zero coroutine tests and answers `supported=False`. The harness printed that and returned success anyway. Reproduced on the attached RP2350 before the change:

```
RESULT: COROUTINE UNSUPPORTED (backend=null): RP2xxx currently selects the generic Arduino null coroutine backend
rc=0
```

Two problems with that, and the second is the worse one:

1. It is how #3832's acceptance matrix came to record a **passing** coroutine criterion on the strength of no test having run. A criterion that cannot fail is not evidence.
2. It makes a genuine regression **indistinguishable from the absent backend** — if a real backend broke and started answering `supported=False`, the output and the exit code would be identical to today's.

## Change

Three outcomes now get three codes:

| code | meaning |
|---|---|
| `0` | tests ran, all passed |
| `1` | tests ran, at least one failed |
| `2` | no real backend — nothing ran |

The decision moves into `coroutine_exit_code()`, which the async path routes **all three** of its decisions through. That is deliberate: it makes the mapping reachable from a test without standing up an `RpcClient`, and it stops the pass/fail branch and the unsupported branch from drifting apart.

Omitted keys still read optimistically (`supported` defaults true, `success` defaults false), so firmware predating the `supported` flag is read the way it was written rather than reported as broken.

## Blast radius

None in CI. No workflow invokes `--coroutine` — it is a bench acceptance criterion, which is precisely where a vacuous pass does its damage. Confirmed by grepping `.github/` and `ci/` for the flag.

## Verification

On the attached RP2350 (`2DCB876B587EA334`), after the change:

```
RESULT: COROUTINE UNSUPPORTED (backend=null): RP2xxx currently selects the generic Arduino null coroutine backend
Not a pass: the device ran no coroutine test at all, so nothing here can regress visibly. Exiting 2 (unsupported), distinct from 1 (tests failed).
AUTORESEARCH_RC=2
```

The existing end-to-end test `test_rp_coroutine_mode_reports_null_backend_as_unsupported` asserted `rc == 0`, so it had locked the defect in. It now asserts the unsupported code — keeping its real value, which is proving the code survives out through `_run_tests_or_special_mode` to the caller, something the unit test of the mapping cannot show.

**Both tests were confirmed to fail with the old `return 0` restored**, so neither passes for the wrong reason:

```
FAILED test_rp_coroutine_mode_reports_null_backend_as_unsupported
FAILED test_coroutine_unsupported_is_not_reported_as_a_pass
```

`215 passed` across the three autoresearch test modules; `bash lint` clean.

## Not addressed here

This does not give RP2xxx a coroutine backend — that is the substance of #3832 and needs a real implementation. It only stops the harness from claiming the criterion is met. Expect `--coroutine` on RP2xxx to exit 2 until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unsupported coroutine-test backends now return a distinct nonzero status instead of being reported as successful.
  - Test results distinguish unsupported environments, failed tests, and passing tests.
  - Older firmware remains compatible through sensible default result handling.
  - Driver-declined test runs now report the driver-provided reason when available.

- **Documentation**
  - Updated contributor guidance with executable commands for fetching upstream changes and comparing filtered file history.
  - Clarified how to identify relevant files and interpret the resulting commit range and path filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->