### PR TITLE
fix(chipsets): stop the HD encoders halving the strip (#4321)

### DIFF
--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -246,9 +246,9 @@ class PixelIterator {
         if (hd_gamma) {
             // HD gamma mode: per-LED brightness
             auto pixel_range = makeScaledPixelRangeRGB(this);
-            auto brightness_range = makeScaledBrightnessRange(this);
+            auto brightness = makeScaledBrightness(this);
             encodeAPA102_HD(pixel_range.first, pixel_range.second,
-                                      brightness_range.first, back_ins);
+                                      brightness, back_ins);
             return;
         }
         #endif
@@ -279,9 +279,9 @@ class PixelIterator {
         if (hd_gamma) {
             // HD gamma mode: per-LED brightness
             auto pixel_range = makeScaledPixelRangeRGB(this);
-            auto brightness_range = makeScaledBrightnessRange(this);
+            auto brightness = makeScaledBrightness(this);
             encodeSK9822_HD(pixel_range.first, pixel_range.second,
-                                      brightness_range.first, back_ins);
+                                      brightness, back_ins);
             return;
         }
         #endif
@@ -374,9 +374,9 @@ class PixelIterator {
         #if FASTLED_HD_COLOR_MIXING
         // HD mode: per-LED brightness
         auto pixel_range = makeScaledPixelRangeRGB(this);
-        auto brightness_range = makeScaledBrightnessRange(this);
+        auto brightness = makeScaledBrightness(this);
         encodeHD108_HD(pixel_range.first, pixel_range.second,
-                                 brightness_range.first, back_ins);
+                                 brightness, back_ins);
         #else
         // Standard mode: global brightness (255 = full)
         auto pixel_range = makeScaledPixelRangeRGB(this);
@@ -474,12 +474,12 @@ inline void ScaledPixelIteratorRGBWW::advance() FL_NO_EXCEPT {
 #if FASTLED_HD_COLOR_MIXING
 // ScaledPixelIteratorBrightness implementation
 //
-// Deliberately does NOT call stepDithering()/advanceData(): the RGB adapter
-// alongside owns the shared cursor. Both advancing it consumed two source
-// pixels per emitted LED and halved the strip (#4321).
-inline void ScaledPixelIteratorBrightness::advance() FL_NO_EXCEPT {
+// Named load() rather than advance() because it advances nothing. It must not
+// call stepDithering()/advanceData(): the RGB adapter alongside owns the
+// shared cursor, and both moving it consumed two source pixels per emitted
+// LED and halved the strip (#4321).
+inline void ScaledPixelIteratorBrightness::load() FL_NO_EXCEPT {
     if (!mPixels) {
-        mHasValue = false;
         return;
     }
 
@@ -488,7 +488,6 @@ inline void ScaledPixelIteratorBrightness::advance() FL_NO_EXCEPT {
     u8 r, g, b, brightness;
     mPixels->loadRGBScaleAndBrightness(&r, &g, &b, &brightness);
     mCurrent = brightness;
-    mHasValue = true;
 }
 #endif  // FASTLED_HD_COLOR_MIXING
 

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -471,33 +471,26 @@ inline void ScaledPixelIteratorRGBWW::advance() FL_NO_EXCEPT {
     }
 }
 
+#if FASTLED_HD_COLOR_MIXING
 // ScaledPixelIteratorBrightness implementation
+//
+// Deliberately does NOT call stepDithering()/advanceData(): the RGB adapter
+// alongside owns the shared cursor. Both advancing it consumed two source
+// pixels per emitted LED and halved the strip (#4321).
 inline void ScaledPixelIteratorBrightness::advance() FL_NO_EXCEPT {
     if (!mPixels) {
         mHasValue = false;
         return;
     }
 
-    if (mPixels->has(1)) {
-        #if FASTLED_HD_COLOR_MIXING
-        u8 r, g, b, brightness;
-        mPixels->loadRGBScaleAndBrightness(&r, &g, &b, &brightness);
-        mCurrent = brightness;
-        #else
-        // Fallback: compute brightness from max RGB component
-        u8 r, g, b;
-        mPixels->loadAndScaleRGB(&r, &g, &b);
-        // Use sequential comparisons to avoid nested fl::max (helps AVR register allocation)
-        u8 max_rg = (r > g) ? r : g;
-        mCurrent = (max_rg > b) ? max_rg : b;
-        #endif
-        mPixels->stepDithering();
-        mPixels->advanceData();
-        mHasValue = true;
-    } else {
-        mHasValue = false;
-    }
+    // ColorAdjustment::brightness -- a per-strip constant, so the same value
+    // is correct at every position and no cursor movement is needed.
+    u8 r, g, b, brightness;
+    mPixels->loadRGBScaleAndBrightness(&r, &g, &b, &brightness);
+    mCurrent = brightness;
+    mHasValue = true;
 }
+#endif  // FASTLED_HD_COLOR_MIXING
 
 // ScaledPixelIteratorRGB16 implementation
 inline void ScaledPixelIteratorRGB16::advance() FL_NO_EXCEPT {

--- a/src/fl/chipsets/encoders/pixel_iterator_adapters.h
+++ b/src/fl/chipsets/encoders/pixel_iterator_adapters.h
@@ -260,13 +260,9 @@ public:
     /// @brief Construct from PixelIterator
     /// @param pixels Pointer to PixelIterator (must outlive this adapter)
     explicit ScaledPixelIteratorBrightness(PixelIterator* pixels) FL_NO_EXCEPT
-        : mPixels(pixels), mCurrent(0), mHasValue(false) {
-        advance();  // Preload first brightness
+        : mPixels(pixels), mCurrent(0) {
+        load();
     }
-
-    /// @brief Sentinel constructor (end iterator)
-    ScaledPixelIteratorBrightness() FL_NO_EXCEPT
-        : mPixels(nullptr), mCurrent(0), mHasValue(false) {}
 
     /// @brief Dereference operator
     u8 operator*() const FL_NO_EXCEPT {
@@ -275,40 +271,28 @@ public:
 
     /// @brief Pre-increment operator
     ScaledPixelIteratorBrightness& operator++() FL_NO_EXCEPT {
-        advance();
+        load();
         return *this;
     }
 
     /// @brief Post-increment operator
     ScaledPixelIteratorBrightness operator++(int) FL_NO_EXCEPT {
         ScaledPixelIteratorBrightness tmp = *this;
-        advance();
+        load();
         return tmp;
     }
 
-    /// @brief Equality comparison
-    bool operator==(const ScaledPixelIteratorBrightness& other) const FL_NO_EXCEPT {
-        if (!mHasValue && !other.mHasValue) {
-            return true;
-        }
-        if (mHasValue != other.mHasValue) {
-            return false;
-        }
-        return mPixels == other.mPixels;
-    }
-
-    /// @brief Inequality comparison
-    bool operator!=(const ScaledPixelIteratorBrightness& other) const FL_NO_EXCEPT {
-        return !(*this == other);
-    }
+    // No sentinel constructor and no comparisons, on purpose. This iterator
+    // advances nothing, so it can never reach an end -- any loop written
+    // against a sentinel here would spin forever. The encoders stop on the
+    // RGB range they walk alongside, which is the only real termination.
 
 private:
-    /// @brief Advance to next brightness value (or mark as end)
-    void advance() FL_NO_EXCEPT;
+    /// @brief Re-read the strip's brightness. Moves no cursor.
+    void load() FL_NO_EXCEPT;
 
     PixelIterator* mPixels;  ///< Underlying PixelIterator
     u8 mCurrent;             ///< Current brightness value (cached)
-    bool mHasValue;          ///< true if current value is valid
 };
 #endif  // FASTLED_HD_COLOR_MIXING
 
@@ -432,15 +416,25 @@ makeScaledPixelRangeRGBWW(PixelIterator* pixels) FL_NO_EXCEPT {
 }
 
 #if FASTLED_HD_COLOR_MIXING
-/// @brief Create brightness input iterator range from PixelIterator
+/// @brief Create the brightness input iterator for the HD encoders
 /// @param pixels PixelIterator to wrap
-/// @return Pair of begin/end iterators
-inline pair<detail::ScaledPixelIteratorBrightness, detail::ScaledPixelIteratorBrightness>
-makeScaledBrightnessRange(PixelIterator* pixels) FL_NO_EXCEPT {
-    return make_pair(
-        detail::ScaledPixelIteratorBrightness(pixels),
-        detail::ScaledPixelIteratorBrightness()  // End sentinel
-    );
+/// @return A single iterator, deliberately not a range
+///
+/// This used to return a begin/end pair, and it should not have. The iterator
+/// yields a per-strip constant and must not move the shared `PixelIterator`
+/// cursor -- the `ScaledPixelIteratorRGB` it is paired with owns that (#4321).
+/// An iterator that advances nothing can never reach an end sentinel, so a
+/// standalone `for (it = r.first; it != r.second; ++it)` over the old pair
+/// could not terminate whatever the sentinel checked. Making `mHasValue`
+/// track `has(1)` would not have fixed it either: with nothing advancing the
+/// cursor, `has(1)` never becomes false on its own.
+///
+/// So there is no end to hand out. The HD encoders take this iterator
+/// alongside the RGB range and stop on the RGB range, which is the only
+/// termination that was ever real. All callers used `.first`.
+inline detail::ScaledPixelIteratorBrightness
+makeScaledBrightness(PixelIterator* pixels) FL_NO_EXCEPT {
+    return detail::ScaledPixelIteratorBrightness(pixels);
 }
 #endif  // FASTLED_HD_COLOR_MIXING
 

--- a/src/fl/chipsets/encoders/pixel_iterator_adapters.h
+++ b/src/fl/chipsets/encoders/pixel_iterator_adapters.h
@@ -17,6 +17,7 @@
 #include "fl/stl/pair.h"
 #include "fl/stl/iterator.h"
 #include "fl/stl/noexcept.h"
+#include "crgb.h"  // FASTLED_HD_COLOR_MIXING
 
 namespace fl {
 
@@ -234,9 +235,19 @@ private:
     bool mHasValue;
 };
 
+#if FASTLED_HD_COLOR_MIXING
 /// @brief Input iterator adapter for PixelIterator yielding brightness values
 ///
-/// Extracts per-LED brightness values from PixelIterator for HD encoders.
+/// Yields the strip's brightness for the HD encoders, which pair it with a
+/// `ScaledPixelIteratorRGB` over the *same* `PixelIterator`.
+///
+/// It must never move that shared cursor. It used to: `advance()` ended with
+/// `stepDithering()` + `advanceData()` exactly as the RGB adapter's does, so
+/// with both stepped in lockstep by the encoder two source pixels were eaten
+/// per emitted LED and the strip came out half length, showing every other
+/// pixel (#4321). Under `FASTLED_HD_COLOR_MIXING` the value is a per-strip
+/// constant -- `ColorAdjustment::brightness` -- so there is nothing to walk
+/// for in the first place.
 class ScaledPixelIteratorBrightness {
 public:
     // Iterator traits
@@ -299,6 +310,7 @@ private:
     u8 mCurrent;             ///< Current brightness value (cached)
     bool mHasValue;          ///< true if current value is valid
 };
+#endif  // FASTLED_HD_COLOR_MIXING
 
 /// @brief Input iterator adapter for PixelIterator yielding 16-bit RGB pixel data
 ///
@@ -419,6 +431,7 @@ makeScaledPixelRangeRGBWW(PixelIterator* pixels) FL_NO_EXCEPT {
     );
 }
 
+#if FASTLED_HD_COLOR_MIXING
 /// @brief Create brightness input iterator range from PixelIterator
 /// @param pixels PixelIterator to wrap
 /// @return Pair of begin/end iterators
@@ -429,6 +442,7 @@ makeScaledBrightnessRange(PixelIterator* pixels) FL_NO_EXCEPT {
         detail::ScaledPixelIteratorBrightness()  // End sentinel
     );
 }
+#endif  // FASTLED_HD_COLOR_MIXING
 
 /// @brief Create 16-bit RGB input iterator range from PixelIterator
 /// @param pixels PixelIterator to wrap

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -580,6 +580,13 @@ FL_TEST_CASE("[#4321] the length check is not vacuous -- an odd count cannot be 
     }
 }
 
+#if FASTLED_HD_COLOR_MIXING
+// makeScaledBrightnessRange() only exists under HD colour mixing -- every
+// caller of it is inside that guard, so the adapter is compiled only there.
+// encoders.cpp includes this header unguarded, so this case has to carry the
+// same condition or a FASTLED_HD_COLOR_MIXING=0 test build stops compiling.
+// The cases above need no guard: their HD branches are selected at compile
+// time and the non-HD paths they fall back to still emit one LED per pixel.
 FL_TEST_CASE("[#4321] the brightness adapter does not move the shared cursor") {
     // Directly: draining the RGB adapter alone and with a brightness adapter
     // alive alongside must yield the same bytes. This is the property the
@@ -618,5 +625,6 @@ FL_TEST_CASE("[#4321] the brightness adapter does not move the shared cursor") {
         FL_CHECK_EQ((int)paired[i], (int)alone[i]);
     }
 }
+#endif  // FASTLED_HD_COLOR_MIXING
 
 } // namespace test_hd108

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -25,6 +25,8 @@
 #include "fl/stl/int.h"
 #include "fl/stl/allocator.h"
 #include "fl/stl/vector.h"
+#include "fl/gfx/pixel_iterator_any.h"
+#include "pixel_controller.h"
 
 namespace test_hd108 {
 
@@ -489,6 +491,132 @@ FL_TEST_CASE("hd108GammaCorrect() - gamma 2.8 correction") {
 
     // 64 should be much less than 128/2
     FL_CHECK_LT(v64, v128 / 2);
+}
+
+
+//-----------------------------------------------------------------------------
+// #4321: the HD paths must consume every source pixel
+//
+// writeHD108/writeAPA102(hd)/writeSK9822(hd) each build a ScaledPixelIteratorRGB
+// and a ScaledPixelIteratorBrightness over the SAME PixelIterator. Both used to
+// end advance() with stepDithering()+advanceData(), and the encoders step them
+// in lockstep, so two source pixels were eaten per emitted LED: a four-pixel
+// strip came out as two LEDs showing pixels 0 and 2.
+//
+// These go through PixelIterator on purpose. The existing cases in this file
+// call the encoders directly with fl::vector iterators, where there is no
+// shared cursor to double-advance, which is why they all passed throughout.
+//-----------------------------------------------------------------------------
+
+FL_TEST_CASE("[#4321] writeHD108 emits one LED per source pixel") {
+    fl::CRGB leds[4] = {fl::CRGB(10, 0, 0), fl::CRGB(20, 0, 0),
+                        fl::CRGB(30, 0, 0), fl::CRGB(40, 0, 0)};
+    PixelController<RGB> source(leds, 4, ColorAdjustment::noAdjustment(),
+                                DISABLE_DITHER);
+    fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+    fl::vector<fl::u8> out;
+    adapter.get().writeHD108(&out);
+
+    // 8 start + 8 per LED + (N/2 + 4) end.  N=4 -> 8 + 32 + 6.
+    FL_CHECK_EQ((int)out.size(), 46);
+
+    // Each LED carries its own pixel, in order -- not every other one. The
+    // halving bug left LED 1 showing pixel 2, so checking the red channel of
+    // every LED is what separates "all four present" from "two, doubled".
+    // Guarded rather than REQUIRE'd so a short buffer reports every case in
+    // this file instead of aborting the run at the first one.
+    const fl::u8 expected[4] = {10, 20, 30, 40};
+    for (int led = 0; led < 4 && out.size() >= 46u; ++led) {
+        const fl::size at = 8 + (fl::size)led * 8 + 2;  // past the 2 header bytes
+        const int r16 = (out[at] << 8) | out[at + 1];
+        FL_CHECK_EQ(r16, (int)fl::Gamma28LUT16::read(expected[led]));
+    }
+}
+
+FL_TEST_CASE("[#4321] writeAPA102 and writeSK9822 emit one LED per source pixel in HD mode") {
+    // 4 start bytes + 4 per LED + ((N/32)+1)*4 end.  N=4 -> 4 + 16 + 4.
+    FL_SUBCASE("APA102") {
+        fl::CRGB leds[4] = {fl::CRGB(10, 0, 0), fl::CRGB(20, 0, 0),
+                            fl::CRGB(30, 0, 0), fl::CRGB(40, 0, 0)};
+        PixelController<RGB> source(leds, 4, ColorAdjustment::noAdjustment(),
+                                    DISABLE_DITHER);
+        fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+        fl::vector<fl::u8> out;
+        adapter.get().writeAPA102(&out, true);
+        FL_CHECK_EQ((int)out.size(), 24);
+    }
+
+    FL_SUBCASE("SK9822") {
+        fl::CRGB leds[4] = {fl::CRGB(10, 0, 0), fl::CRGB(20, 0, 0),
+                            fl::CRGB(30, 0, 0), fl::CRGB(40, 0, 0)};
+        PixelController<RGB> source(leds, 4, ColorAdjustment::noAdjustment(),
+                                    DISABLE_DITHER);
+        fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+        fl::vector<fl::u8> out;
+        adapter.get().writeSK9822(&out, true);
+        FL_CHECK_EQ((int)out.size(), 24);
+    }
+}
+
+FL_TEST_CASE("[#4321] the length check is not vacuous -- an odd count cannot be halved cleanly") {
+    // A five-pixel strip is the guard: halving gives 3 LEDs (ceil), so a
+    // length assertion alone could be satisfied by an off-by-one fix that
+    // still dropped pixels. Checking the last LED carries the last pixel is
+    // what pins "every source pixel reached the wire".
+    fl::CRGB leds[5] = {fl::CRGB(11, 0, 0), fl::CRGB(22, 0, 0), fl::CRGB(33, 0, 0),
+                        fl::CRGB(44, 0, 0), fl::CRGB(55, 0, 0)};
+    PixelController<RGB> source(leds, 5, ColorAdjustment::noAdjustment(),
+                                DISABLE_DITHER);
+    fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+    fl::vector<fl::u8> out;
+    adapter.get().writeHD108(&out);
+
+    // 8 + 5*8 + (5/2 + 4) = 8 + 40 + 6 = 54
+    FL_CHECK_EQ((int)out.size(), 54);
+    const fl::size last = 8 + 4 * 8 + 2;
+    if (last + 1 < out.size()) {
+        const int r16 = (out[last] << 8) | out[last + 1];
+        FL_CHECK_EQ(r16, (int)fl::Gamma28LUT16::read(55));
+    }
+}
+
+FL_TEST_CASE("[#4321] the brightness adapter does not move the shared cursor") {
+    // Directly: draining the RGB adapter alone and with a brightness adapter
+    // alive alongside must yield the same bytes. This is the property the
+    // encoders rely on, stated without going through one.
+    fl::CRGB leds[4] = {fl::CRGB(10, 0, 0), fl::CRGB(20, 0, 0),
+                        fl::CRGB(30, 0, 0), fl::CRGB(40, 0, 0)};
+
+    fl::vector<fl::u8> alone;
+    {
+        PixelController<RGB> source(leds, 4, ColorAdjustment::noAdjustment(),
+                                    DISABLE_DITHER);
+        fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+        auto range = fl::makeScaledPixelRangeRGB(&adapter.get());
+        for (auto it = range.first; it != range.second; ++it) {
+            alone.push_back((*it)[0]);
+        }
+    }
+
+    fl::vector<fl::u8> paired;
+    {
+        PixelController<RGB> source(leds, 4, ColorAdjustment::noAdjustment(),
+                                    DISABLE_DITHER);
+        fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+        auto range = fl::makeScaledPixelRangeRGB(&adapter.get());
+        auto bright = fl::makeScaledBrightnessRange(&adapter.get());
+        auto b = bright.first;
+        for (auto it = range.first; it != range.second; ++it, ++b) {
+            paired.push_back((*it)[0]);
+            (void)*b;
+        }
+    }
+
+    FL_CHECK_EQ((int)alone.size(), 4);
+    FL_CHECK_EQ((int)paired.size(), (int)alone.size());
+    for (fl::size i = 0; i < alone.size() && i < paired.size(); ++i) {
+        FL_CHECK_EQ((int)paired[i], (int)alone[i]);
+    }
 }
 
 } // namespace test_hd108

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -581,7 +581,7 @@ FL_TEST_CASE("[#4321] the length check is not vacuous -- an odd count cannot be 
 }
 
 #if FASTLED_HD_COLOR_MIXING
-// makeScaledBrightnessRange() only exists under HD colour mixing -- every
+// makeScaledBrightness() only exists under HD colour mixing -- every
 // caller of it is inside that guard, so the adapter is compiled only there.
 // encoders.cpp includes this header unguarded, so this case has to carry the
 // same condition or a FASTLED_HD_COLOR_MIXING=0 test build stops compiling.
@@ -611,8 +611,7 @@ FL_TEST_CASE("[#4321] the brightness adapter does not move the shared cursor") {
                                     DISABLE_DITHER);
         fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
         auto range = fl::makeScaledPixelRangeRGB(&adapter.get());
-        auto bright = fl::makeScaledBrightnessRange(&adapter.get());
-        auto b = bright.first;
+        auto b = fl::makeScaledBrightness(&adapter.get());
         for (auto it = range.first; it != range.second; ++it, ++b) {
             paired.push_back((*it)[0]);
             (void)*b;


### PR DESCRIPTION
Fixes #4321.

## What was wrong

`writeHD108`, `writeAPA102(out, true)` and `writeSK9822(out, true)` each build a `ScaledPixelIteratorRGB` **and** a `ScaledPixelIteratorBrightness` over the *same* `PixelIterator`. Both ended `advance()` with

```cpp
mPixels->stepDithering();
mPixels->advanceData();
```

and the encoders step the pair in lockstep (`++first; ++brightness_first;`), so **two source pixels were consumed per emitted LED**.

Four pixels in:

| path | bytes out | bytes due | LEDs |
|---|---:|---:|---:|
| `writeHD108` | 29 | 46 | 2 of 4 |
| `writeAPA102(out, true)` | 16 | 24 | 2 of 4 |
| `writeSK9822(out, true)` | 16 | 24 | 2 of 4 |

The survivors are pixels 0 and 2, undamaged — so this is not corruption, it is **half the strip dropped and the rest showing every other pixel**.

`FASTLED_HD_COLOR_MIXING` is `1` on every non-AVR platform (`src/crgb.h`) and `writeHD108`'s HD branch is selected purely at compile time, with no runtime flag to miss.

## The second cursor was not buying anything

`ScaledPixelIteratorBrightness` is documented as yielding "per-LED brightness values". Under HD colour mixing it reads `loadRGBScaleAndBrightness`, which returns `mColorAdjustment.color.raw[...]` and `mColorAdjustment.brightness` — **per-strip constants**. It consumed a pixel per LED to re-read the same number.

## The fix

The brightness adapter no longer touches the shared cursor; the RGB adapter alongside owns it. Since the value is a strip constant, there is nothing to walk for.

Its non-HD fallback (max of R/G/B, genuinely per-LED) is removed along with the class's compilation in non-HD builds. Every caller of `makeScaledBrightnessRange` sits inside `#if FASTLED_HD_COLOR_MIXING`, so that branch was dead where the callers are — and leaving it would have left a wrong answer waiting for a future caller, because without owning the cursor its value depends on which adapter was constructed first. Better to not compile than to be quietly wrong.

## Evidence

Four regression cases, all driving the encoders **through a `PixelIterator`**. That is the gap: the existing cases in `hd108.hpp` call `encodeHD108`/`encodeHD108_HD` directly with `fl::vector` iterators, where there is no shared cursor to double-advance, which is why they passed throughout.

Verified by restoring the two removed calls — all four fail independently:

```
FAIL: [#4321] writeHD108 emits one LED per source pixel
  29 == 46
  164 == 53          <- LED 1 carries pixel 2 (gamma(30) vs gamma(20))
FAIL: [#4321] writeAPA102 and writeSK9822 emit one LED per source pixel in HD mode
  16 == 24  /  16 == 24
FAIL: [#4321] the length check is not vacuous -- an odd count cannot be halved cleanly
  37 == 54
FAIL: [#4321] the brightness adapter does not move the shared cursor
  2 == 4
  30 == 20           <- the every-other-pixel signature, stated directly
```

The odd-count case exists because halving a five-pixel strip gives three LEDs, so a length assertion alone could be satisfied by an off-by-one fix that still dropped pixels; it checks the last LED carries the last pixel. The cursor case states the property without going through an encoder at all.

`bash test --cpp`: 51/51 unit, 84/84 examples. `bash lint` clean.

## Noted, not fixed here

`ScaledPixelIteratorRGB` uses `loadAndScaleRGB`, which scales by brightness, while the 5-bit field emitted alongside also carries brightness. `loadRGBScaleAndBrightness`'s own comment says the pair exists so RGB is "color-corrected but NOT scaled by brightness". That reads like brightness applied twice, but I measured the LED count, not this, so it stays on #4321 rather than being asserted in a commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HD color-mixing output so LED strips no longer skip every other source pixel.
  - Ensured the final LED receives the correct source pixel on odd-length strips.
  - Corrected brightness handling to prevent unintended cursor movement and preserve accurate output across HD108, APA102, and SK9822 devices.
- **Tests**
  - Added regression coverage for pixel output and brightness behavior in HD mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->