### PR TITLE
docs(chipsets): stop advertising an HD108 brightness that does nothing (#4042)

### DIFF
--- a/src/fl/chipsets/encoders/encoder_utils.h
+++ b/src/fl/chipsets/encoders/encoder_utils.h
@@ -70,7 +70,10 @@ inline u16 hd108GammaCorrect(u8 value) FL_NO_EXCEPT {
 }
 
 /// @brief Generate HD108 per-channel gain header bytes
-/// @param brightness_8bit 8-bit brightness (0-255) - UNUSED, kept for API compatibility
+/// @param brightness_8bit 8-bit brightness (0-255) - UNUSED, kept for API
+///        compatibility. Callers advertising a working brightness parameter on
+///        top of this are advertising something that does not happen; see
+///        encodeHD108() (FastLED#4042).
 /// @param f0_out Output: first header byte
 /// @param f1_out Output: second header byte
 /// @note HD108 uses per-channel gain encoding: 5 bits each for R/G/B

--- a/src/fl/chipsets/encoders/hd108.h
+++ b/src/fl/chipsets/encoders/hd108.h
@@ -31,7 +31,12 @@ namespace fl {
 /// @param first Iterator to first pixel
 /// @param last Iterator past last pixel
 /// @param out Output iterator for encoded bytes
-/// @param global_brightness Global 8-bit brightness (0-255), default 255
+/// @param global_brightness Accepted and ignored. HD108's per-channel 5-bit
+///        gains are pinned at maximum (31) for precision and brightness is
+///        expected to be applied to the 16-bit values before encoding, so this
+///        argument reaches neither the header nor the payload. Kept for source
+///        compatibility; the sole in-tree caller passes 255 and pre-scales.
+///        Passing anything else does not dim (FastLED#4042).
 /// @note Uses gamma 2.8 correction for 16-bit RGB
 /// @note HD108 uses RGB wire order: pixel[0]=Red, pixel[1]=Green, pixel[2]=Blue
 template <typename InputIterator, typename OutputIterator>
@@ -83,7 +88,10 @@ void encodeHD108(InputIterator first, InputIterator last, OutputIterator out,
 /// @tparam OutputIterator Output iterator accepting uint8_t
 /// @param first Iterator to first pixel
 /// @param last Iterator past last pixel
-/// @param brightness_first Iterator to first brightness value (8-bit, 0-255)
+/// @param brightness_first Iterator to first brightness value (8-bit, 0-255).
+///        Read once per LED and then discarded: hd108BrightnessHeader() pins
+///        all gains at 31 regardless. Per-LED brightness has no effect on the
+///        output (FastLED#4042).
 /// @param out Output iterator for encoded bytes
 /// @note HD108 uses RGB wire order: pixel[0]=Red, pixel[1]=Green, pixel[2]=Blue
 template <typename InputIterator, typename BrightnessIterator, typename OutputIterator>

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -110,7 +110,8 @@ FL_TEST_CASE("encodeHD108() - single LED, max brightness") {
 
     verifyStartFrame(output);
 
-    // Verify header: brightness 255 -> 5-bit 31
+    // Header is 0xFF/0xFF whatever brightness is passed: HD108 gains are
+    // pinned at 31 and the argument is ignored.
     verifyHeaderBytes(output, 8);
 
     // Verify RGB data with gamma correction
@@ -127,7 +128,7 @@ FL_TEST_CASE("encodeHD108() - single LED, mid brightness") {
 
     FL_REQUIRE_EQ(output.size(), 20);
 
-    // Verify header: brightness 128 -> 5-bit 16
+    // Header unchanged at mid brightness -- the argument reaches nothing.
     verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 200, 100, 50);
@@ -141,7 +142,7 @@ FL_TEST_CASE("encodeHD108() - single LED, min brightness") {
 
     FL_REQUIRE_EQ(output.size(), 20);
 
-    // Verify header: brightness 1 -> 5-bit 1 (non-zero preservation)
+    // Header unchanged at minimum brightness too.
     verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 100, 50, 25);
@@ -184,7 +185,7 @@ FL_TEST_CASE("encodeHD108() - three LEDs, end frame size") {
 
     verifyStartFrame(output);
 
-    // Verify brightness 200 -> 5-bit 24 (200*31+127)/255 = 24.8
+    // Header unchanged; brightness 200 is passed and discarded.
     verifyHeaderBytes(output, 8);
 
     verifyEndFrame(output, 5);
@@ -326,7 +327,7 @@ FL_TEST_CASE("encodeHD108_HD() - single LED with per-LED brightness") {
 
     verifyStartFrame(output);
 
-    // Verify per-LED brightness 200 -> 5-bit 24
+    // Per-LED brightness is read and discarded; the header stays 0xFF/0xFF.
     verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 255, 128, 64);
@@ -350,15 +351,15 @@ FL_TEST_CASE("encodeHD108_HD() - multiple LEDs with varying brightness") {
 
     verifyStartFrame(output);
 
-    // LED 1: brightness 255 -> 31
+    // LED 1: header pinned regardless of its brightness
     verifyHeaderBytes(output, 8);
     verifyLEDData(output, 10, 255, 0, 0);
 
-    // LED 2: brightness 128 -> 16
+    // LED 2: same header, different brightness
     verifyHeaderBytes(output, 16);
     verifyLEDData(output, 18, 0, 255, 0);
 
-    // LED 3: brightness 64 -> 8
+    // LED 3: same header again
     verifyHeaderBytes(output, 24);
     verifyLEDData(output, 26, 0, 0, 255);
 
@@ -379,7 +380,7 @@ FL_TEST_CASE("encodeHD108_HD() - brightness caching optimization") {
 
     FL_REQUIRE_EQ(output.size(), 37);
 
-    // All LEDs should have same header bytes (brightness 200 -> 24)
+    // All LEDs share the same header -- as they would for any brightness.
     verifyHeaderBytes(output, 8);
     verifyHeaderBytes(output, 16);
     verifyHeaderBytes(output, 24);
@@ -434,10 +435,10 @@ FL_TEST_CASE("encodeHD108_HD() - min/max brightness values") {
 
     encodeHD108_HD(leds.begin(), leds.end(), brightness.begin(), fl::back_inserter(output));
 
-    // LED 1: brightness 0 -> 0
+    // LED 1: brightness 0 still yields the pinned header
     verifyHeaderBytes(output, 8);
 
-    // LED 2: brightness 255 -> 31
+    // LED 2: and so does brightness 255
     verifyHeaderBytes(output, 16);
 }
 

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -51,11 +51,13 @@ static void verifyEndFrame(const fl::vector<u8>& data, size_t expected_size) {
     }
 }
 
-/// Helper to verify header bytes use maximum gain (31) for all channels
-/// Brightness parameter is ignored - gain is always max for maximum precision
-static void verifyHeaderBytes(const fl::vector<u8>& data, size_t offset, u8 expected_bri5) {
-    (void)expected_bri5;  // Unused - all gains are max (31) regardless of brightness input
-
+/// Verify the header pins all three gains at maximum (31).
+///
+/// It takes no expected value on purpose. It used to accept one and open with
+/// `(void)expected_bri5;`, so a caller could pass any number and still pass --
+/// which is what let the case below carry a twelve-row table of expected 5-bit
+/// gains that nothing compared against.
+static void verifyHeaderBytes(const fl::vector<u8>& data, size_t offset) {
     u8 f0 = data[offset];
     u8 f1 = data[offset + 1];
 
@@ -109,7 +111,7 @@ FL_TEST_CASE("encodeHD108() - single LED, max brightness") {
     verifyStartFrame(output);
 
     // Verify header: brightness 255 -> 5-bit 31
-    verifyHeaderBytes(output, 8, 31);
+    verifyHeaderBytes(output, 8);
 
     // Verify RGB data with gamma correction
     verifyLEDData(output, 10, 255, 128, 64);
@@ -126,7 +128,7 @@ FL_TEST_CASE("encodeHD108() - single LED, mid brightness") {
     FL_REQUIRE_EQ(output.size(), 20);
 
     // Verify header: brightness 128 -> 5-bit 16
-    verifyHeaderBytes(output, 8, 16);
+    verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 200, 100, 50);
 }
@@ -140,7 +142,7 @@ FL_TEST_CASE("encodeHD108() - single LED, min brightness") {
     FL_REQUIRE_EQ(output.size(), 20);
 
     // Verify header: brightness 1 -> 5-bit 1 (non-zero preservation)
-    verifyHeaderBytes(output, 8, 1);
+    verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 100, 50, 25);
 }
@@ -157,11 +159,11 @@ FL_TEST_CASE("encodeHD108() - two LEDs, end frame boundary") {
     verifyStartFrame(output);
 
     // LED 1
-    verifyHeaderBytes(output, 8, 31);
+    verifyHeaderBytes(output, 8);
     verifyLEDData(output, 10, 255, 0, 0);
 
     // LED 2
-    verifyHeaderBytes(output, 16, 31);
+    verifyHeaderBytes(output, 16);
     verifyLEDData(output, 18, 0, 255, 0);
 
     verifyEndFrame(output, 5);
@@ -183,7 +185,7 @@ FL_TEST_CASE("encodeHD108() - three LEDs, end frame size") {
     verifyStartFrame(output);
 
     // Verify brightness 200 -> 5-bit 24 (200*31+127)/255 = 24.8
-    verifyHeaderBytes(output, 8, 24);
+    verifyHeaderBytes(output, 8);
 
     verifyEndFrame(output, 5);
 }
@@ -212,36 +214,52 @@ FL_TEST_CASE("encodeHD108() - eight LEDs, end frame size") {
     verifyEndFrame(output, 8);
 }
 
-FL_TEST_CASE("encodeHD108() - brightness mapping 8-bit to 5-bit") {
-    // Test critical brightness values
-    struct BrightnessTest {
-        u8 input;
-        u8 expected_5bit;
-    };
+FL_TEST_CASE("encodeHD108() - the gain header ignores global_brightness, by design") {
+    // HD108 carries a 5-bit gain per channel. FastLED pins all three at 31 and
+    // does brightness in the 16-bit values instead, which is what
+    // hd108BrightnessHeader() means by ignoring its argument.
+    //
+    // This case used to be called "brightness mapping 8-bit to 5-bit" and
+    // carried a twelve-row table mapping inputs to expected 5-bit gains --
+    // {0,0}, {128,16}, {255,31} and so on. None of it was compared: the helper
+    // discarded the expectation and asserted the constant. Every row asserted
+    // the same thing, so the case would not have failed if a mapping had been
+    // introduced, or if an existing one had broken.
+    //
+    // Stated as what actually holds: across the full 8-bit range the header is
+    // invariant, and it is 0xFF/0xFF.
+    const u8 brightnesses[] = {0, 1, 8, 16, 64, 127, 128, 191, 192, 200, 254, 255};
 
-    BrightnessTest tests[] = {
-        {0, 0},      // Zero maps to zero
-        {1, 1},      // Min non-zero preserved
-        {8, 1},      // Low values map to 1
-        {16, 2},
-        {64, 8},
-        {127, 15},
-        {128, 16},
-        {191, 23},
-        {192, 23},   // 192*31+127 = 6079/255 = 23.8
-        {200, 24},   // 200*31+127 = 6327/255 = 24.8
-        {254, 31},
-        {255, 31}    // Max maps to max
-    };
-
-    for (const auto& test : tests) {
+    for (const u8 brightness : brightnesses) {
         fl::vector<fl::array<u8, 3>> leds = {{{50, 50, 50}}};
         fl::vector<u8> output;
 
-        encodeHD108(leds.begin(), leds.end(), fl::back_inserter(output), test.input);
+        encodeHD108(leds.begin(), leds.end(), fl::back_inserter(output), brightness);
 
-        verifyHeaderBytes(output, 8, test.expected_5bit);
+        verifyHeaderBytes(output, 8);
     }
+}
+
+FL_TEST_CASE("encodeHD108() - brightness does not reach the payload either") {
+    // The other half of the contract, and the guard that keeps the case above
+    // from being satisfiable by an encoder that ignores brightness everywhere:
+    // the 16-bit values are the gamma-corrected input, unscaled. So
+    // global_brightness reaches neither the header nor the payload -- it is
+    // accepted and discarded, which is worth pinning because the public
+    // signature still advertises it.
+    fl::vector<u8> dim;
+    fl::vector<u8> bright;
+    fl::vector<fl::array<u8, 3>> leds = {{{200, 100, 50}}};
+
+    encodeHD108(leds.begin(), leds.end(), fl::back_inserter(dim), 1);
+    encodeHD108(leds.begin(), leds.end(), fl::back_inserter(bright), 255);
+
+    FL_REQUIRE_EQ(dim.size(), bright.size());
+    FL_CHECK_EQ(dim, bright);
+
+    // And the payload is the gamma of the input, so "unscaled" is a claim
+    // about a known value rather than about two things merely matching.
+    FL_CHECK_EQ(getBigEndian16(dim, 10), Gamma28LUT16::read(200));
 }
 
 FL_TEST_CASE("encodeHD108() - gamma correction verification") {
@@ -309,7 +327,7 @@ FL_TEST_CASE("encodeHD108_HD() - single LED with per-LED brightness") {
     verifyStartFrame(output);
 
     // Verify per-LED brightness 200 -> 5-bit 24
-    verifyHeaderBytes(output, 8, 24);
+    verifyHeaderBytes(output, 8);
 
     verifyLEDData(output, 10, 255, 128, 64);
 
@@ -333,15 +351,15 @@ FL_TEST_CASE("encodeHD108_HD() - multiple LEDs with varying brightness") {
     verifyStartFrame(output);
 
     // LED 1: brightness 255 -> 31
-    verifyHeaderBytes(output, 8, 31);
+    verifyHeaderBytes(output, 8);
     verifyLEDData(output, 10, 255, 0, 0);
 
     // LED 2: brightness 128 -> 16
-    verifyHeaderBytes(output, 16, 16);
+    verifyHeaderBytes(output, 16);
     verifyLEDData(output, 18, 0, 255, 0);
 
     // LED 3: brightness 64 -> 8
-    verifyHeaderBytes(output, 24, 8);
+    verifyHeaderBytes(output, 24);
     verifyLEDData(output, 26, 0, 0, 255);
 
     verifyEndFrame(output, 5);
@@ -362,9 +380,9 @@ FL_TEST_CASE("encodeHD108_HD() - brightness caching optimization") {
     FL_REQUIRE_EQ(output.size(), 37);
 
     // All LEDs should have same header bytes (brightness 200 -> 24)
-    verifyHeaderBytes(output, 8, 24);
-    verifyHeaderBytes(output, 16, 24);
-    verifyHeaderBytes(output, 24, 24);
+    verifyHeaderBytes(output, 8);
+    verifyHeaderBytes(output, 16);
+    verifyHeaderBytes(output, 24);
 
     // Verify colors differ despite same brightness
     verifyLEDData(output, 10, 100, 0, 0);
@@ -417,10 +435,10 @@ FL_TEST_CASE("encodeHD108_HD() - min/max brightness values") {
     encodeHD108_HD(leds.begin(), leds.end(), brightness.begin(), fl::back_inserter(output));
 
     // LED 1: brightness 0 -> 0
-    verifyHeaderBytes(output, 8, 0);
+    verifyHeaderBytes(output, 8);
 
     // LED 2: brightness 255 -> 31
-    verifyHeaderBytes(output, 16, 31);
+    verifyHeaderBytes(output, 16);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
A P8 (#4042) loose end I flagged while fixing #4321, and the half of it that needs no design decision.

## The public signature is not true

```cpp
/// @param global_brightness Global 8-bit brightness (0-255), default 255
void encodeHD108(InputIterator first, InputIterator last, OutputIterator out,
                 u8 global_brightness = 255);
```

The value reaches nothing:

- `hd108BrightnessHeader()` pins all three 5-bit gains at 31 and opens with `(void)brightness_8bit;`
- the payload is `hd108GammaCorrect(pixel[i])` — the gamma of the input, unscaled

So it affects neither the header nor the payload. Only the *private* helper documented that; the public entry advertised working brightness. `encodeHD108_HD` is the same shape with a whole per-LED brightness **iterator** feeding the same ignoring function.

**The behaviour is deliberate and is left alone.** HD108 brightness is meant to be applied to the 16-bit values before encoding, and the sole in-tree caller passes 255 and pre-scales. Making the parameter work would change HD108 output — that is P8's call, not a documentation fix's. What changes here is that the signature describes what happens.

## And a test whose name and data described something it did not check

`encodeHD108() - brightness mapping 8-bit to 5-bit` built a twelve-row table — `{0,0}`, `{128,16}`, `{255,31}`, … — and passed each expectation to a helper beginning `(void)expected_bri5;`.

**To be accurate about what was wrong with it:** the assertion was real. It pinned `0xFF/0xFF`, so the case *did* catch a gain change. What it did not do was check any mapping, while its name and its data described one that does not exist — so a reader would take it as evidence of a contract that isn't there. (I described this as toothless on #4042; that was an overstatement, and I have corrected it there.)

Now:

- the helper no longer accepts an expectation it cannot use, so no future caller can pass one and believe it was checked
- the case is renamed to `the gain header ignores global_brightness, by design` and asserts the invariance it actually verifies, across the same twelve brightnesses
- a second case pins the other half, which nothing covered: two encodes at brightness 1 and 255 produce **identical bytes**, and the payload is `Gamma28LUT16::read(200)` for an input of 200 — a known value, so "unscaled" is a claim about the number rather than about two outputs merely matching each other

## Verification

Making the gains follow brightness (`r_gain = mapBrightness8to5(brightness_8bit)`) fails **10 of 184** cases, including both cases added here. Restored, the suite is green.

`bash lint` clean.

## Not in scope

The live HD108/APA102/SK9822 defects are #4321 (#4322) and #4323 (#4324). This touches documentation and tests only — no encoder behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that HD108 brightness parameters are accepted but do not affect encoded output.
  * Documented that brightness should be applied to 16-bit channel values before encoding.

* **Tests**
  * Updated HD108 coverage to verify invariant maximum-gain headers.
  * Added validation that brightness does not alter headers or payload data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->