### PR TITLE
feat(channels): emit C5's one-time colour-management fallback warning (#4333)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -364,6 +364,21 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
     if (options.mColorProfile.mRequested && !options.hasColorProfile()) {
         mColorProfileFallback = true;
         mProfileBindingAccepted = !detail::colorProfileStrictMode();
+        // C5's one-time warning. The event below is the machine-readable
+        // half; this is the half a sketch sees without subscribing to
+        // anything, and it was the only one of C5's four items never built
+        // (#4333). Strict mode turns the same condition into a disabled
+        // channel, so say which happened.
+        if (!mWarnedColorProfileFallback) {
+            if (mProfileBindingAccepted) {
+                FL_WARN_F("Channel %d: color management requested but no profile "
+                          "bound; falling back to the legacy path", id());
+            } else {
+                FL_WARN_F("Channel %d: color management requested but no profile "
+                          "bound; strict mode disables this channel", id());
+            }
+            mWarnedColorProfileFallback = true;
+        }
     }
     if (options.mColorProfile.mUseGlobalSourceDefault) {
         mSettings.mColorProfile.mSource = detail::defaultSourceProfile();

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -397,6 +397,11 @@ private:
 
     bool mColorProfileFallback = false;
     bool mProfileBindingAccepted = true;
+    // C5 asks for the fallback warning to be one-time. Set on the first
+    // emission and never cleared: a channel reconfigured repeatedly while
+    // still unable to bind should say so once, not once per configure
+    // (#4333).
+    bool mWarnedColorProfileFallback = false;
 #endif
 };
 

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -5,6 +5,7 @@
 #include "fl/channels/color_profile.h"
 #include "fl/gfx/pipeline.h"
 #include "test.h"
+#include "fl/stl/cstdio.h"
 
 using namespace fl;
 
@@ -783,6 +784,78 @@ FL_TEST_CASE("[#4331] a profile bound over untouched defaults stays quiet") {
     FastLED.channelEvents().onColorProfileWarning.remove(listener);
 
     FL_CHECK_EQ(events.size(), size_t(0));
+}
+
+// #4333: C5 promises a channel that asks for colour management and does not
+// get it four things -- a one-time warning, a queryable isColorManaged(), a
+// fallback flag in telemetry, and strict mode. The last three were built.
+// The warning was not, and stayed missing because nothing checked for it.
+FL_TEST_CASE("[#4333] falling back to the legacy path warns once") {
+    CRGB leds[1] = {};
+    fl::vector<fl::string> lines;
+    fl::inject_print_handler([&](const char* text) { lines.push_back(fl::string(text)); });
+
+    ChannelOptions options;
+    options.requestColorManagement(SourceProfile::linearSrgb());   // no profile
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    fl::clear_print_handler();
+
+    FL_REQUIRE(channel != nullptr);
+    FL_REQUIRE(channel->hasColorProfileFallback());
+
+    int warned = 0;
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        if (lines[i].find("color management") != fl::string::npos) { ++warned; }
+    }
+    FL_CHECK_EQ(warned, 1);
+}
+
+FL_TEST_CASE("[#4333] a channel that gets its profile says nothing") {
+    // The guard. Without it, a warning emitted unconditionally on every
+    // channel would satisfy the case above.
+    CRGB leds[1] = {};
+    fl::vector<fl::string> lines;
+    fl::inject_print_handler([&](const char* text) { lines.push_back(fl::string(text)); });
+
+    ChannelOptions options;
+    FL_REQUIRE(options.setColorProfile(kFixtureProfile, SourceProfile::linearSrgb()));
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    fl::clear_print_handler();
+
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK_FALSE(channel->hasColorProfileFallback());
+
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        FL_CHECK(lines[i].find("color management") == fl::string::npos);
+    }
+}
+
+
+FL_TEST_CASE("[#4333] and it stays quiet on every reconfigure after the first") {
+    // "One-time" is the contract word, so it has to be the thing checked.
+    // Without this, a warning emitted on every reconcile would pass the case
+    // above, and applyConfig() reconciles again each time it is called.
+    CRGB leds[1] = {};
+    ChannelOptions options;
+    options.requestColorManagement(SourceProfile::linearSrgb());
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    FL_REQUIRE(channel != nullptr);
+    FL_REQUIRE(channel->hasColorProfileFallback());
+
+    // Capture only the reconfigures, so the create-time warning is not
+    // counted here -- the case above owns that one.
+    fl::vector<fl::string> lines;
+    fl::inject_print_handler([&](const char* text) { lines.push_back(fl::string(text)); });
+    channel->applyConfig(config);
+    channel->applyConfig(config);
+    fl::clear_print_handler();
+
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        FL_CHECK(lines[i].find("color management") == fl::string::npos);
+    }
 }
 
 }  // FL_TEST_FILE

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -804,11 +804,48 @@ FL_TEST_CASE("[#4333] falling back to the legacy path warns once") {
     FL_REQUIRE(channel != nullptr);
     FL_REQUIRE(channel->hasColorProfileFallback());
 
+    // The distinguishing half of the message, not the shared prefix: the two
+    // branches differ only after "no profile bound", so matching the common
+    // text would pass even if the strict-mode wording were emitted here.
     int warned = 0;
+    int wrong_branch = 0;
     for (fl::size i = 0; i < lines.size(); ++i) {
-        if (lines[i].find("color management") != fl::string::npos) { ++warned; }
+        if (lines[i].find("falling back to the legacy path") != fl::string::npos) { ++warned; }
+        if (lines[i].find("strict mode disables this channel") != fl::string::npos) { ++wrong_branch; }
     }
     FL_CHECK_EQ(warned, 1);
+    FL_CHECK_EQ(wrong_branch, 0);
+}
+
+FL_TEST_CASE("[#4333] strict mode says it disabled the channel, not that it fell back") {
+    // The other branch. Without it the message text is only half checked, and
+    // swapping the two arms would go unnoticed -- the condition that selects
+    // them is the same one that decides whether the channel stays enabled.
+    CRGB leds[1] = {};
+    fl::vector<fl::string> lines;
+    FastLED.setColorManagementStrict(true);
+    fl::inject_print_handler([&](const char* text) { lines.push_back(fl::string(text)); });
+
+    ChannelOptions options;
+    options.requestColorManagement(SourceProfile::linearSrgb());
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+
+    fl::clear_print_handler();
+    FastLED.setColorManagementStrict(false);
+
+    FL_REQUIRE(channel != nullptr);
+    FL_REQUIRE(channel->hasColorProfileFallback());
+    FL_REQUIRE_FALSE(channel->profileBindingAccepted());
+
+    int strict = 0;
+    int wrong_branch = 0;
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        if (lines[i].find("strict mode disables this channel") != fl::string::npos) { ++strict; }
+        if (lines[i].find("falling back to the legacy path") != fl::string::npos) { ++wrong_branch; }
+    }
+    FL_CHECK_EQ(strict, 1);
+    FL_CHECK_EQ(wrong_branch, 0);
 }
 
 FL_TEST_CASE("[#4333] a channel that gets its profile says nothing") {


### PR DESCRIPTION
Fixes #4333.

## The gap

#4034 C5 promises four things to a channel that asks for colour management and doesn't get it:

| item | state before |
|---|---|
| queryable `isColorManaged()` | was a hardcoded `false` — fixed in #4329 |
| fallback flag in events/telemetry | present, fired at two sites, with a test |
| opt-in strict mode | present, with tests |
| **one-time warning** | **never written** |

So a sketch whose profile failed to bind fell back to the legacy path **silently**, unless it had subscribed to the event. The event is the machine-readable half; C5 lists the warning separately because it's the half you see without writing code.

`reconcileColorProfile` now says so once, naming which of the two happened — ordinary fallback, or strict mode disabling the channel.

## I filed this issue claiming the fix couldn't be tested. That was wrong.

I wrote that a warning here would be unverifiable because "there is no capture hook in `fl/log/log.h`". True of `log.h`, false of the codebase:

```cpp
// fl/stl/cstdio.h
void inject_print_handler(const print_handler_t& handler) FL_NO_EXCEPT;
void clear_print_handler() FL_NO_EXCEPT;
```

`println` routes through it, and both `log_emit` and `log_emit_f` end at `println` — so every `FL_WARN` is capturable, and `tests/fl/stl/cstdio.cpp` already installs handlers this way. I searched the layer where I expected the hook, didn't find it, and stopped — the same mistake as #4326, where I looked for a guard at the wrong layer and reported it missing. Corrected on the issue rather than quietly.

The upshot is better than the plan: this is verified as **text**, not through the event surface.

## Cases

| case | pins |
|---|---|
| falling back warns once | the fix |
| a channel that gets its profile says nothing | stops an unconditional warning passing the first |
| two `applyConfig()` calls after the first add nothing | makes "one-time" mean something |

The third matters because `applyConfig()` reconciles again on every call, so without a guard the warning would repeat for the life of the channel.

Two mutations, each caught by exactly one case:

```
MUT: warning removed      -> FAIL: falling back to the legacy path warns once
MUT: once-guard removed   -> FAIL: and it stays quiet on every reconfigure after the first
```

`bash test --cpp`: **303/303 unit, 84/84 examples.** `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a one-time warning when color management is requested without an available color profile.
  - Clarified warnings to distinguish between strict mode disabling the channel and legacy fallback behavior.
  - Prevented repeated configuration attempts from generating duplicate warnings for the same channel.
  - Configured color profiles continue to operate without unnecessary warnings.
  - Improved feedback when color-profile configuration cannot be applied, making fallback behavior clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->