### PR TITLE
test(channels): pin the legacy bytes emitted when CM is disabled (#4034)

### DIFF
--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -884,4 +884,93 @@ FL_TEST_CASE("[#4326] a bound profile reaches the encode path") {
     // whichever of the two landed second fail.
 }
 
+
+// ============ Legacy output with colour management disabled (#4034) ============
+// The tracker lists "Legacy output byte-identical with CM disabled" as an
+// acceptance criterion and nothing verified it. The colour pipeline reaches
+// into `showPixels` and into how the pixel iterator is built, so a change
+// there can alter output for every sketch that never asked for colour
+// management -- silently, because no managed test would notice.
+//
+// The observable form of "byte-identical" in one build is that an unbound
+// channel emits exactly the legacy arithmetic: colour order applied, each
+// channel scaled by brightness, and nothing else. Literals rather than a
+// recomputation, so this compares against a recorded answer instead of
+// against the same code that produced it.
+
+FL_TEST_CASE("[#4034] an unbound channel emits the legacy bytes exactly") {
+    struct Case {
+        const char* name;
+        EOrder order;
+        u8 brightness;
+        int expect[3];
+    };
+    // Source is CRGB(200, 100, 50) throughout.
+    const Case cases[] = {
+        {"full brightness is the identity",   RGB, 255, {200, 100, 50}},
+        {"half",                              RGB, 128, {100,  50, 25}},
+        {"quarter",                           RGB,  64, { 50,  25, 12}},
+        // scale8 with FASTLED_SCALE8_FIXED is (v * (b + 1)) >> 8, so the
+        // lowest brightness keeps a non-zero channel alive rather than
+        // rounding the whole pixel to black.
+        {"lowest brightness keeps red lit",   RGB,   1, {  1,   0,  0}},
+        // Colour order moves bytes and must not touch values.
+        {"GRB reorders without rescaling",    GRB, 255, {100, 200, 50}},
+        {"BGR reorders and scales",           BGR, 128, { 25,  50, 100}},
+    };
+
+    for (fl::size i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        FL_SUBCASE(cases[i].name) {
+            auto& mgr = ChannelManager::instance();
+            mgr.clearAllDrivers();
+            auto driver = fl::make_shared<CapturingDriver>();
+            mgr.addDriver(9300, driver);
+            auto cleanup = fl::make_scope_exit([&mgr]() { mgr.clearAllDrivers(); });
+
+            CRGB leds[1] = {CRGB(200, 100, 50)};
+            ChannelOptions options;
+            options.mDitherMode = DISABLE_DITHER;
+            auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+            ChannelConfig config(120 + (int)i, timing, fl::span<CRGB>(leds, 1),
+                                 cases[i].order, options);
+            ChannelPtr ch = Channel::create(config);
+            FL_REQUIRE(ch != nullptr);
+            FL_CHECK_FALSE(ch->hasColorProfile());
+            ch->showLeds(cases[i].brightness);
+
+            FL_REQUIRE_EQ((int)driver->last.size(), 3);
+            FL_CHECK_EQ((int)driver->last[0], cases[i].expect[0]);
+            FL_CHECK_EQ((int)driver->last[1], cases[i].expect[1]);
+            FL_CHECK_EQ((int)driver->last[2], cases[i].expect[2]);
+        }
+    }
+}
+
+FL_TEST_CASE("[#4034] and binding a profile does change them") {
+    // The guard. Without it, the case above would pass just as well against a
+    // pipeline that had stopped doing anything at all -- which is the other
+    // way this criterion can be satisfied for the wrong reason.
+    auto& mgr = ChannelManager::instance();
+    mgr.clearAllDrivers();
+    auto driver = fl::make_shared<CapturingDriver>();
+    mgr.addDriver(9300, driver);
+    auto cleanup = fl::make_scope_exit([&mgr]() { mgr.clearAllDrivers(); });
+
+    CRGB leds[1] = {CRGB(200, 100, 50)};
+    ChannelOptions options;
+    options.mDitherMode = DISABLE_DITHER;
+    FL_REQUIRE(options.setColorProfile(kProfile, SourceProfile::linearSrgb()));
+    auto timing = makeTimingConfig<TIMING_WS2812_800KHZ>();
+    ChannelConfig config(126, timing, fl::span<CRGB>(leds, 1), RGB, options);
+    ChannelPtr ch = Channel::create(config);
+    FL_REQUIRE(ch != nullptr);
+    FL_REQUIRE(ch->isColorManaged());
+    ch->showLeds(255);
+
+    FL_REQUIRE_EQ((int)driver->last.size(), 3);
+    const bool same = driver->last[0] == 200 && driver->last[1] == 100 &&
+                      driver->last[2] == 50;
+    FL_CHECK_FALSE(same);
+}
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
## The gap

#4034 lists **"Legacy output byte-identical with CM disabled"** among its sixteen acceptance criteria. Nothing verified it.

That matters more than an ordinary coverage hole: the colour pipeline reaches into `showPixels` and into how the pixel iterator is constructed, so a change there can alter output for **every sketch that never asked for colour management** — silently, because no managed test would notice. Several PRs this cycle touched exactly those functions.

## What is pinned

Within one build, the observable form of "byte-identical" is that an unbound channel emits the legacy arithmetic exactly: colour order applied, each channel scaled by brightness, nothing else.

Six subcases over `CRGB(200, 100, 50)`:

| order | brightness | bytes | |
|---|---:|---|---|
| RGB | 255 | `200 100 50` | the identity |
| RGB | 128 | `100 50 25` | |
| RGB | 64 | `50 25 12` | |
| RGB | 1 | `1 0 0` | `scale8` is `(v * (b+1)) >> 8`, so red stays lit rather than the pixel rounding to black |
| GRB | 255 | `100 200 50` | reorder without rescaling |
| BGR | 128 | `25 50 100` | |

**Literals, not a recomputation.** Deriving the expectation from `scale8` would compare the code against itself; these are recorded answers.

## The second case

Binding a profile **must** change the bytes. Without that, the first case would pass equally well against a pipeline that had quietly stopped doing anything — which is the other way this criterion can be satisfied for the wrong reason.

## Verified

Perturbing the legacy path — one subtracted LSB in `ScaledPixelIteratorRGB::advance()` — fails six subcases:

```
FAIL: [#4034] an unbound channel emits the legacy bytes exactly
[doctest] test cases: 17 | 11 passed | 6 failed
```

`bash test --cpp --clean`: **305/305 unit, 84/84 examples.** `bash lint` clean. Tests only; no source changes.

## Scope

P10 owns this criterion and P10 also needs hardware. This is the half that does not: a host-side guard against regression in the legacy path. It does not close the criterion, which still wants the measured legacy comparison on real strips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for legacy output when color management is disabled.
  - Verified RGB, GRB, and BGR byte ordering across multiple brightness levels.
  - Added coverage for minimum brightness behavior.
  - Added a check confirming that applying a color profile changes emitted color data and marks the channel as color-managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->