### PR TITLE
test(gfx): R7's neutral-axis question, measured — and the override that reaches nothing

### DIFF
--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -111,6 +111,56 @@ FL_TEST_CASE("Profile binding validates and owns response tables") {
     FL_CHECK_EQ(options.emitterProfile()->response_lut_r[1], fl::u16(257));
 }
 
+FL_TEST_CASE("A target white is accepted, stored, and reaches nothing") {
+    // FastLED#4156 R7 asks for "target-white overrides" that "preserve the
+    // selected neutral axis". `setTargetWhite` exists, validates its input,
+    // stores it, and is carried through `Channel` -- three cases below
+    // already check that plumbing. None of them asks the question R7 does,
+    // which is whether it reaches the rendering path.
+    //
+    // It does not. Outside these accessors nothing in `src/` reads it, and
+    // the gamut mapper's neutral is `kGamutD65Q16`, a compile-time constant
+    // no override can move. So the setter is settable and inert, which is
+    // where `setColorProfile` was before P6 wired it.
+    //
+    // Recorded rather than left to be discovered, because a setter that
+    // returns true is a promise. When someone wires it, this case fails, and
+    // what to re-measure is "a neutral request stays neutral whatever the
+    // device white is" in `tests/fl/gfx/gamut_map.cpp` -- which holds today
+    // with the mapping white fixed at D65.
+    ChannelOptions options;
+    FL_CHECK_FALSE(options.hasTargetWhite());
+
+    // A warm white, well away from D65.
+    FL_REQUIRE(options.setTargetWhite(Chromaticity(0.4476f, 0.4074f)));
+    FL_CHECK(options.hasTargetWhite());
+    FL_CHECK_CLOSE(options.targetWhite().x, 0.4476f, 0.0001f);
+
+    // Validated rather than taken on trust, which is the half that works.
+    FL_CHECK_FALSE(options.setTargetWhite(Chromaticity(1.5f, 0.5f)));
+
+    // The inert half: a profile bound alongside a target white is the same
+    // profile as one bound without, because there is nothing for the
+    // override to change.
+    ChannelOptions with_white;
+    FL_REQUIRE(with_white.setTargetWhite(Chromaticity(0.4476f, 0.4074f)));
+    FL_REQUIRE(with_white.setColorProfile(kFixtureProfile,
+                                          SourceProfile::linearSrgb()));
+    ChannelOptions without_white;
+    FL_REQUIRE(without_white.setColorProfile(kFixtureProfile,
+                                             SourceProfile::linearSrgb()));
+
+    const EmitterProfile* bound_with = with_white.emitterProfile();
+    const EmitterProfile* bound_without = without_white.emitterProfile();
+    FL_REQUIRE(bound_with != nullptr);
+    FL_REQUIRE(bound_without != nullptr);
+    for (int i = 0; i < 2; ++i) {
+        FL_CHECK_EQ(bound_with->xy_r[i], bound_without->xy_r[i]);
+        FL_CHECK_EQ(bound_with->xy_b[i], bound_without->xy_b[i]);
+    }
+    FL_CHECK_EQ(bound_with->lum_g, bound_without->lum_g);
+}
+
 FL_TEST_CASE("Rebinding replaces the profile and releases the first") {
     // FastLED#4156 R9 names "profile/lut lifetime and rebind tests" as
     // required evidence, and asks what happens to cache invalidation when a

--- a/tests/fl/gfx/gamut_map.cpp
+++ b/tests/fl/gfx/gamut_map.cpp
@@ -1657,6 +1657,89 @@ FL_TEST_CASE("the two-white allocator never clamps a drive the solve put out of 
     FL_CHECK_GT(worst, 0.0f);
 }
 
+FL_TEST_CASE("a neutral request stays neutral whatever the device white is") {
+    // FastLED#4156 R7 says standard Oklab assumes D65 with white Y = 1, and
+    // that "feeding arbitrary warm/profile-white XYZ directly into those
+    // matrices does not make the target neutral axis zero-chroma".
+    //
+    // Measured, that failure does not arise here -- because the mapper never
+    // feeds it profile white. `kGamutD65Q16` is a compile-time D65, and the
+    // brightest-neutral walk, the neutral cap and the chroma ray are all
+    // anchored to it. A D65 target goes in and comes back D65 regardless of
+    // where the device's own white sits.
+    //
+    // Worst OKLab chroma over a twenty-step neutral ramp, by device blue:
+    //
+    //   (0.150, 0.060)  D65-ish   6.5e-05
+    //   (0.180, 0.100)  warm-ish  6.3e-05
+    //   (0.220, 0.160)  warmer    6.5e-05
+    //
+    // Flat across the three, which is what a mapping space independent of
+    // the device white looks like; the figures are Q16 rounding.
+    //
+    // The ramp runs past the device's brightest neutral on purpose. Inside
+    // the hull the mapper hands a neutral straight back and this would be
+    // measuring the solve -- moving `kGamutD65Q16` to a warm white then
+    // changes nothing, which is how the first version of this case passed
+    // that mutation. Above the cap the walk-down runs and the mapping white
+    // is load-bearing: the same mutation now takes the chroma to 0.02.
+    struct DeviceBlue {
+        float x;
+        float y;
+    };
+    const DeviceBlue kBlues[] = {{0.1500f, 0.0600f},
+                                 {0.1800f, 0.1000f},
+                                 {0.2200f, 0.1600f}};
+    int measured = 0;
+    for (const auto& blue : kBlues) {
+        EmitterProfile device = rgbDevice();
+        device.xy_b[0] = blue.x;
+        device.xy_b[1] = blue.y;
+        GamutMapQ16 map;
+        FL_REQUIRE(buildGamutMapQ16(device, &map));
+
+        // Up to 2.0, well past the brightest neutral the device can make,
+        // so the cap and the walk-down actually run. Staying inside the hull
+        // would let the mapper pass the target through untouched, and then
+        // this would be measuring the solve rather than the mapping space.
+        for (int step = 1; step <= 20; ++step) {
+            i32 xyz[3];
+            xyzAt(0.3127f, 0.3290f, static_cast<float>(step) / 10.0f, xyz);
+            i32 drives[3];
+            mapAndSolveDrivesQ16(map, xyz, drives);
+
+            float as_float[3];
+            for (int i = 0; i < 3; ++i) {
+                as_float[i] = toFloat(drives[i]);
+            }
+            float columns[3][3];
+            colorimetric_response::xyY_to_XYZ(device.xy_r[0], device.xy_r[1],
+                                              device.lum_r, columns[0]);
+            colorimetric_response::xyY_to_XYZ(device.xy_g[0], device.xy_g[1],
+                                              device.lum_g, columns[1]);
+            colorimetric_response::xyY_to_XYZ(device.xy_b[0], device.xy_b[1],
+                                              device.lum_b, columns[2]);
+            float produced[3];
+            for (int axis = 0; axis < 3; ++axis) {
+                produced[axis] = columns[0][axis] * as_float[0] +
+                                 columns[1][axis] * as_float[1] +
+                                 columns[2][axis] * as_float[2];
+            }
+            const i32 produced_q16[3] = {q16(produced[0]), q16(produced[1]),
+                                         q16(produced[2])};
+            i32 lab[3];
+            xyzToOklabQ16(produced_q16, lab);
+            const float a = toFloat(lab[1]);
+            const float b = toFloat(lab[2]);
+            FL_CHECK_LT(fl::sqrtf(a * a + b * b), 1.0e-04f);
+            ++measured;
+        }
+    }
+    // Vacuity guard: a build that refused every device would satisfy the
+    // loop body by never entering it.
+    FL_CHECK_EQ(measured, 60);
+}
+
 FL_TEST_CASE("RGBWW mapper preserves hue while compressing chroma") {
     // The last corner of the criterion: the hue objective on the five-emitter
     // hull.


### PR DESCRIPTION
#4156 **R7**, one of the three least-discussed findings (4 mentions). Stacked on #4316 —
**merge that one first**; retargeting a stack past its base is how #4313 got swallowed.

## R7's stated failure does not arise

It says standard Oklab assumes D65 with white Y = 1, and that feeding "arbitrary
warm/profile-white XYZ directly into those matrices does not make the target neutral axis
zero-chroma".

The mapper never feeds it profile white. `kGamutD65Q16` is a compile-time D65, and the
brightest-neutral walk, the neutral cap and the chroma ray are all anchored to it. Worst
OKLab chroma over a twenty-step neutral ramp:

| device blue | worst neutral chroma |
|---|---:|
| (0.150, 0.060) — D65-ish | 6.5e-05 |
| (0.180, 0.100) — warm-ish | 6.3e-05 |
| (0.220, 0.160) — warmer | 6.5e-05 |

Flat across the three, which is what a mapping space independent of the device white looks
like. The figures are Q16 rounding.

## The first version of this case proved nothing

It ramped only *inside* the hull, where the mapper hands a neutral straight back — so it
was measuring the solve, not the mapping space. Moving `kGamutD65Q16` to a warm white
**passed** it.

The ramp now runs past the device's brightest neutral, where the walk-down actually runs
and the mapping white is load-bearing. The same mutation now takes the neutral chroma to
**0.02** and fails.

## R7's other half is live, in a form it did not name

It asks for "target-white overrides" that preserve the neutral axis. `setTargetWhite`
exists, validates its input, stores it, and is carried through `Channel` — three cases
already check that plumbing.

**Nothing outside those accessors reads it.** The only reference in `src/` beyond
`options.h` is another accessor in `channel.h`, and the mapper's neutral is a `constexpr`
no override can move. So the setter is settable and inert — where `setColorProfile` was
before P6 wired it.

Recorded rather than left to be discovered, because a setter returning `true` is a promise.
When someone wires it, the new case fails and its comment says what to re-measure.

Test-only. 304/304 unit + 84/84 examples, `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming target-white settings are stored correctly and invalid values are rejected.
  * Added coverage verifying target-white overrides do not currently affect rendered output.
  * Added gamut-mapping tests to ensure neutral requests remain neutral across devices with different white points.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->