### PR TITLE
perf(serial): stop paying 220 ms of dead wait on every device RPC

### DIFF
--- a/ci/util/serial_interface.py
+++ b/ci/util/serial_interface.py
@@ -255,11 +255,30 @@ class FbuildSerialAdapter:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
                         break
-                    # Cap each inner read at 0.25s so we re-check
-                    # stop_event regularly -- otherwise a quiet serial
-                    # line lets read_lines(timeout=remaining) block for
-                    # minutes ignoring the cancel signal.
-                    inner = min(remaining, 0.25)
+                    # Cap each inner read so we re-check stop_event
+                    # regularly -- otherwise a quiet serial line lets
+                    # read_lines(timeout=remaining) block for minutes
+                    # ignoring the cancel signal.
+                    #
+                    # 0.05, not the 0.25 this used to be. A request/reply
+                    # costs two reads here: the first returns the ACK
+                    # promptly, the second waits for the result and blocks
+                    # the full cap when the device has not answered yet. So
+                    # the cap is paid once per RPC, on top of the round trip
+                    # rather than overlapping it. Measured on an RP2350W over
+                    # the fbuild monitor, 20 `ping` calls per point:
+                    #
+                    #   cap 0.005 -> 110.5 ms    cap 0.10 -> 119.9 ms
+                    #   cap 0.02  -> 110.1 ms    cap 0.25 -> 330.7 ms
+                    #   cap 0.05  -> 110.2 ms
+                    #
+                    # ~110 ms is the real round trip; the old cap was adding
+                    # ~220 ms of pure waiting to every call, which is 3x. The
+                    # curve is flat below 0.05 so there is nothing to gain
+                    # going smaller, and 0.05 still re-checks stop_event 20
+                    # times a second rather than 4 -- strictly more
+                    # responsive to cancellation than before.
+                    inner = min(remaining, 0.05)
                     for line in self._monitor.read_lines(timeout=inner):
                         loop.call_soon_threadsafe(queue.put_nowait, line)
                         if stop_event.is_set():


### PR DESCRIPTION
Every AutoResearch serial RPC was costing ~330 ms. About 220 ms of that was the harness waiting on a timeout it did not need to wait on.

## Where it goes

`FbuildSerialAdapter`'s producer loop caps each inner `read_lines` so `stop_event` gets re-checked. A request/reply costs **two** reads: the first returns the ACK promptly, the second waits for the result and blocks the **full cap** when the device has not answered yet. So the cap is paid once per RPC, added to the round trip rather than overlapping it.

## Measurement

Attached RP2350W (`2DCB876B587EA334`) over the fbuild monitor, 20 `ping` calls per point, median:

| inner cap | latency |
|---|---|
| 0.005 s | 110.5 ms |
| 0.02 s | 110.1 ms |
| 0.05 s | **110.2 ms** |
| 0.10 s | 119.9 ms |
| 0.25 s *(before)* | **330.7 ms** |

Two things make this a harness artifact rather than transport cost:

- **A `ping` is ~4 ms of wire time at 115200.** 330 ms was never the wire.
- **The curve is a step, not a slope.** Flat at ~110 ms for every cap ≤ 0.05, then a sharp jump at 0.25. A real transport cost would scale with payload; this does not — the original figure was already known to be "~318 ms, size-independent", which is the signature of a fixed wait.

Variance is near zero either way (`110 110 110 110 110 110 110 110`), which is what you would expect from a constant, and is why this went unnoticed: it looks like a stable, healthy transport.

## The change

`0.25` → `0.05`. That keeps the property the cap exists for and improves it — `stop_event` is re-checked **20 times a second instead of 4**, so cancellation is strictly more responsive than before, not less. Nothing is gained below 0.05, so this is not shaved to the bone.

## Why it matters beyond the microbenchmark

3x on every serial RPC in AutoResearch. It matters most where calls are counted in thousands: the peer-OTA artifact transfer is 3,241 round trips — about **17.8 minutes at 330 ms, about 5.9 at 110**. That transfer has been the one part of #3956 I could not verify end to end, because every attempt outran this bench's memory monitor.

## Verification

- `bash autoresearch rp2350w --rpc-smoke` → `RESULT: RPC smoke PASS (...)`
- `bash autoresearch rp2350w --flex-io --rp-pio-index 0` → `TEST PIO0 lanes=1 leds=100 PASS`, `RESULT PASS 2 test(s)`
- 329 host tests pass, 3 skipped
- `bash lint` clean

Found while investigating why the peer-OTA transfer takes ~20 minutes (#3956, #4318).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial communication responsiveness by reducing the maximum wait time when reading incoming lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->