### PR TITLE
fix(gfx): size the allocator's feasibility slack in colour, not in drive units (#4303)

### DIFF
--- a/ci/tests/test_fixed_point_headers_are_self_contained.py
+++ b/ci/tests/test_fixed_point_headers_are_self_contained.py
@@ -36,10 +36,15 @@ kSelfContainedHeaders = [
     "fl/math/fixed_point/s0x32x4.h",
     "fl/math/fixed_point/s16x16.h",
     "fl/math/fixed_point/s0x32.h",
-    # Same defect, different cause: `device_solve.h` spelled `EmitterProfile`
+    # Same defect, different cause: these spelled `EmitterProfile`
     # unqualified, which only resolves once some *other* header has pulled in
-    # the `using` from `fl/channels/color_profile.h`. FastLED#4043.
+    # the `using` from `fl/channels/color_profile.h`. FastLED#4043, and then
+    # the same thing again in its neighbour -- which is the argument for
+    # listing the whole group rather than adding them one incident at a time.
     "fl/gfx/device_solve.h",
+    "fl/gfx/white_allocation.h",
+    "fl/gfx/gamut_map.h",
+    "fl/gfx/colorimetric_response.h",
 ]
 
 

--- a/src/fl/gfx/gamut_map.cpp.hpp
+++ b/src/fl/gfx/gamut_map.cpp.hpp
@@ -287,7 +287,7 @@ i32 clampChromaFactor(i32 low, i32 high) FL_NO_EXCEPT {
 
 }  // namespace
 
-bool buildGamutMapQ16(const EmitterProfile& profile, GamutMapQ16* out) FL_NO_EXCEPT {
+bool buildGamutMapQ16(const colorimetric_response::EmitterProfile& profile, GamutMapQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {
         return false;
     }
@@ -424,7 +424,7 @@ void mapAndSolveDrivesQ16(const GamutMapQ16& map, const i32 (&xyz)[3],
     clampGamutDrives(drives);
 }
 
-bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
+bool buildGamutMapRgbwQ16(const colorimetric_response::EmitterProfile& profile,
                           const i32 (&white_xyz)[3],
                           WhiteAllocationPolicy policy,
                           GamutMapRgbwQ16* out) FL_NO_EXCEPT {
@@ -605,7 +605,7 @@ void mapAndAllocateRgbwQ16(const GamutMapRgbwQ16& map, const i32 (&xyz)[3],
 }
 
 
-bool buildGamutMapRgbwwQ16(const EmitterProfile& profile,
+bool buildGamutMapRgbwwQ16(const colorimetric_response::EmitterProfile& profile,
                            const i32 (&white1_xyz)[3],
                            const i32 (&white2_xyz)[3],
                            WhiteAllocationPolicy policy,

--- a/src/fl/gfx/gamut_map.h
+++ b/src/fl/gfx/gamut_map.h
@@ -91,7 +91,7 @@ struct GamutMapRgbwQ16 {
 /// `policy` is C3's per-profile choice of which end of the feasible white
 /// interval to take; it changes the drives, never which targets are
 /// reachable, so the hull this maps onto is the same either way.
-bool buildGamutMapRgbwQ16(const EmitterProfile& profile,
+bool buildGamutMapRgbwQ16(const colorimetric_response::EmitterProfile& profile,
                           const i32 (&white_xyz)[3],
                           WhiteAllocationPolicy policy,
                           GamutMapRgbwQ16* out) FL_NO_EXCEPT;
@@ -131,7 +131,7 @@ struct GamutMapRgbwwQ16 {
 /// s16.16. `policy` is C3's per-profile choice of which end of the feasible
 /// *total* to take; as with one white it changes the drives, never which
 /// targets are reachable.
-bool buildGamutMapRgbwwQ16(const EmitterProfile& profile,
+bool buildGamutMapRgbwwQ16(const colorimetric_response::EmitterProfile& profile,
                            const i32 (&white1_xyz)[3],
                            const i32 (&white2_xyz)[3],
                            WhiteAllocationPolicy policy,
@@ -151,7 +151,7 @@ void mapAndAllocateRgbwwQ16(const GamutMapRgbwwQ16& map, const i32 (&xyz)[3],
 ///
 /// False on the same degenerate profiles `buildRgbSolveMatrixQ16` rejects,
 /// and on a profile that cannot reach any neutral at all.
-bool buildGamutMapQ16(const EmitterProfile& profile, GamutMapQ16* out) FL_NO_EXCEPT;
+bool buildGamutMapQ16(const colorimetric_response::EmitterProfile& profile, GamutMapQ16* out) FL_NO_EXCEPT;
 
 /// One pixel: XYZ in s16.16 to in-gamut emitter drives in s16.16.
 ///

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -86,7 +86,7 @@ i32 scaleWhiteQ16(i32 value, i32 factor) FL_NO_EXCEPT {
 
 }  // namespace
 
-bool buildWhiteAllocationQ16(const EmitterProfile& profile,
+bool buildWhiteAllocationQ16(const colorimetric_response::EmitterProfile& profile,
                              const i32 (&white_xyz)[3],
                              WhiteAllocationPolicy policy,
                              WhiteAllocationQ16* out) FL_NO_EXCEPT {
@@ -131,6 +131,22 @@ bool buildWhiteAllocationQ16(const EmitterProfile& profile,
             // would reject the rounding this exists to tolerate.
             if (scaled < 1.0f) {
                 scaled = 1.0f;
+            }
+            // And never larger than the allowance it is scaling. Dim
+            // emitters have small columns, so the division wants to *grow*
+            // the slack -- at a luminance of 1e-4 it reaches 640,000 raw
+            // units, nearly ten in drive space, which accepts any drive at
+            // all and clamps it. That is the defect this function exists to
+            // remove, reinstated an order of magnitude worse.
+            //
+            // The tolerance is for rounding in the solve, which is a few raw
+            // units whatever the emitter's brightness. So this only ever
+            // narrows: 64 stays the ceiling and the column decides how far
+            // below it each channel sits. For the corpus device nothing is
+            // clipped -- green is already at 64 and the others below it --
+            // so the measurements above are unaffected.
+            if (scaled > static_cast<float>(kWhiteSlackAtUnitColumn)) {
+                scaled = static_cast<float>(kWhiteSlackAtUnitColumn);
             }
             out->slack[channel] = static_cast<i32>(scaled + 0.5f);
         }
@@ -327,7 +343,7 @@ bool narrowTotalForPair(const SplitBound& lower, const SplitBound& upper, i64* l
 
 }  // namespace
 
-bool buildTwoWhiteAllocationQ16(const EmitterProfile& profile,
+bool buildTwoWhiteAllocationQ16(const colorimetric_response::EmitterProfile& profile,
                                 const i32 (&white1_xyz)[3],
                                 const i32 (&white2_xyz)[3],
                                 WhiteAllocationPolicy policy,

--- a/src/fl/gfx/white_allocation.cpp.hpp
+++ b/src/fl/gfx/white_allocation.cpp.hpp
@@ -9,12 +9,37 @@ namespace {
 /// Full drive, as an s16.16 raw value.
 constexpr i32 kWhiteFullDrive = 65536;
 
-/// Slack on the drive bounds, in s16.16 raw units.
+/// Slack on the drive bounds, for an emitter whose XYZ column peaks at 1.
 ///
 /// The same reason the gamut mapper carries one: a colour the device
 /// reproduces exactly does not solve to exactly 0 or 1, and without slack
 /// the allocation would reject targets it can actually hit. 64 raw units is
 /// a quarter of one code at 8-bit output.
+///
+/// The qualifier is the point, and was missing. This is a *drive* allowance
+/// and it is paid in *colour*, at an exchange rate of one emitter column per
+/// drive unit. A green primary at unit luminance has a column peaking at 1,
+/// so 64 units there costs what the number suggests. The blue primary of the
+/// corpus device sits at xy = (0.15, 0.06), which puts its Z at 13.17 -- so
+/// the same 64 units bought thirteen times the colour error, and a target
+/// whose blue solved to -62 was reported reachable and answered 0.0125 off
+/// in Z, 26% of the target's own Z. FastLED#4303.
+///
+/// `buildWhiteAllocationQ16` divides this by each column's peak so the
+/// colour cost is the same on every channel. Measured over 291 in-gamut
+/// targets on the xy plane at Y = 0.5: worst OKLab hue divergence falls from
+/// 0.0197 to 0.0034 and nothing exceeds 0.005, at the cost of 8 targets that
+/// the gamut mapper now compresses instead of answering wrongly.
+constexpr i32 kWhiteSlackAtUnitColumn = 64;
+
+/// The same allowance, uniform, for the two-white (RGBWW) path.
+///
+/// Deliberately unchanged. The defect above was measured on the single-white
+/// allocation; RGBWW holds hue under 0.02 on the same five targets that gave
+/// RGBW its 0.026, so it is better behaved and may not have the same problem
+/// at all. Whether it does is unmeasured, and scaling its slack on a guess
+/// would be changing a shipped colour path without evidence. FastLED#4303
+/// carries it as follow-up.
 constexpr i32 kWhiteSlack = 64;
 
 /// `(numerator << 16) / denominator` as s16.16, kept in i64.
@@ -74,6 +99,43 @@ bool buildWhiteAllocationQ16(const EmitterProfile& profile,
     }
     solveRgbDrivesQ16(out->rgb_solve, white_xyz, out->per_white);
 
+    // Per-channel slack, so the allowance costs the same colour everywhere.
+    // Bind time, once per profile -- there is no per-pixel work here.
+    {
+        float columns[3][3];
+        colorimetric_response::xyY_to_XYZ(profile.xy_r[0], profile.xy_r[1],
+                                          profile.lum_r, columns[0]);
+        colorimetric_response::xyY_to_XYZ(profile.xy_g[0], profile.xy_g[1],
+                                          profile.lum_g, columns[1]);
+        colorimetric_response::xyY_to_XYZ(profile.xy_b[0], profile.xy_b[1],
+                                          profile.lum_b, columns[2]);
+        for (int channel = 0; channel < 3; ++channel) {
+            // The peak component, because that is what bounds the per-axis
+            // XYZ error a clamp of one drive unit can cause.
+            float peak = 0.0f;
+            for (int axis = 0; axis < 3; ++axis) {
+                const float magnitude = columns[channel][axis] < 0.0f
+                                            ? -columns[channel][axis]
+                                            : columns[channel][axis];
+                if (magnitude > peak) {
+                    peak = magnitude;
+                }
+            }
+            // A degenerate column would divide by zero; the solve build
+            // above has already refused those, so this is belt and braces.
+            if (!(peak > 0.0f)) {
+                peak = 1.0f;
+            }
+            float scaled = static_cast<float>(kWhiteSlackAtUnitColumn) / peak;
+            // Never zero: a column so large that the allowance rounds away
+            // would reject the rounding this exists to tolerate.
+            if (scaled < 1.0f) {
+                scaled = 1.0f;
+            }
+            out->slack[channel] = static_cast<i32>(scaled + 0.5f);
+        }
+    }
+
     // A white emitter the primaries cannot express at all leaves nothing for
     // the allocation to trade against, and every bound below would divide by
     // zero or be vacuous.
@@ -119,8 +181,8 @@ bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
             if (lower > low) {
                 low = lower;
             }
-        } else if (at_zero[i] < -kWhiteSlack ||
-                   at_zero[i] > kWhiteFullDrive + kWhiteSlack) {
+        } else if (at_zero[i] < -allocation.slack[i] ||
+                   at_zero[i] > kWhiteFullDrive + allocation.slack[i]) {
             // White cannot move this drive at all, and it is already out.
             return false;
         }
@@ -143,7 +205,8 @@ bool allocateEmitterDrivesQ16(const WhiteAllocationQ16& allocation,
     i32 rgb[3];
     for (int i = 0; i < 3; ++i) {
         const i32 drive = at_zero[i] - scaleWhiteQ16(allocation.per_white[i], level);
-        if (drive < -kWhiteSlack || drive > kWhiteFullDrive + kWhiteSlack) {
+        const i32 channel_slack = allocation.slack[i];
+        if (drive < -channel_slack || drive > kWhiteFullDrive + channel_slack) {
             return false;
         }
         rgb[i] = drive < 0 ? 0 : (drive > kWhiteFullDrive ? kWhiteFullDrive : drive);

--- a/src/fl/gfx/white_allocation.h
+++ b/src/fl/gfx/white_allocation.h
@@ -69,6 +69,16 @@ struct WhiteAllocationQ16 {
     /// matrix multiply. It does not depend on the pixel.
     i32 per_white[3];
 
+    /// Per-channel drive slack, in s16.16 raw units.
+    ///
+    /// The allowance a drive may fall outside [0, 1] and still be treated as
+    /// reachable. It is per channel because its *cost* is per channel: one
+    /// drive unit of an emitter is that emitter's XYZ column, and a saturated
+    /// blue primary carries a column an order of magnitude larger than a
+    /// green one. A single number in drive space therefore buys a different
+    /// amount of colour error on each channel. FastLED#4303.
+    i32 slack[3];
+
     /// Which end of the interval this profile takes.
     WhiteAllocationPolicy policy;
 };

--- a/src/fl/gfx/white_allocation.h
+++ b/src/fl/gfx/white_allocation.h
@@ -90,7 +90,7 @@ struct WhiteAllocationQ16 {
 ///
 /// False on the profiles `buildRgbSolveMatrixQ16` rejects, and on a white
 /// emitter the RGB primaries cannot express at all.
-bool buildWhiteAllocationQ16(const EmitterProfile& profile,
+bool buildWhiteAllocationQ16(const colorimetric_response::EmitterProfile& profile,
                              const i32 (&white_xyz)[3],
                              WhiteAllocationPolicy policy,
                              WhiteAllocationQ16* out) FL_NO_EXCEPT;
@@ -144,7 +144,7 @@ struct TwoWhiteAllocationQ16 {
 /// white lands so far outside what the primaries express that the per-pixel
 /// bounds would overflow their accumulators -- see `kTwoWhiteMaxColumn` in
 /// the implementation, which a real white emitter is nowhere near.
-bool buildTwoWhiteAllocationQ16(const EmitterProfile& profile,
+bool buildTwoWhiteAllocationQ16(const colorimetric_response::EmitterProfile& profile,
                                 const i32 (&white1_xyz)[3],
                                 const i32 (&white2_xyz)[3],
                                 WhiteAllocationPolicy policy,

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1357,6 +1357,51 @@ FL_TEST_CASE("RGBW mapper preserves hue while compressing chroma") {
     // target 0.210, so the hue angle is well determined.
 }
 
+FL_TEST_CASE("the per-channel slack only ever narrows the allowance") {
+    // Scaling by the column peak divides, so a *dim* emitter -- whose column
+    // is small -- wants a larger slack, not a smaller one. Unbounded, that
+    // reinstates the defect this is meant to remove: measured at a luminance
+    // of 1e-4, the three channels came out at 330000, 640000 and 48608 raw
+    // units, and 640000 is nearly ten in drive space. A check of
+    // `drive > 65536 + 640000` accepts anything at all and clamps it.
+    //
+    // So the scaling only narrows. 64 is the ceiling and the column decides
+    // how far below it each channel sits.
+    const float kLuminances[] = {1.0f, 0.5f, 0.01f, 0.001f, 0.0001f};
+    int dimmer_than_unit_seen = 0;
+    for (float luminance : kLuminances) {
+        EmitterProfile profile = rgbDevice();
+        profile.lum_r = luminance;
+        profile.lum_g = luminance;
+        profile.lum_b = luminance;
+        GamutMapRgbwQ16 map;
+        if (!buildGamutMapRgbwQ16(profile, kWhiteD65,
+                                  WhiteAllocationPolicy::WhitePreferred, &map)) {
+            // Dim enough that the solve matrix itself is refused, which is
+            // the guard in front of this one.
+            continue;
+        }
+        if (luminance < 1.0f) {
+            ++dimmer_than_unit_seen;
+        }
+        for (int channel = 0; channel < 3; ++channel) {
+            FL_CHECK_LE(map.allocation.slack[channel], 64);
+            FL_CHECK_GE(map.allocation.slack[channel], 1);
+        }
+    }
+    // Vacuity guard: if every dim profile were refused before reaching the
+    // slack, the bound above would hold over the unit case alone -- which is
+    // the case that never wanted to grow.
+    FL_CHECK_GT(dimmer_than_unit_seen, 2);
+
+    // And the unit profile is unaffected by the ceiling: green sits exactly
+    // at it, so the measurements the other cases pin are unchanged.
+    GamutMapRgbwQ16 unit;
+    FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
+                                     WhiteAllocationPolicy::WhitePreferred, &unit));
+    FL_CHECK_EQ(unit.allocation.slack[1], 64);
+}
+
 FL_TEST_CASE("a drive the solve puts out of range is refused, not clamped") {
     // This case used to record the opposite. It measured an in-gamut target
     // at (0.55, 0.41) whose blue drive the solve put at -62 raw, showed that

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1317,54 +1317,18 @@ FL_TEST_CASE("RGBW mapper preserves hue while compressing chroma") {
         i32 mapped_lab[3];
         xyzToOklabQ16(xyz, target_lab);
         xyzToOklabQ16(mapped_xyz, mapped_lab);
-        // Bounded per target rather than by a single blanket tolerance,
-        // because the five do not behave alike and a bound loose enough for
-        // the worst would stop saying anything about the other four.
+        // One bound for all five now. It used to be split, because
+        // (0.55, 0.42) diverged by 0.026 -- an order of magnitude above its
+        // four neighbours -- and that outlier had its own bracket with a
+        // lower bound, so it could not vanish unremarked.
         //
-        // Measured, in the same units `hueDivergence` returns (a sine, so
-        // 0.026 is about 1.5 degrees of OKLab hue):
-        //
-        //   (0.70, 0.28)   0.00018
-        //   (0.18, 0.72)   0.00174
-        //   (0.10, 0.03)   0.00025
-        //   (0.55, 0.42)   0.02610   <- the outlier
-        //   (0.08, 0.55)   0.00309
-        //
-        // RGBWW holds under 0.02 on the identical five, so this is a
-        // four-emitter property and not a corpus that is hard for everyone.
-        // Reported on FastLED#4041; see the note below the loop for what is
-        // and is not established about where it comes from.
+        // It vanished, and this is the remark. #4304 traced it to
+        // `allocateEmitterDrivesQ16` clamping a blue drive the solve had put
+        // at -62, inside a slack sized in drive space; scaling that slack by
+        // each emitter's XYZ column (FastLED#4303) removed it. Measured
+        // across the five, worst divergence is now 0.0000.
         const float divergence = hueDivergence(target_lab, mapped_lab);
-        if (fl::fabsf(c[0] - 0.55f) < 1e-6f && fl::fabsf(c[1] - 0.42f) < 1e-6f) {
-            FL_CHECK_LT(divergence, 0.030f);
-            // Bounded from below as well, which is deliberate and is the
-            // same shape as the flash-bloat gate: that one fails on
-            // *unclaimed headroom* rather than congratulating you on it,
-            // because a ratchet with slack is not a ratchet.
-            //
-            // What makes it apply here is that 0.026 is unexplained. It is
-            // an order of magnitude above its four neighbours and above what
-            // RGBWW does on the same input, and nobody has established
-            // whether it comes from the allocation or the quantisation. If
-            // it quietly drops, something touched that path and the anomaly
-            // stopped being reproducible -- which is exactly when you want
-            // to be told rather than have the evidence absorbed.
-            //
-            // So this firing is not a defect, and the message says so,
-            // because a bound that fails on good news has to explain itself.
-            if (divergence <= 0.010f) {
-                FL_WARN_F("RGBW hue divergence at (0.55, 0.42) improved to %f "
-                          "from the 0.026 recorded here. That is good news, "
-                          "not a failure: find what changed, note it on "
-                          "FastLED#4041, and re-pin this bound. The point of "
-                          "the lower bound is that the anomaly cannot vanish "
-                          "unremarked.",
-                          static_cast<double>(divergence));
-            }
-            FL_CHECK_GT(divergence, 0.010f);
-        } else {
-            FL_CHECK_LT(divergence, 0.005f);
-        }
+        FL_CHECK_LT(divergence, 0.005f);
         FL_CHECK(chromaDidNotGrow(target_lab, mapped_lab));
         if (!in_gamut) {
             ++compressed;
@@ -1393,101 +1357,74 @@ FL_TEST_CASE("RGBW mapper preserves hue while compressing chroma") {
     // target 0.210, so the hue angle is well determined.
 }
 
-FL_TEST_CASE("RGBW hue divergence is the allocation clamping a negative drive") {
-    // The experiment the case above says its corpus cannot run.
+FL_TEST_CASE("a drive the solve puts out of range is refused, not clamped") {
+    // This case used to record the opposite. It measured an in-gamut target
+    // at (0.55, 0.41) whose blue drive the solve put at -62 raw, showed that
+    // `allocateEmitterDrivesQ16` accepted it as reachable and clamped it to
+    // zero, and priced the result at 0.026 of OKLab hue and 0.0158 of XYZ --
+    // 26% of the target's own Z, because this device's blue column carries a
+    // Z of 13.17 and 62 drive units of it is 0.0125.
     //
-    // That one measured 0.026 of OKLab hue divergence on an out-of-gamut
-    // target and could not say whether the four-emitter allocation or the
-    // Q16 quantisation produced it, because every target it uses needs
-    // compressing first. An *in-gamut* target separates them:
-    // `mapAndAllocateRgbwQ16` returns the plain allocation untouched, so
-    // whatever divergence remains is the allocator's.
+    // FastLED#4303 fixed the cause: the allowance was sized in drive space
+    // and paid in colour, so it is scaled by each emitter's column now. Blue
+    // gets 5 raw units where green gets 64. -62 is outside that, so the
+    // target is refused and the gamut mapper compresses it instead of the
+    // allocator answering it wrongly.
+    //
+    // The case is kept rather than deleted because the mechanism is what
+    // must not come back: a drive the solve put well out of range being
+    // clamped into range and reported as reachable.
     GamutMapRgbwQ16 map;
     FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
                                      WhiteAllocationPolicy::WhitePreferred,
                                      &map));
 
-    // (0.55, 0.41) at Y = 0.5, one step in y from the outlier above. The
-    // anomaly is not peculiar to targets outside the hull.
     i32 xyz[3];
     xyzAt(0.55f, 0.41f, 0.5f, xyz);
 
-    i32 allocated[4];
-    FL_REQUIRE(allocateEmitterDrivesQ16(map.allocation, xyz, allocated));
-
-    // What the solve actually asked for, before the allocator clamped it.
-    // Derived rather than written down, so this reports whatever the solve
-    // does today.
+    // Still what the solve asks for -- the fix changed the verdict, not the
+    // arithmetic. Derived rather than written down.
     i32 at_zero[3];
     solveRgbDrivesQ16(map.allocation.rgb_solve, xyz, at_zero);
-
-    // Blue solves *negative*. `allocateEmitterDrivesQ16` accepts a drive down
-    // to -64 raw as a rounding allowance and then clamps it into range, so
-    // this target is reported reachable and answered with a different colour.
     FL_CHECK_LT(at_zero[2], 0);
     FL_CHECK_GT(at_zero[2], -64);
-    FL_CHECK_EQ(allocated[2], 0);
 
+    // Outside blue's allowance, so refused.
+    FL_CHECK_LT(map.allocation.slack[2], -at_zero[2]);
+    i32 allocated[4];
+    FL_CHECK(!allocateEmitterDrivesQ16(map.allocation, xyz, allocated));
+
+    // And green's is unchanged, so this is a rescaling and not a blanket
+    // tightening -- a uniform slack of 5 would refuse targets nothing is
+    // wrong with.
+    FL_CHECK_EQ(map.allocation.slack[1], 64);
+    FL_CHECK_GT(map.allocation.slack[0], map.allocation.slack[2]);
+
+    // The mapper still answers the target, in gamut, with the hue intact.
+    i32 drives[4];
+    mapAndAllocateRgbwQ16(map, xyz, drives);
+    float as_float[4];
+    for (int i = 0; i < 4; ++i) {
+        as_float[i] = toFloat(drives[i]);
+    }
+    float produced[3];
+    reproduceRgbw(as_float, produced);
+    const i32 produced_q16[3] = {q16(produced[0]), q16(produced[1]),
+                                 q16(produced[2])};
     i32 target_lab[3];
+    i32 produced_lab[3];
     xyzToOklabQ16(xyz, target_lab);
-
-    // The clamp is worth 0.0125 in Z on this device, because the blue
-    // primary at xy = (0.15, 0.06) normalised to Y = 1 carries a Z column of
-    // 13.17 -- so one drive unit of blue is thirteen units of Z. `kWhiteSlack`
-    // is sized in drive space ("a quarter of one code at 8-bit output"),
-    // which is not the space its cost is paid in.
-    struct Reproduction {
-        float xyz_error;
-        float hue;
-    };
-    auto reproduce = [&](const i32 (&drives)[4]) {
-        float as_float[4];
-        for (int i = 0; i < 4; ++i) {
-            as_float[i] = toFloat(drives[i]);
-        }
-        float produced[3];
-        reproduceRgbw(as_float, produced);
-        const i32 produced_q16[3] = {q16(produced[0]), q16(produced[1]),
-                                     q16(produced[2])};
-        i32 produced_lab[3];
-        xyzToOklabQ16(produced_q16, produced_lab);
-        float error = 0.0f;
-        for (int i = 0; i < 3; ++i) {
-            error += fl::fabsf(produced[i] - toFloat(xyz[i]));
-        }
-        Reproduction out;
-        out.xyz_error = error;
-        out.hue = hueDivergence(target_lab, produced_lab);
-        return out;
-    };
-
-    const i32 unclamped[4] = {at_zero[0], at_zero[1], at_zero[2], allocated[3]};
-    const Reproduction honest = reproduce(unclamped);
-    const Reproduction clamped = reproduce(allocated);
-
-    // Measured: the solve is essentially exact -- 5.3e-05 of XYZ and no hue
-    // shift at all. So neither the matrix nor the Q16 quantisation is the
-    // source, which is what this case set out to determine.
-    FL_CHECK_LT(honest.xyz_error, 1.0e-04f);
-    FL_CHECK_LT(honest.hue, 1.0e-04f);
-
-    // And the clamp alone accounts for the whole anomaly: 0.0158 of XYZ and
-    // 0.026 of hue, the same 0.026 the case above records on its own target.
-    FL_CHECK_GT(clamped.xyz_error, 0.010f);
-    FL_CHECK_LT(clamped.xyz_error, 0.020f);
-    FL_CHECK_GT(clamped.hue, 0.020f);
-    FL_CHECK_LT(clamped.hue, 0.030f);
-
-    // Vacuity guard. If the two reproductions ever agree, the comparison
-    // above is asserting a number against itself and the case has stopped
-    // measuring anything.
-    FL_CHECK_GT(clamped.hue, honest.hue * 100.0f);
+    xyzToOklabQ16(produced_q16, produced_lab);
+    // Measured 0.0000, against the 0.026 this case was written to record.
+    FL_CHECK_LT(hueDivergence(target_lab, produced_lab), 0.005f);
 }
 
-FL_TEST_CASE("RGBW allocation hue divergence is confined to one region") {
-    // Extent, so the finding above is not read as either an isolated
-    // coincidence or a pervasive fault. Every in-gamut target on a coarse
-    // grid of the xy plane at Y = 0.5, which is 291 of them.
+FL_TEST_CASE("the allocator is accurate across the plane, not just at one point") {
+    // Extent. This measured the defect when there was one -- worst 0.0197 of
+    // OKLab hue at (0.56, 0.40), with 6 of 291 in-gamut targets above 0.005
+    // -- and measures its absence now.
+    //
+    // Every in-gamut target on a coarse grid of the xy plane at Y = 0.5.
     GamutMapRgbwQ16 map;
     FL_REQUIRE(buildGamutMapRgbwQ16(rgbDevice(), kWhiteD65,
                                      WhiteAllocationPolicy::WhitePreferred,
@@ -1539,19 +1476,23 @@ FL_TEST_CASE("RGBW allocation hue divergence is confined to one region") {
 
     // Vacuity guard: a grid that found nothing in gamut would pass every
     // bound below by measuring an empty set.
-    FL_CHECK_EQ(in_gamut, 291);
-
-    // Measured: worst 0.0197 at (0.56, 0.40), median 6.9e-05, and only 6 of
-    // 291 above 0.005. So the allocator is accurate nearly everywhere and
-    // wrong in a small orange-yellow region -- which is where the blue drive
-    // solves just below zero, and is what the case above is about.
     //
-    // The grid steps 0.02 and so steps over (0.55, 0.41); the worst it can
-    // see is the 0.0197 neighbour rather than that target's 0.026.
-    FL_CHECK_GT(worst, 0.015f);
-    FL_CHECK_LT(worst, 0.025f);
-    FL_CHECK_EQ(above_005, 6);
-    FL_CHECK_EQ(above_010, 2);
+    // 283, down from 291 before FastLED#4303. Those 8 are the targets whose
+    // blue drive falls outside the rescaled allowance; they are not lost,
+    // the gamut mapper compresses them into the hull instead of the
+    // allocator answering them wrongly. Pinned so the cost of the fix is
+    // visible and cannot grow unnoticed.
+    FL_CHECK_EQ(in_gamut, 283);
+
+    // Measured: worst 0.0034, and nothing above 0.005 at all -- against
+    // 0.0197 with 6 above 0.005 and 2 above 0.010 before the fix. The
+    // orange-yellow region that used to be wrong is not wrong any more.
+    FL_CHECK_LT(worst, 0.005f);
+    FL_CHECK_EQ(above_005, 0);
+    FL_CHECK_EQ(above_010, 0);
+    // Bounded below, because a grid measuring nothing would also report
+    // zero: some divergence is expected from Q16 rounding alone.
+    FL_CHECK_GT(worst, 0.0f);
 }
 
 FL_TEST_CASE("RGBWW mapper preserves hue while compressing chroma") {


### PR DESCRIPTION
Closes #4303. Direction 2 of the four that issue lists — implemented, and measured against
the other outcome the issue asked for.

## The defect

`allocateEmitterDrivesQ16` let each RGB drive fall 64 raw units outside `[0, 1]` before
refusing, then **clamped it** — returning "reachable" and an allocation that reproduces a
different colour.

The constant's own comment sized it as "a quarter of one code at 8-bit output". True in
drive space; not the space the cost is paid in. One drive unit of an emitter is that
emitter's **XYZ column**, and the corpus device's blue sits at xy = (0.15, 0.06), putting
its Z at **13.17**. So the same 64 units bought thirteen times the colour error on blue as
on green.

At (0.55, 0.41) — *inside* the hull, needing no compression — blue solved to −62 and was
clamped to 0: **0.0125 off in Z** against a target Z of 0.0488, 26% of it, and 0.026 of
OKLab hue.

## The fix, and what it costs

The slack is divided by each column's peak component at bind time, so the colour cost of
the allowance is uniform: **green keeps 64, red gets 33, blue gets 5**. No per-pixel work,
no new matrix, three integers per profile.

Measured over 291 in-gamut targets on the xy plane at Y = 0.5:

| | before | after |
|---|---:|---:|
| worst OKLab hue divergence | 0.0197 | **0.0034** |
| targets above 0.005 | 6 | **0** |
| targets above 0.010 | 2 | **0** |
| targets reported reachable | 291 | **283** |

Those 8 are the price, and they are **not lost** — the gamut mapper compresses them into
the hull instead of the allocator answering them wrongly. The count is pinned so the cost
stays visible and cannot grow unnoticed.

## Three cases change, which is what they were built for

The RGBW hue case bracketed its outlier **from below**, with a message saying that if the
anomaly ever vanished someone should find out why and re-pin the bound rather than let the
evidence be absorbed silently. It fired:

```
WARN: RGBW hue divergence at (0.55, 0.42) improved to 0.00 from the 0.026 recorded here.
That is good news, not a failure: find what changed, note it on FastLED#4041, and re-pin
this bound.
```

This is that. It now holds one bound for all five targets. The mechanism case #4304 added
becomes a regression guard on the mechanism — a drive well out of range being clamped in
and reported reachable — rather than a record of the defect. The extent case measures the
absence with the same grid that measured the presence.

## What is deliberately not changed

The two-white **RGBWW** path keeps its uniform slack. The defect was measured on the
single-white allocation, and RGBWW holds hue under 0.02 on the same five targets that gave
RGBW its 0.026 — so it is better behaved and may not have the same problem. Whether it does
is unmeasured, and scaling its slack on a guess would be changing a shipped colour path
without evidence. Left on #4303 as follow-up.

303/303 unit + 84/84 examples, `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RGBW gamut mapping consistency across hue targets, keeping color divergence within the intended tolerance.
  - Corrected white-channel allocation so out-of-range drive values are rejected appropriately instead of being incorrectly clamped into range.
  - Added per-channel allowance handling to better account for differences between emitters.
  - Improved color accuracy across the tested gamut, reducing worst-case color divergence and narrowing allocation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->