### PR TITLE
test(gfx): R2's ordering constraint as arithmetic, and the response LUT that reaches nothing

### DIFF
--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -3,6 +3,7 @@
 #include "FastLED.h"
 #include "fl/channels/channel.h"
 #include "fl/channels/color_profile.h"
+#include "fl/gfx/pipeline.h"
 #include "test.h"
 
 using namespace fl;
@@ -109,6 +110,83 @@ FL_TEST_CASE("Profile binding validates and owns response tables") {
     FL_REQUIRE(options.emitterProfile() != nullptr);
     FL_CHECK_EQ(options.emitterProfile()->response_lut_size, fl::u16(3));
     FL_CHECK_EQ(options.emitterProfile()->response_lut_r[1], fl::u16(257));
+}
+
+FL_TEST_CASE("A response LUT is validated, owned, and applied by nothing") {
+    // FastLED#4156 R2 turns on P2 permitting a per-channel nonlinear
+    // code-to-light response: a shared brightness scalar preserves
+    // chromaticity only while what it scales is linear light, so a
+    // compensation stage and the flux stage cannot be in either order.
+    //
+    // The defect is not live, because the compensation does not exist.
+    // `response_lut_r/g/b` are checked for non-null and monotonicity on bind
+    // and copied into owned storage -- and outside `options.h` nothing in
+    // `src/` reads them. `processPixelQ16` goes decode, source matrix, gamut
+    // map, device solve, flux, with no response stage anywhere.
+    //
+    // When one is added, the ordering constraint is written down as
+    // arithmetic in `tests/fl/gfx/flux_scalar.cpp`: "A shared scalar is only
+    // chromaticity-preserving on linear quantities".
+    ChannelOptions options;
+    EmitterProfile profile = kFixtureProfile;
+    const fl::u16 curve[] = {0, 4096, 32768, 65535};
+    profile.response_lut_r = curve;
+    profile.response_lut_g = curve;
+    profile.response_lut_b = curve;
+    profile.response_lut_size = 4;
+    FL_REQUIRE(options.setColorProfile(profile, SourceProfile::linearSrgb()));
+
+    // Validated and owned -- that half works.
+    const EmitterProfile* stored = options.emitterProfile();
+    FL_REQUIRE(stored != nullptr);
+    FL_CHECK_EQ(stored->response_lut_size, fl::u16(4));
+    FL_CHECK_EQ(stored->response_lut_r[1], fl::u16(4096));
+
+    // A non-monotonic curve is refused, which is the check that exists.
+    EmitterProfile bad = kFixtureProfile;
+    const fl::u16 backwards[] = {0, 32768, 4096, 65535};
+    bad.response_lut_r = backwards;
+    bad.response_lut_g = backwards;
+    bad.response_lut_b = backwards;
+    bad.response_lut_size = 4;
+    ChannelOptions rejecting;
+    FL_CHECK_FALSE(rejecting.setColorProfile(bad, SourceProfile::linearSrgb()));
+
+    // The inert half: a profile carrying a response curve builds the same
+    // streaming pipeline as one without, because no stage consults it.
+    EmitterProfile plain = kFixtureProfile;
+    ChannelOptions plain_options;
+    FL_REQUIRE(plain_options.setColorProfile(plain, SourceProfile::linearSrgb()));
+
+    StreamingPipelineQ16 with_curve;
+    StreamingPipelineQ16 without_curve;
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::linearSrgb(), *stored,
+                                         GamutPolicy::ChromaCompress,
+                                         &with_curve));
+    FL_REQUIRE(buildStreamingPipelineQ16(SourceProfile::linearSrgb(),
+                                         *plain_options.emitterProfile(),
+                                         GamutPolicy::ChromaCompress,
+                                         &without_curve));
+    setPipelineFluxQ16(&with_curve, FluxScalar::fromBrightness(64));
+    setPipelineFluxQ16(&without_curve, FluxScalar::fromBrightness(64));
+
+    // Same drives for the same source pixel, curve or no curve. When the
+    // curve starts being applied this stops holding, and that is the signal
+    // to go and read the ordering case.
+    int compared = 0;
+    const fl::u8 kSamples[][3] = {{200, 40, 10}, {10, 180, 90}, {128, 128, 128}};
+    for (const auto& pixel : kSamples) {
+        i32 with_drives[3];
+        i32 without_drives[3];
+        processPixelQ16(with_curve, pixel[0], pixel[1], pixel[2], with_drives);
+        processPixelQ16(without_curve, pixel[0], pixel[1], pixel[2],
+                        without_drives);
+        for (int i = 0; i < 3; ++i) {
+            FL_CHECK_EQ(with_drives[i], without_drives[i]);
+            ++compared;
+        }
+    }
+    FL_CHECK_EQ(compared, 9);
 }
 
 FL_TEST_CASE("A target white is accepted, stored, and reaches nothing") {

--- a/tests/fl/gfx/flux_scalar.cpp
+++ b/tests/fl/gfx/flux_scalar.cpp
@@ -114,6 +114,13 @@ i32 emittedLightQ16(int channel, i32 drive) {
     return static_cast<i32>((squared + 32768) >> 16);
 }
 
+/// A plain Q16 multiply, so the nonlinear control below can be built out of
+/// the same "scale, then scale again" shape the linear check uses.
+i32 scaleQ16(i32 value, i32 scalar_q16) {
+    const i64 product = static_cast<i64>(value) * static_cast<i64>(scalar_q16);
+    return static_cast<i32>((product + 32768) >> 16);
+}
+
 /// The drive that emits a given light, i.e. `F^-1`.
 i32 driveForLightQ16(int channel, i32 light) {
     if (channel == 0) {
@@ -201,6 +208,12 @@ FL_TEST_CASE("The shipped order scales linear drives, which is the safe one") {
     i32 once[3] = {60000, 40000, 12345};
     applyFluxScalar(FluxScalar::fromRawQ16(16384), span<i32>(once, 3));
 
+    // The scaling has to have happened, or the agreement below is the
+    // agreement of two untouched values: a no-op `applyFluxScalar` would
+    // satisfy the +/-1 bound perfectly.
+    FL_CHECK_EQ(once[0], 15000);
+    FL_CHECK_EQ(twice[0], 15000);
+
     for (int i = 0; i < 3; ++i) {
         // Within one raw unit, which is the two roundings rather than a
         // curve. A square-law stage would put these thousands apart.
@@ -209,11 +222,20 @@ FL_TEST_CASE("The shipped order scales linear drives, which is the safe one") {
         FL_CHECK_GT(difference, -2);
     }
 
-    // And the same operands through a square law, so the check above is
-    // shown to be capable of separating the two.
-    const i32 squared_twice = emittedLightQ16(1, emittedLightQ16(1, 60000));
-    const i32 squared_once = emittedLightQ16(1, 60000);
-    FL_CHECK_GT(squared_once - squared_twice, 1000);
+    // The same comparison under a nonlinear stage, so the bound above is
+    // shown to discriminate rather than to be satisfiable by anything. Same
+    // structure -- half applied twice against a quarter applied once -- with
+    // the square law standing in for the linear scale.
+    const i32 half = 32768;
+    const i32 quarter = 16384;
+    i32 nonlinear_twice = 60000;
+    nonlinear_twice = emittedLightQ16(1, scaleQ16(nonlinear_twice, half));
+    nonlinear_twice = emittedLightQ16(1, scaleQ16(nonlinear_twice, half));
+    const i32 nonlinear_once = emittedLightQ16(1, scaleQ16(60000, quarter));
+    // Not "different by a bit": the two orders separate by thousands of raw
+    // units, which is what the +/-1 bound above would have caught.
+    const i32 gap = nonlinear_once - nonlinear_twice;
+    FL_CHECK_GT(gap > 0 ? gap : -gap, 1000);
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/gfx/flux_scalar.cpp
+++ b/tests/fl/gfx/flux_scalar.cpp
@@ -99,4 +99,121 @@ FL_TEST_CASE("Signed wide intermediates scale symmetrically") {
     FL_CHECK_EQ(drives[1], -20000);
 }
 
+namespace {
+
+/// A synthetic emitter response: light emitted for a given drive.
+///
+/// R2's counterexample exactly -- `F_R(d) = d` and `F_G(d) = d^2`, in s16.16.
+/// Two emitters whose code-to-light curves differ is the whole point; a
+/// device where they matched would show nothing.
+i32 emittedLightQ16(int channel, i32 drive) {
+    if (channel == 0) {
+        return drive;
+    }
+    const i64 squared = static_cast<i64>(drive) * static_cast<i64>(drive);
+    return static_cast<i32>((squared + 32768) >> 16);
+}
+
+/// The drive that emits a given light, i.e. `F^-1`.
+i32 driveForLightQ16(int channel, i32 light) {
+    if (channel == 0) {
+        return light;
+    }
+    // Integer square root in Q16: sqrt(light) with the scale carried through.
+    i64 low = 0;
+    i64 high = 65536;
+    while (low < high) {
+        const i64 mid = (low + high + 1) / 2;
+        if (((mid * mid + 32768) >> 16) <= light) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return static_cast<i32>(low);
+}
+
+}  // namespace
+
+FL_TEST_CASE("A shared scalar is only chromaticity-preserving on linear quantities") {
+    // FastLED#4156 R2. P2 permits a per-channel nonlinear code-to-light
+    // response; a shared brightness scalar preserves chromaticity only while
+    // the quantities it scales are linear light. This is that argument as
+    // arithmetic rather than prose, so whoever implements response
+    // compensation has the ordering constraint in a form that fails.
+    //
+    // Two emitters, F_R(d) = d and F_G(d) = d^2. An equal-light target at
+    // full output uses drives (1, 1).
+    const i32 kOne = 65536;
+    const FluxScalar quarter = FluxScalar::fromRawQ16(kOne / 4);
+
+    // Wrong order: scale the compensated drives.
+    i32 wrong[2] = {kOne, kOne};
+    applyFluxScalar(quarter, span<i32>(wrong, 2));
+    const i32 wrong_light[2] = {emittedLightQ16(0, wrong[0]),
+                                emittedLightQ16(1, wrong[1])};
+
+    // Right order: scale the light, then invert the response.
+    i32 light[2] = {emittedLightQ16(0, kOne), emittedLightQ16(1, kOne)};
+    applyFluxScalar(quarter, span<i32>(light, 2));
+    const i32 right_drives[2] = {driveForLightQ16(0, light[0]),
+                                 driveForLightQ16(1, light[1])};
+    const i32 right_light[2] = {emittedLightQ16(0, right_drives[0]),
+                                emittedLightQ16(1, right_drives[1])};
+
+    // The numbers R2 gives. Scaling drives lands on light (1/4, 1/16) --
+    // a four-to-one ratio where the target was one to one.
+    FL_CHECK_EQ(wrong[0], kOne / 4);
+    FL_CHECK_EQ(wrong[1], kOne / 4);
+    FL_CHECK_EQ(wrong_light[0], kOne / 4);
+    FL_CHECK_EQ(wrong_light[1], kOne / 16);
+
+    // Scaling light lands on drives (1/4, 1/2) and light (1/4, 1/4).
+    FL_CHECK_EQ(right_drives[0], kOne / 4);
+    FL_CHECK_EQ(right_drives[1], kOne / 2);
+    FL_CHECK_EQ(right_light[0], kOne / 4);
+    FL_CHECK_EQ(right_light[1], kOne / 4);
+
+    // Stated as the property rather than as four constants: the ratio the
+    // target asked for survives one order and not the other.
+    FL_CHECK_EQ(right_light[0], right_light[1]);
+    FL_CHECK_NE(wrong_light[0], wrong_light[1]);
+}
+
+FL_TEST_CASE("The shipped order scales linear drives, which is the safe one") {
+    // The other half, and the reason R2 is not a live defect. What
+    // `processPixelQ16` hands to `applyFluxScalar` is the device solve's
+    // output, and the emitter matrix it solves against is linear -- so the
+    // quantity being scaled is emitter light and the counterexample above
+    // cannot arise.
+    //
+    // A per-channel response would change that, and `EmitterProfile` already
+    // carries `response_lut_r/g/b`. Those are validated on bind and applied
+    // by nothing; `tests/fl/channels/color_profile.cpp` pins that. When they
+    // are applied, the case above says where.
+    //
+    // Linearity, checked directly: scaling by a half twice is scaling by a
+    // quarter once, which is only true of a linear quantity.
+    i32 twice[3] = {60000, 40000, 12345};
+    applyFluxScalar(FluxScalar::fromRawQ16(32768), span<i32>(twice, 3));
+    applyFluxScalar(FluxScalar::fromRawQ16(32768), span<i32>(twice, 3));
+
+    i32 once[3] = {60000, 40000, 12345};
+    applyFluxScalar(FluxScalar::fromRawQ16(16384), span<i32>(once, 3));
+
+    for (int i = 0; i < 3; ++i) {
+        // Within one raw unit, which is the two roundings rather than a
+        // curve. A square-law stage would put these thousands apart.
+        const i32 difference = twice[i] - once[i];
+        FL_CHECK_LT(difference, 2);
+        FL_CHECK_GT(difference, -2);
+    }
+
+    // And the same operands through a square law, so the check above is
+    // shown to be capable of separating the two.
+    const i32 squared_twice = emittedLightQ16(1, emittedLightQ16(1, 60000));
+    const i32 squared_once = emittedLightQ16(1, 60000);
+    FL_CHECK_GT(squared_once - squared_twice, 1000);
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
#4156 **R2**, the last HIGH finding with thin coverage. Stacked on #4317 → #4316 — merge in
that order.

## R2's defect is not live, and the reason is specific

R2 says a shared brightness scalar preserves chromaticity only while what it scales is
linear light, and gives a counterexample: `F_R(d) = d`, `F_G(d) = d²`, equal-light target at
drives (1, 1), scaled by a quarter.

**The compensation does not exist.** `EmitterProfile` carries `response_lut_r/g/b`; they are
checked for non-null and monotonicity on bind, copied into owned storage, and read by
**nothing** outside `options.h`. `processPixelQ16` runs decode → source matrix → gamut map →
device solve → flux, with no response stage anywhere. So what `applyFluxScalar` receives is
the linear solve output — which is exactly what R2's resolution asks for.

That is the second "validated and inert" input this review has turned up, after
`setTargetWhite` in #4317.

## Two cases, because "not live" is a statement about today

**The counterexample, as arithmetic.** Scaling the compensated drives lands on light
(1/4, **1/16**) where the target asked for equal; scaling the light and then inverting the
response lands on drives (1/4, 1/2) and light (1/4, 1/4). Both of R2's number pairs checked,
plus the property they illustrate — one order keeps the ratio and the other does not.
Whoever implements response compensation gets the constraint in a form that fails.

**The inert half.** A profile carrying a response curve builds the same pipeline and
produces the same drives for the same pixels as one without. When the curve starts being
applied that stops holding, which is the signal to go and read the ordering case.

## Mutation-checked, including two that proved nothing

| mutation | result |
|---|---|
| a bound curve perturbs the solve matrix | inert case fails |
| `applyFluxScalar` made nonlinear | ordering case fails, alongside three existing ones |
| ~~a square law inside `processPixelQ16`~~ | **passed** — it changed both pipelines equally, and the case compares them to each other |
| ~~a build-time change to `out->flux`~~ | **passed** — erased by the `setPipelineFluxQ16` the case calls afterwards |

The two failures are worth recording: both looked like clean passes and neither said
anything about the claim.

Test-only. 304/304 unit + 84/84 examples, `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for color pipeline response curves and lookup-table validation, including ownership checks and rejection of non-monotonic curves.
  * Added coverage for brightness and power scaling, including zero and full brightness, channel-ratio preservation, composition behavior, limiter bounds, and signed values.
  * Added checks for linear and non-linear emitter responses and the ordering of brightness scaling operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->