### PR TITLE
fix(autoresearch): report a declined driver as declined, not as zero capture (#3899)

### DIFF
--- a/ci/autoresearch/phases.py
+++ b/ci/autoresearch/phases.py
@@ -4405,6 +4405,23 @@ def _validate_test_rpc_response(
 
 def _classify_test_failure(data: dict[str, Any]) -> tuple[str, str]:
     """Classify a failed test response using structured RPC evidence."""
+    # Checked before any capture evidence, because a driver that never
+    # transmitted makes that evidence meaningless. The RP UART backend
+    # refuses a chipset whose bit period needs a baud above its maximum and
+    # reports why in `rpUartLastError`; classifying that as `zero_capture`
+    # ("RX produced no raw edges or decodable bytes") states the consequence
+    # and buries the cause, so a declined capability reads as a wiring or
+    # capture fault. FastLED#3899 requires an unreachable path to be listed
+    # with the exact constraint, which is what the driver already supplied.
+    if data.get("rpUartStartAttempted") is False:
+        reason = data.get("rpUartLastError")
+        if isinstance(reason, str) and reason:
+            return ("driver_declined", reason)
+        return (
+            "driver_declined",
+            "the driver did not attempt transmission and gave no reason",
+        )
+
     patterns = data.get("patterns")
     if isinstance(patterns, list) and patterns:
         saw_pattern = False

--- a/ci/tests/test_autoresearch_rpc_acceptance.py
+++ b/ci/tests/test_autoresearch_rpc_acceptance.py
@@ -360,3 +360,88 @@ def test_failed_response_with_edges_is_decode_mismatch() -> None:
 
     assert failure_class == "decode_mismatch"
     assert "did not match" in detail
+
+
+def test_driver_that_declined_is_not_a_capture_failure() -> None:
+    """A backend that refused the chipset must not read as a wiring fault.
+
+    Verbatim shape of a `bash autoresearch rp2350 --uart` response on the
+    Pico 2 W: GPIO0 -> GPIO1 *is* UART0 TX/RX, so the route is wired, but
+    the RP UART backend declines WS2812B-V5 because the bit period needs a
+    baud above its maximum. It never transmitted, so of course RX saw
+    nothing -- reporting `zero_capture` describes the consequence and hides
+    the driver's own explanation. See FastLED#3899.
+    """
+    failure_class, detail = _classify_test_failure(
+        {
+            "passed": False,
+            "rpUartStartAttempted": False,
+            "rpUartStartSucceeded": False,
+            "rpUartEncodedSize": 0,
+            "rpUartActualBaud": 0,
+            "rpUartLastError": (
+                "RP UART: chipset timing needs a baud above the UART backend maximum"
+            ),
+            "captureEvidenceBytes": 0,
+            "captureEvidenceRawEdges": 0,
+            "patterns": [
+                {
+                    "capturedBytes": 0,
+                    "rawEdgesAfterWait": 0,
+                    "mismatchedBytes": 300,
+                    "captureFailed": True,
+                }
+            ],
+        }
+    )
+
+    assert failure_class == "driver_declined"
+    # The driver's own words reach the operator, not a paraphrase.
+    assert "baud above the UART backend maximum" in detail
+
+
+def test_driver_that_did_transmit_still_classifies_on_capture() -> None:
+    """`rpUartStartAttempted=True` must not divert a real capture failure.
+
+    The new branch sits ahead of the capture evidence, so this pins that it
+    only catches a genuine decline rather than swallowing every RP UART
+    failure.
+    """
+    failure_class, _ = _classify_test_failure(
+        {
+            "passed": False,
+            "rpUartStartAttempted": True,
+            "rpUartStartSucceeded": True,
+            "captureEvidenceBytes": 0,
+            "captureEvidenceRawEdges": 0,
+            "patterns": [
+                {
+                    "capturedBytes": 0,
+                    "rawEdgesAfterWait": 0,
+                    "mismatchedBytes": 300,
+                    "captureFailed": True,
+                }
+            ],
+        }
+    )
+
+    assert failure_class == "zero_capture"
+
+
+def test_driver_decline_without_a_reason_still_says_it_declined() -> None:
+    """Absent `rpUartLastError`, the class must still be the decline.
+
+    Losing the reason is worse reporting; silently falling back to
+    `zero_capture` would be a wrong finding.
+    """
+    failure_class, detail = _classify_test_failure(
+        {
+            "passed": False,
+            "rpUartStartAttempted": False,
+            "captureEvidenceBytes": 0,
+            "captureEvidenceRawEdges": 0,
+        }
+    )
+
+    assert failure_class == "driver_declined"
+    assert "gave no reason" in detail


### PR DESCRIPTION
GPIO0 → GPIO1 on the Pico 2 W is UART0 TX/RX, so the UART route **is** physically wired. The RP UART backend still refuses `WS2812B-V5` — the bit period needs a baud above its maximum — and it says so plainly in the response:

```
RP UART: attempted=False started=False encodedBytes=0 actualBaud=0
lastError='RP UART: chipset timing needs a baud above the UART backend maximum'
```

The harness reported that as:

```
TEST UART0 lanes=1 leds=100 FAIL 2017ms class=zero_capture
   Detail: RX produced no raw edges or decodable bytes
```

True, and useless. The driver never transmitted, so RX seeing nothing is the *consequence*; the cause was already sitting in the response and got dropped on the floor. Read from the summary line — which is what a bench operator or an agent actually reads — a declined capability is **indistinguishable from a broken jumper or a dead capture path**. I went looking for a wiring fault before noticing the driver had already explained itself.

#3899 requires every unreachable path to be listed with its exact wiring or peripheral constraint. The driver supplied that constraint; the harness discarded it.

## Change

`_classify_test_failure` checks `rpUartStartAttempted is False` **before** any capture evidence — a driver that never transmitted makes that evidence meaningless — and surfaces the driver's own words rather than a paraphrase:

```
TEST UART0 lanes=1 leds=100 FAIL 2017ms class=driver_declined
   Detail: RP UART: chipset timing needs a baud above the UART backend maximum
```

## Scope

- The failure class is **display-only** — nothing in `ci/` switches on it — so adding a value changes no control flow. Verified by grepping every use.
- **Exit status is unchanged.** The criterion is still unmet and the run still exits 1. This makes the failure legible, it does not excuse it.
- Only the RP UART backend carries attempt evidence today, so the check keys on the fields that exist rather than inventing a generic scheme the firmware does not populate.

## Verification

Run on the attached RP2350 (`2DCB876B587EA334`), before and after, quoted above.

Three tests, using the verbatim response shape from that run:

| test | pins |
|---|---|
| `test_driver_that_declined_is_not_a_capture_failure` | the decline classifies as `driver_declined`, and the driver's own text reaches the operator |
| `test_driver_decline_without_a_reason_still_says_it_declined` | a missing `rpUartLastError` still reports the decline — falling back to `zero_capture` would be a wrong finding, not merely a vaguer one |
| `test_driver_that_did_transmit_still_classifies_on_capture` | `rpUartStartAttempted=True` still classifies on capture, so the new branch cannot swallow a genuine capture failure |

The first two were confirmed to **fail** with the new branch removed, so neither passes for the wrong reason. `21 passed` in the module; `bash lint` clean.

## Context

Found during a live HIL sweep of #3899, [reported there](https://github.com/FastLED/FastLED/issues/3899#issuecomment-5622772436) along with the confirmed GPIO0 → GPIO1 bridge, PIO0/PIO1/PIO2 all passing, and a separate finding that `Bus::BIT_BANG` is never registered on RP — which I deliberately did **not** fix, because registering it exposes a ~4× timing shortfall and would turn a clear `UnknownDriver` error into silently wrong LED output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure reporting for RP UART transmission attempts that were declined by the driver.
  * Preserves the driver-provided reason when available, or reports clearly when no reason is supplied.
  * Prevents declined transmissions from being incorrectly reported as capture failures.

* **Tests**
  * Added coverage for driver-declined transmissions with and without error details.
  * Verified that transmissions that did occur continue to be classified based on capture results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->