### PR TITLE
test(ci): cover the two stage headers nothing was compiling (#4337)

### DIFF
--- a/ci/tests/test_fixed_point_headers_are_self_contained.py
+++ b/ci/tests/test_fixed_point_headers_are_self_contained.py
@@ -41,6 +41,20 @@ kSelfContainedHeaders = [
     # the `using` from `fl/channels/color_profile.h`. FastLED#4043, and then
     # the same thing again in its neighbour -- which is the argument for
     # listing the whole group rather than adding them one incident at a time.
+    # The eight per-pixel stages, kept whole on purpose. This list held six
+    # of them. `flux_scalar.h` and `source_xyz.h` were covered by accident --
+    # `pipeline.h` is listed and includes both, so a break failed, blamed on
+    # `pipeline.h`. `transfer.h` and `chromatic_adaptation.h` are included by
+    # no listed header and had no coverage at all: dropping an include from
+    # `transfer.h` left this file green at 15 passed (FastLED#4337).
+    #
+    # Two sibling guards scan the same eight -- test_no_rgb8_intermediate.py
+    # and test_no_iterative_solver_per_pixel.py. Three hand-maintained lists
+    # over one path; keep them in step.
+    "fl/gfx/transfer.h",
+    "fl/gfx/source_xyz.h",
+    "fl/gfx/chromatic_adaptation.h",
+    "fl/gfx/flux_scalar.h",
     "fl/gfx/device_solve.h",
     "fl/gfx/white_allocation.h",
     "fl/gfx/gamut_map.h",


### PR DESCRIPTION
Fixes #4337.

## The gap

`test_fixed_point_headers_are_self_contained.py` compiles each listed header as a translation unit's only include. Its list named **six of the eight** per-pixel stage headers.

Two of the four omissions were covered by accident: `pipeline.h` is listed and includes `flux_scalar.h` and `source_xyz.h`, so breaking either fails — blamed on `pipeline.h` rather than the header at fault, but it fails.

**`transfer.h` and `chromatic_adaptation.h` are included by no listed header.** No coverage at all.

## Measured

Removing `#include "fl/gfx/color_profile.h"` from `transfer.h`, leaving it depending on an include it doesn't make:

| list | result |
|---|---|
| as it was | `15 passed` — **silent** |
| with the four | `FAILED ... [fl/gfx/transfer.h]`, `1 failed, 18 passed` |

All four are self-contained today, so this stays green at **19 instead of 15** and closes the gap rather than reporting one.

`transfer.h` is worth more than its size here: it's the decode stage, the "one semantic conversion" B3 is written around, and the only stage the reference corpus checks numerically.

## Third of a kind, and that is the part worth reading

| guard | failure |
|---|---|
| #4330 | docstring **over-claimed** the scope it scanned |
| #4335 | **under-covered** the stages it claimed — missed the gamut mapper, the one stage A3 is about |
| this | covers six of eight; two had no coverage at all |

Three structural guards over the same eight-stage path, three hand-maintained lists, none agreeing. Each was defensible read alone; the gaps only appeared side by side. **A guard's list is itself a thing nothing checks.**

Each file now carries a comment naming the other two. Whether the stage set should be declared once and imported — so adding a stage cannot silently skip a guard — is raised on #4337 as a question rather than decided in a test fix.

`bash lint` clean. Test-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage to verify additional graphics headers can be included independently.
  - Improved validation for per-pixel graphics stages, including transfer, source, chromatic adaptation, and scalar processing components.
  - No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->