### PR TITLE
test(ci): make the per-pixel stage lists check each other (#4337)

### DIFF
--- a/ci/tests/test_per_pixel_stage_lists_agree.py
+++ b/ci/tests/test_per_pixel_stage_lists_agree.py
@@ -1,0 +1,102 @@
+"""The per-pixel stage lists must agree with each other.
+
+Three guards scan the same eight-stage pipeline, each with its own
+hand-maintained list, and all three drifted independently:
+
+* FastLED#4330 -- `test_no_rgb8_intermediate.py` claimed to cover "the
+  streaming path" and covered the pipeline's interior.
+* FastLED#4335 -- `test_no_iterative_solver_per_pixel.py` scanned five of the
+  eight, missing `gamut_map.cpp.hpp`: the one stage A3 is about, and the only
+  place anyone would put an iterative solver.
+* FastLED#4337 -- `test_fixed_point_headers_are_self_contained.py` listed six
+  of the eight headers. `transfer.h` and `chromatic_adaptation.h` were
+  included by no listed header and had no coverage at all.
+
+Each list was defensible read alone. The gaps only appeared reading them side
+by side, which nothing did -- a guard's list was itself a thing nothing
+checked.
+
+This is the cheap half of the fix. It does not restructure the three files or
+introduce a shared stage module; it asserts they agree, so the next
+divergence fails here instead of waiting to be noticed. FastLED#4339 showed
+the value of that shape: the reference corpus names its source set in five
+places too, and every one of them failed loudly when a source was added,
+which is why that duplication never silently rotted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+GFX = TESTS_DIR.parent.parent / "src" / "fl" / "gfx"
+
+
+def _load(name: str) -> ModuleType:
+    """Import a sibling guard by path, without needing a package."""
+
+    path = TESTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec_module, not after: the self-containment guard
+    # decorates with typeguard's @typechecked, which reads its own module
+    # source out of sys.modules while the decorator runs and raises KeyError
+    # if it is not there yet.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestPerPixelStageListsAgree(unittest.TestCase):
+    def test_the_two_stage_scanners_cover_the_same_files(self) -> None:
+        rgb8 = _load("test_no_rgb8_intermediate")
+        solver = _load("test_no_iterative_solver_per_pixel")
+
+        self.assertEqual(
+            tuple(rgb8.PER_PIXEL_STAGES),
+            tuple(solver.PER_PIXEL_STAGES),
+            msg=(
+                "the RGB8 and iterative-solver guards scan the same per-pixel "
+                "path and must scan the same files; see FastLED#4335, where "
+                "one of them was missing the gamut mapper"
+            ),
+        )
+
+    def test_every_scanned_stage_exists(self) -> None:
+        rgb8 = _load("test_no_rgb8_intermediate")
+        for name in rgb8.PER_PIXEL_STAGES:
+            with self.subTest(stage=name):
+                self.assertTrue((GFX / name).is_file(), msg=f"missing {name}")
+
+    def test_each_stage_header_is_checked_for_self_containment(self) -> None:
+        # The self-containment guard lists headers, not stage bodies, and
+        # carries entries this file has no opinion about -- fixed-point and
+        # channels headers. What it must not do is skip a stage: that is
+        # exactly FastLED#4337, where `transfer.h` compiled nowhere on its own
+        # and nothing noticed.
+        rgb8 = _load("test_no_rgb8_intermediate")
+        headers = _load("test_fixed_point_headers_are_self_contained")
+        listed = set(headers.kSelfContainedHeaders)
+
+        for stage in rgb8.PER_PIXEL_STAGES:
+            header = "fl/gfx/" + stage.replace(".cpp.hpp", ".h")
+            with self.subTest(stage=stage, header=header):
+                self.assertIn(
+                    header,
+                    listed,
+                    msg=(
+                        f"{header} backs a per-pixel stage and is not checked "
+                        "for self-containment (FastLED#4337)"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses the cheap half of #4337. The structural question there stays open.

## Why

Three guards scan the same eight-stage per-pixel path, each with its own hand-maintained list, and **all three drifted independently**:

| | failure |
|---|---|
| #4330 | claimed to cover "the streaming path"; covered the pipeline's interior |
| #4335 | scanned five of eight — missing `gamut_map.cpp.hpp`, the one stage A3 is about and the only place anyone would put an iterative solver |
| #4337 | listed six of eight headers; `transfer.h` and `chromatic_adaptation.h` compiled nowhere on their own |

Each list was defensible read alone. The gaps only appeared reading them side by side, which nothing did — **a guard's list was itself a thing nothing checked.**

## What this adds

Three assertions, no restructuring:

- the two `PER_PIXEL_STAGES` tuples are identical
- every scanned stage file exists
- each stage's header is on the self-containment list

## Verified by replaying both regressions

| replayed | caught by |
|---|---|
| drop `gamut_map.cpp.hpp` from the solver guard (#4335) | `test_the_two_stage_scanners_cover_the_same_files` |
| drop `fl/gfx/transfer.h` from self-containment (#4337) | `SUBFAILED(stage='transfer.cpp.hpp', header='fl/gfx/transfer.h')` |

Both would now fail at the point of drift.

## Why this shape and not the shared module

#4339 is the argument. The P5 corpus names its source set in **five** places, and when I added one, every copy that could object did — a `ValueError` from the exporter, an assertion in the corpus test, and `-Werror,-Wswitch` on the C++ switch. Same duplication as here; opposite outcome. The difference is not the number of copies, it is that each one **fails loudly**.

So this gives the guard lists that property and stops there. Declaring the stage set once and importing it is strictly better, is still an open question on #4337, and is not blocked by this — the next divergence just isn't free any more. I'd rather not restructure three guards on my own reading of a question I asked.

## One implementation note

The loader registers each module in `sys.modules` *before* `exec_module`. The self-containment guard decorates with typeguard's `@typechecked`, which reads its own module source out of `sys.modules` while the decorator runs — registering afterwards gives `KeyError`.

`bash lint` clean. The four guards together: **30 passed, 68 subtests.** New file only; no changes to the guards themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage to verify consistency among per-pixel stage validation checks.
  - Confirmed that all scanned stage files exist and that their headers are included in self-containment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->