### PR TITLE
fix(channels): isColorManaged() reports the transform, not a constant (#4328)

### DIFF
--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -185,9 +185,22 @@ public:
     Rgbw getRgbw() const;
 
     bool hasColorProfile() const FL_NO_EXCEPT { return emitterProfile() != nullptr; }
-    /// P2 binds profiles only. P6 changes this to true when the streaming
-    /// transform is actually installed in the output path.
-    bool isColorManaged() const FL_NO_EXCEPT { return false; }
+    /// True when the streaming transform is actually installed in the output
+    /// path, which is not the same question as `hasColorProfile()`: a binding
+    /// can be accepted and still fail to build a usable pipeline, and that
+    /// channel stays on the legacy path. That difference is why both exist.
+    ///
+    /// This was a hardcoded `false` with a note saying P6 would change it.
+    /// P6 landed, `mPipeline` is built in `reconcileColorProfile` and read in
+    /// `showPixels`, and the accessor was not updated -- so it answered "no"
+    /// on channels that were demonstrably transforming colour (#4328).
+    bool isColorManaged() const FL_NO_EXCEPT {
+#if FL_COLOR_PROFILE_RUNTIME
+        return mPipeline != nullptr;
+#else
+        return false;
+#endif
+    }
     const EmitterProfile* emitterProfile() const FL_NO_EXCEPT {
         return CLEDController::emitterProfile();
     }

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -12,6 +12,7 @@
 #include "fl/channels/color_profile.h"
 #include "fl/channels/channel_events.h"
 #include "fl/log/log.h"
+#include "fl/stl/compiler_control.h"  // FL_DEPRECATED
 
 namespace fl {
 
@@ -181,13 +182,20 @@ struct ChannelOptions {
         return false;
 #endif
     }
-    // No isColorManaged() here on purpose. It used to exist as a hardcoded
-    // `false` with no callers anywhere, and options cannot answer the
-    // question: they carry the *request*, while the transform is built by
-    // Channel::reconcileColorProfile and can fail for a binding these options
-    // accepted. Asking a request object whether rendering is installed can
-    // only ever return a plausible-looking guess. Channel::isColorManaged()
-    // is the one that knows (#4328).
+    /// @deprecated Ask the channel, not the request.
+    ///
+    /// Options carry the *request*; the transform is built by
+    /// `Channel::reconcileColorProfile` and can fail for a binding these
+    /// options accepted -- which is exactly the case
+    /// `Channel::isColorManaged()` distinguishes. A request object asked
+    /// whether rendering is installed can only return a guess, and this one
+    /// returned a hardcoded `false` (#4328).
+    ///
+    /// Kept, returning that same legacy value, so no downstream call stops
+    /// compiling; the attribute is what moves callers along. No in-tree
+    /// caller exists.
+    FL_DEPRECATED("Ask the channel: Channel::isColorManaged()")
+    bool isColorManaged() const FL_NO_EXCEPT { return false; }
     const EmitterProfile* emitterProfile() const FL_NO_EXCEPT {
 #if FL_COLOR_PROFILE_RUNTIME
         return mColorProfile.profile();

--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -181,7 +181,13 @@ struct ChannelOptions {
         return false;
 #endif
     }
-    bool isColorManaged() const FL_NO_EXCEPT { return false; }
+    // No isColorManaged() here on purpose. It used to exist as a hardcoded
+    // `false` with no callers anywhere, and options cannot answer the
+    // question: they carry the *request*, while the transform is built by
+    // Channel::reconcileColorProfile and can fail for a binding these options
+    // accepted. Asking a request object whether rendering is installed can
+    // only ever return a plausible-looking guess. Channel::isColorManaged()
+    // is the one that knows (#4328).
     const EmitterProfile* emitterProfile() const FL_NO_EXCEPT {
 #if FL_COLOR_PROFILE_RUNTIME
         return mColorProfile.profile();

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -49,7 +49,7 @@ FL_TEST_CASE("SourceProfile provides independent named and custom source spaces"
     FL_CHECK_CLOSE(custom.primaries.green.y, 0.600f, 0.0001f);
 }
 
-FL_TEST_CASE("Channel profile binding owns fixture calibration without activating P6 rendering") {
+FL_TEST_CASE("Channel profile binding owns fixture calibration and activates P6 rendering") {
     CRGB leds[1] = {};
     ChannelOptions options;
     options.setColorProfile(kFixtureProfile, SourceProfile::linearSrgb());
@@ -58,7 +58,7 @@ FL_TEST_CASE("Channel profile binding owns fixture calibration without activatin
     ChannelPtr channel = Channel::create(config);
     FL_REQUIRE(channel != nullptr);
     FL_CHECK(channel->hasColorProfile());
-    FL_CHECK_FALSE(channel->isColorManaged());
+    FL_CHECK(channel->isColorManaged());
     FL_REQUIRE(channel->emitterProfile() != nullptr);
     FL_CHECK_EQ(fl::string(channel->emitterProfile()->id), fl::string("fixture/test-r1"));
 }
@@ -80,7 +80,7 @@ FL_TEST_CASE("SourceProfile default is the ordinary-buffer linear BT.709 space")
     FL_CHECK_CLOSE(profile.primaries.white.y, 0.3290f, 0.0001f);
 }
 
-FL_TEST_CASE("Configured color profiles are not reported active before P6 rendering") {
+FL_TEST_CASE("A configured color profile is reported active once P6 installs the transform") {
     CRGB leds[1] = {};
     ChannelOptions options;
     FL_REQUIRE(options.setColorProfile(kFixtureProfile, SourceProfile::linearSrgb()));
@@ -88,7 +88,7 @@ FL_TEST_CASE("Configured color profiles are not reported active before P6 render
     ChannelPtr channel = Channel::create(config);
     FL_REQUIRE(channel != nullptr);
     FL_CHECK(channel->hasColorProfile());
-    FL_CHECK_FALSE(channel->isColorManaged());
+    FL_CHECK(channel->isColorManaged());
 }
 
 FL_TEST_CASE("Profile binding validates and owns response tables") {
@@ -343,8 +343,8 @@ FL_TEST_CASE("Clearing a binding releases it and leaves nothing bound") {
 // other isColorManaged() assertions in this file are all on channels with no
 // profile, so without this one nothing distinguishes "false because nothing
 // is bound" from "false because P6 has not landed" -- and nothing would fail
-// if someone flipped the accessor to true here ahead of the transform.
-FL_TEST_CASE("A bound fixture profile is configured but not yet color managed") {
+// The transform now exists, so the accessor tracks it rather than a constant.
+FL_TEST_CASE("A bound fixture profile is configured and color managed") {
     CRGB leds[1] = {};
     ChannelOptions options;
     FL_REQUIRE(options.setColorProfile(kFixtureProfile, SourceProfile::linearSrgb()));
@@ -360,8 +360,10 @@ FL_TEST_CASE("A bound fixture profile is configured but not yet color managed") 
     FL_CHECK_EQ(fl::string(channel->emitterProfile()->id),
                 fl::string(kFixtureProfile.id));
 
-    // Deliberate: flip this in P6 (#4040), not before.
-    FL_CHECK_FALSE(channel->isColorManaged());
+    // P6 (#4040) landed, so this is flipped. The accessor used to be a
+    // hardcoded `false` carrying a note that P6 would change it; it did not,
+    // so it answered "no" on channels that were transforming colour (#4328).
+    FL_CHECK(channel->isColorManaged());
 }
 
 FL_TEST_CASE("Strict fallback turns an unavailable profile into an observable bind error") {
@@ -432,14 +434,14 @@ FL_TEST_CASE("Binding carries target white and CFastLED exposes only global sour
     FastLED.setDefaultSourceProfile(SourceProfile::linearSrgb());
 }
 
-FL_TEST_CASE("Static profile sugar and fallback status are observable without enabling rendering") {
+FL_TEST_CASE("Static profile sugar and fallback status are observable, and rendering is on") {
     CRGB leds[1] = {};
     ChannelOptions options = ChannelOptions::withColorProfile<kFixtureProfile>();
     ChannelConfig config(ClocklessChipset(), leds, RGB, options);
     ChannelPtr channel = Channel::create(config);
     FL_REQUIRE(channel != nullptr);
     FL_CHECK(channel->hasColorProfile());
-    FL_CHECK_FALSE(channel->isColorManaged());
+    FL_CHECK(channel->isColorManaged());
     FL_CHECK_EQ(channel->colorProfileStatus(), ColorProfileStatus::Configured);
 }
 
@@ -695,5 +697,32 @@ FL_TEST_CASE("Runtime static Channel factory yields to legacy clear and runtime 
     FL_CHECK_EQ(fl::string(channel->emitterProfile()->id), fl::string("fixture/channel-runtime-r2"));
 }
 
+
+
+FL_TEST_CASE("[#4328] isColorManaged is not a synonym for hasColorProfile") {
+    // The guard that keeps the accessor honest. If every accepted binding
+    // were managed, `isColorManaged()` would carry no information that
+    // `hasColorProfile()` does not, and flipping it from a hardcoded false to
+    // a hardcoded true would pass every other case in this file.
+    //
+    // A profile whose three primaries are the same chromaticity is accepted
+    // on bind -- it is structurally well formed -- but describes no invertible
+    // emitter matrix, so no pipeline is built and the channel stays on the
+    // legacy path. Configured, and not managed.
+    CRGB leds[1] = {};
+    ChannelOptions options;
+    const EmitterProfile degenerate = EmitterProfile::rgb(
+        "fixture/degenerate",
+        Chromaticity(0.3127f, 0.3290f), Chromaticity(0.3127f, 0.3290f),
+        Chromaticity(0.3127f, 0.3290f), 1.0f, 1.0f, 1.0f);
+    FL_REQUIRE(options.setColorProfile(degenerate, SourceProfile::linearSrgb()));
+
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    FL_REQUIRE(channel != nullptr);
+
+    FL_CHECK(channel->hasColorProfile());
+    FL_CHECK_FALSE(channel->isColorManaged());
+}
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Fixes #4328.

## What it was

`src/fl/channels/channel.h`:

```cpp
/// P2 binds profiles only. P6 changes this to true when the streaming
/// transform is actually installed in the output path.
bool isColorManaged() const FL_NO_EXCEPT { return false; }
```

**P6 (#4040) landed.** `mPipeline` is built in `reconcileColorProfile` and read in `showPixels`. The accessor was never updated, so it returned `false` on every channel, unconditionally — including channels that were transforming colour.

#4034's decision digest lists it among what a caller is promised: *"one-time warning, **queryable `isColorManaged()`**, fallback flag in channel events/telemetry"*. Its entire purpose is to answer this question, and it could not.

## Measured, not inferred

A channel bound to an sRGB-primaries emitter profile with unit luminances, encoded through WS2812 so no gamma sits anywhere on the path:

| input | drive out | expected |
|---|---:|---|
| `CRGB(255,0,0)` | **54** | 0.2126 × 255 = 54 |
| `CRGB(0,255,0)` | **182** | 0.7152 × 255 = 182 |
| `CRGB(0,0,255)` | **18** | 0.0722 × 255 = 18 |

sRGB's luminance coefficients, exactly. The device's emitters each produce luminance 1.0 at full drive, so reproducing sRGB red's Y = 0.2126 requires drive 0.2126 — **the pipeline is doing the right thing**, which is what makes the accessor's answer wrong. An unbound channel on the same path passes `127` through as `127`.

## The four stale cases

`color_profile.cpp` had four asserting the old value — three named "not yet color managed", one carrying `// Deliberate: flip this in P6 (#4040), not before.`

They are flipped and renamed, not adjusted to stay green. Their **premise** went stale, not their expectation: P6 has landed, so "without activating P6 rendering" no longer describes what the channel does.

## The guard that keeps it honest

If every accepted binding were managed, `isColorManaged()` would carry no information `hasColorProfile()` doesn't, and swapping one hardcoded constant for the other would pass every case in the file.

So: a profile whose three primaries share a single chromaticity is accepted on bind — it is structurally well formed — but describes no invertible emitter matrix, so no pipeline is built. **Configured, and not managed.**

Mutating the accessor to the plausible `return hasColorProfile();` fails exactly that case and nothing else:

```
FAIL: [#4328] isColorManaged is not a synonym for hasColorProfile
[doctest] test cases: 37 | 36 passed | 1 failed
```

`bash test --cpp`: **304/304 unit, 84/84 examples.** `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Color management status now accurately reflects when a runtime color pipeline is active.
  * Valid color profiles can activate color-managed rendering for supported configurations, including static and runtime profile bindings.

* **Bug Fixes**
  * Corrected color-profile status reporting across supported profile configurations.
  * Degenerate but accepted profiles remain configured without being incorrectly marked as color-managed.
  * Improved accuracy when determining whether color-managed rendering is active.

* **Deprecations**
  * The legacy color-management status check is deprecated; use the channel-level status instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->