### PR TITLE
test(gfx): P9's per-pixel path reaches no float runtime, and fix the walk that said otherwise

### DIFF
--- a/ci/tests/test_fixed_point_headers_are_self_contained.py
+++ b/ci/tests/test_fixed_point_headers_are_self_contained.py
@@ -45,6 +45,16 @@ kSelfContainedHeaders = [
     "fl/gfx/white_allocation.h",
     "fl/gfx/gamut_map.h",
     "fl/gfx/colorimetric_response.h",
+    "fl/gfx/pipeline.h",
+    "fl/gfx/oklab_q16.h",
+    # The channels layer reaches the same type through its own
+    # `fl/channels/color_profile.h`, so these are fixed by including that
+    # rather than by qualifying.
+    "fl/channels/color_profile.h",
+    "fl/channels/color_managed_source.h",
+    "fl/channels/cled_controller.h",
+    "fl/channels/options.h",
+    "fl/channels/channel.h",
 ]
 
 

--- a/ci/tests/test_q16_inverse_is_float_free.py
+++ b/ci/tests/test_q16_inverse_is_float_free.py
@@ -80,12 +80,22 @@ def _arm_tools() -> ArmTools | None:
 
 @typechecked
 def _disassembly(objdump: str, obj: Path) -> dict[str, list[str]]:
-    """Every function in the object, keyed by symbol."""
+    """Every function in the object, keyed by symbol, with relocations.
+
+    `-r` matters. In an unlinked object a call to an undefined symbol
+    disassembles as `bl 0 <name>`, and objdump resolves that `0` against the
+    symbol table -- so when a *defined* function happens to sit at address
+    zero, every unrelocated call in the object appears to go to it. Walking
+    those printed names had `signedCbrtQ16` calling
+    `isUsableSolveChromaticity`: a cube root calling a chromaticity
+    validator, which is what gave it away. The relocation records say where
+    the calls really go.
+    """
 
     # `subprocess.run` and not `RunningProcess.run`: the latter merges stderr
     # into stdout, which would put objdump's warnings into what this parses.
     completed = subprocess.run(  # noqa: SRC001
-        [objdump, "-d", "--no-show-raw-insn", str(obj)],
+        [objdump, "-d", "-r", "--no-show-raw-insn", str(obj)],
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -108,6 +118,33 @@ def _disassembly(objdump: str, obj: Path) -> dict[str, list[str]]:
 
 
 @typechecked
+def _callees(body: list[str]) -> set[str]:
+    """Who this function actually calls.
+
+    Two forms, and only two. A relocation record names the real target of a
+    call to an undefined symbol; a resolved local call carries a non-zero
+    address. A `bl 0 <name>` with no relocation beside it is neither -- that
+    is the unrelocated case, and the name objdump prints for it is whatever
+    happens to sit at address zero. Following those printed names had this
+    walk believing `signedCbrtQ16` called `isUsableSolveChromaticity`: a cube
+    root calling a chromaticity validator, which is what gave it away.
+    """
+
+    out: set[str] = set()
+    for line in body:
+        relocation = re.search(r"R_ARM_\w+\s+([A-Za-z_][A-Za-z0-9_.]*)", line)
+        if relocation:
+            out.add(relocation.group(1))
+            continue
+        call = re.search(
+            r"\bbl(?:\.w)?\s+([0-9a-f]+) <([A-Za-z_][A-Za-z0-9_.]*)>", line
+        )
+        if call and int(call.group(1), 16) != 0:
+            out.add(call.group(2))
+    return out
+
+
+@typechecked
 def _reachable_helpers(objdump: str, obj: Path, symbol: str) -> set[str]:
     """Soft-float helpers reachable from `symbol`, following calls.
 
@@ -127,12 +164,10 @@ def _reachable_helpers(objdump: str, obj: Path, symbol: str) -> set[str]:
         if name in seen:
             continue
         seen.add(name)
-        text = "\n".join(bodies.get(name, []))
-        found |= set(kFloatHelper.findall(text))
-        for callee in re.findall(
-            r"<([A-Za-z_][A-Za-z0-9_.]*)(?:\+0x[0-9a-f]+)?>", text
-        ):
-            if callee in bodies and callee != name:
+        for callee in _callees(bodies.get(name, [])):
+            if kFloatHelper.match(callee):
+                found.add(callee)
+            elif callee in bodies and callee != name:
                 pending.append(callee)
     return found
 
@@ -169,6 +204,116 @@ def _helpers_called(objdump: str, obj: Path, symbol: str) -> set[str]:
     if not body:
         raise AssertionError(f"{symbol} not found in {obj.name}")
     return set(kFloatHelper.findall("\n".join(body)))
+
+
+kPerPixelSymbol = "_ZN2fl15processPixelQ16ERKNS_20StreamingPipelineQ16EhhhRA3_l"
+kBindSymbol = (
+    "_ZN2fl25buildStreamingPipelineQ16ERKNS_13SourceProfileERKNS_"
+    "21colorimetric_response14EmitterProfileENS_11GamutPolicyEPNS_"
+    "20StreamingPipelineQ16E"
+)
+
+kPipelineSource = """
+#include "fl/gfx/device_solve.cpp.hpp"
+#include "fl/gfx/flux_scalar.cpp.hpp"
+#include "fl/gfx/gamut_map.cpp.hpp"
+#include "fl/gfx/oklab_q16.cpp.hpp"
+#include "fl/gfx/pipeline.cpp.hpp"
+#include "fl/gfx/source_xyz.cpp.hpp"
+#include "fl/gfx/transfer.cpp.hpp"
+#include "fl/gfx/white_allocation.cpp.hpp"
+"""
+
+
+@pytest.fixture(scope="module")
+@typechecked
+def compiled_pipeline(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[ArmTools, Path]:
+    """The whole streaming pipeline in one object, so calls can be followed.
+
+    Every stage `processPixelQ16` reaches lives in a different translation
+    unit, and reachability cannot cross an object boundary. Compiling them
+    together is what makes the walk complete.
+    """
+
+    tools = _arm_tools()
+    if tools is None:
+        pytest.skip("no arm-none-eabi cross compiler on this machine")
+
+    tmp_path = tmp_path_factory.mktemp("pipeline_float_free")
+    source = tmp_path / "pipeline_tu.cpp"
+    source.write_text(kPipelineSource, encoding="utf-8")
+    obj = tmp_path / "pipeline_tu.o"
+    subprocess.run(  # noqa: SRC001
+        [
+            tools.compiler,
+            "-c",
+            str(source),
+            "-o",
+            str(obj),
+            "-I",
+            str(PROJECT_ROOT / "src"),
+            "-mcpu=cortex-m0plus",
+            "-march=armv6-m",
+            "-mthumb",
+            "-Os",
+            "-std=gnu++17",
+            "-ffreestanding",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-DARDUINO_ARCH_RP2040",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return tools, obj
+
+
+@typechecked
+def test_the_per_pixel_path_reaches_no_float_runtime(
+    compiled_pipeline: tuple[ArmTools, Path],
+) -> None:
+    """P9's criterion, at the place it actually matters (FastLED#4043).
+
+    The phase asks for a tier with no float symbols linked. `processPixelQ16`
+    is the per-pixel path -- decode, source matrix, gamut map, device solve,
+    flux -- and it runs for every pixel of every frame.
+
+    It reaches none. Measured across the 19 functions the walk visits.
+    """
+
+    tools, obj = compiled_pipeline
+    helpers = _reachable_helpers(tools.objdump, obj, kPerPixelSymbol)
+    assert helpers == set(), (
+        f"the per-pixel path reaches the float runtime: {sorted(helpers)}"
+    )
+
+
+@typechecked
+def test_the_bind_path_is_where_the_float_still_is(
+    compiled_pipeline: tuple[ArmTools, Path],
+) -> None:
+    """Control for the case above, and a statement of what remains.
+
+    If the walk reported nothing for both, it would prove the traversal
+    stopped rather than that the pipeline is clean. `buildStreamingPipelineQ16`
+    is in the same object and derives its matrices in float, so it must show
+    the helpers the per-pixel path does not.
+
+    That float is confined to bind time is P9 item 2's remaining work rather
+    than a defect here -- `buildRgbSolveMatrixFromQ16` is the float-free
+    counterpart, and nothing routes to it yet.
+    """
+
+    tools, obj = compiled_pipeline
+    helpers = _reachable_helpers(tools.objdump, obj, kBindSymbol)
+    assert len(helpers) >= 8, (
+        f"expected the bind path to reach the soft-float runtime, found {sorted(helpers)}"
+    )
 
 
 @pytest.fixture(scope="module")

--- a/ci/tests/test_q16_inverse_is_float_free.py
+++ b/ci/tests/test_q16_inverse_is_float_free.py
@@ -139,24 +139,45 @@ kResolvedTransfer = re.compile(
 def _callees(body: list[str]) -> set[str]:
     """Who this function actually transfers control to.
 
-    Two forms, and only two. A control-flow relocation names the real target
-    of a call to an undefined symbol; a resolved local transfer carries a
-    non-zero address. A `bl 0 <name>` with no relocation beside it is neither
-    -- that is the unrelocated case, and the name objdump prints for it is
-    whatever happens to sit at address zero. Following those printed names had
-    this walk believing `signedCbrtQ16` called `isUsableSolveChromaticity`: a
-    cube root calling a chromaticity validator, which is what gave it away.
+    A relocation record on the line *after* a transfer names its real target,
+    and supersedes the name objdump printed. Without one, the printed name is
+    correct and is used as it stands.
+
+    The pairing matters in both directions, and getting it wrong is how this
+    walk has been wrong twice.
+
+    Reading the printed name always: an unrelocated call disassembles as
+    `bl 0 <name>` and objdump resolves that `0` against the symbol table, so
+    every such call appears to go to whatever function sits at address zero.
+    That had `signedCbrtQ16` calling `isUsableSolveChromaticity` -- a cube
+    root calling a chromaticity validator, which is what gave it away.
+
+    Discarding every address-zero transfer instead: a function genuinely
+    placed at offset zero in its section is a legitimate target, and dropping
+    the edge loses a real call. Measured in this object, 254 of the 257
+    address-zero transfers carry a relocation and are the ambiguous kind,
+    and the remaining 3 are `buildRgbSolveMatrixQ16` calling
+    `isUsableSolveChromaticity` for real. Losing an edge is the dangerous
+    direction: it makes "reaches no float" pass by not looking.
     """
 
     out: set[str] = set()
+    pending_transfer: str | None = None
     for line in body:
         relocation = kControlRelocation.search(line)
         if relocation:
+            # Supersedes the transfer it belongs to, which is the line above.
             out.add(relocation.group(1))
+            pending_transfer = None
             continue
+        if pending_transfer is not None:
+            out.add(pending_transfer)
+            pending_transfer = None
         transfer = kResolvedTransfer.search(line)
-        if transfer and int(transfer.group(1), 16) != 0:
-            out.add(transfer.group(2))
+        if transfer:
+            pending_transfer = transfer.group(2)
+    if pending_transfer is not None:
+        out.add(pending_transfer)
     return out
 
 
@@ -261,13 +282,27 @@ class CompiledPipeline:
 # tail call does become `b.n`. That is what makes the branch handling in
 # `_callees` load-bearing rather than defensive; on the M0+ build alone it
 # would never be exercised.
-kFloatFreeTargets: tuple[tuple[str, ...], ...] = (
-    ("cortex-m0plus", "-march=armv6-m"),
-    ("cortex-m33+nofp", "-march=armv8-m.main+dsp"),
+@typechecked
+@dataclass(frozen=True)
+class FloatFreeTarget:
+    """One core to compile the pipeline for."""
+
+    core: str
+    march: str
+
+
+@typechecked
+def _target_id(target: FloatFreeTarget) -> str:
+    return target.core
+
+
+kFloatFreeTargets: tuple[FloatFreeTarget, ...] = (
+    FloatFreeTarget(core="cortex-m0plus", march="-march=armv6-m"),
+    FloatFreeTarget(core="cortex-m33+nofp", march="-march=armv8-m.main+dsp"),
 )
 
 
-@pytest.fixture(scope="module", params=kFloatFreeTargets, ids=lambda t: t[0])
+@pytest.fixture(scope="module", params=kFloatFreeTargets, ids=_target_id)
 @typechecked
 def compiled_pipeline(
     request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
@@ -283,7 +318,8 @@ def compiled_pipeline(
     if tools is None:
         pytest.skip("no arm-none-eabi cross compiler on this machine")
 
-    core, march = request.param
+    target: FloatFreeTarget = request.param
+    core = target.core
     tmp_path = tmp_path_factory.mktemp(f"pipeline_{core.replace('+', '_')}")
     source = tmp_path / "pipeline_tu.cpp"
     source.write_text(kPipelineSource, encoding="utf-8")
@@ -298,7 +334,7 @@ def compiled_pipeline(
             "-I",
             str(PROJECT_ROOT / "src"),
             f"-mcpu={core}",
-            march,
+            target.march,
             "-mthumb",
             "-Os",
             "-std=gnu++17",
@@ -314,6 +350,65 @@ def compiled_pipeline(
         check=True,
     )
     return CompiledPipeline(tools=tools, obj=obj, core=core)
+
+
+@typechecked
+def test_the_callee_parser_pairs_relocations_with_their_transfer() -> None:
+    """`_callees` on disassembly written out by hand.
+
+    The walk has been wrong twice, in opposite directions, and both mistakes
+    survived every reachability case because they only changed which edges
+    existed -- not whether the walk ran. So the parser is tested on input
+    where the right answer is known by construction.
+    """
+
+    # An unrelocated call: the printed name is whatever sits at address zero,
+    # and the relocation on the next line is the real target.
+    relocated = [
+        "     a20:\tbl\t0 <_ZN2fl9decoyAtZeroEv>",
+        "\t\t\ta20: R_ARM_THM_CALL\t__aeabi_fadd",
+    ]
+    assert _callees(relocated) == {"__aeabi_fadd"}
+
+    # A genuine local call to a function at offset zero: no relocation, so
+    # the printed name stands. Discarding this is how a real edge gets lost.
+    at_zero = ["     78e:\tbl\t0 <_ZN2fl20isUsableChromaticityEv>"]
+    assert _callees(at_zero) == {"_ZN2fl20isUsableChromaticityEv"}
+
+    # A resolved local call, and a tail call emitted as a branch.
+    resolved = [
+        "     a7a:\tbl\t1ba <_ZN2fl9someLeafEv>",
+        "     18c:\tb.n\t16e <_ZN2fl9tailLeafEv>",
+    ]
+    assert _callees(resolved) == {"_ZN2fl9someLeafEv", "_ZN2fl9tailLeafEv"}
+
+    # A data relocation is not a call. Counting it invents an edge.
+    #
+    # Naming a *function* here on purpose: the nine `R_ARM_ABS32` records in
+    # the real object all name `.rodata`, which the symbol pattern rejects on
+    # the leading dot anyway -- so a case built from those would pass whether
+    # or not the relocation type is checked, and would say nothing. A
+    # function-pointer table entry is the shape that needs the type check.
+    data = [
+        "     1c0:\tldr\tr1, [pc, #8]",
+        "\t\t\t1c4: R_ARM_ABS32\t_ZN2fl11addressOnlyEv",
+    ]
+    assert _callees(data) == set()
+
+    # And the two forms interleaved, which is what a real body looks like --
+    # a relocation must attach to the transfer above it and not to the next
+    # one down.
+    mixed = [
+        "     100:\tbl\t0 <_ZN2fl9decoyAtZeroEv>",
+        "\t\t\t100: R_ARM_THM_CALL\t__aeabi_fmul",
+        "     104:\tbl\t0 <_ZN2fl9realAtZeroEv>",
+        "     108:\tbl\t200 <_ZN2fl9plainCallEv>",
+    ]
+    assert _callees(mixed) == {
+        "__aeabi_fmul",
+        "_ZN2fl9realAtZeroEv",
+        "_ZN2fl9plainCallEv",
+    }
 
 
 @typechecked

--- a/ci/tests/test_q16_inverse_is_float_free.py
+++ b/ci/tests/test_q16_inverse_is_float_free.py
@@ -117,30 +117,46 @@ def _disassembly(objdump: str, obj: Path) -> dict[str, list[str]]:
     return bodies
 
 
+# Relocations that stand for a transfer of control. `R_ARM_ABS32` and its
+# relatives are data references -- this object carries nine of them, all
+# naming `.rodata` -- and counting those as calls invents edges. False edges
+# only *add* reachability, so they cannot make an absence claim pass wrongly,
+# but they can make the control below pass for the wrong reason.
+kControlRelocation = re.compile(
+    r"\bR_ARM_(?:THM_)?(?:CALL|JUMP24|JUMP19|JUMP11|JUMP8|PC24|PLT32)\b"
+    r"\s+([A-Za-z_][A-Za-z0-9_.]*)"
+)
+
+# A resolved local transfer: `bl`, or a plain `b` when the compiler turns a
+# call in tail position into a jump. Missing the branch form is the dangerous
+# direction -- a lost edge makes "reaches no float" pass by not looking.
+kResolvedTransfer = re.compile(
+    r"\bb(?:l)?(?:\.[nw])?\s+([0-9a-f]+) <([A-Za-z_][A-Za-z0-9_.]*)>"
+)
+
+
 @typechecked
 def _callees(body: list[str]) -> set[str]:
-    """Who this function actually calls.
+    """Who this function actually transfers control to.
 
-    Two forms, and only two. A relocation record names the real target of a
-    call to an undefined symbol; a resolved local call carries a non-zero
-    address. A `bl 0 <name>` with no relocation beside it is neither -- that
-    is the unrelocated case, and the name objdump prints for it is whatever
-    happens to sit at address zero. Following those printed names had this
-    walk believing `signedCbrtQ16` called `isUsableSolveChromaticity`: a cube
-    root calling a chromaticity validator, which is what gave it away.
+    Two forms, and only two. A control-flow relocation names the real target
+    of a call to an undefined symbol; a resolved local transfer carries a
+    non-zero address. A `bl 0 <name>` with no relocation beside it is neither
+    -- that is the unrelocated case, and the name objdump prints for it is
+    whatever happens to sit at address zero. Following those printed names had
+    this walk believing `signedCbrtQ16` called `isUsableSolveChromaticity`: a
+    cube root calling a chromaticity validator, which is what gave it away.
     """
 
     out: set[str] = set()
     for line in body:
-        relocation = re.search(r"R_ARM_\w+\s+([A-Za-z_][A-Za-z0-9_.]*)", line)
+        relocation = kControlRelocation.search(line)
         if relocation:
             out.add(relocation.group(1))
             continue
-        call = re.search(
-            r"\bbl(?:\.w)?\s+([0-9a-f]+) <([A-Za-z_][A-Za-z0-9_.]*)>", line
-        )
-        if call and int(call.group(1), 16) != 0:
-            out.add(call.group(2))
+        transfer = kResolvedTransfer.search(line)
+        if transfer and int(transfer.group(1), 16) != 0:
+            out.add(transfer.group(2))
     return out
 
 
@@ -225,11 +241,37 @@ kPipelineSource = """
 """
 
 
-@pytest.fixture(scope="module")
+@typechecked
+@dataclass(frozen=True)
+class CompiledPipeline:
+    """One build of the streaming pipeline, and the tools that read it."""
+
+    tools: ArmTools
+    obj: Path
+    core: str
+
+
+# Two cores, because they exercise different halves of the walk.
+#
+# Cortex-M0+ is ARMv6-M: soft float, and its limited branch range means the
+# compiler never turns a call in tail position into a jump -- measured, zero
+# such branches in this object.
+#
+# Cortex-M33 without an FPU is ARMv8-M: soft float *and* Thumb-2, where a
+# tail call does become `b.n`. That is what makes the branch handling in
+# `_callees` load-bearing rather than defensive; on the M0+ build alone it
+# would never be exercised.
+kFloatFreeTargets: tuple[tuple[str, ...], ...] = (
+    ("cortex-m0plus", "-march=armv6-m"),
+    ("cortex-m33+nofp", "-march=armv8-m.main+dsp"),
+)
+
+
+@pytest.fixture(scope="module", params=kFloatFreeTargets, ids=lambda t: t[0])
 @typechecked
 def compiled_pipeline(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> tuple[ArmTools, Path]:
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> CompiledPipeline:
     """The whole streaming pipeline in one object, so calls can be followed.
 
     Every stage `processPixelQ16` reaches lives in a different translation
@@ -241,7 +283,8 @@ def compiled_pipeline(
     if tools is None:
         pytest.skip("no arm-none-eabi cross compiler on this machine")
 
-    tmp_path = tmp_path_factory.mktemp("pipeline_float_free")
+    core, march = request.param
+    tmp_path = tmp_path_factory.mktemp(f"pipeline_{core.replace('+', '_')}")
     source = tmp_path / "pipeline_tu.cpp"
     source.write_text(kPipelineSource, encoding="utf-8")
     obj = tmp_path / "pipeline_tu.o"
@@ -254,8 +297,8 @@ def compiled_pipeline(
             str(obj),
             "-I",
             str(PROJECT_ROOT / "src"),
-            "-mcpu=cortex-m0plus",
-            "-march=armv6-m",
+            f"-mcpu={core}",
+            march,
             "-mthumb",
             "-Os",
             "-std=gnu++17",
@@ -270,12 +313,12 @@ def compiled_pipeline(
         errors="replace",
         check=True,
     )
-    return tools, obj
+    return CompiledPipeline(tools=tools, obj=obj, core=core)
 
 
 @typechecked
 def test_the_per_pixel_path_reaches_no_float_runtime(
-    compiled_pipeline: tuple[ArmTools, Path],
+    compiled_pipeline: CompiledPipeline,
 ) -> None:
     """P9's criterion, at the place it actually matters (FastLED#4043).
 
@@ -286,16 +329,18 @@ def test_the_per_pixel_path_reaches_no_float_runtime(
     It reaches none. Measured across the 19 functions the walk visits.
     """
 
-    tools, obj = compiled_pipeline
-    helpers = _reachable_helpers(tools.objdump, obj, kPerPixelSymbol)
+    helpers = _reachable_helpers(
+        compiled_pipeline.tools.objdump, compiled_pipeline.obj, kPerPixelSymbol
+    )
     assert helpers == set(), (
-        f"the per-pixel path reaches the float runtime: {sorted(helpers)}"
+        f"the per-pixel path reaches the float runtime on "
+        f"{compiled_pipeline.core}: {sorted(helpers)}"
     )
 
 
 @typechecked
 def test_the_bind_path_is_where_the_float_still_is(
-    compiled_pipeline: tuple[ArmTools, Path],
+    compiled_pipeline: CompiledPipeline,
 ) -> None:
     """Control for the case above, and a statement of what remains.
 
@@ -309,10 +354,12 @@ def test_the_bind_path_is_where_the_float_still_is(
     counterpart, and nothing routes to it yet.
     """
 
-    tools, obj = compiled_pipeline
-    helpers = _reachable_helpers(tools.objdump, obj, kBindSymbol)
+    helpers = _reachable_helpers(
+        compiled_pipeline.tools.objdump, compiled_pipeline.obj, kBindSymbol
+    )
     assert len(helpers) >= 8, (
-        f"expected the bind path to reach the soft-float runtime, found {sorted(helpers)}"
+        f"expected the bind path to reach the soft-float runtime on "
+        f"{compiled_pipeline.core}, found {sorted(helpers)}"
     )
 
 

--- a/src/fl/channels/cled_controller.h
+++ b/src/fl/channels/cled_controller.h
@@ -4,6 +4,8 @@
 /// base definitions used by led controllers for writing out led data
 
 #include "color.h"
+#include "fl/channels/color_profile.h"  // IWYU pragma: keep  (EmitterProfile)
+#include "pixel_controller.h"  // IWYU pragma: keep  (ColorAdjustment)
 
 #include "fl/stl/compiler_control.h"
 #include "dither_mode.h"

--- a/src/fl/channels/color_managed_source.h
+++ b/src/fl/channels/color_managed_source.h
@@ -20,6 +20,7 @@
 // decided at bind time.
 
 #include "fl/gfx/pipeline.h"
+#include "fl/channels/color_profile.h"  // IWYU pragma: keep  (EmitterProfile)
 #include "fl/stl/int.h"
 #include "fl/stl/noexcept.h"
 #include "fl/gfx/eorder.h"

--- a/src/fl/gfx/pipeline.cpp.hpp
+++ b/src/fl/gfx/pipeline.cpp.hpp
@@ -18,7 +18,7 @@ constexpr Chromaticity kPipelineD65 = Chromaticity(0.3127f, 0.3290f);
 }  // namespace
 
 bool buildStreamingPipelineQ16(const SourceProfile& source,
-                               const EmitterProfile& device,
+                               const colorimetric_response::EmitterProfile& device,
                                GamutPolicy policy,
                                StreamingPipelineQ16* out) FL_NO_EXCEPT {
     if (out == nullptr) {

--- a/src/fl/gfx/pipeline.h
+++ b/src/fl/gfx/pipeline.h
@@ -87,7 +87,7 @@ struct StreamingPipelineQ16 {
 /// and the power limiter reach it, because they change between frames while
 /// everything else here does not.
 bool buildStreamingPipelineQ16(const SourceProfile& source,
-                               const EmitterProfile& device,
+                               const colorimetric_response::EmitterProfile& device,
                                GamutPolicy policy,
                                StreamingPipelineQ16* out) FL_NO_EXCEPT;
 


### PR DESCRIPTION
P9 (#4043). #4305 and #4312 proved float-freeness for the matrix build; this measures the
thing that actually runs for every pixel of every frame.

## The result

`processPixelQ16` — decode, source matrix, gamut map, device solve, flux — reaches **no**
float-runtime helper, across the 19 functions the walk visits.

`buildStreamingPipelineQ16`, in the same object, reaches **33**. That is the control: if
both reported nothing, it would prove the walk stopped rather than the pipeline being
clean.

So the float is confined to **bind time**. That is P9 item 2's remaining work rather than a
defect here — `buildRgbSolveMatrixFromQ16` is the float-free counterpart and nothing routes
to it yet.

## The walk was wrong, and it is the walk #4312 merged

In an unlinked object, a call to an undefined symbol disassembles as `bl 0 <name>`, and
objdump resolves that `0` against the symbol table. So when a *defined* function happens to
sit at address zero, **every unrelocated call in the object appears to go to it**.

The first run of this measurement reported the per-pixel path reaching
`isUsableSolveChromaticity` via `signedCbrtQ16` — a cube root calling a chromaticity
validator. That is what gave it away; the number itself looked plausible.

Fixed by reading relocation records (`objdump -d -r`) rather than printed names.

**What this means for #4312's merged test:** its "clean" assertions were still sound —
phantom edges can only *add* reachable helpers, making `== set()` harder to pass. Its
*control* was the one at risk, and it was: with the walk corrected it initially found zero,
because I had also made the callee rule too strict before getting the `-r` flag onto the
right one of the two objdump calls. Both are right now and the control finds its helpers
again.

## Mutation-checked, including one mutation that proved nothing

| mutation | result |
|---|---|
| drop `-r` (restore the bug) | the control fails |
| an unfoldable float multiply inside the OKLab cube root | the per-pixel case fails |
| ~~a float comparison against `1e30f`~~ | **passed — the compiler folded it**, since an i32 cannot exceed 1e30 |

The third is worth recording: it looked like a clean pass and demonstrated nothing.

## Also, five more non-self-contained headers

Found by trying to build the probe: `pipeline.h`, `oklab_q16.h`, `cled_controller.h`,
`color_managed_source.h`, `color_profile.h`. The gfx ones are qualified like their
neighbours; the channels ones include their own layer's `color_profile.h`.
`cled_controller.h` also wanted `ColorAdjustment`. That is the fourth through eighth
instance of this defect, so the list now covers the group rather than growing one incident
at a time.

304/304 unit + 84/84 examples, `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for self-contained color-processing headers, including pipeline, Oklab, and channel-layer components.
  * Improved verification of fixed-point processing on Cortex-M0+ and Cortex-M33 targets without floating-point hardware.
  * Added coverage for relocation parsing, address-zero targets, and interleaved cases.

* **Maintenance**
  * Clarified type references and header dependencies to improve build consistency and portability.
  * No runtime behavior or user-facing functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->