### PR TITLE
fix(ota): unblock four stages of the RP2350W peer OTA flow, and stop the criterion passing without one (#3956)

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -363,6 +363,36 @@
   minutes left. Anchor a completion pattern on text only the result can
   produce (`AUTORESEARCH PASSED`, `autoresearch failed`), and check what the
   first hundred lines of the log already contain before trusting a match.
+- On a machine with no swap, a "low memory" alarm can mean a full page cache
+  rather than exhaustion -- read `MemFree` and `MemAvailable` separately
+  before acting on it. Three long device runs were killed for low memory
+  while a 20-minute sampler I had running showed `MemAvailable` never
+  dropping below 77 GB of 131 GB. The real reading was `MemFree: 1.4 GB`
+  against `Cached: 59.6 GB` with `SwapTotal: 0`: build I/O had filled the
+  page cache, so anything thresholding on `MemFree` saw 1.4 GB while
+  `MemAvailable`, which counts reclaimable cache, correctly reported 80 GB.
+  This corrects my earlier conclusion that daemon growth was the cause.
+  Killing `fbuild-daemon` and `zccache-daemon` appeared to fix it once
+  because it briefly returned pages to `MemFree`, then stopped working,
+  because the daemons were never it -- `fbuild-daemon` was back at 5.26 GB
+  within ten minutes and the run died anyway. Page cache is reclaimable and
+  cannot be dropped from userspace without root, so the honest responses are
+  to retry, shorten the exposed run, or fix the threshold -- not to reap
+  processes and call it fixed.
+- Do not hunt a deterministic cause for an intermittent failure until you have
+  established it is deterministic. `No response with ID 1 within 20.0s` failed
+  two peer-OTA runs in a row, which I took as proof it was not flaky, and I
+  then produced four wrong causes in sequence -- a first-boot filesystem
+  format, a 2 MB filesystem slowing boot, a short `boot_wait`, and a stale
+  CDC on the primary. Each was built on a two-sample correlation with my own
+  most recent change. The next run passed the same point untouched: it is a
+  race on the companion's USB-CDC re-enumeration, which
+  `_connect_peer_with_retry`'s docstring had already recorded across four
+  prior captures, naming the C6 and saying a fixed `boot_wait` cannot cover
+  it. Two consecutive failures of a race are unremarkable. Read the existing
+  docstrings on the failing path before forming a theory, and prefer adding
+  attribution over adding a hypothesis when the error names neither the
+  component nor the operation.
 - `git fetch` before starting work, not before pushing. I root-caused the
   `s16x16x4` 15x penalty in #4216 (rolled 4-lane loops defeating
   scalar-replacement), fixed it, and measured it on hardware -- and only when

--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -325,6 +325,44 @@
   content, not state, and
   when commits are stranded rebuild them onto current master as a fresh PR
   rather than reopening the merged one.
+- The last line of a log and the code path that produced it can disagree, and
+  the code path wins. A peer OTA run ended with `C6 artifact server failed`,
+  and I read the tail as "the transfer never ran". Reading `ota.py` in order
+  showed the opposite: reaching that raise requires the whole
+  `writeOtaArtifact` chunk loop to have returned success and
+  `finishOtaArtifact` to have matched the SHA-256, because either one failing
+  raises earlier and differently. The transfer had in fact completed and
+  verified 1,030,348 bytes. An error message names where execution stopped,
+  which is also a statement that everything before it passed -- for a
+  sequential flow that is free evidence, and I nearly discarded it by reading
+  bottom-up. Before concluding a stage did not run, find the raise that would
+  have fired if it had failed.
+- When two runs of the same thing disagree, subtract before calling either
+  one flaky. Run 1 of a peer OTA transferred all 1,030,348 bytes; run 2 died
+  at byte 200,448. The fixture partition is 0x130000 (1,245,184 B) and
+  `finishOtaArtifact` deletes the previous artifact only after the new one
+  verifies, so run 2 needed room for two copies:
+  1,245,184 - 1,030,348 = 214,836 B of headroom against a failure at 200,448 B,
+  the difference being LittleFS block overhead. One cause explained both runs
+  exactly. Arithmetic that lands within a few percent is a root cause;
+  "probably flaky" is what I would have written without doing it.
+- A stale branch head is not evidence that nobody is working on it. I
+  diagnosed the seven red builds on #4311, posted the cause, then implemented
+  the fix anyway because the head had not moved in 21 minutes. It was another
+  session's active branch; they pushed the same fix while I was testing and my
+  push was rejected. My existing lesson said to fetch before starting, and I
+  did fetch -- the gap was treating "no commits for N minutes" as "abandoned".
+  On a branch this session does not own, the diagnosis comment is the whole
+  contribution; implementing on top of it is duplicated work with a merge
+  conflict attached. See [[fetch-before-starting-not-before-pushing]].
+- Grep patterns used as completion signals must not match the configuration
+  that announces the work. I polled a log for `TEST_COMPLETED` to detect the
+  end of a 20-minute run and got a hit within 30 seconds -- from the startup
+  banner `stop on 'TEST_COMPLETED_EXIT_(OK|ERROR)'`, which is the harness
+  printing what it will look for. I reported the run finished while it had 18
+  minutes left. Anchor a completion pattern on text only the result can
+  produce (`AUTORESEARCH PASSED`, `autoresearch failed`), and check what the
+  first hundred lines of the log already contain before trusting a match.
 - `git fetch` before starting work, not before pushing. I root-caused the
   `s16x16x4` 15x penalty in #4216 (rolled 4-lane loops defeating
   scalar-replacement), fixed it, and measured it on hardware -- and only when

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -371,7 +371,19 @@ async def run_ota_peer_autoresearch(
         await rpc_data(primary, "ping", {})
         served = await rpc_data(peer, "otaArtifactStatus", {})
         if not served.get("success") or _served_request_count(served) < 1:
-            raise RuntimeError(f"C6 did not serve the RP2350W artifact: {served}")
+            # The RP fetches with the RPC link closed, so its own reason for
+            # failing never reaches the host live. Ask for it now that the
+            # link is back: without this the C6's `servedRequests: 0` is the
+            # whole report, and a fetch that failed looks exactly like one
+            # that never ran. See FastLED#3956.
+            try:
+                rp_update = await rpc_data(primary, "rpOtaUpdateStatus", {})
+            except (RpcTimeoutError, RuntimeError, OSError) as probe_error:
+                rp_update = {"probeFailed": str(probe_error)}
+            raise RuntimeError(
+                f"C6 did not serve the RP2350W artifact: {served}; "
+                f"RP2350W update state: {rp_update}"
+            )
         print(f"{Fore.GREEN}OTA PEER AUTORESEARCH PASSED{Style.RESET_ALL}")
         return 0
     except KeyboardInterrupt as ki:

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -405,12 +405,36 @@ async def run_ota_peer_autoresearch(
             # that never ran. See FastLED#3956.
             try:
                 rp_update = await rpc_data(primary, "rpOtaUpdateStatus", {})
+            except KeyboardInterrupt as ki:
+                # Ahead of the tuple below on purpose. KeyboardInterrupt
+                # derives from BaseException so the tuple cannot catch it
+                # today, but this file already keeps the handler explicit
+                # everywhere else so a later widening cannot silently start
+                # swallowing Ctrl-C -- and this probe runs inside the failure
+                # path, where an interrupt is most likely.
+                handle_keyboard_interrupt(ki)
+                raise
             except (RpcTimeoutError, RuntimeError, OSError) as probe_error:
                 rp_update = {"probeFailed": str(probe_error)}
             raise RuntimeError(
                 f"C6 did not serve the RP2350W artifact: {served}; "
                 f"RP2350W update state: {rp_update}"
             )
+
+        # The C6 having served the image proves a download happened, not that
+        # the RP accepted it. `HTTPUpdate` can fetch the whole artifact and
+        # still reject it -- `ERROR[4]: Not Enough Space` is exactly that
+        # shape -- so passing on `servedRequests >= 1` alone would score the
+        # run on the transfer and call an update proven that never applied.
+        # #3832 asks this criterion to prove the expected build after reboot;
+        # ask the board. See FastLED#3956.
+        applied = await rpc_data(primary, "rpOtaUpdateStatus", {})
+        if applied.get("attempted") is not True or applied.get("succeeded") is not True:
+            raise RuntimeError(
+                f"RP2350W did not apply the artifact it fetched: {applied}; "
+                f"C6 side: {served}"
+            )
+
         print(f"{Fore.GREEN}OTA PEER AUTORESEARCH PASSED{Style.RESET_ALL}")
         return 0
     except KeyboardInterrupt as ki:

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -220,13 +220,32 @@ async def run_ota_peer_autoresearch(
         method: str,
         params: str | list[Any] | dict[str, Any] | None,
     ) -> dict[str, Any]:
-        response = await client.send(
-            method,
-            {} if params is None else params,
-            timeout=rpc_timeout(),
-        )
+        # Name the board and the call. `RpcClient.send` reports only
+        # `No response with ID 1 within 20.0s`, which identifies neither which
+        # of the two links went silent nor what was asked of it. This flow
+        # alternates between two boards, so that message is not a small
+        # inconvenience: it sent me after the wrong board repeatedly, and the
+        # existing `_settle_link` / `_connect_peer_with_retry` helpers both
+        # label their failures precisely because of it. See FastLED#3899.
+        which = "RP2350W" if client is primary else "ESP32-C6"
+        port = upload_port if client is primary else peer_upload_port
+        try:
+            response = await client.send(
+                method,
+                {} if params is None else params,
+                timeout=rpc_timeout(),
+            )
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except (RpcError, RpcTimeoutError) as exc:
+            raise RpcTimeoutError(
+                f"{which} ({port}) did not answer {method!r}: {exc}"
+            ) from exc
         if not isinstance(response.data, dict):
-            raise RuntimeError(f"{method} returned a non-object response")
+            raise RuntimeError(
+                f"{which} ({port}) returned a non-object response to {method!r}"
+            )
         return response.data
 
     try:
@@ -242,7 +261,15 @@ async def run_ota_peer_autoresearch(
         # locked in the daemon; reclaim before either client connects.
         # See FastLED/fbuild#1429.
         _reclaim_stale_port_locks([upload_port, peer_upload_port])
-        await primary.connect(boot_wait=3.0, drain_boot=True)
+        try:
+            await primary.connect(boot_wait=3.0, drain_boot=True)
+        except KeyboardInterrupt as ki:
+            handle_keyboard_interrupt(ki)
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise RpcTimeoutError(
+                f"RP2350W ({upload_port}) failed to attach: {exc}"
+            ) from exc
         # The peer flashes last, so its USB-CDC is the one most likely to be
         # mid-re-enumeration here. Four of the captured `No response with ID 1`
         # failures came from this path. See FastLED#3899.

--- a/ci/autoresearch/ota.py
+++ b/ci/autoresearch/ota.py
@@ -52,6 +52,25 @@ def _served_request_count(status: dict[str, Any]) -> int:
     return value if value >= 0 else 0
 
 
+def ota_applied_ok(applied: dict[str, Any]) -> bool:
+    """Whether `rpOtaUpdateStatus` says the RP actually applied the image.
+
+    Both flags are required, and both must be exactly `True`:
+
+    * ``attempted`` false means `pollOtaArtifactUpdate` never ran the fetch,
+      so nothing was applied regardless of what the C6 served.
+    * ``succeeded`` false means it ran and `HTTPUpdate` rejected the image --
+      `ERROR[4]: Not Enough Space` is that case, and it is reached *after*
+      the artifact has been served, so the C6 side looks healthy.
+
+    Identity against `True` rather than truthiness on purpose: a device that
+    answers `"succeeded": "false"` or `1` is malformed, and reading either as
+    a pass is the failure mode this whole flow keeps producing. Anything that
+    is not the boolean means "not proven", which fails.
+    """
+    return applied.get("attempted") is True and applied.get("succeeded") is True
+
+
 async def _settle_link(
     client: "RpcClient",
     label: str,
@@ -429,7 +448,7 @@ async def run_ota_peer_autoresearch(
         # #3832 asks this criterion to prove the expected build after reboot;
         # ask the board. See FastLED#3956.
         applied = await rpc_data(primary, "rpOtaUpdateStatus", {})
-        if applied.get("attempted") is not True or applied.get("succeeded") is not True:
+        if not ota_applied_ok(applied):
             raise RuntimeError(
                 f"RP2350W did not apply the artifact it fetched: {applied}; "
                 f"C6 side: {served}"

--- a/ci/boards.py
+++ b/ci/boards.py
@@ -1232,7 +1232,32 @@ RPI_PICO2_W = Board(
     platform_packages="framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/5.7.0/rp2040-5.7.0.zip",
     framework="arduino",
     board_build_core="earlephilhower",
-    board_build_filesystem_size="0.5m",
+    # Sized by the OTA image, not by filesystem need. Arduino-Pico stages an
+    # incoming OTA firmware *into the filesystem region* -- Updater.cpp:101
+    # rejects with UPDATE_ERROR_SPACE when `&_FS_start + size > &_FS_end`,
+    # and Updater.cpp:121 sets `updateStartAddress = &_FS_start`. So the
+    # region has to be at least as large as the whole image, not merely large
+    # enough for whatever the sketch stores.
+    #
+    # At the 0.5m this used to carry, the peer OTA flow reached the RP and
+    # died there with `Update error: ERROR[4]: Not Enough Space`: the image is
+    # 1,030,348 B against a 524,288 B region. Nothing in the log said so --
+    # the C6 reported `servedRequests: 0`, and the reason only surfaced once
+    # `rpOtaUpdateStatus` existed to carry it back.
+    #
+    # Only the sizes rpipico2w declares in boards.txt are selectable -- 0,
+    # 64K, 128K, 256K, 512K, 1M, 2M, 3M -- because fbuild matches this string
+    # against `menu.flash.<flash>_<fs>` and takes the geometry from the
+    # matching entry. A value that matches nothing does not fail: it yields
+    # fs_start == fs_end, and the build dies much later and much less
+    # obviously in PicoOTA.cpp with `the comparison reduces to (0 > 130048)`.
+    # 1.5m is such a value; do not "split the difference" here.
+    #
+    # 2m over 1m: 1M is 1,048,576 B against a 1,030,348 B image, an 18 KB
+    # margin that the next commit to this sketch would erase. 2m keeps ~2x
+    # headroom and still leaves 2,097,152 B for a sketch using 1,030,348.
+    # See FastLED#3956.
+    board_build_filesystem_size="2m",
     # Arduino-Pico's default IPv4 profile excludes BTstack. Enable the Pico W
     # BLE-capable archive so FastLED's RP2350W transport can link.
     board_build_options={"ipbtstack": "ipv4btcble"},

--- a/ci/tests/test_ota_peer_hardening.py
+++ b/ci/tests/test_ota_peer_hardening.py
@@ -17,6 +17,7 @@ from ci.autoresearch.ota import (
     _served_request_count,
     kOtaChunkBytes,
     kOtaLargestAnsweredRequestCharacters,
+    ota_applied_ok,
     ota_chunk_is_deliverable,
     ota_largest_request_bytes,
     ota_transfer_is_deliverable,
@@ -281,6 +282,49 @@ class TestOtaChunkDeliverability(unittest.TestCase):
         self.assertTrue(ota_chunk_is_deliverable(4, 8))
         self.assertTrue(ota_chunk_is_deliverable(256, 344))
         self.assertFalse(ota_chunk_is_deliverable(256, 343))
+
+
+class TestOtaAppliedOk(unittest.TestCase):
+    """`servedRequests >= 1` proves a download, not an applied image.
+
+    The peer-OTA run used to report PASSED on the served count alone.
+    `HTTPUpdate` can fetch an entire artifact and still reject it, and
+    `ERROR[4]: Not Enough Space` -- the RP2350W staging-region defect this
+    flow was built to surface -- is exactly that: it happens *after* the C6
+    has served the image, so the C6 side looks healthy. That failure was
+    being scored a pass. See FastLED#3956.
+    """
+
+    def test_both_flags_true_is_the_only_pass(self) -> None:
+        self.assertTrue(ota_applied_ok({"attempted": True, "succeeded": True}))
+
+    def test_fetched_then_rejected_is_not_a_pass(self) -> None:
+        # The verbatim shape of the Not Enough Space failure.
+        self.assertFalse(
+            ota_applied_ok(
+                {
+                    "attempted": True,
+                    "succeeded": False,
+                    "host": "192.168.4.1",
+                    "port": 8081,
+                    "lastError": "Update error: ERROR[4]: Not Enough Space",
+                }
+            )
+        )
+
+    def test_never_attempted_is_not_a_pass(self) -> None:
+        # `succeeded` left true while nothing ran must not carry the check.
+        self.assertFalse(ota_applied_ok({"attempted": False, "succeeded": True}))
+
+    def test_missing_flags_are_not_a_pass(self) -> None:
+        # Firmware too old to answer this cannot be assumed to have applied it.
+        self.assertFalse(ota_applied_ok({}))
+
+    def test_truthy_non_booleans_do_not_count_as_proof(self) -> None:
+        # A device answering `1` or `"true"` is malformed, and reading either
+        # as a pass is the failure mode this flow keeps producing.
+        self.assertFalse(ota_applied_ok({"attempted": 1, "succeeded": 1}))
+        self.assertFalse(ota_applied_ok({"attempted": True, "succeeded": "true"}))
 
 
 if __name__ == "__main__":

--- a/examples/AutoResearch/AutoResearchOta.cpp
+++ b/examples/AutoResearch/AutoResearchOta.cpp
@@ -28,6 +28,17 @@ struct RpOtaUpdateState {
     bool pending = false;
     char host[16] = {};
     uint16_t port = 0;
+    // Why the last attempt ended as it did. `pollOtaArtifactUpdate` runs from
+    // loop() long after the host has closed the RPC link -- the peer OTA flow
+    // closes it deliberately so the board can reboot into the new image -- so
+    // the FL_WARN it used to emit went to a serial port with nobody on the
+    // other end. A failed fetch was then indistinguishable from one that
+    // never ran: both left the C6 reporting `servedRequests: 0` and no reason
+    // anywhere. Keep the outcome here so the host can ask once it reconnects.
+    // See FastLED#3956.
+    bool attempted = false;
+    bool succeeded = false;
+    char last_error[96] = {};
 };
 
 RpOtaUpdateState& getRpOtaUpdateState() {
@@ -358,6 +369,34 @@ fl::json beginOtaArtifact(size_t expected_size, const char* sha256) {
         state.file.close();
     }
     LittleFS.remove("/rp2350.bin.part");
+    // Drop the previous artifact before staging the next one, not after.
+    //
+    // `finishOtaArtifact` replaces `/rp2350.bin` only once `.part` is
+    // complete and its SHA-256 checks out, which is the right order when
+    // there is room for both. There is not: the fixture's spiffs partition
+    // is 0x130000 (1,245,184 B) and the RP image is 1,030,348 B, so a second
+    // transfer needs 2,060,696 B of a 1,245,184 B filesystem. The first run
+    // on a blank filesystem transfers and verifies fine; every run after it
+    // dies partway with `Artifact write failed`, at byte 200,448 on this
+    // bench -- which is the 214,836 B of headroom left over, less LittleFS
+    // block overhead. See FastLED#3956.
+    //
+    // The cost is that a transfer which fails midway now leaves no artifact
+    // rather than the previous one. That trade is right here: the artifact
+    // is a test fixture the harness re-stages on every run, and the
+    // alternative is that the second and every subsequent run cannot stage
+    // at all.
+    LittleFS.remove("/rp2350.bin");
+    const size_t free_bytes = LittleFS.totalBytes() - LittleFS.usedBytes();
+    if (expected_size > free_bytes) {
+        // Fail here with the numbers rather than partway through the
+        // transfer with a bare "write failed" 20 minutes in.
+        response.set("success", false);
+        response.set("error", "Artifact exceeds free space on fixture filesystem");
+        response.set("freeBytes", static_cast<int64_t>(free_bytes));
+        response.set("neededBytes", static_cast<int64_t>(expected_size));
+        return response;
+    }
     state.file = LittleFS.open("/rp2350.bin.part", FILE_WRITE);
     if (!state.file) {
         response.set("success", false);
@@ -430,6 +469,16 @@ fl::json startOtaArtifactServer() {
     if (!state.server) {
         httpd_config_t config = HTTPD_DEFAULT_CONFIG();
         config.server_port = 8081;
+        // Distinct from the control socket the peer's main HTTP server is
+        // already holding. `HTTPD_DEFAULT_CONFIG()` hardcodes
+        // `.ctrl_port = ESP_HTTPD_DEF_CTRL_PORT` (32768), and
+        // `fl::asio::http::Server::start()` takes that default too, so the
+        // second `httpd_start` on the device binds a UDP port the first one
+        // owns and fails. `server_port` differing is not enough -- the
+        // conflict is on the control socket, not the listening socket.
+        // Reached only in the peer OTA flow, where `startNetServer` runs
+        // immediately before this. See FastLED#3956.
+        config.ctrl_port = 32769;
         if (httpd_start(&state.server, &config) != ESP_OK) {
             response.set("success", false);
             response.set("error", "Artifact HTTP server start failed");
@@ -581,9 +630,36 @@ void pollOtaArtifactUpdate(uint32_t watchdog_restore_ms) {
     wdt.begin(watchdog_restore_ms);
     wdt.feed();
 
+    state.attempted = true;
+    state.succeeded = (result == HTTP_UPDATE_OK);
+    // `auto`, not `fl::string`: HTTPUpdate hands back an `arduino::String`
+    // and there is no conversion. Naming it keeps the temporary alive for
+    // the c_str() read below.
+    auto reason = updater.getLastErrorString();
+    const char* reason_text = reason.c_str();
+    size_t copied = 0;
+    while (copied + 1 < sizeof(state.last_error) && reason_text[copied] != '\0') {
+        state.last_error[copied] = reason_text[copied];
+        ++copied;
+    }
+    state.last_error[copied] = '\0';
+
     if (result != HTTP_UPDATE_OK) {
         FL_WARN("[OTA] RP2350W artifact update failed: " << updater.getLastErrorString());
     }
+}
+
+fl::json rpOtaUpdateStatus() {
+    fl::json response = fl::json::object();
+    RpOtaUpdateState& state = getRpOtaUpdateState();
+    response.set("success", true);
+    response.set("attempted", state.attempted);
+    response.set("succeeded", state.succeeded);
+    response.set("pending", state.pending);
+    response.set("lastError", state.last_error);
+    response.set("host", state.host);
+    response.set("port", static_cast<int64_t>(state.port));
+    return response;
 }
 
 #else
@@ -596,6 +672,13 @@ fl::json queueOtaArtifactUpdate(const char* host, uint16_t port) {
 }
 
 void pollOtaArtifactUpdate(uint32_t /*watchdog_restore_ms*/) {}
+
+fl::json rpOtaUpdateStatus() {
+    fl::json response = fl::json::object();
+    response.set("success", false);
+    response.set("error", "Artifact update only supported on RP2350W");
+    return response;
+}
 
 #endif
 

--- a/examples/AutoResearch/AutoResearchOta.cpp
+++ b/examples/AutoResearch/AutoResearchOta.cpp
@@ -452,6 +452,16 @@ fl::json finishOtaArtifact() {
         response.set("error", "Artifact publish failed");
         return response;
     }
+    // A fresh artifact starts with a fresh serve count. `served_requests`
+    // lives in singleton state that outlives any one transfer, and
+    // `otaArtifactStatus` is what the host uses to decide whether the RP
+    // actually fetched: `servedRequests < 1` is the failure condition. Left
+    // carrying a previous artifact's count, that check passes on history --
+    // the run is scored on a download that happened before this image
+    // existed. In practice the C6 is reflashed between runs, which hides it;
+    // any path that stages twice without a reflash does not. See
+    // FastLED#3956.
+    state.served_requests = 0;
     response.set("success", true);
     response.set("size", static_cast<int64_t>(state.received_size));
     response.set("sha256", actual_sha256);

--- a/examples/AutoResearch/AutoResearchOta.h
+++ b/examples/AutoResearch/AutoResearchOta.h
@@ -50,6 +50,11 @@ fl::json otaArtifactStatus();
 /// @brief Queue an RP2350W HTTP update so the RPC response can be sent first.
 fl::json queueOtaArtifactUpdate(const char* host, uint16_t port);
 
+/// Outcome of the last `pollOtaArtifactUpdate` fetch, readable after the
+/// host reconnects. The fetch runs with the RPC link closed, so without this
+/// a failure leaves no reason anywhere. See FastLED#3956.
+fl::json rpOtaUpdateStatus();
+
 /// @brief Execute a queued RP2350W update from the sketch loop.
 ///
 /// The HTTP update blocks for the whole firmware download, which routinely

--- a/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteNetworkMethods.cpp
@@ -384,6 +384,10 @@ void AutoResearchRemoteControl::bindNetworkMethods(fl::Remote& remote) {
         return otaArtifactStatus();
     });
 
+    remote.bind("rpOtaUpdateStatus", [](const fl::json& args) -> fl::json {
+        return rpOtaUpdateStatus();
+    });
+
     remote.bind("applyOtaArtifact", [](const fl::json& args) -> fl::json {
         if (!args.contains("host") || !args["host"].is_string() ||
             !args.contains("port") || !args["port"].is_int()) {


### PR DESCRIPTION
Peer OTA does not complete. Three separate failures sit behind one another; this fixes the first two on hardware and makes the third diagnosable instead of silent.

I closed #3956 as completed earlier today on the strength of having root-caused the 512-byte chunk limit. **That was premature** — clearing that limit only reveals the next two layers, both of which are real device-side bugs.

## 1. The artifact server could never start

```
OTA peer autoresearch failed: C6 artifact server failed:
  {'error': 'Artifact HTTP server start failed', 'success': False}
```

`startOtaArtifactServer` calls `httpd_start` with `HTTPD_DEFAULT_CONFIG()`, which hardcodes `.ctrl_port = ESP_HTTPD_DEF_CTRL_PORT` — 32768, confirmed in the IDF header rather than assumed. `startNetServer` runs immediately before it in this flow, and `fl::asio::http::Server::start()` (`src/fl/stl/asio/http/server.cpp.hpp:980`) takes the same default. The second server therefore tries to bind a control socket the first already owns.

A distinct `server_port` does not help: **the collision is on the control socket, not the listening socket** — which is why 8081-vs-80 looked like it should have been sufficient.

## 2. The second transfer onto any given board always failed

```
OTA peer autoresearch failed: C6 artifact write failed at byte 200448:
  {'error': 'Artifact write failed', 'success': False, 'received': 200448}
```

`finishOtaArtifact` replaces `/rp2350.bin` only once `.part` is complete and its SHA-256 verifies — correct when there is room for both copies. There is not:

| | bytes |
|---|---|
| fixture spiffs partition `0x130000` | 1,245,184 |
| RP image | 1,030,348 |
| headroom with the previous artifact present | 214,836 |
| **observed write failure** | **200,448** |

The guard checked `expected_size > LittleFS.totalBytes()` — one copy — so a two-copy shortfall surfaced as a bare "write failed" twenty minutes into a transfer.

This is what made the two runs look contradictory: run 1 hit a blank filesystem and transferred all 1,030,348 bytes with a matching SHA-256; run 2 inherited run 1's artifact and died 200 KB in. One cause, both runs, to within LittleFS block overhead. I would have written run 2 off as flaky without doing that subtraction.

The old artifact is now dropped at `begin`, and the guard checks real free space so any remaining shortfall fails immediately with `freeBytes`/`neededBytes` attached. The cost — a failed transfer leaves no artifact rather than the previous one — is the right trade for a fixture the harness re-stages every run, against the alternative of no run after the first being able to stage at all.

## 3. The third failure had no reason anywhere

With those two fixed, the C6 holds the artifact and its server is up, and serves nothing:

```
OTA peer autoresearch failed: C6 did not serve the RP2350W artifact:
  {'success': True, 'received': 1030348, 'servedRequests': 0}
```

Note what that line already proves: `received: 1030348` is the **full artifact transferred onto a non-blank filesystem**, and reaching this raise at all requires `finishOtaArtifact` to have matched the SHA-256, `startNetServer` to have come up, the RP to have joined the AP, and `applyOtaArtifact` to have been accepted. Only the HTTP GET never happened.

The RP does explain itself — `FL_WARN("[OTA] RP2350W artifact update failed: ...")` — but `pollOtaArtifactUpdate` runs from `loop()` *after* the harness deliberately closes the RPC link so the board can reboot into the new image. The explanation goes to a serial port with nobody on the other end. A fetch that failed and a fetch that never ran produce byte-identical evidence.

`rpOtaUpdateStatus` keeps `attempted` / `succeeded` / `lastError` in device state, and the host asks for it once the link is back, so the next run names the cause.

## Verification

Attached pair: RP2350W `2DCB876B587EA334` + ESP32-C6 `8C:BF:EA:CF:87:B4`. Each fix is confirmed by the run advancing past the failure it previously died on — server start went from `Artifact HTTP server start failed` to `success: True`, and a transfer onto a non-blank filesystem went from failing at byte 200,448 to `received: 1030348`. Device schema goes 75 → 76 methods with `rpOtaUpdateStatus` bound.

## What this does not do

**It does not make peer OTA pass.** `kOtaChunkBytes` stays at 512, and the preflight refuses that size, so the flow still cannot run end to end unedited.

I have evidence that 256 works — it transferred and SHA-verified twice here — but only because I passed `--timeout 2500`. Against the default budget 256 needs ~21 minutes, which is exactly why 512 was chosen when *both* values failed. The honest fix is the constant **plus** a budget the mode can meet, and reversing that decision deserves the measurements argued on the issue rather than a constant quietly flipped inside a bug fix. I will post those numbers to #3956 separately.

Found while working #3899's OTA criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTA status reporting for whether an update was attempted, succeeded, or failed, including error details.
  * Added remote access to peer OTA status after reconnection.
  * Added early detection of insufficient storage for OTA artifacts.
  * Improved peer-OTA failure messages with diagnostics from both devices.

* **Bug Fixes**
  * Increased storage available for peer OTA artifacts.
  * Prevented stale artifact download counts after publishing a new artifact.
  * OTA completion now requires confirmed application, not merely successful transfer.

* **Documentation**
  * Added lessons on execution diagnostics, troubleshooting, memory analysis, and intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->