### PR TITLE
fix(autoresearch): stop three coroutine RPCs wedging an RP board until the watchdog fires (#3832)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteAsyncMethods.cpp
@@ -57,6 +57,53 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
     // ========================================================================
 
     // Test: Basic coroutine creation and completion
+// Decline the await-based coroutine tests where no coroutine can run.
+//
+// `fl::platforms::await()` (platforms/await.h) polls
+// `while (!promise.is_completed()) { promise.update(); suspendMainthread(); }`
+// with no bound. On RP the coroutine backend is null, so the producer
+// coroutine that would resolve the promise never executes and that loop never
+// exits: the sketch stops answering RPC entirely and only comes back when the
+// watchdog resets the board. Confirmed on an RP2350W, each of the three
+// tested *in isolation* with a `ping` after it: the call returns no response,
+// the following `ping` returns nothing either, and the board re-enumerates
+// reporting `lastResetCause: WATCHDOG`.
+//
+// Only the three tests that actually call `fl::task::await()` are guarded --
+// Await and AwaitError have one call site each, ChainedAwait two. The two
+// promise-callback tests call it zero times: they wait on
+// `while (producer.isRunning() && millis() - start < 5000)`, which is bounded
+// and exits immediately on RP because a coroutine that never starts is never
+// running. They measure 0 ms and 1 ms. They first looked like hangs only
+// because they were called *after* `testCoroutineAwait` had already wedged
+// the board -- "returned null" and "was called after something else died"
+// are indistinguishable from a transcript.
+//
+// `testCoroutineAll` already declines on FL_IS_RP, but these binds are
+// unconditional and `rpc.discover` advertises them, so the RPC surface invites
+// exactly the call that wedges the board. The three non-await tests
+// (Basic/Stop/Concurrent) are deliberately left callable: they return
+// `taskRan: false` promptly and are the evidence that the backend is null.
+//
+// This guards the symptom. The underlying hazard is that an unbounded
+// `await()` hangs wherever a promise cannot be resolved; see FastLED#3832.
+#if defined(FL_IS_RP)
+#define AUTORESEARCH_DECLINE_AWAIT_ON_RP(name)                                 \
+    do {                                                                       \
+        fl::json r = fl::json::object();                                       \
+        r.set("success", false);                                               \
+        r.set("supported", false);                                             \
+        r.set("backend", "null");                                              \
+        r.set("reason",                                                        \
+              "RP2xxx selects the null coroutine backend; " name               \
+              " would block forever in await() and wedge the board "           \
+              "until the watchdog resets it");                                 \
+        return r;                                                              \
+    } while (0)
+#else
+#define AUTORESEARCH_DECLINE_AWAIT_ON_RP(name) do { } while (0)
+#endif
+
     remote.bind("testCoroutineBasic", [](const fl::json& args) -> fl::json {
         (void)args;
         fl::json r = fl::json::object();
@@ -172,6 +219,7 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
     // Main thread does NOT touch the promise — only the producer coroutine does.
     remote.bind("testCoroutineAwait", [](const fl::json& args) -> fl::json {
         (void)args;
+        AUTORESEARCH_DECLINE_AWAIT_ON_RP("testCoroutineAwait");
         fl::json r = fl::json::object();
 
         auto promise_ptr = fl::make_shared<fl::task::Promise<int>>(fl::task::Promise<int>::create());
@@ -238,6 +286,7 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
     // Verifies that fl::task::await() properly propagates errors from producer.
     remote.bind("testCoroutineAwaitError", [](const fl::json& args) -> fl::json {
         (void)args;
+        AUTORESEARCH_DECLINE_AWAIT_ON_RP("testCoroutineAwaitError");
         fl::json r = fl::json::object();
 
         auto promise_ptr = fl::make_shared<fl::task::Promise<int>>(fl::task::Promise<int>::create());
@@ -382,6 +431,7 @@ void AutoResearchRemoteControl::bindAsyncMethods(fl::Remote& remote) {
     // coroutine A produces value -> promise1 -> coroutine B transforms -> promise2 -> coroutine C consumes
     remote.bind("testCoroutineChainedAwait", [](const fl::json& args) -> fl::json {
         (void)args;
+        AUTORESEARCH_DECLINE_AWAIT_ON_RP("testCoroutineChainedAwait");
         fl::json r = fl::json::object();
 
         auto p1 = fl::make_shared<fl::task::Promise<int>>(fl::task::Promise<int>::create());


### PR DESCRIPTION
Three coroutine RPCs hang an RP2350W. Not slow — **gone**:

```
testCoroutineAwait: null
ping:               null      <- device no longer answering at all
status:             null
```

It comes back only because the watchdog resets it:

```
{"message": "pong", "uptimeMs": 78827,
 "lastResetCause": "WATCHDOG", "lastResetWasWatchdog": true}
```

`testCoroutineAwait`, `testCoroutineAwaitError`, `testCoroutineChainedAwait`.

## Cause

`fl::platforms::await()` — `platforms/await.h:51`:

```cpp
while (!promise.is_completed()) {
    promise.update();
    if (promise.is_completed()) break;
    runtime.suspendMainthread(1000);
}
```

Unbounded. On RP the coroutine backend is null, so the producer coroutine that would resolve the promise never runs, and the loop never exits. Tracked on its own as #4369 — **this PR guards the symptom on one platform, not the hazard.**

## Why the existing guard doesn't cover it

`testCoroutineAll` already declines on `FL_IS_RP` — but **these binds are unconditional** and `rpc.discover` advertises them. The RPC surface therefore invites precisely the call that wedges the board. An agent enumerating methods, a bench script, or anyone driving the API directly hits it with no warning. I hit it that way.

## Scope: three, not five

An earlier revision of this PR guarded five methods. That was wrong, and the error is worth recording because the evidence was misleading in a specific way.

My original sweep called seven tests **sequentially in one session**. `testCoroutineAwait` hung the board, so everything after it returned `null`:

```
testCoroutineAwait:                null   <- actually hung
testCoroutineAwaitError:           null
testCoroutinePromiseCallbacks:     null   <- just downstream of a dead device
testCoroutinePromiseCatchCallback: null
testCoroutineChainedAwait:         null
```

"Returned null" and "was called after something else died" are indistinguishable from that transcript. Re-tested **in isolation**, one call plus a `ping`:

| test | `await` call sites | isolated result |
|---|---|---|
| `testCoroutineAwait` | 1 | hangs — ping dead, `lastResetCause: WATCHDOG` |
| `testCoroutineAwaitError` | 1 | hangs — ping dead, `lastResetCause: WATCHDOG` |
| `testCoroutineChainedAwait` | 2 | hangs — ping dead |
| `testCoroutinePromiseCallbacks` | 0 | returns in **0 ms** |
| `testCoroutinePromiseCatchCallback` | 0 | returns in **1 ms** |

The two promise tests call `await()` zero times — they wait on `while (producer.isRunning() && millis() - start < 5000)`, which is bounded and exits immediately on RP because a coroutine that never starts is never running.

## What stays callable, deliberately

The five non-await tests. Basic/Stop/Concurrent return `taskRan: false` / `completedCount: 0`, and the two promise tests return promptly:

```
testCoroutineBasic:      {"success": false, "taskRan": false, "durationMs": 0}
testCoroutineStop:       {"success": false, "taskStarted": false, "durationMs": 2000}
testCoroutineConcurrent: {"success": false, "completedCount": 0, "durationMs": 3000}
```

Until now `#if defined(FL_IS_RP)` on the aggregate asserted `backend: null` without anything ever running. These five **demonstrate** it. Gating them all would be tidier and would throw away the only evidence the assertion is true.

## Verification

On RP2350W `2DCB876B587EA334`:

- the three decline with a reason — each confirmed individually, not inferred from the macro being applied uniformly
- `ping` immediately after reports `lastResetWasWatchdog: false` — **no wedge, no reset**
- `testCoroutinePromiseCallbacks` runs unguarded at 0 ms
- `bash autoresearch rp2350w --rpc-smoke` passes
- `bash lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51
