### PR TITLE
fix(channels): warn when a profile clears the caller's gamma (#4331)

### DIFF
--- a/src/fl/channels/options.h
+++ b/src/fl/channels/options.h
@@ -127,10 +127,26 @@ struct ChannelOptions {
         // mWarnedLegacyCleared on a profile that was then rejected, and
         // clearColorProfile() leaves mCorrection/mTemperature alone -- so the
         // next *valid* profile cleared the caller's legacy settings silently.
-        if (!had_profile &&
-            (mCorrection != UncorrectedColor || mTemperature != UncorrectedTemperature) &&
-            !mWarnedLegacyCleared) {
-            FL_WARN_F("Color profile clears legacy correction/temperature");
+        // Every field cleared below whose loss is detectable has to be
+        // represented here, or the caller loses it in silence. This used to
+        // name mCorrection and mTemperature only, while the clear also resets
+        // mGamma -- so a caller who set just a gamma had it discarded with no
+        // warning, which is exactly what the note above is about (#4331).
+        //
+        // mDitherMode is deliberately absent, and cannot be added by
+        // comparison. Its default is BINARY_DITHER and the clear sets
+        // DISABLE_DITHER, so `mDitherMode != BINARY_DITHER` is true precisely
+        // when the caller already chose DISABLE_DITHER and nothing is being
+        // taken away, and false in the case that loses dithering. Detecting
+        // that needs a "the caller set this" flag, which mGamma gets for free
+        // by being an optional. Until then, binding a profile turns dithering
+        // off quietly (#4331).
+        const bool clearing_legacy =
+            mCorrection != UncorrectedColor ||
+            mTemperature != UncorrectedTemperature ||
+            mGamma.has_value();
+        if (!had_profile && clearing_legacy && !mWarnedLegacyCleared) {
+            FL_WARN_F("Color profile clears legacy correction/temperature/gamma");
             ChannelEvents::instance().onColorProfileWarning(
                 ColorProfileEvent{-1, {}, ColorProfileWarning::LegacyClearedByProfile});
             mWarnedLegacyCleared = true;

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -725,4 +725,64 @@ FL_TEST_CASE("[#4328] isColorManaged is not a synonym for hasColorProfile") {
     FL_CHECK_FALSE(channel->isColorManaged());
 }
 
+// #4331: setColorProfile() clears four legacy settings and the warning used
+// to check two of them, so a caller who set only gamma or only dither had it
+// discarded in silence -- the very failure the comment on that guard says it
+// exists to prevent.
+FL_TEST_CASE("[#4331] a profile warns when it clears gamma, not only correction") {
+    ChannelOptions options;
+    fl::vector<ColorProfileEvent> events;
+    const int listener = FastLED.channelEvents().onColorProfileWarning.add(
+        [&](const ColorProfileEvent& event) { events.push_back(event); });
+
+    // Correction and temperature deliberately untouched: this is the case the
+    // old condition could not see.
+    options.mGamma = 2.2f;
+    FL_REQUIRE(options.setColorProfile(kFixtureProfile));
+    FastLED.channelEvents().onColorProfileWarning.remove(listener);
+
+    FL_CHECK_FALSE(options.mGamma.has_value());
+    FL_REQUIRE_EQ(events.size(), size_t(1));
+    FL_CHECK_EQ(events[0].warning, ColorProfileWarning::LegacyClearedByProfile);
+}
+
+FL_TEST_CASE("[#4331] losing the dither mode is not detectable, and is not warned") {
+    // Recorded rather than fixed. mDitherMode's default is BINARY_DITHER and
+    // setColorProfile() sets DISABLE_DITHER, so a caller who wanted dithering
+    // has it by default and loses it -- while a caller who set BINARY_DITHER
+    // explicitly is byte-identical to one who never touched it. Comparison
+    // cannot tell the two apart, so no condition on this field can warn in
+    // the case that loses something without also warning in the case that
+    // does not. mGamma escapes this by being an optional.
+    //
+    // This pins the current, silent behaviour so that giving mDitherMode a
+    // "caller set this" flag is a visible change rather than a quiet one.
+    ChannelOptions options;
+    fl::vector<ColorProfileEvent> events;
+    const int listener = FastLED.channelEvents().onColorProfileWarning.add(
+        [&](const ColorProfileEvent& event) { events.push_back(event); });
+
+    options.mDitherMode = BINARY_DITHER;   // the default: indistinguishable
+    FL_REQUIRE(options.setColorProfile(kFixtureProfile));
+    FastLED.channelEvents().onColorProfileWarning.remove(listener);
+
+    FL_CHECK_EQ((int)options.mDitherMode, (int)DISABLE_DITHER);
+    FL_CHECK_EQ(events.size(), size_t(0));
+}
+
+FL_TEST_CASE("[#4331] a profile bound over untouched defaults stays quiet") {
+    // The guard that keeps the two cases above from passing under a warning
+    // that simply always fires. BINARY_DITHER is mDitherMode's default, so
+    // nothing here was set by a caller and nothing is being taken away.
+    ChannelOptions options;
+    fl::vector<ColorProfileEvent> events;
+    const int listener = FastLED.channelEvents().onColorProfileWarning.add(
+        [&](const ColorProfileEvent& event) { events.push_back(event); });
+
+    FL_REQUIRE(options.setColorProfile(kFixtureProfile));
+    FastLED.channelEvents().onColorProfileWarning.remove(listener);
+
+    FL_CHECK_EQ(events.size(), size_t(0));
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
Fixes #4331.

## The gap

`ChannelOptions::setColorProfile()` clears four legacy settings:

```cpp
mCorrection = UncorrectedColor;
mTemperature = UncorrectedTemperature;
mGamma.reset();
mDitherMode = DISABLE_DITHER;
```

Its one-time warning tested two:

```cpp
if (!had_profile &&
    (mCorrection != UncorrectedColor || mTemperature != UncorrectedTemperature) && ...
```

So `options.mGamma = 2.2f` followed by a profile bind lost the gamma **silently** — the failure the comment directly above that guard exists to prevent, and precisely what #4156 R9 asked for:

> Include existing `ChannelOptions::mGamma` in the managed-mode compatibility policy, **alongside correction/temperature/dither**, so a legacy default cannot add unintended shaping.

## `mDitherMode` is deliberately still out, and that is the interesting part

I wrote the obvious condition first — add `mDitherMode != BINARY_DITHER` — and a test caught that it is **backwards on both sides**:

- `BINARY_DITHER` is the field's default and the clear sets `DISABLE_DITHER`
- so the term is **true** exactly when the caller already chose `DISABLE_DITHER` and nothing is being taken away
- and **false** in the case that actually loses dithering

A caller who wants dithering has it by default, so "set it explicitly" and "never touched it" are byte-identical. No comparison on that field can warn in the losing case without also warning in the harmless one. `mGamma` escapes this only because it is an `optional` and `has_value()` records that someone set it.

Telling them apart needs a "the caller set this" flag on `mDitherMode`. Rather than smuggle that in here, the current silent behaviour is **pinned by a case**, so adding the flag later is a visible change instead of a quiet one.

## Cases

| case | pins |
|---|---|
| gamma warns with correction untouched | the fix |
| dither's loss is undetectable, and unwarned | the honest limit, so it cannot be lost |
| a profile over untouched defaults stays quiet | the vacuity guard |

Without the third, the first would pass under a warning that always fires.

Dropping the `mGamma.has_value()` term fails the first case and nothing else:

```
REQUIRE FAILED: color_profile.cpp:717: 0 == 1
```

`bash test --cpp`: **304/304 unit, 84/84 examples.** `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Color profile changes now warn when an existing gamma setting is cleared.
  * Warning text clarifies that correction, temperature, and gamma settings may be cleared.

* **Documentation**
  * Marked the legacy color-management check as deprecated and identified the recommended replacement.

* **Tests**
  * Added coverage for gamma-clearing warnings, default settings, and dither-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->