### PR TITLE
fix(autoresearch): carry the encoder into the channel so UCS7604 tests the chipset (#4373)

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -900,8 +900,19 @@ void runTest(const char* test_name,
         size_t num_leds = leds.size();
         const bool lane_uses_rgbw =
             legacyLaneUsesRgbw(config, config_idx);
+        // UCS7604 puts a 15-byte preamble and 16-bit channels on the wire, so
+        // its frame runs several times the pixel byte count. This number sizes
+        // the RX edge capacity as well as the comparison below, so deriving it
+        // from the pixel count truncates the capture (FastLED#4373).
+        const bool lane_uses_ucs7604 = isUCS7604(config.encoder);
+        fl::vector<uint8_t> expected_encoded;
+        if (lane_uses_ucs7604) {
+            expected_encoded = buildExpectedUCS7604(
+                config.tx_configs[config_idx].mLeds, config.encoder);
+        }
         const size_t expected_data_bytes =
-            num_leds * (lane_uses_rgbw ? 4u : 3u);
+            lane_uses_ucs7604 ? expected_encoded.size()
+                              : num_leds * (lane_uses_rgbw ? 4u : 3u);
 
         fl::TestContext ctx{
             config.driver_name,
@@ -944,10 +955,8 @@ void runTest(const char* test_name,
 
         int mismatches = 0;
 
-        if (isUCS7604(config.encoder)) {
+        if (lane_uses_ucs7604) {
             // UCS7604: Compare full encoded frame (preamble + padding + pixel data) byte-for-byte
-            fl::vector<uint8_t> expected_encoded = buildExpectedUCS7604(
-                config.tx_configs[config_idx].mLeds, config.encoder);
             size_t expected_len = expected_encoded.size();
 
             AR_FL_WARN("UCS7604 encoded comparison: expected " << expected_len << " bytes, captured " << bytes_captured);
@@ -1106,6 +1115,17 @@ void runMultiTest(const char* test_name,
             buildExpectedClockless(config.tx_configs[0].mLeds, true);
     }
 
+    // Same reasoning for the UCS7604 encoded frame, plus one more: its length
+    // is what sizes the RX edge capacity in capture(). UCS7604 carries a
+    // 15-byte preamble and 16-bit channels, so the pixel byte count is several
+    // times short of the wire frame and truncates the capture (FastLED#4373).
+    const bool lane_uses_ucs7604 = isUCS7604(config.encoder);
+    fl::vector<uint8_t> expected_ucs7604;
+    if (channels_to_test > 0 && lane_uses_ucs7604) {
+        expected_ucs7604 =
+            buildExpectedUCS7604(config.tx_configs[0].mLeds, config.encoder);
+    }
+
     // Execute multiple runs
     for (int run = 1; run <= multi_config.num_runs; run++) {
         // runSingleTest executes synchronously inside the RPC task, so the
@@ -1130,7 +1150,8 @@ void runMultiTest(const char* test_name,
             const bool lane_uses_rgbw =
                 legacyLaneUsesRgbw(config, config_idx);
             const size_t expected_data_bytes =
-                num_leds * (lane_uses_rgbw ? 4u : 3u);
+                lane_uses_ucs7604 ? expected_ucs7604.size()
+                                  : num_leds * (lane_uses_rgbw ? 4u : 3u);
             result.total_leds = num_leds;
             result.totalBytes = static_cast<int>(expected_data_bytes);
 
@@ -1178,10 +1199,9 @@ void runMultiTest(const char* test_name,
                         << " first" << static_cast<int>(dump_count) << "=" << hex_dump.str());
             }
 
-            if (isUCS7604(config.encoder)) {
+            if (lane_uses_ucs7604) {
                 // UCS7604: Compare full encoded frame byte-for-byte
-                fl::vector<uint8_t> expected_encoded = buildExpectedUCS7604(
-                    config.tx_configs[config_idx].mLeds, config.encoder);
+                const fl::vector<uint8_t>& expected_encoded = expected_ucs7604;
                 size_t expected_len = expected_encoded.size();
                 result.totalBytes = static_cast<int>(expected_len);
 
@@ -1508,8 +1528,16 @@ void autoResearchChipsetTiming(fl::AutoResearchConfig& config,
             // SPI chipset: pass through the SPI config directly
             channel = FastLED.add(config.tx_configs[i]);
         } else {
-            // Clockless chipset: re-create with runtime timing
-            fl::ChannelConfig channel_config(config.tx_configs[i].getDataPin(), config.timing, config.tx_configs[i].mLeds, config.tx_configs[i].rgb_order);
+            // Clockless chipset: re-create with runtime timing. The encoder
+            // has to come with it. ChannelConfig(pin, timing, ...) defaults
+            // the encoder to WS2812, so a UCS7604 timing used to put raw
+            // pixel bytes on the wire while the comparison below expected the
+            // encoded frame -- every UCS7604 run failed at every LED count
+            // with a captured pattern that looked like a driver fault
+            // (FastLED#4373).
+            fl::ClocklessChipset clockless_chipset(
+                config.tx_configs[i].getDataPin(), config.timing, config.encoder);
+            fl::ChannelConfig channel_config(clockless_chipset, config.tx_configs[i].mLeds, config.tx_configs[i].rgb_order);
             channel = FastLED.add(channel_config);
         }
         if (!channel) {


### PR DESCRIPTION
`--chipset ucs7604` failed on the RP2350 PIO loopback at **every** LED count from 1 upward (#4373). Capture succeeded, the decoder reported success, and the comparison then disagreed on every byte — which reads as a driver or wiring fault.

## What it actually was

`autoResearchChipsetTiming()` re-creates each clockless channel from the runtime timing:

```cpp
fl::ChannelConfig channel_config(pin, config.timing, leds, rgb_order);
```

That constructor builds a `ClocklessChipset(pin, timing)`, and *that* overload defaults the encoder to `CLOCKLESS_ENCODER_WS2812`. The encoder the timing resolved to — `encoder_for<TIMING_UCS7604_800KHZ>()` → `UCS7604_16BIT` — reached the **comparison** through `config.encoder` but never reached the **transmitter**.

So the wire carried raw 8-bit pixel bytes while the expectation was the full UCS7604 frame, which starts with six `0xFF` sync bytes. Measured on the device before the fix, at 4 LEDs:

| | |
|---|---|
| captured | 12 bytes = 4 × 3 raw pixel bytes |
| expected | 39 bytes = 15 preamble + 4 × 6 |
| `actual[0..2]` | `F0 0F AA` — the `MSB_LSB_A` pattern |
| `expected[0..2]` | `255 255 255` — the sync pattern |

Passing the encoder through makes both halves describe the same protocol.

## The frame length is the other half

UCS7604 puts a 15-byte preamble and 16-bit channels on the wire, so its frame is more than twice the pixel byte count — and that count is what sizes the RX edge capacity in `capture()`. Deriving it from `num_leds * 3` truncates the capture even once the encoder is right. `runTest()` and `runMultiTest()` now build the expected frame before the capture and use its length for the capacity, which also drops a per-run allocation from the multi-run loop.

## Measured

RP2350W `2DCB876B587EA334`, PIO0, GPIO0 → GPIO1, driven through `runSingleTest`:

```
UCS7604-800KHZ leds=  1 passed=True  4/4  bytes=84    (21 x 4 patterns)
UCS7604-800KHZ leds=  4 passed=True  4/4  bytes=156   (39 x 4)
UCS7604-800KHZ leds= 10 passed=True  4/4  bytes=300   (75 x 4)
UCS7604-800KHZ leds= 25 passed=True  4/4  bytes=660   (165 x 4)
UCS7604-800KHZ leds= 40 passed=True  4/4  bytes=1020  (255 x 4)
UCS7604-800KHZ leds= 45 passed=True  4/4  bytes=1140  (285 x 4)
UCS7604-800KHZ leds= 50 passed=False 0/4  bytes=0
```

Every passing row captures exactly `15 + 6*leds` bytes per pattern — the encoded frame length, to the byte. Before the fix every one of these was 0/4.

50 LEDs (315 wire bytes) hits the capture ceiling tracked in #4371; that is a separate defect and is not addressed here.

Unchanged on the paths that already worked: `WS2812B-V5` at 100 LEDs, `WS2818` and `WS2814` at 50, all 4/4, plus `bash autoresearch rp2350w --flex-io` at its default 100 LEDs.

Fixes #4373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UCS7604 encoder support to the autoresearch test harness.
  * Tests now validate encoded wire frames, including preamble, padding, and pixel data.
  * Timing tests now use the configured encoder when generating UCS7604 output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->