### PR TITLE
fix(chipsets): make the rgb16 adapter yield the pixel, not the correction (#4323)

### DIFF
--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -507,30 +507,31 @@ inline void ScaledPixelIteratorRGB16::advance() FL_NO_EXCEPT {
     }
 
     if (mPixels->has(1)) {
-        // Get wire-ordered, color-corrected RGB bytes from PixelIterator (RGB reordering already applied)
+        // Wire-ordered, colour-corrected, brightness-scaled pixel bytes.
+        //
+        // This used to branch on FASTLED_HD_COLOR_MIXING and call
+        // loadRGBScaleAndBrightness() here, treating its three outputs as the
+        // pixel. They are not the pixel: that call returns
+        // ColorAdjustment::color -- the correction *scale* at full
+        // brightness, a per-strip constant -- for a caller that will apply it
+        // to a pixel itself. So every LED came out the same colour and the
+        // frame never reached the wire (#4323). WS2816, the only user of this
+        // range, showed one flat tint on every non-AVR build.
+        //
+        // loadAndScaleRGB() is the call that loads the pixel. It applies
+        // `premixed`, which already carries brightness, so there is no
+        // separate brightness step left to do. The old branch existed to
+        // defer brightness to 16-bit precision, but it was producing a
+        // constant rather than extra precision, so nothing is given up by
+        // dropping it. Doing that properly needs a primitive that loads the
+        // pixel scaled at full brightness, which PixelIterator does not
+        // expose today.
         u8 b0, b1, b2;
-        u8 brightness;
-
-        #if FASTLED_HD_COLOR_MIXING
-        // HD mode: RGB is color-corrected but NOT brightness-scaled
-        mPixels->loadRGBScaleAndBrightness(&b0, &b1, &b2, &brightness);
-        #else
-        // Standard mode: RGB is color-corrected AND brightness-scaled (premixed)
         mPixels->loadAndScaleRGB(&b0, &b1, &b2);
-        brightness = 255;  // No separate brightness scaling needed
-        #endif
 
-        // Map 8-bit → 16-bit RGB (color correction already applied)
-        u16 r16 = fl::map8_to_16(b0);
-        u16 g16 = fl::map8_to_16(b1);
-        u16 b16 = fl::map8_to_16(b2);
-
-        // Apply brightness scaling in HD mode (brightness not yet applied by loadRGBScaleAndBrightness)
-        if (brightness != 255) {
-            r16 = scale16by8(r16, brightness);
-            g16 = scale16by8(g16, brightness);
-            b16 = scale16by8(b16, brightness);
-        }
+        const u16 r16 = fl::map8_to_16(b0);
+        const u16 g16 = fl::map8_to_16(b1);
+        const u16 b16 = fl::map8_to_16(b2);
 
         mCurrent = array<u16, 3>{{r16, g16, b16}};  // Wire order 16-bit channels
         mPixels->stepDithering();

--- a/tests/fl/chipsets/encoders/ws2816.hpp
+++ b/tests/fl/chipsets/encoders/ws2816.hpp
@@ -22,6 +22,9 @@
 #include "fl/stl/array.h"
 #include "fl/stl/vector.h"
 #include "fl/stl/pair.h"
+#include "fl/chipsets/encoders/pixel_iterator.h"
+#include "fl/gfx/pixel_iterator_any.h"
+#include "pixel_controller.h"
 
 using namespace fl;
 
@@ -421,3 +424,101 @@ FL_TEST_CASE("encodeWS2816 - channel layout documentation") {
 }
 
 } // namespace test_ws2816
+
+
+//-----------------------------------------------------------------------------
+// #4323: the rgb16 adapter must yield the pixel, not the correction constant
+//
+// Everything else in this file drives packWS2816Pixel/encodeWS2816 with plain
+// fl::vector iterators, so nothing observed what a PixelIterator actually
+// hands them. Under FASTLED_HD_COLOR_MIXING the adapter called
+// loadRGBScaleAndBrightness() and treated its outputs as the pixel; those are
+// ColorAdjustment::color, a per-strip constant, so every LED came out the same
+// colour. WS2816 is the only user of this range.
+//-----------------------------------------------------------------------------
+
+FL_TEST_CASE("[#4323] the rgb16 adapter yields each pixel, not one flat colour") {
+    fl::CRGB leds[3] = {fl::CRGB(255, 0, 0), fl::CRGB(0, 255, 0), fl::CRGB(0, 0, 255)};
+    PixelController<RGB> source(leds, 3, ColorAdjustment::noAdjustment(),
+                                DISABLE_DITHER);
+    fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+
+    fl::vector<fl::array<fl::u16, 3>> seen;
+    auto range = fl::makeScaledPixelRangeRGB16(&adapter.get());
+    for (auto it = range.first; it != range.second; ++it) {
+        seen.push_back(*it);
+    }
+
+    FL_CHECK_EQ((int)seen.size(), 3);
+    if (seen.size() == 3) {
+        // Red, green, blue -- each in its own channel and nowhere else. The
+        // bug returned (65535, 65535, 65535) three times, which is why the
+        // off-channels are checked and not just the on-channel.
+        FL_CHECK_EQ((int)seen[0][0], 65535);
+        FL_CHECK_EQ((int)seen[0][1], 0);
+        FL_CHECK_EQ((int)seen[0][2], 0);
+
+        FL_CHECK_EQ((int)seen[1][0], 0);
+        FL_CHECK_EQ((int)seen[1][1], 65535);
+        FL_CHECK_EQ((int)seen[1][2], 0);
+
+        FL_CHECK_EQ((int)seen[2][0], 0);
+        FL_CHECK_EQ((int)seen[2][1], 0);
+        FL_CHECK_EQ((int)seen[2][2], 65535);
+    }
+}
+
+FL_TEST_CASE("[#4323] brightness reaches the rgb16 adapter exactly once") {
+    // A vacuity guard on the case above: it uses noAdjustment(), where the
+    // correction constant (255,255,255) and a full-brightness white pixel are
+    // easy to confuse. Here brightness is 128, so a constant-returning adapter
+    // and a correct one differ in value, not just in position.
+    ColorAdjustment adj = ColorAdjustment::noAdjustment();
+    adj.brightness = 128;
+    adj.premixed = fl::CRGB(128, 128, 128);   // what PixelController computes
+    adj.color = fl::CRGB(255, 255, 255);
+
+    fl::CRGB leds[1] = {fl::CRGB(255, 0, 0)};
+    PixelController<RGB> source(leds, 1, adj, DISABLE_DITHER);
+    fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+
+    auto range = fl::makeScaledPixelRangeRGB16(&adapter.get());
+    const fl::array<fl::u16, 3> first = *range.first;
+
+    // 255 scaled by 128/255 is 128, mapped to 16 bits. Applied twice it would
+    // be 64 -> 16448; not at all, 65535.
+    FL_CHECK_EQ((int)first[0], (int)fl::map8_to_16(128));
+    FL_CHECK_EQ((int)first[1], 0);
+    FL_CHECK_EQ((int)first[2], 0);
+}
+
+FL_TEST_CASE("[#4323] a WS2816 frame carries three different LEDs to the wire") {
+    // End to end, the way WS2816Controller::showPixels does it: adapter into
+    // encodeWS2816. Three LEDs of the same colour would have satisfied any
+    // per-LED check, so the claim is that the encoded LEDs differ.
+    fl::CRGB leds[3] = {fl::CRGB(255, 0, 0), fl::CRGB(0, 255, 0), fl::CRGB(0, 0, 255)};
+    PixelController<RGB> source(leds, 3, ColorAdjustment::noAdjustment(),
+                                DISABLE_DITHER);
+    fl::PixelIteratorAny adapter(source, RGB, fl::Rgbw());
+
+    fl::vector<CRGB> out;
+    auto range = fl::makeScaledPixelRangeRGB16(&adapter.get());
+    encodeWS2816(range.first, range.second, fl::back_inserter(out));
+
+    // Two CRGBs per LED, three LEDs.
+    FL_CHECK_EQ((int)out.size(), 6);
+    if (out.size() == 6) {
+        // LED 0 is red: [R_hi, R_lo, G_hi] = [0xFF, 0xFF, 0x00].
+        FL_CHECK_EQ((int)out[0].r, 0xFF);
+        FL_CHECK_EQ((int)out[0].g, 0xFF);
+        FL_CHECK_EQ((int)out[0].b, 0x00);
+        // LED 1 is green, so its red bytes are zero where LED 0's were full.
+        FL_CHECK_EQ((int)out[2].r, 0x00);
+        FL_CHECK_EQ((int)out[2].g, 0x00);
+        FL_CHECK_EQ((int)out[2].b, 0xFF);
+        // And the three LEDs are not all the same pair, which is the whole
+        // failure this pins.
+        const bool all_equal = (out[0] == out[2]) && (out[0] == out[4]);
+        FL_CHECK_FALSE(all_equal);
+    }
+}


### PR DESCRIPTION
Fixes #4323.

## Measured

Three pixels — red, green, blue — drained through `fl::makeScaledPixelRangeRGB16`:

```
(255,0,0) -> (65535, 65535, 65535)
(0,255,0) -> (65535, 65535, 65535)
(0,0,255) -> (65535, 65535, 65535)
```

**Every pixel the same, and none of them the pixel.**

## Cause

`ScaledPixelIteratorRGB16::advance()` under `FASTLED_HD_COLOR_MIXING`:

```cpp
// HD mode: RGB is color-corrected but NOT brightness-scaled
mPixels->loadRGBScaleAndBrightness(&b0, &b1, &b2, &brightness);
...
u16 r16 = fl::map8_to_16(b0);
```

`b0/b1/b2` are treated as the pixel. They are not. That call reaches `PixelController::loadRGBScaleAndBrightness`, which returns `mColorAdjustment.color.raw[...]` — the **correction scale at full brightness, a per-strip constant** — for a caller that will apply it to a pixel itself. The name says so: it loads the RGB *scale*. Nothing in the function ever reads the LED.

The `#else` branch (`loadAndScaleRGB`) is correct, so this only bites where `FASTLED_HD_COLOR_MIXING` is 1 — **every non-AVR platform**.

## Impact

`WS2816Controller::showPixels` (`src/chipsets.h:725`) is the sole user of this range, and `encodeWS2816` packs faithfully whatever it is handed. A **WS2816 strip showed one flat tint — the correction colour at full brightness — instead of the frame.**

## The fix

Use `loadAndScaleRGB`, the call that loads the pixel. It applies `premixed`, which already carries brightness, so there is no separate brightness step left to do.

The HD branch existed to defer brightness so it could be applied at 16-bit precision. That is a real idea, but as written it produced a *constant*, not extra precision — so nothing is given up by dropping it. Doing it properly needs a `PixelIterator` primitive that loads the pixel scaled at full brightness, which does not exist today; I raised that on #4042 rather than inventing an API inside a bug fix.

## Evidence

Three cases, all through a `PixelIterator`. That is the gap being closed: every existing case in `ws2816.hpp` drives `packWS2816Pixel`/`encodeWS2816` with plain `fl::vector` iterators, so nothing in the suite observed what the adapter yields.

Verified by restoring the old call — all three fail:

```
FAIL: [#4323] the rgb16 adapter yields each pixel, not one flat colour
  65535 == 0   (x6, the off-channels)
FAIL: [#4323] brightness reaches the rgb16 adapter exactly once
  65535 == 32896
FAIL: [#4323] a WS2816 frame carries three different LEDs to the wire
  255 == 0
```

The brightness case is the vacuity guard: the first case uses `noAdjustment()`, where the correction constant `(255,255,255)` and a full-brightness white pixel are easy to confuse. At brightness 128 a constant-returning adapter and a correct one differ in *value* (`65535` vs `32896`), not just in position. The end-to-end case checks the three encoded LEDs are not all the same pair, since three identical LEDs would satisfy any per-LED byte check.

`bash test --cpp`: **304/304 unit, 84/84 examples.** `bash lint` clean.

## Relationship to #4322

Same file, different function, independent defect — that one is the halving in the 8-bit HD paths. Two bugs in two adapters, both invisible to a fully green suite, because in each case the encoder was tested and the adapter feeding it was tested by nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed WS2816 LED output on supported platforms so each pixel displays its intended color instead of a uniform tint.
  - Corrected brightness handling to ensure it is applied exactly once.
  - Improved full-frame output so different LEDs retain their individual colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->