### PR TITLE
fix(fled): let the compiler check the pixel-format mapping (#4034 D1)

### DIFF
--- a/src/fl/fled/detail/pixel_format.cpp.hpp
+++ b/src/fl/fled/detail/pixel_format.cpp.hpp
@@ -30,9 +30,19 @@ bool toPixelStorage(PixelFormat fledFormat, PixelStorage* out) FL_NO_EXCEPT {
         out->mFormat = fl::PixelFormat::Rgb16;
         out->mComponentByteOrder = ComponentByteOrder::LittleEndian;
         return true;
-    default:
+    // Known to the container and carried by `bytesPerLed`, but with no
+    // generic storage descriptor to map onto. Listed rather than swept into a
+    // `default:` so that a *seventh* wire format is a compile error naming
+    // this function instead of a silent `false` discovered at playback --
+    // D1 asks for a checked explicit mapping, and the check is worth more
+    // when the compiler performs it.
+    case PixelFormat::Gray8:
+    case PixelFormat::Rgba8:
+    case PixelFormat::Rgbw8:
+    case PixelFormat::Rgb565Le:
         return false;
     }
+    return false;
 }
 
 }  // namespace fled


### PR DESCRIPTION
#4034's D1 asks callers to use **"checked, explicit mapping rather than casting between enums"** for `fl::fled::PixelFormat` → `fl::PixelFormat`.

`toPixelStorage()` did exactly that — and then swept four of the six wire formats into `default: return false`. The mapping was checked; **nothing checked that the mapping was complete.**

## What changes

`Gray8`, `Rgba8`, `Rgbw8` and `Rgb565Le` are listed explicitly. Two consequences:

- they read as *known and unmapped* rather than *possibly forgotten* — `bytesPerLed` already knows all six, so the asymmetry was real and undocumented
- a **seventh** wire format becomes a compile error naming this function, instead of a silent `false` discovered at playback

## Verified

Adding a probe enumerator:

```
error: enumeration value 'MutProbe' not handled in switch [-Werror,-Wswitch]
  src/fl/fled/detail/pixel_format.cpp.hpp:24
```

Before the change, the same probe compiled clean.

## What deliberately keeps its default

`bytesPerLed()` takes a raw wire byte, not the enum, so it must answer for values that are not enumerators at all. Its `default: return 0` is doing real work and stays.

## Why this is worth a PR on its own

Same lesson as two earlier ones this cycle, from opposite directions:

- **#4340** — a `SourceKind` switch with *no* default caught an added source at compile time, which is how the corpus change was kept honest
- **#4341** — three guard lists that *could* drift silently were made to check each other

This is the third: a mapping that was correct today and had no way to stay correct. The fix is to let the compiler hold it rather than a reader.

`bash test --cpp --clean`: **304/304 unit, 84/84 examples.** `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Explicitly handles supported wire formats when determining pixel storage.
  * Future unsupported wire formats are more likely to be identified during compilation rather than silently at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->