### PR TITLE
feat(color): let the 16-bit encoder consume the device drive (P8, #4042/#4326)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -515,7 +515,15 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
     UCS7604CurrentControl wire_current(
         rgb_currents[pos0], rgb_currents[pos1], rgb_currents[pos2], current.w);
 
-    // Get gamma LUT
+    // Get gamma LUT.
+    //
+    // Only the unbound path uses it. With a profile bound the pixel source
+    // has already produced the device drive and quantized it once, to 16
+    // bits, so widening it again through a curve is the second shaping stage
+    // B1/§6 forbid after the device solve -- and the 2.8 here is
+    // `value_or`'s default rather than anything the caller asked for, since
+    // `setColorProfile` clears `mGamma`. #4326.
+    const bool wide_source = settings.hasColorProfile();
     float gamma = settings.mGamma.value_or(2.8f);
     fl::shared_ptr<const Gamma8> gamma8 = Gamma8::getOrCreate(gamma);
 
@@ -538,7 +546,7 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
 
     // Encode into the data buffer
     encodeUCS7604(pixelIterator, num_leds, fl::back_inserter(*data),
-                  mode, wire_current, is_rgbw, gamma8.get());
+                  mode, wire_current, is_rgbw, gamma8.get(), wide_source);
 }
 
 } // anonymous namespace

--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -173,6 +173,22 @@ class ReorderingPixelIteratorAny {
     const PixelIterator& get() const FL_NO_EXCEPT {
         return const_cast<ReorderingPixelIteratorAny*>(this)->get();
     }
+
+    /// True when `get()` hands back the colour-managed iterator.
+    ///
+    /// Not the same question as "is a profile configured". The managed
+    /// iterator exists only when a pipeline was actually built and the hooks
+    /// were installed; a channel can have a profile on its options and still
+    /// be iterating the legacy controller -- a rejected binding, or a build
+    /// where the seam is not linked. Asking the options instead would send
+    /// 8-bit legacy pixels down the no-gamma path.
+    bool isManaged() const FL_NO_EXCEPT {
+#if FL_COLOR_PROFILE_RUNTIME
+        return mManagedIterator != nullptr;
+#else
+        return false;
+#endif
+    }
 };
 
 /// @brief Out-of-line cold-path emitter for the #2517 silent-drop
@@ -485,7 +501,7 @@ namespace {
 /// @param rgbOrder RGB ordering for current control reordering
 void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
                   ClocklessEncoder encoder, const ChannelOptions& settings,
-                  EOrder rgbOrder) {
+                  EOrder rgbOrder, bool managed) FL_NO_EXCEPT {
     // Map encoder enum to UCS7604Mode
     UCS7604Mode mode;
     switch (encoder) {
@@ -520,10 +536,15 @@ void writeUCS7604(fl::vector_psram<u8>* data, PixelIterator& pixelIterator,
     // Only the unbound path uses it. With a profile bound the pixel source
     // has already produced the device drive and quantized it once, to 16
     // bits, so widening it again through a curve is the second shaping stage
-    // B1/§6 forbid after the device solve -- and the 2.8 here is
+    // B1 and section 6 forbid after the device solve -- and the 2.8 here is
     // `value_or`'s default rather than anything the caller asked for, since
     // `setColorProfile` clears `mGamma`. #4326.
-    const bool wide_source = settings.hasColorProfile();
+    // The iterator's own state, not the options'. `hasColorProfile()` says a
+    // profile is configured; it does not say the managed iterator was built.
+    // A rejected binding leaves the legacy controller in place, and taking
+    // the no-gamma path over its 8-bit pixels would drop a stage that path
+    // still needs.
+    const bool wide_source = managed;
     float gamma = settings.mGamma.value_or(2.8f);
     fl::shared_ptr<const Gamma8> gamma8 = Gamma8::getOrCreate(gamma);
 
@@ -735,7 +756,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
             case ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT:
             case ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT_1600:
                 writeUCS7604(&data, pixelIterator, clockless->encoder,
-                             mSettings, mRgbOrder);
+                             mSettings, mRgbOrder, iterator.isManaged());
                 break;
 #endif  // !FASTLED_DISABLE_UCS7604
         }

--- a/src/fl/channels/color_managed_source.cpp.hpp
+++ b/src/fl/channels/color_managed_source.cpp.hpp
@@ -18,6 +18,22 @@ void ColorManagedPixelSource::loadAndScaleRGB(u8* b0_out, u8* b1_out,
         *b2_out = channels[mSlot2];
 }
 
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+void ColorManagedPixelSource::loadAndScaleRGB16(u16* b0_out, u16* b1_out,
+                                               u16* b2_out) FL_NO_EXCEPT {
+        const u8* raw = mController.mData;
+        i32 drives[3];
+        processPixelQ16(mPipeline, raw[0], raw[1], raw[2], drives);
+        u16 channels[3];
+        for (int i = 0; i < 3; ++i) {
+            channels[i] = quantize16(drives[i]);
+        }
+        *b0_out = channels[mSlot0];
+        *b1_out = channels[mSlot1];
+        *b2_out = channels[mSlot2];
+}
+#endif
+
 void ColorManagedPixelSource::loadAndScaleRGBW(const Rgbw& rgbw, u8* b0_out,
                                               u8* b1_out, u8* b2_out,
                                               u8* b3_out) FL_NO_EXCEPT {
@@ -51,4 +67,20 @@ u8 ColorManagedPixelSource::quantize(i32 drive) FL_NO_EXCEPT {
         }
         return static_cast<u8>((static_cast<i32>(drive) * 255 + 32768) >> 16);
 }
+
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+u16 ColorManagedPixelSource::quantize16(i32 drive) FL_NO_EXCEPT {
+        if (drive <= 0) {
+            return 0;
+        }
+        if (drive >= 65536) {
+            return 65535;
+        }
+        // 64-bit intermediate on purpose: drive reaches 65535 and 65535*65535
+        // leaves i32. The 8-bit form above multiplies by 255 and stays inside
+        // it, which is why it does not need this.
+        return static_cast<u16>(
+            (static_cast<i64>(drive) * 65535 + 32768) >> 16);
+}
+#endif
 }  // namespace fl

--- a/src/fl/channels/color_managed_source.h
+++ b/src/fl/channels/color_managed_source.h
@@ -55,6 +55,17 @@ class ColorManagedPixelSource {
     /// which is what the `LegacyClearedByProfile` warning is for.
     void loadAndScaleRGB(u8* b0_out, u8* b1_out, u8* b2_out) FL_NO_EXCEPT;
 
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    /// The same pixel, quantized once to 16 bits instead of to 8 (P8, #4042).
+    ///
+    /// B3 asks for a single final quantization. The 8-bit entry point above is
+    /// that, for an 8-bit wire. A 16-bit encoder fed from it gets the drive
+    /// narrowed to 256 levels and then widened again, which is a quantization
+    /// the wire never asked for -- measured on UCS7604-16 in #4326 as 252 of
+    /// 65536 reachable levels.
+    void loadAndScaleRGB16(u16* b0_out, u16* b1_out, u16* b2_out) FL_NO_EXCEPT;
+#endif
+
     /// Legacy. An RGBW device's white emitter has no home in
     /// `EmitterProfile`, which carries three primaries and nothing else, so
     /// there is no profile for `allocateEmitterDrivesQ16` to be given. That
@@ -90,6 +101,12 @@ class ColorManagedPixelSource {
     /// This is the single final quantization B3 asks for: nothing upstream
     /// of it is 8-bit, and nothing downstream re-quantizes.
     static u8 quantize(i32 drive) FL_NO_EXCEPT;
+
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    /// `quantize` onto the 16-bit wire. Same clamps, same rounding, 65535
+    /// full scale rather than 255.
+    static u16 quantize16(i32 drive) FL_NO_EXCEPT;
+#endif
 
     PixelController<RGB>& mController;
     const StreamingPipelineQ16& mPipeline;

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -11,6 +11,7 @@
 #include "fl/gfx/rgbww.h"
 #include "crgb.h"
 #include "fl/math/intmap.h"
+#include "fl/system/sketch_macros.h"  // IWYU pragma: keep  (FL_PLATFORM_HAS_TINY_MEMORY)
 #include "fl/chipsets/encoders/ws2801.h"
 #include "fl/chipsets/encoders/ws2803.h"
 #include "fl/chipsets/encoders/ws2812.h"
@@ -64,6 +65,18 @@ struct PixelControllerVtable {
     pc->loadAndScaleRGB(r_out, g_out, b_out);
   }
 
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+  // Wide load (P8, #4042). Guarded the way the HD pointers are, and for the
+  // same reason: it costs one function pointer per PixelIterator, and a
+  // tiny-memory target has no colour pipeline to feed it. The condition is
+  // the one `FL_COLOR_PROFILE_RUNTIME` expands to, spelled without reaching
+  // up into the channels layer for the macro.
+  static void loadAndScaleRGB16(void* pixel_controller, u16* r_out, u16* g_out, u16* b_out) FL_NO_EXCEPT {
+    PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
+    pc->loadAndScaleRGB16(r_out, g_out, b_out);
+  }
+#endif
+
   // NOTE: loadAndScale_APA102_HD() removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
   // NOTE: loadAndScale_WS2816_HD() removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
 
@@ -103,6 +116,9 @@ struct PixelControllerVtable {
 typedef void (*loadAndScaleRGBWFunction)(void* pixel_controller, const Rgbw& rgbw, u8* b0_out, u8* b1_out, u8* b2_out, u8* b3_out);
 typedef void (*loadAndScaleRGBWWFunction)(void* pixel_controller, Rgbww rgbww, u8* b0_out, u8* b1_out, u8* b2_out, u8* b3_out, u8* b4_out);
 typedef void (*loadAndScaleRGBFunction)(void* pixel_controller, u8* r_out, u8* g_out, u8* b_out);
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+typedef void (*loadAndScaleRGB16Function)(void* pixel_controller, u16* r_out, u16* g_out, u16* b_out);
+#endif
 // NOTE: loadAndScale_APA102_HDFunction removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
 // NOTE: loadAndScale_WS2816_HDFunction removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
 typedef void (*stepDitheringFunction)(void* pixel_controller);
@@ -154,6 +170,9 @@ class PixelIterator {
       mLoadAndScaleRGBW = &Vtable::loadAndScaleRGBW;
       mLoadAndScaleRGBWW = &Vtable::loadAndScaleRGBWW;
       mLoadAndScaleRGB = &Vtable::loadAndScaleRGB;
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+      mLoadAndScaleRGB16 = &Vtable::loadAndScaleRGB16;
+#endif
       // NOTE: mLoadAndScale_APA102_HD removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
       // NOTE: mLoadAndScale_WS2816_HD removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
       mStepDithering = &Vtable::stepDithering;
@@ -177,6 +196,16 @@ class PixelIterator {
     void loadAndScaleRGB(u8 *r_out, u8 *g_out, u8 *b_out) FL_NO_EXCEPT {
       mLoadAndScaleRGB(mPixelController, r_out, g_out, b_out);
     }
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    /// One pixel at the source's own precision, wire-ordered.
+    ///
+    /// For an ordinary `PixelController` that is its 8-bit pixel widened
+    /// exactly; for a colour-managed source it is the s16.16 device drive
+    /// quantized once, to 16 bits rather than to 8 and back up.
+    void loadAndScaleRGB16(u16 *r_out, u16 *g_out, u16 *b_out) FL_NO_EXCEPT {
+      mLoadAndScaleRGB16(mPixelController, r_out, g_out, b_out);
+    }
+#endif
     // NOTE: loadAndScale_APA102_HD() removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
     // NOTE: loadAndScale_WS2816_HD() removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
     void stepDithering() FL_NO_EXCEPT { mStepDithering(mPixelController); }
@@ -393,6 +422,9 @@ class PixelIterator {
     loadAndScaleRGBWFunction mLoadAndScaleRGBW = nullptr;
     loadAndScaleRGBWWFunction mLoadAndScaleRGBWW = nullptr;
     loadAndScaleRGBFunction mLoadAndScaleRGB = nullptr;
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    loadAndScaleRGB16Function mLoadAndScaleRGB16 = nullptr;
+#endif
     // NOTE: mLoadAndScale_APA102_HD removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
     // NOTE: mLoadAndScale_WS2816_HD removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
     stepDitheringFunction mStepDithering = nullptr;
@@ -518,12 +550,25 @@ inline void ScaledPixelIteratorRGB16::advance() FL_NO_EXCEPT {
         // dropping it. Doing that properly needs a primitive that loads the
         // pixel scaled at full brightness, which PixelIterator does not
         // expose today.
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+        // The wide load the comment above asks for (P8, #4042). For an
+        // ordinary controller it is `map8_to_16` of the same 8-bit pixel, so
+        // an unbound channel is byte-identical to what this did before. A
+        // colour-managed source instead quantizes its s16.16 drive straight
+        // to 16 bits, which is what lets a 16-bit encoder reach more than 256
+        // levels.
+        u16 r16, g16, b16;
+        mPixels->loadAndScaleRGB16(&r16, &g16, &b16);
+#else
+        // TINY carries no colour pipeline, so there is nothing wider than the
+        // 8-bit pixel to load and the extra function pointer is not spent.
         u8 b0, b1, b2;
         mPixels->loadAndScaleRGB(&b0, &b1, &b2);
 
         const u16 r16 = fl::map8_to_16(b0);
         const u16 g16 = fl::map8_to_16(b1);
         const u16 b16 = fl::map8_to_16(b2);
+#endif
 
         mCurrent = array<u16, 3>{{r16, g16, b16}};  // Wire order 16-bit channels
         mPixels->stepDithering();

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -12,6 +12,7 @@
 #include "crgb.h"
 #include "fl/math/intmap.h"
 #include "fl/system/sketch_macros.h"  // IWYU pragma: keep  (FL_PLATFORM_HAS_TINY_MEMORY)
+#include "fl/stl/type_traits.h"  // IWYU pragma: keep  (declval for WideLoadBinder)
 #include "fl/chipsets/encoders/ws2801.h"
 #include "fl/chipsets/encoders/ws2803.h"
 #include "fl/chipsets/encoders/ws2812.h"
@@ -66,11 +67,13 @@ struct PixelControllerVtable {
   }
 
 #if !FL_PLATFORM_HAS_TINY_MEMORY
-  // Wide load (P8, #4042). Guarded the way the HD pointers are, and for the
-  // same reason: it costs one function pointer per PixelIterator, and a
-  // tiny-memory target has no colour pipeline to feed it. The condition is
-  // the one `FL_COLOR_PROFILE_RUNTIME` expands to, spelled without reaching
-  // up into the channels layer for the macro.
+  // Wide load (P8, #4042), bound only for sources that actually have one.
+  //
+  // Measured: binding it for every source cost 750 B on an ESP32-S3 Blink
+  // build -- six copies of this thunk at 125 B, one per EOrder
+  // instantiation, all doing the identical widening. Only a colour-managed
+  // source has a wider pixel to offer; every PixelController just widens its
+  // 8-bit one, and PixelIterator can do that once for all of them.
   static void loadAndScaleRGB16(void* pixel_controller, u16* r_out, u16* g_out, u16* b_out) FL_NO_EXCEPT {
     PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
     pc->loadAndScaleRGB16(r_out, g_out, b_out);
@@ -118,6 +121,27 @@ typedef void (*loadAndScaleRGBWWFunction)(void* pixel_controller, Rgbww rgbww, u
 typedef void (*loadAndScaleRGBFunction)(void* pixel_controller, u8* r_out, u8* g_out, u8* b_out);
 #if !FL_PLATFORM_HAS_TINY_MEMORY
 typedef void (*loadAndScaleRGB16Function)(void* pixel_controller, u16* r_out, u16* g_out, u16* b_out);
+
+/// Binds the wide thunk only when `T` declares `loadAndScaleRGB16`.
+///
+/// A plain `PixelController` does not, so nothing is emitted for it and the
+/// pointer stays null; `PixelIterator::loadAndScaleRGB16` then widens the
+/// 8-bit load in one place instead of once per colour order.
+template <typename T, typename = void>
+struct WideLoadBinder {
+    static loadAndScaleRGB16Function get() FL_NO_EXCEPT { return nullptr; }
+};
+
+template <typename T>
+struct WideLoadBinder<T, decltype(static_cast<void>(
+                             fl::declval<T&>().loadAndScaleRGB16(
+                                 static_cast<u16*>(nullptr),
+                                 static_cast<u16*>(nullptr),
+                                 static_cast<u16*>(nullptr))))> {
+    static loadAndScaleRGB16Function get() FL_NO_EXCEPT {
+        return &PixelControllerVtable<T>::loadAndScaleRGB16;
+    }
+};
 #endif
 // NOTE: loadAndScale_APA102_HDFunction removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
 // NOTE: loadAndScale_WS2816_HDFunction removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
@@ -171,7 +195,7 @@ class PixelIterator {
       mLoadAndScaleRGBWW = &Vtable::loadAndScaleRGBWW;
       mLoadAndScaleRGB = &Vtable::loadAndScaleRGB;
 #if !FL_PLATFORM_HAS_TINY_MEMORY
-      mLoadAndScaleRGB16 = &Vtable::loadAndScaleRGB16;
+      mLoadAndScaleRGB16 = WideLoadBinder<PixelControllerT>::get();
 #endif
       // NOTE: mLoadAndScale_APA102_HD removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
       // NOTE: mLoadAndScale_WS2816_HD removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
@@ -203,7 +227,17 @@ class PixelIterator {
     /// exactly; for a colour-managed source it is the s16.16 device drive
     /// quantized once, to 16 bits rather than to 8 and back up.
     void loadAndScaleRGB16(u16 *r_out, u16 *g_out, u16 *b_out) FL_NO_EXCEPT {
-      mLoadAndScaleRGB16(mPixelController, r_out, g_out, b_out);
+      if (mLoadAndScaleRGB16 != nullptr) {
+        mLoadAndScaleRGB16(mPixelController, r_out, g_out, b_out);
+        return;
+      }
+      // The source has no wider pixel than its 8-bit one. Widening exactly,
+      // here rather than in a per-source thunk.
+      u8 r8, g8, b8;
+      loadAndScaleRGB(&r8, &g8, &b8);
+      *r_out = fl::map8_to_16(r8);
+      *g_out = fl::map8_to_16(g8);
+      *b_out = fl::map8_to_16(b8);
     }
 #endif
     // NOTE: loadAndScale_APA102_HD() removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -140,39 +140,16 @@ void encodeUCS7604_8bit_RGBW(InputIterator first, InputIterator last, OutputIter
 /// @param out Output iterator for encoded bytes
 /// @param gamma Gamma8 LUT for 8-to-16 bit expansion
 /// @note Writes 6 bytes per pixel (R16_hi, R16_lo, G16_hi, G16_lo, B16_hi, B16_lo)
-/// One range, one encoder, both paths (P8, #4042 / #4326).
-///
-/// The input is always the 16-bit range now. For an unbound channel that is
-/// `map8_to_16` of the same 8-bit pixel, and `map8_to_16(b) >> 8 == b`
-/// exactly -- `b * 257 >> 8` is `b` for every `b <= 255` -- so recovering the
-/// byte the gamma LUT wants is lossless and this stays byte-identical to the
-/// 8-bit range it replaces.
-///
-/// Keeping one range rather than branching between two matters: both would be
-/// instantiated, and a Blink build that binds no profile would carry the
-/// second for nothing. Measured at +1,120 B on ESP32-S3 before this was
-/// folded together.
-///
-/// `gamma == nullptr` is the colour-managed case: the source has already
-/// quantized its device drive once, to 16 bits, and a curve on top of that is
-/// the second shaping stage B1 and section 6 of the spec forbid after the device solve.
 template <typename InputIterator, typename OutputIterator>
 void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIterator out,
-                              const Gamma8* gamma) FL_NO_EXCEPT {
+                              const Gamma8& gamma) FL_NO_EXCEPT {
     while (first != last) {
         const auto& pixel = *first;
 
+        // Apply gamma correction for 16-bit output
+        u8 rgb_in[3] = { pixel[0], pixel[1], pixel[2] };
         u16 rgb_out[3];
-        if (gamma) {
-            u8 rgb_in[3] = { static_cast<u8>(pixel[0] >> 8),
-                             static_cast<u8>(pixel[1] >> 8),
-                             static_cast<u8>(pixel[2] >> 8) };
-            gamma->convert(fl::span<const u8>(rgb_in, 3), fl::span<u16>(rgb_out, 3));
-        } else {
-            rgb_out[0] = pixel[0];
-            rgb_out[1] = pixel[1];
-            rgb_out[2] = pixel[2];
-        }
+        gamma.convert(fl::span<const u8>(rgb_in, 3), fl::span<u16>(rgb_out, 3));
 
         // Write big-endian 16-bit values
         *out++ = rgb_out[0] >> 8;
@@ -182,6 +159,35 @@ void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIter
         *out++ = rgb_out[2] >> 8;
         *out++ = rgb_out[2] & 0xFF;
         ++first;
+    }
+}
+
+/// Wide RGB straight off the iterator, with no adapter (P8, #4042 / #4326).
+///
+/// Deliberately a plain loop over `PixelIterator` rather than a second
+/// `makeScaledPixelRange*` range. `fl::Channel::showPixels` keeps every
+/// `writeUCS7604(...)` statically reachable, so whatever this path
+/// instantiates is linked into sketches that never touch UCS7604 -- routing
+/// it through `ScaledPixelIteratorRGB16` cost 988 B on an ESP32-S3 Blink
+/// build that binds no profile. This does what that adapter does, in the same
+/// order, without the iterator-pair templates.
+///
+/// No gamma by construction: the source has already quantized its device
+/// drive once, to 16 bits, and a curve on top of that is the second shaping
+/// stage B1 and section 6 of the spec forbid after the device solve.
+template <typename OutputIterator>
+void encodeUCS7604_16bit_RGB_wide(PixelIterator& pixels, OutputIterator out) FL_NO_EXCEPT {
+    while (pixels.has(1)) {
+        u16 r16, g16, b16;
+        pixels.loadAndScaleRGB16(&r16, &g16, &b16);
+        *out++ = r16 >> 8;
+        *out++ = r16 & 0xFF;
+        *out++ = g16 >> 8;
+        *out++ = g16 & 0xFF;
+        *out++ = b16 >> 8;
+        *out++ = b16 & 0xFF;
+        pixels.stepDithering();
+        pixels.advanceData();
     }
 }
 
@@ -275,10 +281,11 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
             // there is no wide drive to consume here yet.
             auto range = makeScaledPixelRangeRGBW(&pixel_iter);
             encodeUCS7604_16bit_RGBW(range.first, range.second, out, g);
+        } else if (wide_source) {
+            encodeUCS7604_16bit_RGB_wide(pixel_iter, out);
         } else {
-            auto range = makeScaledPixelRangeRGB16(&pixel_iter);
-            encodeUCS7604_16bit_RGB(range.first, range.second, out,
-                                    wide_source ? nullptr : &g);
+            auto range = makeScaledPixelRangeRGB(&pixel_iter);
+            encodeUCS7604_16bit_RGB(range.first, range.second, out, g);
         }
     }
 }

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -20,7 +20,9 @@
 #include "fl/stl/stdint.h"
 #include "fl/math/ease.h"
 #include "fl/chipsets/encoders/pixel_iterator_adapters.h"
+#include "fl/stl/compiler_control.h"  // IWYU pragma: keep  (FL_UNUSED)
 #include "fl/stl/noexcept.h"
+#include "fl/system/sketch_macros.h"  // IWYU pragma: keep  (FL_PLATFORM_HAS_TINY_MEMORY)
 
 namespace fl {
 
@@ -59,7 +61,7 @@ struct UCS7604CurrentControl {
 /// @param b_current Blue channel current control (0x0-0xF, wire order)
 /// @param w_current White channel current control (0x0-0xF, wire order)
 /// @note Current control values should already be reordered to match wire protocol (RGB)
-/// @note KNOWN LIMITATION: The UCS7604 protocol spec requires a ~20µs "W-code low"
+/// @note KNOWN LIMITATION: The UCS7604 protocol spec requires a ~20us "W-code low"
 /// delay between the 8-byte verification code and the 7-byte configuration block.
 /// Our clockless controller sends all 15 bytes as a continuous bit-encoded stream
 /// without this gap. If this causes issues on some hardware, the transmission would
@@ -164,6 +166,15 @@ void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIter
 
 /// Wide RGB straight off the iterator, with no adapter (P8, #4042 / #4326).
 ///
+/// TINY only: `PixelIterator::loadAndScaleRGB16` is itself compiled out on
+/// parts with <=1KB SRAM, which carry no colour pipeline and so have nothing
+/// wider than the 8-bit pixel to load. `pixels` is a concrete
+/// `PixelIterator&`, not a dependent type, so that call is looked up when
+/// this template is *defined* rather than when it is instantiated -- leaving
+/// the body visible on TINY is a hard compile error even though no caller
+/// ever selects it. Hence the guard here, and the matching one around the
+/// `wide_source` branch in `encodeUCS7604`.
+///
 /// Deliberately a plain loop over `PixelIterator` rather than a second
 /// `makeScaledPixelRange*` range. `fl::Channel::showPixels` keeps every
 /// `writeUCS7604(...)` statically reachable, so whatever this path
@@ -175,6 +186,7 @@ void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIter
 /// No gamma by construction: the source has already quantized its device
 /// drive once, to 16 bits, and a curve on top of that is the second shaping
 /// stage B1 and section 6 of the spec forbid after the device solve.
+#if !FL_PLATFORM_HAS_TINY_MEMORY
 template <typename OutputIterator>
 void encodeUCS7604_16bit_RGB_wide(PixelIterator& pixels, OutputIterator out) FL_NO_EXCEPT {
     while (pixels.has(1)) {
@@ -190,6 +202,7 @@ void encodeUCS7604_16bit_RGB_wide(PixelIterator& pixels, OutputIterator out) FL_
         pixels.advanceData();
     }
 }
+#endif  // !FL_PLATFORM_HAS_TINY_MEMORY
 
 /// @brief Encode RGBW pixels in UCS7604 16-bit format with gamma correction
 /// @tparam InputIterator Iterator yielding fl::array<uint8_t, 4> (RGBW bytes)
@@ -241,6 +254,11 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
                    bool wide_source = false) FL_NO_EXCEPT {
     constexpr size_t PREAMBLE_LEN = 15;
 
+#if FL_PLATFORM_HAS_TINY_MEMORY
+    // No wide encoder exists on TINY, so the flag selects nothing there.
+    FL_UNUSED(wide_source);
+#endif
+
     // Calculate bytes per LED based on mode and RGB/RGBW
     size_t bytes_per_led;
     if (mode == UCS7604Mode::UCS7604_MODE_8BIT_800KHZ) {
@@ -272,7 +290,7 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
             encodeUCS7604_8bit_RGB(range.first, range.second, out);
         }
     } else {
-        // 16-bit modes — fall back to gamma 2.8 if no gamma provided
+        // 16-bit modes -- fall back to gamma 2.8 if no gamma provided
         static fl::shared_ptr<const Gamma8> default_gamma;
         const Gamma8& g = gamma ? *gamma : *(default_gamma ? default_gamma : (default_gamma = Gamma8::getOrCreate(2.8f)));
         if (is_rgbw) {
@@ -281,8 +299,10 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
             // there is no wide drive to consume here yet.
             auto range = makeScaledPixelRangeRGBW(&pixel_iter);
             encodeUCS7604_16bit_RGBW(range.first, range.second, out, g);
+#if !FL_PLATFORM_HAS_TINY_MEMORY
         } else if (wide_source) {
             encodeUCS7604_16bit_RGB_wide(pixel_iter, out);
+#endif
         } else {
             auto range = makeScaledPixelRangeRGB(&pixel_iter);
             encodeUCS7604_16bit_RGB(range.first, range.second, out, g);

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -155,7 +155,7 @@ void encodeUCS7604_8bit_RGBW(InputIterator first, InputIterator last, OutputIter
 ///
 /// `gamma == nullptr` is the colour-managed case: the source has already
 /// quantized its device drive once, to 16 bits, and a curve on top of that is
-/// the second shaping stage B1/§6 forbid after the device solve.
+/// the second shaping stage B1 and section 6 of the spec forbid after the device solve.
 template <typename InputIterator, typename OutputIterator>
 void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIterator out,
                               const Gamma8* gamma) FL_NO_EXCEPT {

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -162,6 +162,34 @@ void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIter
     }
 }
 
+/// @brief Encode RGB pixels already at 16-bit precision, with no shaping
+/// @tparam InputIterator Iterator yielding fl::array<u16, 3> (wire-order RGB)
+/// @tparam OutputIterator Output iterator accepting u8
+///
+/// The wide path (P8, #4042). The gamma form above exists because its input
+/// is 8-bit and something has to widen it; a LUT that happens to be a gamma
+/// curve is what does. On a colour-managed channel that is a second shaping
+/// stage after the device solve, which B1/§6 forbid, and it was measured in
+/// #4326 putting 849 on the wire where the drive asked for 13933.
+///
+/// Here the source has already quantized once, to 16 bits, so there is
+/// nothing left to do but write the bytes.
+template <typename InputIterator, typename OutputIterator>
+void encodeUCS7604_16bit_RGB_wide(InputIterator first, InputIterator last,
+                                  OutputIterator out) FL_NO_EXCEPT {
+    while (first != last) {
+        const auto& pixel = *first;
+        // Big-endian, matching the gamma form byte for byte.
+        *out++ = pixel[0] >> 8;
+        *out++ = pixel[0] & 0xFF;
+        *out++ = pixel[1] >> 8;
+        *out++ = pixel[1] & 0xFF;
+        *out++ = pixel[2] >> 8;
+        *out++ = pixel[2] & 0xFF;
+        ++first;
+    }
+}
+
 /// @brief Encode RGBW pixels in UCS7604 16-bit format with gamma correction
 /// @tparam InputIterator Iterator yielding fl::array<uint8_t, 4> (RGBW bytes)
 /// @tparam OutputIterator Output iterator accepting uint8_t
@@ -208,7 +236,8 @@ void encodeUCS7604_16bit_RGBW(InputIterator first, InputIterator last, OutputIte
 template <typename OutputIterator>
 void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator out,
                    UCS7604Mode mode, const UCS7604CurrentControl& current, bool is_rgbw,
-                   const Gamma8* gamma = nullptr) {
+                   const Gamma8* gamma = nullptr,
+                   bool wide_source = false) FL_NO_EXCEPT {
     constexpr size_t PREAMBLE_LEN = 15;
 
     // Calculate bytes per LED based on mode and RGB/RGBW
@@ -246,8 +275,14 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
         static fl::shared_ptr<const Gamma8> default_gamma;
         const Gamma8& g = gamma ? *gamma : *(default_gamma ? default_gamma : (default_gamma = Gamma8::getOrCreate(2.8f)));
         if (is_rgbw) {
+            // RGBW stays on the gamma path: `ColorManagedPixelSource`
+            // delegates its RGBW entry point to the legacy controller, so
+            // there is no wide drive to consume here yet.
             auto range = makeScaledPixelRangeRGBW(&pixel_iter);
             encodeUCS7604_16bit_RGBW(range.first, range.second, out, g);
+        } else if (wide_source) {
+            auto range = makeScaledPixelRangeRGB16(&pixel_iter);
+            encodeUCS7604_16bit_RGB_wide(range.first, range.second, out);
         } else {
             auto range = makeScaledPixelRangeRGB(&pixel_iter);
             encodeUCS7604_16bit_RGB(range.first, range.second, out, g);

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -140,16 +140,39 @@ void encodeUCS7604_8bit_RGBW(InputIterator first, InputIterator last, OutputIter
 /// @param out Output iterator for encoded bytes
 /// @param gamma Gamma8 LUT for 8-to-16 bit expansion
 /// @note Writes 6 bytes per pixel (R16_hi, R16_lo, G16_hi, G16_lo, B16_hi, B16_lo)
+/// One range, one encoder, both paths (P8, #4042 / #4326).
+///
+/// The input is always the 16-bit range now. For an unbound channel that is
+/// `map8_to_16` of the same 8-bit pixel, and `map8_to_16(b) >> 8 == b`
+/// exactly -- `b * 257 >> 8` is `b` for every `b <= 255` -- so recovering the
+/// byte the gamma LUT wants is lossless and this stays byte-identical to the
+/// 8-bit range it replaces.
+///
+/// Keeping one range rather than branching between two matters: both would be
+/// instantiated, and a Blink build that binds no profile would carry the
+/// second for nothing. Measured at +1,120 B on ESP32-S3 before this was
+/// folded together.
+///
+/// `gamma == nullptr` is the colour-managed case: the source has already
+/// quantized its device drive once, to 16 bits, and a curve on top of that is
+/// the second shaping stage B1/§6 forbid after the device solve.
 template <typename InputIterator, typename OutputIterator>
 void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIterator out,
-                              const Gamma8& gamma) {
+                              const Gamma8* gamma) FL_NO_EXCEPT {
     while (first != last) {
         const auto& pixel = *first;
 
-        // Apply gamma correction for 16-bit output
-        u8 rgb_in[3] = { pixel[0], pixel[1], pixel[2] };
         u16 rgb_out[3];
-        gamma.convert(fl::span<const u8>(rgb_in, 3), fl::span<u16>(rgb_out, 3));
+        if (gamma) {
+            u8 rgb_in[3] = { static_cast<u8>(pixel[0] >> 8),
+                             static_cast<u8>(pixel[1] >> 8),
+                             static_cast<u8>(pixel[2] >> 8) };
+            gamma->convert(fl::span<const u8>(rgb_in, 3), fl::span<u16>(rgb_out, 3));
+        } else {
+            rgb_out[0] = pixel[0];
+            rgb_out[1] = pixel[1];
+            rgb_out[2] = pixel[2];
+        }
 
         // Write big-endian 16-bit values
         *out++ = rgb_out[0] >> 8;
@@ -158,34 +181,6 @@ void encodeUCS7604_16bit_RGB(InputIterator first, InputIterator last, OutputIter
         *out++ = rgb_out[1] & 0xFF;
         *out++ = rgb_out[2] >> 8;
         *out++ = rgb_out[2] & 0xFF;
-        ++first;
-    }
-}
-
-/// @brief Encode RGB pixels already at 16-bit precision, with no shaping
-/// @tparam InputIterator Iterator yielding fl::array<u16, 3> (wire-order RGB)
-/// @tparam OutputIterator Output iterator accepting u8
-///
-/// The wide path (P8, #4042). The gamma form above exists because its input
-/// is 8-bit and something has to widen it; a LUT that happens to be a gamma
-/// curve is what does. On a colour-managed channel that is a second shaping
-/// stage after the device solve, which B1/§6 forbid, and it was measured in
-/// #4326 putting 849 on the wire where the drive asked for 13933.
-///
-/// Here the source has already quantized once, to 16 bits, so there is
-/// nothing left to do but write the bytes.
-template <typename InputIterator, typename OutputIterator>
-void encodeUCS7604_16bit_RGB_wide(InputIterator first, InputIterator last,
-                                  OutputIterator out) FL_NO_EXCEPT {
-    while (first != last) {
-        const auto& pixel = *first;
-        // Big-endian, matching the gamma form byte for byte.
-        *out++ = pixel[0] >> 8;
-        *out++ = pixel[0] & 0xFF;
-        *out++ = pixel[1] >> 8;
-        *out++ = pixel[1] & 0xFF;
-        *out++ = pixel[2] >> 8;
-        *out++ = pixel[2] & 0xFF;
         ++first;
     }
 }
@@ -280,12 +275,10 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
             // there is no wide drive to consume here yet.
             auto range = makeScaledPixelRangeRGBW(&pixel_iter);
             encodeUCS7604_16bit_RGBW(range.first, range.second, out, g);
-        } else if (wide_source) {
-            auto range = makeScaledPixelRangeRGB16(&pixel_iter);
-            encodeUCS7604_16bit_RGB_wide(range.first, range.second, out);
         } else {
-            auto range = makeScaledPixelRangeRGB(&pixel_iter);
-            encodeUCS7604_16bit_RGB(range.first, range.second, out, g);
+            auto range = makeScaledPixelRangeRGB16(&pixel_iter);
+            encodeUCS7604_16bit_RGB(range.first, range.second, out,
+                                    wide_source ? nullptr : &g);
         }
     }
 }

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -11,6 +11,7 @@
 
 
 #include "fl/math/intmap.h"
+#include "fl/system/sketch_macros.h"  // IWYU pragma: keep  (FL_PLATFORM_HAS_TINY_MEMORY)
 #include "fl/math/math8.h"
 #include "platforms/is_platform.h"
 
@@ -589,6 +590,25 @@ struct PixelController {
         *b1_out = loadAndScale1();
         *b2_out = loadAndScale2();
     }
+
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+    /// Wide load for the 16-bit encoders (P8, #4042).
+    ///
+    /// The legacy answer, and deliberately so: this controller's pixels are
+    /// 8-bit, so widening is all there is to do and `map8_to_16` is the exact
+    /// widening the RGB16 adapter already applied. Byte-identical to what
+    /// WS2816 received before this entry point existed.
+    ///
+    /// What it buys is the seam. A colour-managed source overrides this and
+    /// quantizes its s16.16 drives to 16 bits once, instead of to 8 and back
+    /// up -- which is the "encoders consume wide output" half of P8.
+    FASTLED_FORCE_INLINE void loadAndScaleRGB16(fl::u16 *b0_out, fl::u16 *b1_out,
+                                                fl::u16 *b2_out) {
+        *b0_out = fl::map8_to_16(loadAndScale0());
+        *b1_out = fl::map8_to_16(loadAndScale1());
+        *b2_out = fl::map8_to_16(loadAndScale2());
+    }
+#endif
 
     // NOTE: loadAndScale_WS2816_HD() has been moved to src/fl/chipsets/encoders/ws2816.h
     // Use fl::loadAndScale_WS2816_HD<RGB_ORDER>(pixels, ...) instead

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -591,25 +591,6 @@ struct PixelController {
         *b2_out = loadAndScale2();
     }
 
-#if !FL_PLATFORM_HAS_TINY_MEMORY
-    /// Wide load for the 16-bit encoders (P8, #4042).
-    ///
-    /// The legacy answer, and deliberately so: this controller's pixels are
-    /// 8-bit, so widening is all there is to do and `map8_to_16` is the exact
-    /// widening the RGB16 adapter already applied. Byte-identical to what
-    /// WS2816 received before this entry point existed.
-    ///
-    /// What it buys is the seam. A colour-managed source overrides this and
-    /// quantizes its s16.16 drives to 16 bits once, instead of to 8 and back
-    /// up -- which is the "encoders consume wide output" half of P8.
-    FASTLED_FORCE_INLINE void loadAndScaleRGB16(fl::u16 *b0_out, fl::u16 *b1_out,
-                                                fl::u16 *b2_out) {
-        *b0_out = fl::map8_to_16(loadAndScale0());
-        *b1_out = fl::map8_to_16(loadAndScale1());
-        *b2_out = fl::map8_to_16(loadAndScale2());
-    }
-#endif
-
     // NOTE: loadAndScale_WS2816_HD() has been moved to src/fl/chipsets/encoders/ws2816.h
     // Use fl::loadAndScale_WS2816_HD<RGB_ORDER>(pixels, ...) instead
 

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,3 +1,35 @@
+# 2026-09-12, PR #4368 (issue #4326, colour pipeline P8): +231 B,
+# 342483 -> 342714.
+#
+# The 16-bit encoders now consume the device drive instead of an 8-bit copy
+# of it widened by a gamma LUT. A managed UCS7604-16 channel was putting 849
+# on the wire where the solve asked for 13933; it now puts 13935.
+#
+# What the 231 B is, from a symbol diff against master (`fbuild symbols` on
+# the ELF the build actually produced -- `bash bloat --build` analyses a
+# different one, FastLED#4384):
+#
+#   +157  encodeUCS7604_16bit_RGB_wide<back_insert_iterator<vector_psram<u8>>>
+#    +63  fl::Channel::showPixels(PixelController<(EOrder)10, 1, ...>&)
+#     +17  fl::PixelIterator::has(int)
+#
+# Statically reachable rather than elidable, and for a documented reason:
+# `fl::Channel::showPixels` keeps every `writeUCS7604(...)` reference live so
+# the encoder bodies link, which the switch in that function says in as many
+# words. `-DFASTLED_DISABLE_UCS7604=1` drops this along with the rest of that
+# chipset.
+#
+# What it is NOT: the first three attempts at this cost 1,120 B, 988 B and
+# 940 B. A symbol diff found 750 B of that in six copies of one vtable thunk
+# -- `PixelControllerVtable<...>::loadAndScaleRGB16`, once per colour order,
+# each widening an 8-bit pixel identically. Binding that thunk only for
+# sources that declare a wide load removed all six. The 231 B here is what
+# remains after that, not what the naive version cost.
+#
+# A tiny-memory target pays 0 B: the wide path sits behind
+# !FL_PLATFORM_HAS_TINY_MEMORY, the condition FL_COLOR_PROFILE_RUNTIME
+# expands to.
+#
 # 2026-09-10, PR #4200 (issue #4040, colour pipeline P6): +305 B,
 # 342178 -> 342483.
 #
@@ -20,4 +52,4 @@
 # showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
 # only ever spent where flash is not the binding constraint. On a target
 # that does compile it in, 305 B is 0.089% of the image.
-342483
+342714

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -885,50 +885,49 @@ FL_TEST_CASE("[#4326] a bound profile reaches the encode path") {
 }
 
 
-FL_TEST_CASE("[#4326] the managed path gamma-encodes the device drive") {
-    // The end-to-end measurement #4326 says it lacks: "I have not measured
-    // this end to end ... the claim should be confirmed by it before the fix
-    // is judged."
+FL_TEST_CASE("[#4326] the managed path puts the device drive on the wire") {
+    // This case used to assert the defect. It read 849 and said so, and said
+    // it was written to fail when #4326 was fixed. This is that failure,
+    // turned into the statement of the fix.
     //
     // `kProfile` gives all three emitters luminance 1.0 at sRGB
     // chromaticities, and the source is linear sRGB. Full red is therefore a
     // target of Y = 0.2126 -- sRGB red's luminance share -- against an emitter
-    // that makes Y = 1.0 at full drive, so the device solve's answer is a red
-    // drive of 0.2126. That is correct, and it is where the pipeline's job
-    // ends.
+    // making Y = 1.0 at full drive, so the device solve's answer is a red
+    // drive of 0.2126. That is where the pipeline's job ends, and a 16-bit
+    // encoder should put 0.2126 * 65535 = 13933 on the wire.
     //
-    // A 16-bit encoder consuming that drive should put 0.2126 * 65535 = 13933
-    // on the wire. It puts 849.
-    //
-    // 849 is not arbitrary: it is the drive quantized to 8 bits, 0.2126 * 255
-    // = 54, pushed through the gamma-2.8 LUT -- (54/255)^2.8 * 65535 = 849.
-    // Both halves of #4326 in one number. The drive is narrowed to 8 bits
-    // before the encoder sees it, and then a second shaping stage, the one
-    // B1/§6 forbid after the device solve, is applied on top of it. The 2.8
-    // is `mGamma.value_or(2.8f)` -- a default, not something asked for; the
-    // case above pins that binding a profile clears the caller's gamma.
+    // It used to put 849: the drive narrowed to 8 bits (0.2126 * 255 = 54)
+    // and then widened by the gamma-2.8 LUT, (54/255)^2.8 * 65535 = 849.
+    // Both halves of #4326 in one number -- the 8-bit round trip, and the
+    // second shaping stage B1/§6 forbid after the device solve.
     fl::vector<u8> bound = encodeOnce(CRGB(255, 0, 0), true, 2.8f, 20);
     FL_REQUIRE_EQ((int)bound.size(), 21);
 
     const int red16 = (bound[15] << 8) | bound[16];
-    FL_CHECK_EQ(red16, 849);
 
-    // Stated as the shortfall rather than only as a literal, so the failure
-    // says what is wrong rather than that a number moved. A linear encoding
-    // of the same 8-bit drive would be 54/255 * 65535 = 13878; the emitted
-    // value is more than ten times darker than that.
-    const int linear_of_same_drive = 54 * 65535 / 255;
-    FL_CHECK_GT(linear_of_same_drive, red16 * 10);
+    // Within rounding of the drive itself. Two counts of 65535, which is the
+    // s16.16 drive and `quantize16` each rounding once -- a single
+    // quantization, which is what B3 asks for.
+    FL_CHECK_GT(red16, 13900);
+    FL_CHECK_LT(red16, 13970);
 
-    // Black still encodes to black, so the above is a shaping error and not
-    // an offset.
+    // And specifically not the old value, so a regression that restored the
+    // gamma stage could not pass the bounds above by coincidence.
+    FL_CHECK_NE(red16, 849);
+
+    // Black still encodes to black.
     fl::vector<u8> black = encodeOnce(CRGB(0, 0, 0), true, 2.8f, 20);
     FL_REQUIRE_EQ((int)black.size(), 21);
     FL_CHECK_EQ((int)((black[15] << 8) | black[16]), 0);
 
-    // This case describes behaviour the contract forbids. It is written to
-    // fail when #4326 is fixed -- a 16-bit encoder fed the wide drive would
-    // emit near 13933 -- which is the point of recording it now.
+    // The unbound path is untouched: it has no device drive to carry, its
+    // pixels are 8-bit, and the gamma there is the legacy behaviour rather
+    // than a second stage. The resolution case below measures what that
+    // costs; this one is only about the managed path.
+    fl::vector<u8> unbound = encodeOnce(CRGB(255, 0, 0), false, 2.8f, 20);
+    FL_REQUIRE_EQ((int)unbound.size(), 21);
+    FL_CHECK_EQ((int)((unbound[15] << 8) | unbound[16]), 65535);
 }
 
 FL_TEST_CASE("[#4326] the 16-bit encoder reaches 252 of 65536 levels") {


### PR DESCRIPTION
Fixes the managed half of #4326. Part of #4034 P8 (#4042), "encoders consume wide output directly — no RGB8 correction round-trip".

A colour-managed UCS7604-16 channel put **849** on the wire where the device solve asked for **13933**. #4365 measured that and pinned it; this is the fix. The same pixel now encodes as **13935** — within two counts of the drive, the s16.16 value and `quantize16` each rounding once, which is the single quantization B3 asks for.

849 was the drive narrowed to 8 bits (`0.2126 × 255 = 54`) and widened again by a gamma-2.8 LUT. Two defects in one number: the RGB8 round trip B3 forbids on the managed path, and a second shaping stage after the device solve that B1/§6 forbid outright — from `mGamma.value_or(2.8f)`, a default rather than anything a caller asked for, since `setColorProfile` clears `mGamma`.

### The fix is upstream of where #4326 located it

A no-gamma path fed by `loadAndScaleRGB` would still be 8-bit. `PixelIterator` had no wider primitive to offer, which its own comment already said:

> Doing that properly needs a primitive that loads the pixel scaled at full brightness, **which `PixelIterator` does not expose today**.

So, four pieces:

1. **`PixelIterator::loadAndScaleRGB16`** — the missing primitive.
2. **`PixelController::loadAndScaleRGB16`** — widens its 8-bit pixel with `map8_to_16`, exactly what the RGB16 adapter did before, so unbound channels are byte-identical.
3. **`ColorManagedPixelSource::loadAndScaleRGB16`** — quantizes the s16.16 drives to 16 bits instead of to 8 and back up.
4. **`encodeUCS7604_16bit_RGB_wide`** — writes those bytes with no shaping, selected when a profile is bound.

### Footprint

Guarded by `!FL_PLATFORM_HAS_TINY_MEMORY` — what `FL_COLOR_PROFILE_RUNTIME` expands to, spelled directly rather than including a channels header from the encoders layer. That is the same trade the two `FASTLED_HD_COLOR_MIXING` pointers in the same file already make: one function pointer per `PixelIterator` on targets that can bind a profile, nothing on a tiny one. The header is explicit that this matters —

> we really care about binary size since FastLED needs to run on those tiny little microcontrollers like the Attiny85

### What this does not do

- **RGBW stays on the gamma path.** `ColorManagedPixelSource` delegates its RGBW entry point to the legacy controller, so there is no wide drive to consume there yet.
- **For an 8-bit `CRGB` source this buys accuracy, not more reachable levels.** 256 inputs still give at most 256 outputs; the level count improves when the source itself is wide (`.fled` `rgb16_linear`). The 252-of-65536 measurement in #4365 is about the unbound path and is unchanged.
- **HD108 is untouched.** It still takes no `settings`, so the information needed to select a wide path is not in scope there. That half of #4326 stays open.

### Tests

#4365's two cases were written to fail when this landed, and they did:

```
tests/fl/channels/channel.cpp:914: 13935 == 849
tests/fl/channels/channel.cpp:921: 13878 > 139350
```

The gamma case is now the statement of the fix — it bounds the emitted value to the drive and asserts it is specifically **not** 849, so a regression restoring the gamma stage cannot satisfy the bounds by coincidence. The resolution case is unchanged; it measures the unbound path, where 8-bit-plus-gamma is the legacy behaviour and correct.

`bash lint` clean; 305/305 unit, 84/84 examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UCS7604 wide-source RGB encoding to preserve direct 16-bit color values when the active color pipeline is available.
  * Ensured legacy 8-bit RGB output continues to receive gamma shaping when color management is unavailable.
  * Improved 16-bit RGB scaling, quantization, channel mapping, and value clamping on supported platforms.
  * Preserved gamma-corrected behavior for RGBW and other legacy RGB paths.

* **Tests**
  * Expanded coverage for wide-source encoding, rounding boundaries, black output, and legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->