### PR TITLE
fix(channels): a profile that builds no pipeline is a fallback, and says so (#4345)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -348,6 +348,26 @@ Channel::~Channel() FL_NO_EXCEPT {
 }
 
 #if FL_COLOR_PROFILE_RUNTIME
+void Channel::raiseColorProfileFallback(const char* reason) FL_NO_EXCEPT {
+    mColorProfileFallback = true;
+    mProfileBindingAccepted = !detail::colorProfileStrictMode();
+    // C5's one-time warning. The event fired by the callers is the
+    // machine-readable half; this is the half a sketch sees without
+    // subscribing to anything (#4333). Strict mode turns the same condition
+    // into a disabled channel, so say which happened.
+    if (mWarnedColorProfileFallback) {
+        return;
+    }
+    if (mProfileBindingAccepted) {
+        FL_WARN_F("Channel %d: color management requested but %s; "
+                  "falling back to the legacy path", id(), reason);
+    } else {
+        FL_WARN_F("Channel %d: color management requested but %s; "
+                  "strict mode disables this channel", id(), reason);
+    }
+    mWarnedColorProfileFallback = true;
+}
+
 bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT {
     // A strict-mode rejection disables the channel. Remember whether the
     // current disabled state is ours, so that withdrawing the rejection
@@ -361,24 +381,12 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
     mColorProfileFallback = false;
     mProfileBindingAccepted = true;
 
+    // C5's fallback, raised by the two conditions that mean the same thing to
+    // a caller: management was asked for and is not happening. The second one
+    // -- a profile that binds but builds no pipeline -- is raised further
+    // down, once the build has been attempted.
     if (options.mColorProfile.mRequested && !options.hasColorProfile()) {
-        mColorProfileFallback = true;
-        mProfileBindingAccepted = !detail::colorProfileStrictMode();
-        // C5's one-time warning. The event below is the machine-readable
-        // half; this is the half a sketch sees without subscribing to
-        // anything, and it was the only one of C5's four items never built
-        // (#4333). Strict mode turns the same condition into a disabled
-        // channel, so say which happened.
-        if (!mWarnedColorProfileFallback) {
-            if (mProfileBindingAccepted) {
-                FL_WARN_F("Channel %d: color management requested but no profile "
-                          "bound; falling back to the legacy path", id());
-            } else {
-                FL_WARN_F("Channel %d: color management requested but no profile "
-                          "bound; strict mode disables this channel", id());
-            }
-            mWarnedColorProfileFallback = true;
-        }
+        raiseColorProfileFallback("no profile bound");
     }
     if (options.mColorProfile.mUseGlobalSourceDefault) {
         mSettings.mColorProfile.mSource = detail::defaultSourceProfile();
@@ -403,6 +411,18 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         StreamingPipelineQ16 pipeline;
         if (hooks.build(mSettings.mColorProfile, &pipeline)) {
             mPipeline = fl::make_unique<StreamingPipelineQ16>(pipeline);
+        } else if (options.hasColorProfile()) {
+            // R6: a profile outside the numerical bounds must "fail
+            // explicitly" and "not become native-drive input". A binding that
+            // cannot produce a pipeline used to leave every reporting surface
+            // saying the channel was fine -- Configured, no fallback flag, no
+            // warning -- while it rendered through the legacy path (#4345).
+            //
+            // This reports; it does not reject. Refusing the binding at
+            // setColorProfile() time is R6's fuller reading and needs the
+            // published coefficient bounds it also asks for, which do not
+            // exist yet.
+            raiseColorProfileFallback("bound profile builds no usable pipeline");
         }
     }
 

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -392,7 +392,13 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         mSettings.mColorProfile.mSource = detail::defaultSourceProfile();
     }
 
-    const bool rejectedNow = mColorProfileFallback && !mProfileBindingAccepted;
+    // Guards the build below: a binding already rejected by strict mode must
+    // not be built. It is deliberately *not* reused for the enablement
+    // branch -- the build can raise the fallback itself (#4345), and reading
+    // this stale value there left a strict-mode channel reporting Rejected
+    // while still enabled and rendering through the legacy path, which is the
+    // one thing strict mode exists to prevent.
+    const bool rejectedBeforeBuild = mColorProfileFallback && !mProfileBindingAccepted;
 
     // Derive the pipeline once, here, rather than per frame: it inverts
     // matrices and bisects a lightness bound. A binding that does not
@@ -401,7 +407,7 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
     // error.
     mPipeline.reset();
     const ColorPipelineHooks& hooks = colorPipelineHooks();
-    if (!rejectedNow && hooks.build != nullptr) {
+    if (!rejectedBeforeBuild && hooks.build != nullptr) {
         // Through the hook, not by name. Calling `buildPipelineForBinding`
         // directly from here is what kept the entire pipeline alive in every
         // build; the pointer is null until `setColorProfile` installs it.
@@ -426,6 +432,9 @@ bool Channel::reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT 
         }
     }
 
+    // Recomputed after the build, so a rejection raised by a failed build
+    // reaches this branch.
+    const bool rejectedNow = mColorProfileFallback && !mProfileBindingAccepted;
     if (rejectedNow) {
         setEnabled(false);
     } else if (wasRejectedByUs) {

--- a/src/fl/channels/channel.h
+++ b/src/fl/channels/channel.h
@@ -395,6 +395,11 @@ private:
     // remembers that management was asked for; the caller's options do.
     bool reconcileColorProfile(const ChannelOptions& options) FL_NO_EXCEPT;
 
+    /// Raise C5's fallback state and its one-time warning. Shared by the two
+    /// conditions that mean the same thing to a caller: no profile bound, and
+    /// a profile that binds but builds no usable pipeline (#4345).
+    void raiseColorProfileFallback(const char* reason) FL_NO_EXCEPT;
+
     bool mColorProfileFallback = false;
     bool mProfileBindingAccepted = true;
     // C5 asks for the fallback warning to be one-time. Set on the first

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -972,6 +972,10 @@ FL_TEST_CASE("[#4345] strict mode disables a channel whose profile cannot build"
     FL_CHECK(channel->hasColorProfileFallback());
     FL_CHECK_FALSE(channel->profileBindingAccepted());
     FL_CHECK_EQ(channel->colorProfileStatus(), ColorProfileStatus::Rejected);
+    // The thing strict mode is for. Reporting Rejected while still rendering
+    // through the legacy path is the failure it exists to prevent, and the
+    // first version of this case did not check it.
+    FL_CHECK_FALSE(channel->isEnabled());
 }
 
 

--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -18,6 +18,13 @@ constexpr EmitterProfile kFixtureProfile = EmitterProfile::rgb(
     Chromaticity(0.640f, 0.330f), Chromaticity(0.300f, 0.600f),
     Chromaticity(0.150f, 0.060f), 1.0f, 1.0f, 1.0f);
 
+/// Structurally valid, numerically unusable: three primaries at one
+/// chromaticity describe no invertible emitter matrix (#4345).
+constexpr EmitterProfile kDegenerateProfile = EmitterProfile::rgb(
+    "fixture/degenerate",
+    Chromaticity(0.3127f, 0.3290f), Chromaticity(0.3127f, 0.3290f),
+    Chromaticity(0.3127f, 0.3290f), 1.0f, 1.0f, 1.0f);
+
 ChannelPtr makeChannelWithLocalProfile(CRGB* leds) {
     const fl::u16 response[] = {0, 257, 65535};
     EmitterProfile profile = kFixtureProfile;
@@ -894,5 +901,78 @@ FL_TEST_CASE("[#4333] and it stays quiet on every reconfigure after the first") 
         FL_CHECK(lines[i].find("color management") == fl::string::npos);
     }
 }
+
+
+// #4345: R6 says a profile outside the numerical bounds must "fail
+// explicitly" and "not become native-drive input". A profile whose three
+// primaries share one chromaticity is structurally well formed and describes
+// no invertible emitter matrix, so no pipeline is built -- and every
+// reporting surface used to say the channel was fine.
+FL_TEST_CASE("[#4345] a profile that builds no pipeline reports fallback, not Configured") {
+    CRGB leds[1] = {};
+    ChannelOptions options;
+    FL_REQUIRE(options.setColorProfile(kDegenerateProfile, SourceProfile::linearSrgb()));
+
+    fl::vector<fl::string> lines;
+    fl::inject_print_handler([&](const char* t) { lines.push_back(fl::string(t)); });
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    fl::clear_print_handler();
+
+    FL_REQUIRE(channel != nullptr);
+    // The binding is still owned -- this is not a rejection, it is an honest
+    // report that management asked for something it did not get.
+    FL_CHECK(channel->hasColorProfile());
+    FL_CHECK_FALSE(channel->isColorManaged());
+
+    FL_CHECK(channel->hasColorProfileFallback());
+    FL_CHECK_EQ(channel->colorProfileStatus(), ColorProfileStatus::Fallback);
+
+    int warned = 0;
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        if (lines[i].find("color management") != fl::string::npos) { ++warned; }
+    }
+    FL_CHECK_EQ(warned, 1);
+}
+
+FL_TEST_CASE("[#4345] a usable profile still reports Configured and stays quiet") {
+    // The guard: without it, marking every binding as fallback would satisfy
+    // the case above.
+    CRGB leds[1] = {};
+    ChannelOptions options;
+    FL_REQUIRE(options.setColorProfile(kFixtureProfile, SourceProfile::linearSrgb()));
+
+    fl::vector<fl::string> lines;
+    fl::inject_print_handler([&](const char* t) { lines.push_back(fl::string(t)); });
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    fl::clear_print_handler();
+
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK(channel->isColorManaged());
+    FL_CHECK_FALSE(channel->hasColorProfileFallback());
+    FL_CHECK_EQ(channel->colorProfileStatus(), ColorProfileStatus::Configured);
+    for (fl::size i = 0; i < lines.size(); ++i) {
+        FL_CHECK(lines[i].find("color management") == fl::string::npos);
+    }
+}
+
+FL_TEST_CASE("[#4345] strict mode disables a channel whose profile cannot build") {
+    // C5: strict mode upgrades fallback to a hard error. It could not reach
+    // this case before, because the case did not report fallback.
+    CRGB leds[1] = {};
+    FastLED.setColorManagementStrict(true);
+    ChannelOptions options;
+    FL_REQUIRE(options.setColorProfile(kDegenerateProfile, SourceProfile::linearSrgb()));
+    ChannelConfig config(ClocklessChipset(), leds, RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    FastLED.setColorManagementStrict(false);
+
+    FL_REQUIRE(channel != nullptr);
+    FL_CHECK(channel->hasColorProfileFallback());
+    FL_CHECK_FALSE(channel->profileBindingAccepted());
+    FL_CHECK_EQ(channel->colorProfileStatus(), ColorProfileStatus::Rejected);
+}
+
 
 }  // FL_TEST_FILE


### PR DESCRIPTION
Fixes #4345.

## What it did

R6 requires a profile outside the numerical bounds to **"fail explicitly"** and **"not become native-drive input"**. An `EmitterProfile` whose three primaries share one chromaticity is structurally well formed and describes no invertible emitter matrix. Measured, before this change:

| surface | reported |
|---|---|
| `setColorProfile()` | **true** — accepted |
| `hasColorProfile()` | **true** |
| `isColorManaged()` | false |
| `hasColorProfileFallback()` | **false** |
| `colorProfileStatus()` | **`Configured`** |
| `isEnabled()` | **true** |
| warnings | **0** |

It rendered through the legacy native-drive path with every reporting surface saying the channel was fine.

## The machinery existed; it was wired to one condition

C5 defines explicit failure and all of it is built — one-time warning (#4333), fallback flag, `ColorProfileStatus::Fallback`, `onColorProfileFallback`, strict mode. `reconcileColorProfile` raised it only for *management requested, no profile bound*.

*Profile bound, cannot build* is the same situation from the caller's side: management was asked for and is not happening. Both now go through one helper.

## It reports; it does not reject

Deliberate. Refusing the binding at `setColorProfile()` time is R6's fuller reading — "before a profile is installed" — but it can refuse bindings that work today, and where the conditioning threshold sits is a real numerical decision. R6 asks for published coefficient bounds to set it, and those do not exist yet.

So this fixes the lying, not the admission policy. **The admission threshold stays open under R6**; nothing here forecloses it.

## Cases

| case | pins |
|---|---|
| degenerate binding reports `Fallback` and warns once | the fix |
| a usable profile still reports `Configured`, stays quiet | stops "mark everything as fallback" passing the first |
| strict mode reports `Rejected` | it could not reach this case before, because the case never reported fallback |

Dropping the new branch fails the first and third, and nothing else.

`bash test --cpp`: **303/303 unit, 84/84 examples.** `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Color profiles that cannot build a usable pipeline now correctly report fallback status and display a one-time warning.
  * Strict mode now disables channels when their configured color profile cannot be used.
  * Usable color profiles continue to report as configured without unnecessary warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->