### PR TITLE
docs(ci): say what the B3 guard actually covers, which is the interior (#4040)

### DIFF
--- a/ci/tests/test_no_rgb8_intermediate.py
+++ b/ci/tests/test_no_rgb8_intermediate.py
@@ -1,4 +1,4 @@
-"""B3: the streaming path must not round-trip through RGB8.
+"""B3: the pipeline's own stages must not round-trip through RGB8.
 
 P6 (#4040) asks for decode to be one semantic conversion -- an RGB8 code
 straight to linear light -- with no intermediate RGB8 linear buffer and no
@@ -10,6 +10,29 @@ missing requirement.
 
 So this asserts the shape instead. Companion to
 test_no_iterative_solver_per_pixel.py, which guards A3/B11 the same way.
+
+What it does NOT cover
+----------------------
+Only the eight stage files listed below, all under ``src/fl/gfx``. B3's
+claim is about the whole normative path and includes "single final
+quantization"; this file sees the pipeline's interior and stops at its
+edge.
+
+The handoff from the pipeline to a chipset encoder is outside that edge, and
+it is where the remaining round trip lives. ``ScaledPixelIteratorRGB``
+yields ``array<u8, 3>``, and ``writeHD108`` plus UCS7604's 16-bit modes are
+both fed by it -- so on those parts the wide output is quantized to 8 bits
+and then widened again by a gamma LUT, which is an intermediate
+quantization, not a final one. ``writeWS2816`` is the one that takes
+``makeScaledPixelRangeRGB16``. See FastLED#4326.
+
+For an 8-bit part an 8-bit handoff *is* the single final quantization, so
+the rule that would catch this is "a 16-bit encoder is fed the 16-bit
+adapter" rather than anything about the stage files. That check is not here
+because it would fail today on two of the three; it belongs with the fix.
+
+Quoting a green run of this file as evidence for B3 as a whole therefore
+over-claims. It evidences the interior.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## The over-claim

`ci/tests/test_no_rgb8_intermediate.py` opens:

> B3: **the streaming path** must not round-trip through RGB8.

and P6's (#4040) closure case cites a green run of it as evidence for:

> Normative path: no intermediate RGB8 buffer, **single final quantization** (per B3 restatement)

It scans eight stage files under `src/fl/gfx`. It sees the pipeline's interior and stops at its edge.

## What is past that edge

The handoff from the pipeline to a chipset encoder — and that is where the remaining round trip lives:

| encoder | fed by | width |
|---|---|---|
| `writeWS2816` | `makeScaledPixelRangeRGB16` | 16-bit |
| `writeHD108` | `makeScaledPixelRangeRGB` | **8-bit**, widened again by gamma |
| UCS7604 16-bit | `makeScaledPixelRangeRGB` | **8-bit**, widened again by a `Gamma8` LUT |

`ScaledPixelIteratorRGB` yields `array<u8, 3>`. On those two parts the wide output is quantized to 8 bits and then widened — an *intermediate* quantization followed by an expansion, which is what B3's "single final quantization" forbids. Tracked as #4326.

## Why the check is not extended here

For an 8-bit part an 8-bit handoff **is** the single final quantization, so the property is chipset-dependent. The rule that would catch this is "a 16-bit encoder is fed the 16-bit adapter" — not a property of the stage files at all.

Adding it would fail today on two of the three, and a red test is not a merge. It belongs with the fix, in #4326.

## What changes

The docstring, and nothing else. **6 passed, 20 subtests** — identical to before.

The point is narrow and worth having on its own: a green run of this file was quotable as evidence for B3 in full, and it evidences the interior. P6's closure rests partly on that line, so the record should say what was actually checked.

`bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the scope of the graphics pipeline validation.
  - Documented which pipeline stages are covered and which chipset encoder handoffs are excluded.
  - Added details about intermediate 8-bit quantization in applicable encoding paths.
  - Clarified that a successful validation run confirms only the inspected pipeline stages, not the complete encoding flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->