### PR TITLE
docs(fled): narrow the forward-compat claim FastLED's own reader broke (#4156 R1)

### DIFF
--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -236,7 +236,12 @@ paragraph was asserting could not happen.
 The reader now distinguishes absent magic from recognized-but-unsupported
 FLED: no magic still falls back to raw RGB, but once `FLED` is matched, every
 invalidity — unsupported format, future version, reserved bytes set, truncated
-header, malformed envelope, non-seekable input — closes the stream and fails.
+header, malformed envelope — closes the stream and fails. Non-seekable input
+is not itself an invalidity: a stream whose first bytes are not `FLED` still
+plays as raw RGB, and `probeStreamingMagic()` buffers a partial prefix until
+there are enough bytes to decide. What it cannot do is admit a *recognized*
+FLED container, because the header cannot be re-read, so that case is
+refused rather than replayed as pixels.
 So the gate is true going forward and **false for every FastLED release up to
 and including 3.10.5**; the fix is newer than that tag. Adding a format enum
 cannot repair binaries already in the field.

--- a/src/fl/fled/FLED_FORMAT.md
+++ b/src/fl/fled/FLED_FORMAT.md
@@ -220,9 +220,31 @@ tuple, so old readers degrade to reduced fidelity, never to wrong data. That is
 why adding `video.color` is not a version bump.
 
 Payloads whose color semantics are **mandatory** rather than advisory gate on a
-new `pixel_format` value instead, and readers that predate one already reject
-unknown pixel formats. Mandatory-ness is a property of the payload format, not
-a version flag.
+new `pixel_format` value instead. Mandatory-ness is a property of the payload
+format, not a version flag.
+
+That gate only holds for readers that actually validate the format field, and
+it is worth being exact about which ones do, because FastLED's own reader is
+the counterexample (FastLED #4156 R1). `PixelStream::begin()` recognizes FLED
+v1 with `rgb8`; on **any** other format or version it used to rewind to byte
+zero and succeed as a headerless `.rgb` stream. A seekable `rgb16_linear` file
+with enough bytes was therefore played as raw data, and its first `readPixel()`
+returned the ASCII magic `FLE` — RGB `(70, 76, 69)`, a near-neutral dark grey — rather
+than refusing the file. Header bytes reaching the LEDs is the failure this
+paragraph was asserting could not happen.
+
+The reader now distinguishes absent magic from recognized-but-unsupported
+FLED: no magic still falls back to raw RGB, but once `FLED` is matched, every
+invalidity — unsupported format, future version, reserved bytes set, truncated
+header, malformed envelope, non-seekable input — closes the stream and fails.
+So the gate is true going forward and **false for every FastLED release up to
+and including 3.10.5**; the fix is newer than that tag. Adding a format enum
+cannot repair binaries already in the field.
+
+For producers that is a deployment constraint, not a format one: shipping
+`rgb16_linear` to an audience that may be running a released FastLED means the
+old players show grey noise instead of rejecting the file. Gate on the player,
+not on the container.
 
 "Mandatory" is about *unresolvable* declarations, not about *absent* ones, and
 the two are easy to run together. `rgb16_linear` carries a default tuple like


### PR DESCRIPTION
Closes the documentation half of **#4156 R1**. The code half already landed; this fixes the claim that justified it being unnecessary.

## The claim

`FLED_FORMAT.md` justified adding `rgb16_linear` without a container version bump:

> Payloads whose color semantics are **mandatory** rather than advisory gate on a new `pixel_format` value instead, and **readers that predate one already reject unknown pixel formats.**

That gate only holds for readers that validate the format field. **FastLED's own reader did not.** `PixelStream::begin()` recognized FLED v1 + `rgb8`; on any other format or version it rewound to byte zero and succeeded as a headerless `.rgb` stream. The pre-#4160 comment stated it as intended behavior:

```
// Try to detect a FLED v1 container. Anything that fails the header
// check (wrong magic, wrong version, unsupported pixel_format,
// truncated) falls back to legacy headerless RGB — zero behavior
// change for existing files.
```

So a seekable `rgb16_linear` file with enough bytes played as raw data, and the first `readPixel()` returned the ASCII magic `FLE` — RGB `(70, 76, 69)`. Header bytes reaching the LEDs is exactly what the paragraph asserted could not happen.

## What is already fixed, and what was not

The reader now separates absent magic from recognized-but-unsupported FLED. No magic still falls back to raw RGB; once `FLED` matches, every invalidity closes the stream and fails — unsupported format, future version, reserved bytes set, truncated header, malformed envelope, non-seekable input. All six of R1's required fixture classes are in `tests/fl/fx/video.cpp`, including the two positive controls (`raw RGB remains playable`, `valid RGB8 FLED skips the header`) without which a blanket "reject everything" would pass the rejection cases.

The **claim** was the part left standing, still stated unconditionally.

## The boundary, checked rather than assumed

```
$ git tag --contains b436035901      # the fix
(empty)
$ git merge-base --is-ancestor 3.10.5 b436035901 && echo "3.10.5 predates the fix"
3.10.5 predates the fix
```

True going forward; **false for every release up to and including 3.10.5**. As R1 puts it, historical binaries cannot be repaired by adding a format enum — so the section now says this is a producer deployment constraint. Shipping `rgb16_linear` to an audience that may be running a released FastLED gets grey noise from the old players, not a refusal. Gate on the player, not on the container.

Docs only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified FLED v1 forward-compatibility behavior for unsupported pixel formats and versions.
  - Documented that data without FLED magic continues to fall back to raw RGB playback, including on non-seekable streams.
  - Clarified that recognized but unsupported FLED containers are rejected when they cannot be safely reread.
  - Added a compatibility note that `rgb16_linear` files may display grey noise in older players.
  - Noted that the corrected behavior is newer than release 3.10.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->