### PR TITLE
test(color): prove the response tables are owned, not aliased (#4362)

### DIFF
--- a/tests/fl/channels/color_profile.cpp
+++ b/tests/fl/channels/color_profile.cpp
@@ -107,17 +107,36 @@ FL_TEST_CASE("Profile binding validates and owns response tables") {
     FL_CHECK_FALSE(options.hasColorProfile());
 
     EmitterProfile profile = kFixtureProfile;
-    const fl::u16 response[] = {0, 257, 65535};
+    fl::u16 response[] = {0, 257, 65535};
     profile.response_lut_r = response;
     profile.response_lut_g = response;
     profile.response_lut_b = response;
     profile.response_lut_size = 3;
     FL_REQUIRE(options.setColorProfile(profile, SourceProfile::linearSrgb()));
+
+    // Clearing the struct's fields shows the `EmitterProfile` was copied. It
+    // does not show the *table* was: `response` is still alive and unchanged,
+    // so storage that kept the caller's pointer reads the same values and
+    // passes. R9 asks for ownership of the response tables themselves.
     profile.response_lut_r = nullptr;
     profile.response_lut_size = 0;
+
+    // So change what the caller's array says. A binding that aliased it now
+    // reports the new values; one that copied reports what it was given.
+    response[1] = 4242;
+    response[2] = 1;
+
     FL_REQUIRE(options.emitterProfile() != nullptr);
     FL_CHECK_EQ(options.emitterProfile()->response_lut_size, fl::u16(3));
     FL_CHECK_EQ(options.emitterProfile()->response_lut_r[1], fl::u16(257));
+    FL_CHECK_EQ(options.emitterProfile()->response_lut_r[2], fl::u16(65535));
+    FL_CHECK_EQ(options.emitterProfile()->response_lut_g[1], fl::u16(257));
+    FL_CHECK_EQ(options.emitterProfile()->response_lut_b[1], fl::u16(257));
+
+    // And the copy is a distinct object, checked directly rather than
+    // inferred from the values agreeing.
+    FL_CHECK_NE(options.emitterProfile()->response_lut_r,
+                static_cast<const fl::u16*>(response));
 }
 
 FL_TEST_CASE("A response LUT is validated, owned, and applied by nothing") {
@@ -323,9 +342,15 @@ FL_TEST_CASE("A rebound profile owns its response data after the source expires"
     FL_CHECK_EQ(stored->response_lut_g[1], fl::u16(1000));
     FL_CHECK_EQ(stored->response_lut_b[3], fl::u16(65535));
 
-    // And the storage is not the caller's array, which is the property
-    // itself rather than a consequence of it.
-    FL_CHECK(stored->response_lut_r != nullptr);
+    // This case cannot check that the storage is a distinct object: the
+    // array it would be compared against is gone, and reading a dead
+    // pointer's value to compare it is not something to write into a test.
+    // Reaching the right values after the source expired is what this one
+    // proves. "Profile binding validates and owns response tables" above
+    // makes the distinctness check, while the caller's array is still alive
+    // to be compared with -- and mutates it, so agreement there is not just
+    // two reads of the same memory.
+    FL_CHECK_EQ(stored->response_lut_g[2], fl::u16(20000));
 }
 
 FL_TEST_CASE("Clearing a binding releases it and leaves nothing bound") {


### PR DESCRIPTION
Closes #4362. Part of #4034 (R9, ownership and tiers).

R9 requires runtime bindings to own profile data *"including response tables"*. The implementation does — `ColorProfileStorage` copies all three LUTs into `fl::vector<u16>` members and rebinds the pointers. The test asserting it did not check that.

### What the test actually checked

*"Profile binding validates and owns response tables"* cleared the fields of the caller's `EmitterProfile` after binding:

```cpp
profile.response_lut_r = nullptr;
profile.response_lut_size = 0;
FL_CHECK_EQ(options.emitterProfile()->response_lut_r[1], fl::u16(257));
```

That shows the **struct** was copied. It says nothing about the **table** — `response[]` is still alive and unchanged, so a binding that kept the caller's pointer reads the same values and passes. The half R9 names explicitly was unverified.

### Measured

Deleted the three rebinding lines in `ColorProfileStorage`, which is precisely the aliasing bug:

```cpp
mProfile.response_lut_r = mResponseRed.data();   // deleted
mProfile.response_lut_g = mResponseGreen.data(); // deleted
mProfile.response_lut_b = mResponseBlue.data();  // deleted
```

**That case still passed** — not one assertion in it failed.

It was not wholly invisible: *"Channel binding owns response data after source options and config expire"* failed, reading `32381` and `0` where it wanted `257` and `65535`. But that is a dangling read of a dead stack array returning whatever happened to be there — detection by luck of the heap, not by construction. On a run where that memory survived intact, the aliasing ships green.

### The fix

Mutate `response[]` after binding, while it is still alive to be compared with, and assert the stored table still reports what it was *given* — plus a direct `FL_CHECK_NE` on the pointers rather than inferring distinctness from the values agreeing. Under the same mutation, five assertions now fail deterministically.

Also corrects a comment in the rebind case:

```cpp
// And the storage is not the caller's array, which is the property
// itself rather than a consequence of it.
FL_CHECK(stored->response_lut_r != nullptr);
```

The comment claimed a distinctness check; the line is a null check. It cannot do better there — the array is out of scope by then, and reading a dead pointer's value to compare it does not belong in a test. The comment now states what the case does establish and points at the one that makes the distinctness check.

Local: 305/305 unit, 84/84 examples, `bash lint` clean.

Test-only; no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded color profile tests to verify response tables are copied rather than shared with caller-provided data.
  - Added coverage confirming bound profile data remains valid after the original source data is modified or goes out of scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->