### PR TITLE
study(color): price P9 item 2's luminance half, which the study fixed at unity

### DIFF
--- a/ci/color_fixed_profile_study.py
+++ b/ci/color_fixed_profile_study.py
@@ -133,16 +133,33 @@ def emitter_matrix_q16(
         # z = 1 - x - y, in Q16, from the *quantised* x and y rather than
         # from the floats: a fixed-point profile has no float to go back to.
         z = kQ16One - x - y
-        # X = Y*x/y and Z = Y*z/y. Divide first and scale second, matching
-        # `xyY_to_XYZ`, so this models the shipped path rather than a
-        # rearrangement of it.
+        # X = Y*x/y and Z = Y*z/y, divided first and scaled second.
         #
-        # The order is visible but small: scaling first instead moves 30 of
-        # the corpus's 144 coefficients, by at most 10 raw units (1.5e-04 of
-        # a unit), and moves no dE2000 in this study enough to matter.
-        # Recorded so nobody reads the choice as load-bearing for the budget
-        # -- it is load-bearing for *fidelity to the shipped code*, which is
-        # a different claim.
+        # This deliberately does *not* mirror the shipped order. `xyY_to_XYZ`
+        # is `out[0] = x * Y * inv_y`, which C++ groups left to right, so the
+        # float path scales before it divides. In fixed point that is the
+        # worse arrangement: `x * Y` in Q16 discards low bits before the
+        # divide can use them.
+        #
+        # Measured against the float32 baseline, worst coefficient ULP over
+        # the corpus and the luminance sets:
+        #
+        #   srgb/dim-blue        11 divide-first    18 scale-first
+        #   bt2020/lopsided       5                 10
+        #   display_p3/dim-blue  10                 18
+        #   narrow/dim-blue    2899               7363
+        #
+        # Better in 8 of the 16 combinations and tied in 7 -- the unit sets,
+        # where the two are the same expression. It loses one, `narrow` with
+        # typical luminances, by 21 ULP. What decides it is the extreme.
+        #
+        # And it costs nothing in colour either way: both orders give the
+        # same 0.1085 worst dE2000, because the binding case is unit
+        # luminance where the two are identical.
+        #
+        # Stated at this length because the first version of this comment
+        # claimed the opposite, that divide-first *was* the shipped order.
+        # It is not; keeping it is an accuracy argument, not a fidelity one.
         columns.append(
             [
                 rounded_div(rounded_div(x * kQ16One, y) * luminance, kQ16One),
@@ -161,7 +178,13 @@ def emitter_matrix_q16(
 def emitter_matrix_f32_lum(
     primaries: Primaries, luminances: EmitterLuminances
 ) -> list[list[float]]:
-    """`emitter_matrix_f32` with per-emitter luminance, the shipped order."""
+    """`emitter_matrix_f32` with per-emitter luminance, the shipped order.
+
+    Scale then divide, because `xyY_to_XYZ` is `x * Y * inv_y` and C++ groups
+    that left to right. This is the baseline, so it has to be what ships even
+    where that is the less accurate arrangement -- the candidate is the one
+    allowed to be better, and `emitter_matrix_q16` says why it is.
+    """
 
     columns: list[list[float]] = []
     for (x, y), luminance in zip(primaries, luminances.per_emitter()):

--- a/ci/color_fixed_profile_study.py
+++ b/ci/color_fixed_profile_study.py
@@ -52,6 +52,7 @@ from ci.color_fixed_inverse_study import (
     to_q16,
     xyz_to_lab,
 )
+from ci.color_reference import Matrix3, Xyz
 
 
 kQ16One = 1 << 16
@@ -73,30 +74,104 @@ class ProfileError:
     coefficient_ulps: int
 
 
+# Per-emitter luminances to price alongside the unit case.
+#
+# `EmitterProfile` carries `lum_r`, `lum_g` and `lum_b` and does not require
+# them to be 1. The first version of this study fixed them at unity, which
+# left the question it exists to answer only half priced: quantising a
+# luminance is a second perturbation, and it lands on the same columns the
+# divisor sensitivity already stresses.
 @typechecked
-def emitter_matrix_q16(primaries: Primaries) -> list[list[int]] | None:
+@dataclass(frozen=True, slots=True)
+class EmitterLuminances:
+    """`EmitterProfile`'s `lum_r`, `lum_g` and `lum_b`, with a name."""
+
+    label: str
+    red: float
+    green: float
+    blue: float
+
+    def per_emitter(self) -> list[float]:
+        """The three, in the column order the emitter matrix uses."""
+
+        return [self.red, self.green, self.blue]
+
+
+kUnitLuminance = EmitterLuminances(label="unit", red=1.0, green=1.0, blue=1.0)
+
+kLuminanceSets: tuple[EmitterLuminances, ...] = (
+    kUnitLuminance,
+    # A warm-white part: green carries most of the flux, blue least.
+    EmitterLuminances(label="typical", red=1.0, green=0.8, blue=0.4),
+    # Deliberately lopsided, to find where the derivation stops holding.
+    EmitterLuminances(label="lopsided", red=0.25, green=1.0, blue=0.1),
+    EmitterLuminances(label="dim-blue", red=1.0, green=1.0, blue=0.05),
+)
+
+
+@typechecked
+def emitter_matrix_q16(
+    primaries: Primaries, luminances: EmitterLuminances
+) -> list[list[int]] | None:
     """The emitter columns built entirely in Q16, from Q16 chromaticities.
 
     Mirrors `xyY_to_XYZ`'s operation order -- divide by `y`, then scale --
-    because that order is what decides where a fixed-point path rounds. Unit
-    luminance per emitter, as `EmitterProfile`'s defaults carry.
+    because that order is what decides where a fixed-point path rounds.
 
-    Returns None when a `y` quantises to zero, which is the degenerate case
-    the shipped `isUsableSolveChromaticity` already refuses.
+    Returns None when a `y` or a luminance quantises to zero, which is the
+    degenerate case the shipped `isUsableSolveChromaticity` and
+    `isUsableLuminance` already refuse.
     """
 
     columns: list[list[int]] = []
-    for x_float, y_float in primaries:
+    for (x_float, y_float), luminance_float in zip(primaries, luminances.per_emitter()):
         x = to_q16(x_float)
         y = to_q16(y_float)
-        if y <= 0:
+        luminance = to_q16(luminance_float)
+        if y <= 0 or luminance <= 0:
             return None
         # z = 1 - x - y, in Q16, from the *quantised* x and y rather than
         # from the floats: a fixed-point profile has no float to go back to.
         z = kQ16One - x - y
-        # X = x / y and Z = z / y at unit Y, both in Q16.
+        # X = Y*x/y and Z = Y*z/y. Divide first and scale second, matching
+        # `xyY_to_XYZ`, so this models the shipped path rather than a
+        # rearrangement of it.
+        #
+        # The order is visible but small: scaling first instead moves 30 of
+        # the corpus's 144 coefficients, by at most 10 raw units (1.5e-04 of
+        # a unit), and moves no dE2000 in this study enough to matter.
+        # Recorded so nobody reads the choice as load-bearing for the budget
+        # -- it is load-bearing for *fidelity to the shipped code*, which is
+        # a different claim.
         columns.append(
-            [rounded_div(x * kQ16One, y), kQ16One, rounded_div(z * kQ16One, y)]
+            [
+                rounded_div(rounded_div(x * kQ16One, y) * luminance, kQ16One),
+                luminance,
+                rounded_div(rounded_div(z * kQ16One, y) * luminance, kQ16One),
+            ]
+        )
+    return [
+        [columns[0][0], columns[1][0], columns[2][0]],
+        [columns[0][1], columns[1][1], columns[2][1]],
+        [columns[0][2], columns[1][2], columns[2][2]],
+    ]
+
+
+@typechecked
+def emitter_matrix_f32_lum(
+    primaries: Primaries, luminances: EmitterLuminances
+) -> list[list[float]]:
+    """`emitter_matrix_f32` with per-emitter luminance, the shipped order."""
+
+    columns: list[list[float]] = []
+    for (x, y), luminance in zip(primaries, luminances.per_emitter()):
+        inv_y = f32(1.0 / f32(y))
+        columns.append(
+            [
+                f32(f32(f32(x) * f32(luminance)) * inv_y),
+                f32(luminance),
+                f32(f32(f32(1.0 - f32(x) - f32(y)) * f32(luminance)) * inv_y),
+            ]
         )
     return [
         [columns[0][0], columns[1][0], columns[2][0]],
@@ -107,7 +182,10 @@ def emitter_matrix_q16(primaries: Primaries) -> list[list[int]] | None:
 
 @typechecked
 def compare_profile_quantization(
-    name: str, primaries: Primaries, steps: int
+    name: str,
+    primaries: Primaries,
+    steps: int,
+    luminances: EmitterLuminances = kUnitLuminance,
 ) -> ProfileError:
     """Worst dE2000, drive error and coefficient ULPs for one device.
 
@@ -117,13 +195,13 @@ def compare_profile_quantization(
     reaches float again.
     """
 
-    forward_f32 = emitter_matrix_f32(primaries)
+    forward_f32 = emitter_matrix_f32_lum(primaries, luminances)
     inverse_f32 = invert3x3_f32(forward_f32)
     if inverse_f32 is None:
         raise ValueError(f"{name}: float32 inverse reported singular")
     shipped = quantize_rows(inverse_f32)
 
-    forward_q16 = emitter_matrix_q16(primaries)
+    forward_q16 = emitter_matrix_q16(primaries, luminances)
     if forward_q16 is None:
         raise ValueError(f"{name}: a chromaticity quantised to an unusable y")
     proposed = invert3x3_q16(forward_q16)
@@ -140,7 +218,18 @@ def compare_profile_quantization(
     # Rendering stays float64: it stands in for the device, and modelling it
     # at either candidate's precision would credit one of them with the
     # emulator's rounding.
-    forward = emitter_matrix(primaries)
+    # Rendering in float64, and with the same luminances -- otherwise the two
+    # candidates would be scored against a device neither was built for.
+    # Each column is one emitter, so scaling a column scales that emitter.
+    unit = emitter_matrix(primaries)
+    red, green, blue = luminances.per_emitter()
+
+    def scaled(row: Xyz) -> Xyz:
+        return (row[0] * red, row[1] * green, row[2] * blue)
+
+    forward = Matrix3(
+        row0=scaled(unit.row0), row1=scaled(unit.row1), row2=scaled(unit.row2)
+    )
 
     worst_delta_e = 0.0
     worst_drive_error = 0.0
@@ -203,22 +292,29 @@ def main(argv: list[str]) -> int:
     print("Baseline: the shipped float32 forward + float32 inverse.")
     print()
     print(
-        f"{'primaries':<14}{'chroma q16 err':>16}{'coef ULP':>10}"
+        f"{'primaries':<14}{'luminances':<11}{'chroma q16 err':>16}{'coef ULP':>10}"
         f"{'drive err':>12}{'worst dE2000':>14}"
     )
 
     worst_overall = 0.0
+    worst_where = ""
     for name, primaries in corpus_primaries():
-        measured = compare_profile_quantization(name, primaries, args.steps)
         residual = quantization_residual(primaries)
-        print(
-            f"{name:<14}{residual:>16.2e}{measured.coefficient_ulps:>10d}"
-            f"{measured.drive_error:>12.2e}{measured.delta_e:>14.4f}"
-        )
-        if measured.delta_e > worst_overall:
-            worst_overall = measured.delta_e
+        for luminances in kLuminanceSets:
+            measured = compare_profile_quantization(
+                name, primaries, args.steps, luminances
+            )
+            print(
+                f"{name:<14}{luminances.label:<11}{residual:>16.2e}"
+                f"{measured.coefficient_ulps:>10d}"
+                f"{measured.drive_error:>12.2e}{measured.delta_e:>14.4f}"
+            )
+            if measured.delta_e > worst_overall:
+                worst_overall = measured.delta_e
+                worst_where = f"{name}/{luminances.label}"
 
     print()
+    print(f"worst case: {worst_where}")
     # A1 allows 0.5 dE2000 end to end, and the gamut mapper already spends
     # about 0.15 of it, so a derivation change has roughly 0.35 to work in.
     print(f"worst across the corpus: {worst_overall:.4f} dE2000 (A1 budget 0.5)")

--- a/ci/tests/test_color_fixed_profile_study.py
+++ b/ci/tests/test_color_fixed_profile_study.py
@@ -17,7 +17,10 @@ from ci.color_fixed_inverse_study import (
     Primaries,
     corpus_primaries,
     emitter_matrix_f32,
+    f32,
     from_q16,
+    invert3x3_f32,
+    invert3x3_q16,
     quantize_rows,
     rounded_div,
     to_q16,
@@ -25,6 +28,7 @@ from ci.color_fixed_inverse_study import (
 from ci.color_fixed_profile_study import (
     EmitterLuminances,
     compare_profile_quantization,
+    emitter_matrix_f32_lum,
     emitter_matrix_q16,
     kLuminanceSets,
     kQ16One,
@@ -164,18 +168,72 @@ class TestQuantizedProfileStudy(unittest.TestCase):
         self.assertGreater(narrow.coefficient_ulps, 100 * bt2020.coefficient_ulps)
         self.assertLess(narrow.delta_e, bt2020.delta_e)
 
-    def test_the_divide_then_scale_order_is_visible_but_not_decisive(self) -> None:
-        """Both halves of a claim the comment in `emitter_matrix_q16` makes.
+    def test_the_float_baseline_keeps_the_shipped_grouping(self) -> None:
+        """The baseline models `xyY_to_XYZ`, not the candidate.
 
-        It divides by `y` and then scales by the luminance, matching
-        `xyY_to_XYZ`. Writing that as "reversing it would stop modelling the
-        shipped path" invited the reading that the order carries the budget,
-        and it does not -- reversing it passed every other case here.
+        `colorimetric_response::xyY_to_XYZ` is:
 
-        So this pins what is actually true: the order is visible at the
-        coefficient level (30 of 144 cells move, by up to 10 raw units) and
-        is not visible in the colour figure. Fidelity to the shipped code is
-        the reason to keep it, not accuracy.
+            const float inv_y = 1.0f / y;
+            out[0] = x * Y * inv_y;
+
+        which C++ groups left to right, so it scales before it divides.
+        `emitter_matrix_f32_lum` has to reproduce that even though it is the
+        less accurate arrangement -- it is the thing being measured against,
+        and a baseline that quietly adopted the candidate's better order
+        would understate what quantising the profile costs.
+
+        Review proposed exactly that change, reading the candidate's order as
+        the shipped one. It was the wrong way round, and nothing here caught
+        it: the swap passed every other case in this file. This is that gap.
+        """
+
+        for _name, primaries in corpus_primaries():
+            for luminances in kLuminanceSets:
+                baseline = emitter_matrix_f32_lum(primaries, luminances)
+                scale = luminances.per_emitter()
+                for column, ((x, y), luminance) in enumerate(zip(primaries, scale)):
+                    inv_y = f32(1.0 / f32(y))
+                    # The shipped grouping, spelled out.
+                    shipped_x = f32(f32(f32(x) * f32(luminance)) * inv_y)
+                    self.assertEqual(baseline[0][column], shipped_x)
+                    z = f32(1.0 - f32(x) - f32(y))
+                    shipped_z = f32(f32(z * f32(luminance)) * inv_y)
+                    self.assertEqual(baseline[2][column], shipped_z)
+
+    def test_the_two_float_groupings_are_distinguishable(self) -> None:
+        """Vacuity guard for the case above.
+
+        If float32 rounded both groupings identically, that case would hold
+        no matter which the baseline used, and the swap it exists to catch
+        would slip through anyway.
+        """
+
+        differing = 0
+        for _name, primaries in corpus_primaries():
+            for luminances in kLuminanceSets:
+                for (x, y), luminance in zip(primaries, luminances.per_emitter()):
+                    inv_y = f32(1.0 / f32(y))
+                    scale_then_divide = f32(f32(f32(x) * f32(luminance)) * inv_y)
+                    divide_then_scale = f32(f32(f32(x) * inv_y) * f32(luminance))
+                    if scale_then_divide != divide_then_scale:
+                        differing += 1
+        self.assertGreater(differing, 0)
+
+    def test_the_divide_then_scale_order_is_the_more_accurate_one(self) -> None:
+        """Why `emitter_matrix_q16` diverges from the shipped operation order.
+
+        `xyY_to_XYZ` is `out[0] = x * Y * inv_y`, which C++ groups left to
+        right, so the float path scales before it divides. The Q16 candidate
+        divides first, which is the opposite -- and is deliberate, because in
+        fixed point `x * Y` throws away low bits the divide would have used.
+
+        Twice this comment has said the reverse. It first claimed reversing
+        the order "would stop modelling the shipped path", and then that
+        divide-first *was* the shipped order. Review caught the second. So
+        this stops describing the order and measures it, against the float32
+        baseline both are trying to reproduce -- including the one case where
+        divide-first comes off worse, which a third telling would probably
+        have left out.
         """
 
         def scale_first(
@@ -198,26 +256,54 @@ class TestQuantizedProfileStudy(unittest.TestCase):
                 )
             return [[columns[0][k], columns[1][k], columns[2][k]] for k in range(3)]
 
-        moved = 0
-        worst = 0
+        differed = 0
+        divide_first_worse = 0
+        worst_divide_first = 0
+        worst_scale_first = 0
         for _name, primaries in corpus_primaries():
             for luminances in kLuminanceSets:
-                shipped_order = emitter_matrix_q16(primaries, luminances)
-                self.assertIsNotNone(shipped_order)
-                assert shipped_order is not None
-                other = scale_first(primaries, luminances)
-                for row in range(3):
-                    for col in range(3):
-                        difference = abs(shipped_order[row][col] - other[row][col])
-                        if difference:
-                            moved += 1
-                        worst = max(worst, difference)
+                baseline = quantize_rows(
+                    invert3x3_f32(emitter_matrix_f32_lum(primaries, luminances))
+                )
+                candidate = emitter_matrix_q16(primaries, luminances)
+                self.assertIsNotNone(candidate)
+                assert candidate is not None
+                inverses = {
+                    "divide": invert3x3_q16(candidate),
+                    "scale": invert3x3_q16(scale_first(primaries, luminances)),
+                }
+                errors = {}
+                for label, inverse in inverses.items():
+                    self.assertIsNotNone(inverse)
+                    assert inverse is not None
+                    errors[label] = max(
+                        abs(baseline[row][col] - inverse[row][col])
+                        for row in range(3)
+                        for col in range(3)
+                    )
+                if errors["divide"] != errors["scale"]:
+                    differed += 1
+                if errors["divide"] > errors["scale"]:
+                    divide_first_worse += 1
+                worst_divide_first = max(worst_divide_first, errors["divide"])
+                worst_scale_first = max(worst_scale_first, errors["scale"])
 
-        # Visible: the two orders are genuinely different arithmetic.
-        self.assertGreater(moved, 0)
-        # But small: an order that moved a coefficient by a large amount
-        # would deserve its own dE2000 measurement rather than this note.
-        self.assertLess(worst, 32)
+        # Vacuity guard: if the orders never diverged, everything below would
+        # be comparing a number with itself. They agree at unit luminance,
+        # where scaling by 1.0 makes them the same expression, so only the
+        # non-unit sets can separate them.
+        self.assertGreater(differed, 0)
+
+        # Better in 8 of the 16 combinations, tied in 7 -- the unit sets,
+        # where the two are the same expression -- and worse in exactly one:
+        # `narrow`/`typical`, 113 ULP against 92. So "never worse" is not the
+        # claim, and was the claim until this counted it.
+        self.assertEqual(divide_first_worse, 1)
+
+        # What carries the choice is the extreme, not the average: 2899 ULP
+        # against 7363 on `narrow` with a near-dark blue. The one case
+        # divide-first loses, it loses by 21 ULP.
+        self.assertLess(worst_divide_first * 2, worst_scale_first)
 
     def test_bt2020_is_the_worst_and_its_smallest_y_is_why(self) -> None:
         """The mechanism the study claims, checked rather than asserted.

--- a/ci/tests/test_color_fixed_profile_study.py
+++ b/ci/tests/test_color_fixed_profile_study.py
@@ -14,15 +14,21 @@ from __future__ import annotations
 import unittest
 
 from ci.color_fixed_inverse_study import (
+    Primaries,
     corpus_primaries,
     emitter_matrix_f32,
     from_q16,
     quantize_rows,
+    rounded_div,
     to_q16,
 )
 from ci.color_fixed_profile_study import (
+    EmitterLuminances,
     compare_profile_quantization,
     emitter_matrix_q16,
+    kLuminanceSets,
+    kQ16One,
+    kUnitLuminance,
     main,
     quantization_residual,
 )
@@ -43,7 +49,7 @@ class TestQuantizedProfileStudy(unittest.TestCase):
         differing = 0
         for _name, primaries in corpus_primaries():
             float_built = quantize_rows(emitter_matrix_f32(primaries))
-            q16_built = emitter_matrix_q16(primaries)
+            q16_built = emitter_matrix_q16(primaries, kUnitLuminance)
             self.assertIsNotNone(q16_built)
             assert q16_built is not None
             for row in range(3):
@@ -62,9 +68,10 @@ class TestQuantizedProfileStudy(unittest.TestCase):
 
         worst = 0.0
         for name, primaries in corpus_primaries():
-            measured = compare_profile_quantization(name, primaries, 9)
-            if measured.delta_e > worst:
-                worst = measured.delta_e
+            for luminances in kLuminanceSets:
+                measured = compare_profile_quantization(name, primaries, 9, luminances)
+                if measured.delta_e > worst:
+                    worst = measured.delta_e
         self.assertLess(worst, 0.35)
         # And a band around the measured 0.1085, tight enough that the
         # figure the issue comment reports is the figure this checks. A
@@ -77,6 +84,140 @@ class TestQuantizedProfileStudy(unittest.TestCase):
         # the budget. A change that moves this at all should say so.
         self.assertGreater(worst, 0.1031)
         self.assertLess(worst, 0.1139)
+
+    def test_luminance_is_priced_too_and_does_not_move_the_answer(self) -> None:
+        """The half the study originally left out.
+
+        `EmitterProfile` carries `lum_r`, `lum_g` and `lum_b` and does not
+        require them to be 1, but the first version of this study fixed them
+        at unity. Quantising a luminance is a second perturbation and it
+        lands on the same columns the divisor sensitivity already stresses,
+        so leaving it out priced item 2's precondition only halfway.
+
+        Measured across four luminance sets and the four-profile corpus, the
+        worst case is still BT.2020 at unit luminance, 0.1085 dE2000. Every
+        non-unit set comes in at or below 0.031.
+        """
+
+        worst_unit = 0.0
+        worst_non_unit = 0.0
+        for name, primaries in corpus_primaries():
+            for luminances in kLuminanceSets:
+                measured = compare_profile_quantization(name, primaries, 9, luminances)
+                if luminances.label == "unit":
+                    worst_unit = max(worst_unit, measured.delta_e)
+                else:
+                    worst_non_unit = max(worst_non_unit, measured.delta_e)
+
+        # The published figure is the unit case, and it stays the binding one.
+        self.assertGreater(worst_unit, worst_non_unit)
+        self.assertLess(worst_non_unit, 0.05)
+
+    def test_the_luminance_sets_actually_perturb_the_matrix(self) -> None:
+        """Vacuity guard for the case above.
+
+        A luminance set that produced the same Q16 matrix as unity would make
+        that comparison a number against itself. `dim-blue` scales an emitter
+        by 0.05, so the columns must differ -- and the point is that they
+        differ *without* the colour error following.
+        """
+
+        _name, primaries = corpus_primaries()[0]
+        unit = emitter_matrix_q16(primaries, kUnitLuminance)
+        self.assertIsNotNone(unit)
+        assert unit is not None
+        for luminances in kLuminanceSets:
+            if luminances.label == "unit":
+                continue
+            scaled = emitter_matrix_q16(primaries, luminances)
+            self.assertIsNotNone(scaled, f"{luminances.label} reported degenerate")
+            assert scaled is not None
+            differing = sum(
+                1
+                for row in range(3)
+                for col in range(3)
+                if unit[row][col] != scaled[row][col]
+            )
+            self.assertGreater(
+                differing, 0, f"{luminances.label} matched unit luminance"
+            )
+
+    def test_coefficient_ulps_are_not_a_proxy_for_colour_error(self) -> None:
+        """Recorded because the two separate, and one is the misleading one.
+
+        `narrow` with `lopsided` luminances moves 1515 coefficient ULPs and
+        still lands 0.0135 dE2000, while BT.2020 at unit luminance moves 2
+        ULPs and lands 0.1085 -- eight times the colour error for a
+        seven-hundredth of the coefficient movement. Conditioning moves the
+        coefficients; the small divisor moves the colour.
+
+        So a future change must not conclude from a small ULP count that the
+        colour is fine, nor from a large one that it is not.
+        """
+
+        by_name = dict(corpus_primaries())
+        lopsided = next(item for item in kLuminanceSets if item.label == "lopsided")
+        narrow = compare_profile_quantization("narrow", by_name["narrow"], 9, lopsided)
+        bt2020 = compare_profile_quantization(
+            "bt2020", by_name["bt2020"], 9, kUnitLuminance
+        )
+        self.assertGreater(narrow.coefficient_ulps, 100 * bt2020.coefficient_ulps)
+        self.assertLess(narrow.delta_e, bt2020.delta_e)
+
+    def test_the_divide_then_scale_order_is_visible_but_not_decisive(self) -> None:
+        """Both halves of a claim the comment in `emitter_matrix_q16` makes.
+
+        It divides by `y` and then scales by the luminance, matching
+        `xyY_to_XYZ`. Writing that as "reversing it would stop modelling the
+        shipped path" invited the reading that the order carries the budget,
+        and it does not -- reversing it passed every other case here.
+
+        So this pins what is actually true: the order is visible at the
+        coefficient level (30 of 144 cells move, by up to 10 raw units) and
+        is not visible in the colour figure. Fidelity to the shipped code is
+        the reason to keep it, not accuracy.
+        """
+
+        def scale_first(
+            primaries: Primaries, luminances: EmitterLuminances
+        ) -> list[list[int]]:
+            columns: list[list[int]] = []
+            for (x_float, y_float), luminance_float in zip(
+                primaries, luminances.per_emitter()
+            ):
+                x = to_q16(x_float)
+                y = to_q16(y_float)
+                luminance = to_q16(luminance_float)
+                z = kQ16One - x - y
+                columns.append(
+                    [
+                        rounded_div(rounded_div(x * luminance, kQ16One) * kQ16One, y),
+                        luminance,
+                        rounded_div(rounded_div(z * luminance, kQ16One) * kQ16One, y),
+                    ]
+                )
+            return [[columns[0][k], columns[1][k], columns[2][k]] for k in range(3)]
+
+        moved = 0
+        worst = 0
+        for _name, primaries in corpus_primaries():
+            for luminances in kLuminanceSets:
+                shipped_order = emitter_matrix_q16(primaries, luminances)
+                self.assertIsNotNone(shipped_order)
+                assert shipped_order is not None
+                other = scale_first(primaries, luminances)
+                for row in range(3):
+                    for col in range(3):
+                        difference = abs(shipped_order[row][col] - other[row][col])
+                        if difference:
+                            moved += 1
+                        worst = max(worst, difference)
+
+        # Visible: the two orders are genuinely different arithmetic.
+        self.assertGreater(moved, 0)
+        # But small: an order that moved a coefficient by a large amount
+        # would deserve its own dE2000 measurement rather than this note.
+        self.assertLess(worst, 32)
 
     def test_bt2020_is_the_worst_and_its_smallest_y_is_why(self) -> None:
         """The mechanism the study claims, checked rather than asserted.
@@ -107,7 +248,7 @@ class TestQuantizedProfileStudy(unittest.TestCase):
 
         degenerate = ((0.64, 0.33), (0.30, 0.60), (0.15, 1.0 / 200000.0))
         self.assertEqual(to_q16(1.0 / 200000.0), 0)
-        self.assertIsNone(emitter_matrix_q16(degenerate))
+        self.assertIsNone(emitter_matrix_q16(degenerate, kUnitLuminance))
 
     def test_q16_round_trip_is_within_one_step(self) -> None:
         """The residual the table reports is a quantisation residual."""


### PR DESCRIPTION
For P9 (#4043) item 2. Independent of #4305 — this is the study, not the implementation.

## The gap

`ci/color_fixed_profile_study.py` prices item 2's precondition: whether the emitter matrix
can be **built** in fixed point, not merely inverted in fixed point from a float-built one.
It held every emitter's luminance at 1.0.

`EmitterProfile` carries `lum_r`, `lum_g` and `lum_b` and does not require that. So the
precondition was priced halfway: quantising a luminance is a second perturbation, and it
lands on the same columns the division by `y` already stresses.

## Measured

Four luminance sets — unit, a warm-white part, a deliberately lopsided one, and a
near-dark blue — against the same four-profile corpus:

| primaries | luminances | coef ULP | drive err | worst dE2000 |
|---|---|---:|---:|---:|
| srgb | unit | 1 | 2.14e-04 | 0.0172 |
| srgb | typical / lopsided / dim-blue | 1–11 | ≤1.22e-04 | ≤0.0110 |
| **bt2020** | **unit** | 2 | 3.66e-04 | **0.1085** |
| bt2020 | typical / lopsided / dim-blue | 2–5 | ≤2.29e-04 | ≤0.0129 |
| display_p3 | unit | 1 | 7.63e-05 | 0.0037 |
| display_p3 | typical | 1 | 6.10e-05 | 0.0304 |
| narrow | unit | 34 | 9.16e-05 | 0.0025 |
| narrow | lopsided | **1515** | 8.39e-04 | 0.0135 |
| narrow | dim-blue | **2899** | 5.04e-04 | 0.0066 |

**Non-unit luminance never makes it worse.** The binding case is still BT.2020 at unit
luminance, **0.1085 dE2000** — the figure already reported on #4043 — and every non-unit
set lands at or below 0.031. The unit column reproduces the previous numbers exactly, so
the generalisation did not disturb what was already measured.

So item 2 stays feasible with the half that was missing now priced.

## And it sharpens a curiosity into a rule

#4043 recorded that coefficient error and dE2000 can separate. The luminance sets make it
stark: `narrow`/`lopsided` moves **1515** coefficient ULPs and lands 0.0135 dE2000, while
BT.2020/unit moves **2** and lands 0.1085 — eight times the colour error for a
seven-hundredth of the coefficient movement. Conditioning moves the coefficients; the small
divisor moves the colour. A case pins it so a future change cannot read a small ULP count
as evidence the colour is fine, nor a large one as evidence it is not.

## A comment I wrote wrong

The new build divides by `y` and then scales by the luminance. I annotated that as
"reversing it would stop modelling the shipped path", which reads as though the order
carries the budget — and when I mutation-tested it, reversing the order **passed every
other case here**.

Measured: it moves 30 of the corpus's 144 coefficients, by at most 10 raw units
(1.5e-04 of a unit), and moves no dE2000 that matters. The comment now says that, and a
case pins both halves — visible at the coefficient level, not visible in the colour. The
order is worth keeping for fidelity to `xyY_to_XYZ`, which is a different claim from
accuracy.

## Mutation-checked

| mutation | result |
|---|---|
| ignore the luminance in the Q16 build | 5 cases fail, including the vacuity guard that the sets perturb the matrix at all |
| reverse the divide-then-scale order | the order case fails, and only that one |

10/10 in `test_color_fixed_profile_study.py`, `bash lint` clean. `ci/` only — no `src/`
change and no C++ touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded color profile quantization studies to account for individual emitter luminance levels.
  * Added comparisons across multiple luminance profiles, including reporting of the worst-case device and luminance combination.
  * Improved scoring accuracy by evaluating both chromaticity and luminance effects.

* **Tests**
  * Added coverage for non-uniform luminance profiles, fixed-point matrix changes, and quantization-order behavior.
  * Updated existing validation scenarios for luminance-aware analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->