### PR TITLE
test(ci): scan the gamut mapper for iterative solvers, which is the point (#4335)

### DIFF
--- a/ci/tests/test_no_iterative_solver_per_pixel.py
+++ b/ci/tests/test_no_iterative_solver_per_pixel.py
@@ -18,11 +18,25 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 GFX = PROJECT_ROOT / "src" / "fl" / "gfx"
 
 # The stages that execute once per pixel inside show().
+#
+# This list used to omit `pipeline.cpp.hpp`, `gamut_map.cpp.hpp` and
+# `white_allocation.cpp.hpp`, which is most of the point: `processPixelQ16`
+# calls `mapAndSolveDrivesQ16(pipeline.gamut, ...)` per pixel, so the gamut
+# mapper is exactly where an iterative solve would be reached for -- and it is
+# the stage A3 names when it says iterative solves never run per-pixel. The
+# guard was blind there. Verified by injecting an `nnls3` call into
+# `gamut_map.cpp.hpp`: the old list passed, this one fails (FastLED#4041).
+#
+# Keep in step with `test_no_rgb8_intermediate.py`, which scans the same eight
+# and is where the missing three were noticed.
 PER_PIXEL_STAGES = (
+    "pipeline.cpp.hpp",
     "transfer.cpp.hpp",
     "source_xyz.cpp.hpp",
     "chromatic_adaptation.cpp.hpp",
     "device_solve.cpp.hpp",
+    "gamut_map.cpp.hpp",
+    "white_allocation.cpp.hpp",
     "flux_scalar.cpp.hpp",
 )
 


### PR DESCRIPTION
Fixes #4335.

## The hole

`test_no_iterative_solver_per_pixel.py` exists so that "a future edit that wires one in fails here rather than in a frame-rate report on someone's bench". It scanned five stage files; its companion `test_no_rgb8_intermediate.py` lists eight for the same per-pixel path.

The three missing were `pipeline.cpp.hpp`, `gamut_map.cpp.hpp` and `white_allocation.cpp.hpp`.

**`gamut_map.cpp.hpp` is the one that matters.** `processPixelQ16` calls it per pixel:

```cpp
mapAndSolveDrivesQ16(pipeline.gamut, xyz, drives);   // pipeline.cpp.hpp:94
```

and gamut mapping is the stage A3 is about:

> embedded per-pixel path is matrix + clamp/compress (+ optional LUT) — **iterative solves (incl. `nnls3`) never run per-pixel**

So the guard covered four stages where nobody would put a solver, and skipped the one where someone would.

## Measured, not assumed

```cpp
// injected into src/fl/gfx/gamut_map.cpp.hpp
static void mut_probe() { nnls3(nullptr, nullptr); }
```

| | result |
|---|---|
| old list | `2 passed, 20 subtests passed` — blind |
| new list | `SUBFAILED(stage='gamut_map.cpp.hpp', symbol='nnls3')` |

All three files are clean today, so the suite stays green — **32 subtests instead of 20** — and this closes the hole rather than reporting one.

## Relationship to #4330

Found while narrowing the sibling guard's stated scope. That one **over-claimed** what it covered; this one **under-covered** what it claimed — opposite failures in a matched pair of files. Both now carry a note to keep the two lists in step, since the gap was invisible until they were read side by side.

`bash lint` clean. Test-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage to verify that all streaming stages avoid per-pixel iterative solvers.
  * Added checks for pipeline, gamut mapping, and white allocation stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->