### PR TITLE
fix(net): give the RP peer server the same stall budget as its client (#3899)

### DIFF
--- a/examples/AutoResearch/AutoResearchNet.cpp
+++ b/examples/AutoResearch/AutoResearchNet.cpp
@@ -773,9 +773,35 @@ void pollNetServer() {}
 
 namespace {
 
-// A stalled peer is one that has sent nothing for this long. Kept at the
-// old flat budget so a truly dead connection is reaped just as quickly.
-constexpr uint32_t kRpPeerStallMs = 2000;
+// A stalled peer is one that has sent nothing for this long.
+//
+// 6000, matching kRpHttpClientStallMs. This was left at 2000 when the client
+// side was raised (#4231) on the reasoning that a dead connection should be
+// reaped quickly -- but the argument that justified raising the client
+// applies to the server unchanged, because it is a property of the peer, not
+// of which side we are. The C6 services a request from its sketch main loop
+// and blocks up to 5000 ms doing it, so a gap of more than 2000 ms between
+// our reading its headers and its body arriving is ordinary, not a fault.
+//
+// Observed on the bench: `--net-peer` fails intermittently -- about one run
+// in three, on master as well as on any branch -- with the RP's server taking
+// complete headers and then none of a 4096-byte body:
+//
+//   POST /echo 4096-byte FNV-1a -> 408, received_bytes: 0
+//   {'lastTimeoutWasStall': True, 'lastTimeoutElapsedMs': 2006,
+//    'lastTimeoutBodyLength': 0, 'lastTimeoutExpectedBody': 4096,
+//    'lastTimeoutHeadersComplete': True}
+//
+// 2006 ms: the peer missed the budget by six milliseconds. The client-side
+// fix recorded five requests at 2706-3586 ms that the old value would have
+// failed, all under the peer's 5000 ms ceiling; this is the same distribution
+// seen from the other end.
+//
+// A truly dead connection is still reaped -- kRpPeerMaxRequestMs (10000) is
+// the absolute ceiling and is unchanged. The cost of this change is that a
+// dead peer now occupies the single-client server for up to 6 s rather than
+// 2 s before that ceiling applies. See FastLED#3899.
+constexpr uint32_t kRpPeerStallMs = 6000;
 // Absolute ceiling for one request, so a peer that dribbles a byte at a time
 // cannot occupy the single-client server forever.
 constexpr uint32_t kRpPeerMaxRequestMs = 10000;


### PR DESCRIPTION
`--net-peer` fails intermittently — about **two runs in five**, on master and on unrelated branches alike — with the RP's HTTP **server** taking complete headers and then none of a 4096-byte body:

```
POST /echo 4096-byte FNV-1a -> 408, received_bytes: 0
RP server stats: {'lastTimeoutWasStall': True, 'lastTimeoutElapsedMs': 2006,
                  'lastTimeoutBodyLength': 0, 'lastTimeoutExpectedBody': 4096,
                  'lastTimeoutHeadersComplete': True}
```

**2006 ms against a 2000 ms budget.** The peer missed by six milliseconds.

## The asymmetry

```cpp
constexpr uint32_t kRpPeerStallMs       = 2000;   // RP as server
constexpr uint32_t kRpHttpClientStallMs = 6000;   // RP as client
constexpr uint32_t kRpPeerMaxRequestMs  = 10000;  // absolute ceiling, both
```

The client side was raised 2000 → 6000 in #4231, and its comment records why: five requests at **2706, 2734, 2961, 3108 and 3586 ms** completed correctly, each of which the old value would have failed, with the maximum sitting under the peer's own 5000 ms ceiling.

`kRpPeerStallMs` was deliberately left at 2000 so a dead connection would be reaped quickly. That reasoning treats the budget as a property of **which side we are**, when it is a property of **the peer** — the C6 services a request from its sketch main loop and blocks up to 5000 ms doing it, so a gap over 2000 ms is ordinary in either direction. The failure above is the same distribution observed from the other end.

## Why 6000 and not 2500

6000 matches `kRpHttpClientStallMs`, which was derived independently from the peer's documented 5000 ms handler ceiling. Picking a value that merely clears the observed 2006 ms would be fitting the threshold to the symptom — and would leave the next 3586 ms request failing exactly as before.

## Cost, stated

A genuinely dead peer now holds the single-client server for up to 6 s rather than 2 s before `kRpPeerMaxRequestMs` (10000, unchanged) reaps it. That is the trade the original comment was protecting, and it is real; the absolute ceiling still bounds it.

## Measured

Attached pair, 10 reconnect cycles per run:

| | runs | result |
|---|---|---|
| master | 3 | 2 pass, **1 fail** (cycle 7) |
| unrelated branch (#4343) | 2 | 1 pass, **1 fail** (cycle 5) |
| **this branch** | **6** | **6 pass, 0 stalls** |

Six clean runs against a ~40% failure rate is roughly a 1-in-20 coincidence — **strong but not proof** for a fault of this shape. The six-millisecond miss is what carries it; the runs corroborate.

`bash lint` clean.

Found while running a regression control for #4343, where this failure initially looked like a regression in that PR until master reproduced it identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RP2350W CYW43 peer-server reliability by allowing more time for stalled peer responses before timing out.
  - The existing 10-second maximum request limit remains in place for unresponsive connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->