### PR TITLE
fix(autoresearch): bound RP PIO lane sizes by what the capture can actually hold (#4371)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -138,36 +138,38 @@ bool ucs7604ModeForEncoder(fl::ClocklessEncoder encoder,
 /// @brief Wire bytes one lane of `leds` puts on the wire, or 0 if unknown.
 ///
 /// A UCS7604 lane is more than twice a WS2812 lane of the same length -- a
-/// 15-byte preamble, 16-bit channels, padding to a multiple of three -- so the
-/// capture bound has to be phrased in wire bytes, not LEDs (FastLED#4371).
+/// 15-byte preamble, 16-bit channels, padding to a multiple of three -- and an
+/// RGBW lane is a third wider than an RGB one, so the capture bound has to be
+/// phrased in wire bytes, not LEDs (FastLED#4371).
 ///
 /// TM1812 and TM1908 have layouts this does not model. Neither is reachable
 /// from `runSingleTest`'s timing list, and 0 makes the caller skip the bound
 /// rather than enforce a wrong one: no check is what happens today, a check
 /// with the wrong number is the defect being fixed.
-fl::size rpPioWireFrameBytes(fl::size leds, fl::ClocklessEncoder encoder) {
+fl::size rpPioWireFrameBytes(fl::size leds, fl::ClocklessEncoder encoder,
+                             bool rgbw) {
     fl::UCS7604Mode mode;
     if (ucs7604ModeForEncoder(encoder, &mode)) {
-        return fl::ucs7604FrameBytes(leds, mode, false);
+        return fl::ucs7604FrameBytes(leds, mode, rgbw);
     }
     if (encoder == fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812) {
-        return leds * 3u;
+        return leds * (rgbw ? 4u : 3u);
     }
     return 0;
 }
 
 /// @brief Inverse of `rpPioWireFrameBytes`, for the error message.
 fl::size rpPioMaxLedsForWireBytes(fl::size wire_bytes,
-                                  fl::ClocklessEncoder encoder) {
+                                  fl::ClocklessEncoder encoder, bool rgbw) {
     fl::UCS7604Mode mode;
     if (ucs7604ModeForEncoder(encoder, &mode)) {
         constexpr fl::size kPreambleLen = 15;
         if (wire_bytes <= kPreambleLen) {
             return 0;
         }
-        return (wire_bytes - kPreambleLen) / fl::ucs7604BytesPerLed(mode, false);
+        return (wire_bytes - kPreambleLen) / fl::ucs7604BytesPerLed(mode, rgbw);
     }
-    return wire_bytes / 3u;
+    return wire_bytes / (rgbw ? 4u : 3u);
 }
 
 #endif  // FL_IS_RP2040 || FL_IS_RP2350
@@ -1120,8 +1122,15 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
 
         for (fl::size i = 0; i < lane_sizes.size(); i++) {
             const fl::size leds = static_cast<fl::size>(lane_sizes[i]);
+            // Same predicate the comparison uses (`legacyLaneUsesRgbw`): an
+            // RGBW lane is four bytes per LED, so a 100-LED RGBW frame is 400
+            // wire bytes and does not fit where an RGB one does.
+            const bool lane_rgbw =
+                legacy_rgbw ||
+                (i < legacy_chipsets.size() &&
+                 legacyClocklessChipsetHasAutomaticRgbw(legacy_chipsets[i]));
             const fl::size wire_bytes =
-                rpPioWireFrameBytes(leds, timing_config.encoder);
+                rpPioWireFrameBytes(leds, timing_config.encoder, lane_rgbw);
             if (wire_bytes > max_wire_bytes) {
                 response.set("success", false);
                 response.set("error", "LaneSizeTooLarge");
@@ -1132,7 +1141,8 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
                     << static_cast<int>(max_wire_bytes) << " ("
                     << static_cast<int>(
                            rpPioMaxLedsForWireBytes(max_wire_bytes,
-                                                    timing_config.encoder))
+                                                    timing_config.encoder,
+                                                    lane_rgbw))
                     << " LEDs)";
                 response.set("message", msg.str().c_str());
                 return response;

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -963,58 +963,6 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
     fl::NamedTimingConfig timing_config(resolved_timing, timing_name.c_str(), resolved_encoder);
 
-#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
-    // The `laneSizes` guard above bounds the request with
-    // `rx_buffer.size() / 32`, which measures the wrong thing: `rx_buffer` is
-    // the decode *output*, and 32 has no relation to the capture. It advertised
-    // 103 LEDs, and 101, 102 and 103 were all accepted and then failed in
-    // capture with no error at all -- the outcome a bounds check exists to
-    // prevent (FastLED#4371).
-    //
-    // The real ceiling needs the resolved timing and encoder, which is why the
-    // check lands here rather than with the rest of the argument validation.
-    if (driver_name == "PIO0" || driver_name == "PIO1" || driver_name == "PIO2") {
-        // Reserve for the gap between arming the capture and the transmitter's
-        // first edge, which the sampler also spends words on. Measured on an
-        // RP2350W it sits between 4 us and 64 us: a 63-LED 400 kHz frame passes
-        // with 64 us of budget to spare and a 64-LED one fails with 4 us. Take
-        // the upper end -- advertising a maximum that does not work is the
-        // defect being removed here, so erring long is not symmetric with
-        // erring short.
-        constexpr fl::u32 kArmingLeadInNs = 64000;
-
-        const fl::u32 bit_period_ns =
-            static_cast<fl::u32>(resolved_timing.total_period_ns());
-        const fl::size max_wire_bytes = fl::validation::rpPioMaxWireBytes(
-            fl::kRpPioRxEdgeCapacity, fl::kPioRxDmaTailWords,
-            fl::kPioRxSamplesPerDmaWord,
-            1000000000u / fl::kPioRxClockHz,
-            fl::RxChannelConfig(pin_rx).signal_range_max_ns,
-            kArmingLeadInNs, bit_period_ns);
-
-        for (fl::size i = 0; i < lane_sizes.size(); i++) {
-            const fl::size leds = static_cast<fl::size>(lane_sizes[i]);
-            const fl::size wire_bytes =
-                rpPioWireFrameBytes(leds, timing_config.encoder);
-            if (wire_bytes > max_wire_bytes) {
-                response.set("success", false);
-                response.set("error", "LaneSizeTooLarge");
-                fl::sstream msg;
-                msg << "laneSizes[" << i << "] = " << lane_sizes[i] << " puts "
-                    << static_cast<int>(wire_bytes) << " bytes on the wire at "
-                    << timing_name.c_str() << "; PIO RX capture holds "
-                    << static_cast<int>(max_wire_bytes) << " ("
-                    << static_cast<int>(
-                           rpPioMaxLedsForWireBytes(max_wire_bytes,
-                                                    timing_config.encoder))
-                    << " LEDs)";
-                response.set("message", msg.str().c_str());
-                return response;
-            }
-        }
-    }
-#endif
-
     // Dynamically allocate LED arrays for each lane
     fl::vector<fl::unique_ptr<fl::vector<CRGB>>> led_arrays;
     fl::vector<fl::ChannelConfig> tx_configs;
@@ -1130,6 +1078,68 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             return response;
         }
     }
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+    // The `laneSizes` guard above bounds the request with
+    // `rx_buffer.size() / 32`, which measures the wrong thing: `rx_buffer` is
+    // the decode *output*, and 32 has no relation to the capture. It advertised
+    // 103 LEDs, and 101, 102 and 103 were all accepted and then failed in
+    // capture with no error at all -- the outcome a bounds check exists to
+    // prevent (FastLED#4371).
+    //
+    // Two things decide where this check can live. The real ceiling needs the
+    // resolved timing and encoder, so it cannot sit with the rest of the
+    // argument validation; and it belongs to the backend that *captures*, not
+    // the driver that transmits, so it has to follow the RX channel. On RP,
+    // PLATFORM_DEFAULT resolves to PIO RX whatever the TX driver is -- keying
+    // off `driver_name` would skip the bound for a UART0 request, which is
+    // captured by the same pool and hits the same ceiling, while applying a
+    // PIO-only limit to a PIO TX pointed at some other backend.
+    const fl::RxBackend capture_backend_for_limit =
+        rx_channel_to_use ? rx_channel_to_use->backend()
+                          : fl::RxBackend::PLATFORM_DEFAULT;
+    if (capture_backend_for_limit == fl::RxBackend::PLATFORM_DEFAULT ||
+        capture_backend_for_limit == fl::RxBackend::PIO) {
+        // Reserve for the gap between arming the capture and the transmitter's
+        // first edge, which the sampler also spends words on. Measured on an
+        // RP2350W it sits between 4 us and 64 us: a 63-LED 400 kHz frame passes
+        // with 64 us of budget to spare and a 64-LED one fails with 4 us. Take
+        // the upper end -- advertising a maximum that does not work is the
+        // defect being removed here, so erring long is not symmetric with
+        // erring short.
+        constexpr fl::u32 kArmingLeadInNs = 64000;
+
+        const fl::u32 bit_period_ns =
+            static_cast<fl::u32>(resolved_timing.total_period_ns());
+        const fl::size max_wire_bytes = fl::validation::rpPioMaxWireBytes(
+            fl::kRpPioRxEdgeCapacity, fl::kRpPioRxDmaTailWords,
+            fl::kRpPioRxSamplesPerDmaWord,
+            1000000000u / fl::kRpPioRxClockHz,
+            fl::RxChannelConfig(pin_rx).signal_range_max_ns,
+            kArmingLeadInNs, bit_period_ns);
+
+        for (fl::size i = 0; i < lane_sizes.size(); i++) {
+            const fl::size leds = static_cast<fl::size>(lane_sizes[i]);
+            const fl::size wire_bytes =
+                rpPioWireFrameBytes(leds, timing_config.encoder);
+            if (wire_bytes > max_wire_bytes) {
+                response.set("success", false);
+                response.set("error", "LaneSizeTooLarge");
+                fl::sstream msg;
+                msg << "laneSizes[" << i << "] = " << lane_sizes[i] << " puts "
+                    << static_cast<int>(wire_bytes) << " bytes on the wire at "
+                    << timing_name.c_str() << "; PIO RX capture holds "
+                    << static_cast<int>(max_wire_bytes) << " ("
+                    << static_cast<int>(
+                           rpPioMaxLedsForWireBytes(max_wire_bytes,
+                                                    timing_config.encoder))
+                    << " LEDs)";
+                response.set("message", msg.str().c_str());
+                return response;
+            }
+        }
+    }
+#endif
 
     // Create validation configuration
     fl::AutoResearchConfig autoresearch_config(

--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -48,7 +48,10 @@
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 #include "platforms/arm/rp/rpcommon/rp_pio_tx_bus_traits.h"
 #include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
+#include "platforms/arm/rp/rpcommon/rx_pio_channel.h"
 #endif
+#include "fl/channels/validation.h"
+#include "fl/chipsets/encoders/ucs7604.h"
 #include <Arduino.h>
 
 #include "fl/net/ble.h"
@@ -105,6 +108,69 @@ class StandingRxChannelSwap {
     AutoResearchState* mState;
     bool mReleased;
 };
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+
+/// @brief UCS7604 protocol mode behind an encoder selector, if it is one.
+///
+/// Returns false for every other encoder, including the ones this file cannot
+/// select -- see `rpPioWireFrameBytes`.
+bool ucs7604ModeForEncoder(fl::ClocklessEncoder encoder,
+                           fl::UCS7604Mode* out_mode) {
+    switch (encoder) {
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_8BIT:
+            *out_mode = fl::UCS7604Mode::UCS7604_MODE_8BIT_800KHZ;
+            return true;
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT:
+            *out_mode = fl::UCS7604Mode::UCS7604_MODE_16BIT_800KHZ;
+            return true;
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_UCS7604_16BIT_1600:
+            *out_mode = fl::UCS7604Mode::UCS7604_MODE_16BIT_1600KHZ;
+            return true;
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812:
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_TM1812_RGBWW:
+        case fl::ClocklessEncoder::CLOCKLESS_ENCODER_TM1908:
+            return false;
+    }
+    return false;
+}
+
+/// @brief Wire bytes one lane of `leds` puts on the wire, or 0 if unknown.
+///
+/// A UCS7604 lane is more than twice a WS2812 lane of the same length -- a
+/// 15-byte preamble, 16-bit channels, padding to a multiple of three -- so the
+/// capture bound has to be phrased in wire bytes, not LEDs (FastLED#4371).
+///
+/// TM1812 and TM1908 have layouts this does not model. Neither is reachable
+/// from `runSingleTest`'s timing list, and 0 makes the caller skip the bound
+/// rather than enforce a wrong one: no check is what happens today, a check
+/// with the wrong number is the defect being fixed.
+fl::size rpPioWireFrameBytes(fl::size leds, fl::ClocklessEncoder encoder) {
+    fl::UCS7604Mode mode;
+    if (ucs7604ModeForEncoder(encoder, &mode)) {
+        return fl::ucs7604FrameBytes(leds, mode, false);
+    }
+    if (encoder == fl::ClocklessEncoder::CLOCKLESS_ENCODER_WS2812) {
+        return leds * 3u;
+    }
+    return 0;
+}
+
+/// @brief Inverse of `rpPioWireFrameBytes`, for the error message.
+fl::size rpPioMaxLedsForWireBytes(fl::size wire_bytes,
+                                  fl::ClocklessEncoder encoder) {
+    fl::UCS7604Mode mode;
+    if (ucs7604ModeForEncoder(encoder, &mode)) {
+        constexpr fl::size kPreambleLen = 15;
+        if (wire_bytes <= kPreambleLen) {
+            return 0;
+        }
+        return (wire_bytes - kPreambleLen) / fl::ucs7604BytesPerLed(mode, false);
+    }
+    return wire_bytes / 3u;
+}
+
+#endif  // FL_IS_RP2040 || FL_IS_RP2350
 
 uint32_t expectedClocklessWireUs(const fl::ChipsetTimingConfig& timing,
                                  uint32_t max_leds) {
@@ -555,6 +621,11 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
     }
 
     fl::vector<int> lane_sizes;
+    // A coarse, platform-independent backstop, kept only so an absurd request
+    // is rejected before anything is allocated. It is not the capture limit:
+    // on RP the real, encoder- and timing-aware bound is applied further down,
+    // once the timing is resolved, and is strictly tighter than this one
+    // (FastLED#4371).
     const int max_leds_per_lane = mState->rx_buffer.size() / 32;
     for (fl::size i = 0; i < lane_sizes_json.size(); i++) {
         if (!lane_sizes_json[i].is_int()) {
@@ -891,6 +962,58 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         resolved_encoder = fl::encoder_for<fl::TIMING_WS2812B_V5>();
     }
     fl::NamedTimingConfig timing_config(resolved_timing, timing_name.c_str(), resolved_encoder);
+
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+    // The `laneSizes` guard above bounds the request with
+    // `rx_buffer.size() / 32`, which measures the wrong thing: `rx_buffer` is
+    // the decode *output*, and 32 has no relation to the capture. It advertised
+    // 103 LEDs, and 101, 102 and 103 were all accepted and then failed in
+    // capture with no error at all -- the outcome a bounds check exists to
+    // prevent (FastLED#4371).
+    //
+    // The real ceiling needs the resolved timing and encoder, which is why the
+    // check lands here rather than with the rest of the argument validation.
+    if (driver_name == "PIO0" || driver_name == "PIO1" || driver_name == "PIO2") {
+        // Reserve for the gap between arming the capture and the transmitter's
+        // first edge, which the sampler also spends words on. Measured on an
+        // RP2350W it sits between 4 us and 64 us: a 63-LED 400 kHz frame passes
+        // with 64 us of budget to spare and a 64-LED one fails with 4 us. Take
+        // the upper end -- advertising a maximum that does not work is the
+        // defect being removed here, so erring long is not symmetric with
+        // erring short.
+        constexpr fl::u32 kArmingLeadInNs = 64000;
+
+        const fl::u32 bit_period_ns =
+            static_cast<fl::u32>(resolved_timing.total_period_ns());
+        const fl::size max_wire_bytes = fl::validation::rpPioMaxWireBytes(
+            fl::kRpPioRxEdgeCapacity, fl::kPioRxDmaTailWords,
+            fl::kPioRxSamplesPerDmaWord,
+            1000000000u / fl::kPioRxClockHz,
+            fl::RxChannelConfig(pin_rx).signal_range_max_ns,
+            kArmingLeadInNs, bit_period_ns);
+
+        for (fl::size i = 0; i < lane_sizes.size(); i++) {
+            const fl::size leds = static_cast<fl::size>(lane_sizes[i]);
+            const fl::size wire_bytes =
+                rpPioWireFrameBytes(leds, timing_config.encoder);
+            if (wire_bytes > max_wire_bytes) {
+                response.set("success", false);
+                response.set("error", "LaneSizeTooLarge");
+                fl::sstream msg;
+                msg << "laneSizes[" << i << "] = " << lane_sizes[i] << " puts "
+                    << static_cast<int>(wire_bytes) << " bytes on the wire at "
+                    << timing_name.c_str() << "; PIO RX capture holds "
+                    << static_cast<int>(max_wire_bytes) << " ("
+                    << static_cast<int>(
+                           rpPioMaxLedsForWireBytes(max_wire_bytes,
+                                                    timing_config.encoder))
+                    << " LEDs)";
+                response.set("message", msg.str().c_str());
+                return response;
+            }
+        }
+    }
+#endif
 
     // Dynamically allocate LED arrays for each lane
     fl::vector<fl::unique_ptr<fl::vector<CRGB>>> led_arrays;

--- a/src/fl/channels/rx/pio_geometry.h
+++ b/src/fl/channels/rx/pio_geometry.h
@@ -1,0 +1,38 @@
+/// @file fl/channels/rx/pio_geometry.h
+/// @brief Sampler geometry of the RP PIO RX capture.
+///
+/// These numbers are the contract between the capture device and anything that
+/// has to predict whether a frame will fit in it, and they bound a capture in
+/// two independent ways (FastLED#4371):
+///
+///  - `kRpPioRxEdgeCapacity` is a pool of signal phases, two per bit.
+///  - the DMA word count derived from it is a fixed quantity of *wall clock*,
+///    because each word holds `kRpPioRxSamplesPerDmaWord` pin samples taken at
+///    `kRpPioRxClockHz`.
+///
+/// They live here, portable and free of the RP build guard, so the device, the
+/// bound in `fl/channels/validation.h` and the host tests all read the same
+/// definitions instead of copies that can drift apart.
+
+#pragma once
+
+#include "fl/stl/int.h"
+
+namespace fl {
+
+/// Phase slots in the shared capture pool. Sized for the AutoResearch RP tier:
+/// 100 RGB LEDs x 3 bytes x 16 phases per byte, plus one.
+constexpr size_t kRpPioRxEdgeCapacity = 100u * 3u * 16u + 1u;
+
+/// After synchronizing to the first rising edge the PIO runs one IN PINS
+/// instruction per cycle, so 20 MHz gives 50 ns samples -- enough to separate
+/// WS2812 timing phases without losing the first phase to counter setup.
+constexpr u32 kRpPioRxClockHz = 20000000u;
+
+/// Pin samples packed into each 32-bit DMA word.
+constexpr u32 kRpPioRxSamplesPerDmaWord = 32u;
+
+/// Reset-tail words appended to the DMA transfer.
+constexpr size_t kRpPioRxDmaTailWords = 64u;
+
+}  // namespace fl

--- a/src/fl/channels/validation.h
+++ b/src/fl/channels/validation.h
@@ -120,10 +120,10 @@ inline size_t captureEdgeCapacity(size_t shared_buffer_bytes,
 /// @param edge_capacity        Phase slots in the capture pool
 ///                             (`kRpPioRxEdgeCapacity`)
 /// @param dma_tail_words       Reset-tail words added to the DMA transfer
-///                             (`kPioRxDmaTailWords`)
+///                             (`kRpPioRxDmaTailWords`)
 /// @param samples_per_dma_word Pin samples packed into one DMA word
-///                             (`kPioRxSamplesPerDmaWord`)
-/// @param sample_period_ns     Nanoseconds per sample (1e9 / `kPioRxClockHz`)
+///                             (`kRpPioRxSamplesPerDmaWord`)
+/// @param sample_period_ns     Nanoseconds per sample (1e9 / `kRpPioRxClockHz`)
 /// @param idle_tail_ns         Trailing idle the capture must see to finish
 ///                             (`RxChannelConfig::signal_range_max_ns`)
 /// @param arming_lead_in_ns    Reserve for the arm-to-first-edge gap

--- a/src/fl/channels/validation.h
+++ b/src/fl/channels/validation.h
@@ -91,6 +91,79 @@ inline size_t captureEdgeCapacity(size_t shared_buffer_bytes,
     return capacity;
 }
 
+/// @brief Largest frame, in wire bytes, an RP PIO RX capture can hold.
+///
+/// Two independent ceilings bound a capture, and each is the binding one in
+/// its own regime -- which is why no single constant, and no single model,
+/// predicts both (FastLED#4371):
+///
+///  1. **Edge pool.** The capture appends one `EdgeTime` per signal phase into
+///     a fixed pool: two phases per bit, eight bits per wire byte. Past
+///     `edge_capacity / 16` bytes it overflows.
+///  2. **Sample-time budget.** The sampler writes `samples_per_dma_word`
+///     samples per DMA word at a fixed clock, and the word count is
+///     `(edge_capacity + 1) / 2 + dma_tail_words` for every frame large enough
+///     for either ceiling to matter. That is a constant quantity of *wall
+///     clock*, not of data. The frame, plus the trailing idle the capture must
+///     observe before it will terminate, plus the gap between arming and the
+///     first edge, all have to fit inside it.
+///
+/// At a 1225 ns bit period the pool binds first (300 bytes, 2.9 ms); at
+/// 2500 ns the clock binds first (3.84 ms, 189 bytes). Measured on an RP2350W
+/// across WS2812B-V5, WS2818, WS2814, UCS7604-800KHZ and WS2811-400KHZ, the
+/// smaller of the two reproduces every pass/fail boundary to the byte.
+///
+/// Shorter frames are not shortchanged by using the clamped word count: below
+/// the clamp the budget grows by 16 words per byte while the frame grows by
+/// only 8 bit-periods, so it never becomes the binding constraint there.
+///
+/// @param edge_capacity        Phase slots in the capture pool
+///                             (`kRpPioRxEdgeCapacity`)
+/// @param dma_tail_words       Reset-tail words added to the DMA transfer
+///                             (`kPioRxDmaTailWords`)
+/// @param samples_per_dma_word Pin samples packed into one DMA word
+///                             (`kPioRxSamplesPerDmaWord`)
+/// @param sample_period_ns     Nanoseconds per sample (1e9 / `kPioRxClockHz`)
+/// @param idle_tail_ns         Trailing idle the capture must see to finish
+///                             (`RxChannelConfig::signal_range_max_ns`)
+/// @param arming_lead_in_ns    Reserve for the arm-to-first-edge gap
+/// @param bit_period_ns        T1 + T2 + T3 of the chipset under test
+/// @return Maximum wire bytes, or 0 if nothing fits
+inline size_t rpPioMaxWireBytes(size_t edge_capacity,
+                                size_t dma_tail_words,
+                                u32 samples_per_dma_word,
+                                u32 sample_period_ns,
+                                u32 idle_tail_ns,
+                                u32 arming_lead_in_ns,
+                                u32 bit_period_ns) FL_NO_EXCEPT {
+    constexpr size_t kPhasesPerByte = 16;  // 8 bits x (high + low)
+    constexpr u64 kBitsPerByte = 8;
+
+    if (bit_period_ns == 0 || edge_capacity == 0 || samples_per_dma_word == 0 ||
+        sample_period_ns == 0) {
+        return 0;
+    }
+
+    const size_t by_pool = edge_capacity / kPhasesPerByte;
+
+    const u64 dma_words =
+        static_cast<u64>((edge_capacity + 1u) / 2u) + dma_tail_words;
+    const u64 budget_ns =
+        dma_words * samples_per_dma_word * sample_period_ns;
+    const u64 reserved_ns =
+        static_cast<u64>(idle_tail_ns) + arming_lead_in_ns;
+    if (budget_ns <= reserved_ns) {
+        return 0;
+    }
+    const u64 by_clock =
+        (budget_ns - reserved_ns) / (kBitsPerByte * bit_period_ns);
+
+    if (static_cast<u64>(by_pool) < by_clock) {
+        return by_pool;
+    }
+    return static_cast<size_t>(by_clock);
+}
+
 }  // namespace validation
 
 /// @brief Single test configuration - fully stateless

--- a/src/fl/chipsets/encoders/ucs7604.h
+++ b/src/fl/chipsets/encoders/ucs7604.h
@@ -236,6 +236,28 @@ void encodeUCS7604_16bit_RGBW(InputIterator first, InputIterator last, OutputIte
     }
 }
 
+/// @brief Wire bytes each LED contributes to a UCS7604 frame
+inline size_t ucs7604BytesPerLed(UCS7604Mode mode, bool is_rgbw) FL_NO_EXCEPT {
+    if (mode == UCS7604Mode::UCS7604_MODE_8BIT_800KHZ) {
+        return is_rgbw ? 4u : 3u;
+    }
+    return is_rgbw ? 8u : 6u;
+}
+
+/// @brief Total wire bytes of a complete UCS7604 frame
+///
+/// Preamble + padding + pixel data, the length `encodeUCS7604` writes. Callers
+/// that must size a capture or predict whether a frame fits need this without
+/// encoding it first (FastLED#4371); `encodeUCS7604` computes its own padding
+/// from here so the two cannot drift.
+inline size_t ucs7604FrameBytes(size_t num_leds, UCS7604Mode mode,
+                                bool is_rgbw) FL_NO_EXCEPT {
+    constexpr size_t kPreambleLen = 15;
+    const size_t total = kPreambleLen + num_leds * ucs7604BytesPerLed(mode, is_rgbw);
+    // The protocol requires the total to be divisible by 3.
+    return total + (3u - (total % 3u)) % 3u;
+}
+
 /// @brief Encode complete UCS7604 frame (preamble + padding + pixel data)
 /// @tparam OutputIterator Output iterator accepting uint8_t
 /// @param pixel_iter PixelIterator with pixel data and scaling/gamma/dithering
@@ -259,18 +281,11 @@ void encodeUCS7604(PixelIterator& pixel_iter, size_t num_leds, OutputIterator ou
     FL_UNUSED(wide_source);
 #endif
 
-    // Calculate bytes per LED based on mode and RGB/RGBW
-    size_t bytes_per_led;
-    if (mode == UCS7604Mode::UCS7604_MODE_8BIT_800KHZ) {
-        bytes_per_led = is_rgbw ? 4 : 3;
-    } else {
-        bytes_per_led = is_rgbw ? 8 : 6;
-    }
-
-    // Calculate total data size and padding
-    size_t led_data_size = num_leds * bytes_per_led;
-    size_t total_data_size = PREAMBLE_LEN + led_data_size;
-    size_t padding = (3 - (total_data_size % 3)) % 3;
+    // Padding comes from ucs7604FrameBytes() so the length callers predict and
+    // the length written here are the same number by construction.
+    const size_t led_data_size = num_leds * ucs7604BytesPerLed(mode, is_rgbw);
+    const size_t padding =
+        ucs7604FrameBytes(num_leds, mode, is_rgbw) - PREAMBLE_LEN - led_data_size;
 
     // Build preamble (15 bytes) with current control
     buildUCS7604Preamble(out, mode, current.r, current.g, current.b, current.w);

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
@@ -23,11 +23,6 @@ namespace fl {
 namespace {
 
 constexpr size_t kPioRxProgramLength = 3;
-// After synchronizing to the first rising edge, the PIO runs one IN PINS
-// instruction per cycle. 20 MHz gives 50 ns samples, enough to distinguish
-// WS2812 timing phases without losing the first phase to counter setup.
-constexpr u32 kPioRxClockHz = 20000000u;
-constexpr size_t kPioRxDmaTailWords = 64u;
 // AutoResearch's RP tier is capped at 100 RGB LEDs. A static DMA target keeps
 // capture independent of the Arduino-Pico heap, which is not usable while the
 // full RPC harness owns its transient result objects.
@@ -290,8 +285,9 @@ void RpPioRxDevice::collectDurations() FL_NO_EXCEPT {
     const size_t transferred = mDmaWordCount - dma_hw->ch[mDmaChannel].transfer_count;
     while (mDmaWordsProcessed < transferred) {
         const u32 samples = mDmaWords[mDmaWordsProcessed];
-        for (u32 bit = 0; bit < 32; ++bit) {
-            const bool high = (samples & (1u << (31u - bit))) != 0;
+        for (u32 bit = 0; bit < kPioRxSamplesPerDmaWord; ++bit) {
+            const bool high =
+                (samples & (1u << (kPioRxSamplesPerDmaWord - 1u - bit))) != 0;
             if (!mHaveSample) {
                 mSampleHigh = high;
                 mHaveSample = true;

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.cpp.hpp
@@ -154,14 +154,14 @@ bool RpPioRxDevice::begin(const RxConfig& config) FL_NO_EXCEPT {
     sm_config_set_in_shift(&pio_config, false, true, 32);
     sm_config_set_fifo_join(&pio_config, PIO_FIFO_JOIN_RX);
     const u32 system_clock_hz = clock_get_hz(clk_sys);
-    sm_config_set_clkdiv(&pio_config, static_cast<float>(system_clock_hz) / kPioRxClockHz);
+    sm_config_set_clkdiv(&pio_config, static_cast<float>(system_clock_hz) / kRpPioRxClockHz);
     pio_sm_init(pio, static_cast<uint>(state_machine), static_cast<uint>(program_offset),
                 &pio_config);
     mPio = pio;
     mStateMachine = state_machine;
     mDmaChannel = dma_channel;
     mProgramOffset = program_offset;
-    mPioClockHz = kPioRxClockHz;
+    mPioClockHz = kRpPioRxClockHz;
     mTailLimitNs = config.signal_range_max_ns == 0 ? 1 : config.signal_range_max_ns;
     mLastTransitionUs = micros();
     mCapacity = config.buffer_size;
@@ -169,7 +169,7 @@ bool RpPioRxDevice::begin(const RxConfig& config) FL_NO_EXCEPT {
     // Each 32-bit DMA word stores 32 samples. A WS2812 byte uses roughly
     // seven words at 20 MHz; the edge capacity is sixteen phases per byte,
     // so half that capacity plus a reset tail is safely conservative.
-    mDmaWordCount = (mCapacity + 1u) / 2u + kPioRxDmaTailWords;
+    mDmaWordCount = (mCapacity + 1u) / 2u + kRpPioRxDmaTailWords;
     mDmaWordsProcessed = 0;
     mIdleHigh = !config.start_low;
     mSampleHigh = mIdleHigh;
@@ -285,9 +285,9 @@ void RpPioRxDevice::collectDurations() FL_NO_EXCEPT {
     const size_t transferred = mDmaWordCount - dma_hw->ch[mDmaChannel].transfer_count;
     while (mDmaWordsProcessed < transferred) {
         const u32 samples = mDmaWords[mDmaWordsProcessed];
-        for (u32 bit = 0; bit < kPioRxSamplesPerDmaWord; ++bit) {
+        for (u32 bit = 0; bit < kRpPioRxSamplesPerDmaWord; ++bit) {
             const bool high =
-                (samples & (1u << (kPioRxSamplesPerDmaWord - 1u - bit))) != 0;
+                (samples & (1u << (kRpPioRxSamplesPerDmaWord - 1u - bit))) != 0;
             if (!mHaveSample) {
                 mSampleHigh = high;
                 mHaveSample = true;

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
@@ -16,6 +16,17 @@ namespace fl {
 constexpr size_t kRpPioRxEdgeCapacity = 100u * 3u * 16u + 1u;
 using RpPioRxEdgeStorage = fl::FixedVector<EdgeTime, kRpPioRxEdgeCapacity>;
 
+// Sampler geometry. These live in the header rather than beside their use in
+// rx_pio_channel.cpp.hpp because they are what bounds a capture, and callers
+// that have to predict whether a frame will fit need them (FastLED#4371).
+//
+// After synchronizing to the first rising edge the PIO runs one IN PINS
+// instruction per cycle, so 20 MHz gives 50 ns samples -- enough to separate
+// WS2812 timing phases without losing the first phase to counter setup.
+constexpr u32 kPioRxClockHz = 20000000u;
+constexpr u32 kPioRxSamplesPerDmaWord = 32u;
+constexpr size_t kPioRxDmaTailWords = 64u;
+
 /// @brief RP PIO RX lifecycle device. Capture programming is Phase 2.
 class RpPioRxDevice : public RxDevice {
   public:

--- a/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
+++ b/src/platforms/arm/rp/rpcommon/rx_pio_channel.h
@@ -7,25 +7,14 @@
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 
 #include "fl/channels/rx.h"
+#include "fl/channels/rx/pio_geometry.h"
 #include "platforms/arm/rp/rpcommon/rp_pio_edge_capture.h"
 #include "fl/stl/shared_ptr.h"
 #include "fl/stl/vector.h"
 
 namespace fl {
 
-constexpr size_t kRpPioRxEdgeCapacity = 100u * 3u * 16u + 1u;
 using RpPioRxEdgeStorage = fl::FixedVector<EdgeTime, kRpPioRxEdgeCapacity>;
-
-// Sampler geometry. These live in the header rather than beside their use in
-// rx_pio_channel.cpp.hpp because they are what bounds a capture, and callers
-// that have to predict whether a frame will fit need them (FastLED#4371).
-//
-// After synchronizing to the first rising edge the PIO runs one IN PINS
-// instruction per cycle, so 20 MHz gives 50 ns samples -- enough to separate
-// WS2812 timing phases without losing the first phase to counter setup.
-constexpr u32 kPioRxClockHz = 20000000u;
-constexpr u32 kPioRxSamplesPerDmaWord = 32u;
-constexpr size_t kPioRxDmaTailWords = 64u;
 
 /// @brief RP PIO RX lifecycle device. Capture programming is Phase 2.
 class RpPioRxDevice : public RxDevice {

--- a/tests/fl/channels/validation.cpp
+++ b/tests/fl/channels/validation.cpp
@@ -129,6 +129,72 @@ FL_TEST_CASE("ISR validation capture uses a frame-sized power-of-two buffer") {
                 26400u);
 }
 
+// The RP PIO sampler's own constants, so the expectations below are the
+// numbers the device actually runs with (rx_pio_channel.h). They are repeated
+// rather than included because that header is RP-only and this test builds on
+// the host.
+constexpr size_t kEdgeCapacity = 100u * 3u * 16u + 1u;  // 4801
+constexpr size_t kDmaTailWords = 64u;
+constexpr u32 kSamplesPerWord = 32u;
+constexpr u32 kSamplePeriodNs = 50u;   // 20 MHz
+constexpr u32 kIdleTailNs = 100000u;   // RxChannelConfig default
+constexpr u32 kArmingLeadInNs = 64000u;
+
+size_t maxWireBytesAt(u32 bit_period_ns) {
+    return validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
+                                         kSamplesPerWord, kSamplePeriodNs,
+                                         kIdleTailNs, kArmingLeadInNs,
+                                         bit_period_ns);
+}
+
+FL_TEST_CASE("RP PIO capture bound reproduces the measured hardware ceilings") {
+    // Measured on an RP2350W (PIO0, GPIO0 -> GPIO1), 3/3 per boundary --
+    // FastLED#4371. Each row is the largest frame that captures, expressed in
+    // wire bytes so the chipsets are comparable.
+
+    // 800 kHz class: the edge pool binds. 4801 / 16 phases per byte = 300.
+    FL_CHECK_EQ(maxWireBytesAt(1200u), 300u);  // WS2818,     100 LEDs
+    FL_CHECK_EQ(maxWireBytesAt(1225u), 300u);  // WS2812B-V5, 100 LEDs
+    FL_CHECK_EQ(maxWireBytesAt(1250u), 300u);  // UCS7604,     47 LEDs (15 + 6n)
+    FL_CHECK_EQ(maxWireBytesAt(1280u), 300u);  // WS2814,     100 LEDs
+
+    // 400 kHz: the sample-time budget binds well below the pool.
+    // 63 LEDs = 189 bytes passes, 64 LEDs = 192 bytes fails.
+    FL_CHECK_EQ(maxWireBytesAt(2500u), 189u);
+}
+
+FL_TEST_CASE("RP PIO capture bound is the smaller of the two ceilings") {
+    // Below the crossover the pool is the answer and the bound is flat;
+    // above it the clock takes over and the bound falls with the bit period.
+    FL_CHECK_EQ(maxWireBytesAt(1u), 300u);
+    FL_CHECK(maxWireBytesAt(2000u) < 300u);
+    FL_CHECK(maxWireBytesAt(2500u) < maxWireBytesAt(2000u));
+
+    // A bit period long enough to exhaust the whole budget leaves nothing.
+    FL_CHECK_EQ(maxWireBytesAt(1000000u), 0u);
+}
+
+FL_TEST_CASE("RP PIO capture bound rejects degenerate inputs") {
+    FL_CHECK_EQ(maxWireBytesAt(0u), 0u);
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(0, kDmaTailWords, kSamplesPerWord,
+                                              kSamplePeriodNs, kIdleTailNs,
+                                              kArmingLeadInNs, 1225u),
+                0u);
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords, 0u,
+                                              kSamplePeriodNs, kIdleTailNs,
+                                              kArmingLeadInNs, 1225u),
+                0u);
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
+                                              kSamplesPerWord, 0u, kIdleTailNs,
+                                              kArmingLeadInNs, 1225u),
+                0u);
+    // Reserves that swallow the entire budget yield nothing, not an underflow.
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
+                                              kSamplesPerWord, kSamplePeriodNs,
+                                              4000000u, 0u, 1225u),
+                0u);
+}
+
 FL_TEST_CASE("Invalid driver name - empty") {
     SingleTestConfig config = makeBasicConfig();
     config.driver_name = "";

--- a/tests/fl/channels/validation.cpp
+++ b/tests/fl/channels/validation.cpp
@@ -4,6 +4,7 @@
 
 #include "test.h"
 #include "fl/channels/validation.h"
+#include "fl/channels/rx/pio_geometry.h"
 
 FL_TEST_FILE(FL_FILEPATH) {
 
@@ -129,22 +130,16 @@ FL_TEST_CASE("ISR validation capture uses a frame-sized power-of-two buffer") {
                 26400u);
 }
 
-// The RP PIO sampler's own constants, so the expectations below are the
-// numbers the device actually runs with (rx_pio_channel.h). They are repeated
-// rather than included because that header is RP-only and this test builds on
-// the host.
-constexpr size_t kEdgeCapacity = 100u * 3u * 16u + 1u;  // 4801
-constexpr size_t kDmaTailWords = 64u;
-constexpr u32 kSamplesPerWord = 32u;
-constexpr u32 kSamplePeriodNs = 50u;   // 20 MHz
+// The sampler's own constants, from the header the RP device is built from,
+// so these expectations cannot drift from the numbers production computes.
+constexpr u32 kSamplePeriodNs = 1000000000u / kRpPioRxClockHz;
 constexpr u32 kIdleTailNs = 100000u;   // RxChannelConfig default
 constexpr u32 kArmingLeadInNs = 64000u;
 
 size_t maxWireBytesAt(u32 bit_period_ns) {
-    return validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
-                                         kSamplesPerWord, kSamplePeriodNs,
-                                         kIdleTailNs, kArmingLeadInNs,
-                                         bit_period_ns);
+    return validation::rpPioMaxWireBytes(
+        kRpPioRxEdgeCapacity, kRpPioRxDmaTailWords, kRpPioRxSamplesPerDmaWord,
+        kSamplePeriodNs, kIdleTailNs, kArmingLeadInNs, bit_period_ns);
 }
 
 FL_TEST_CASE("RP PIO capture bound reproduces the measured hardware ceilings") {
@@ -176,22 +171,24 @@ FL_TEST_CASE("RP PIO capture bound is the smaller of the two ceilings") {
 
 FL_TEST_CASE("RP PIO capture bound rejects degenerate inputs") {
     FL_CHECK_EQ(maxWireBytesAt(0u), 0u);
-    FL_CHECK_EQ(validation::rpPioMaxWireBytes(0, kDmaTailWords, kSamplesPerWord,
-                                              kSamplePeriodNs, kIdleTailNs,
-                                              kArmingLeadInNs, 1225u),
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(
+                    0, kRpPioRxDmaTailWords, kRpPioRxSamplesPerDmaWord,
+                    kSamplePeriodNs, kIdleTailNs, kArmingLeadInNs, 1225u),
                 0u);
-    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords, 0u,
-                                              kSamplePeriodNs, kIdleTailNs,
-                                              kArmingLeadInNs, 1225u),
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(
+                    kRpPioRxEdgeCapacity, kRpPioRxDmaTailWords, 0u,
+                    kSamplePeriodNs, kIdleTailNs, kArmingLeadInNs, 1225u),
                 0u);
-    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
-                                              kSamplesPerWord, 0u, kIdleTailNs,
-                                              kArmingLeadInNs, 1225u),
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(
+                    kRpPioRxEdgeCapacity, kRpPioRxDmaTailWords,
+                    kRpPioRxSamplesPerDmaWord, 0u, kIdleTailNs,
+                    kArmingLeadInNs, 1225u),
                 0u);
     // Reserves that swallow the entire budget yield nothing, not an underflow.
-    FL_CHECK_EQ(validation::rpPioMaxWireBytes(kEdgeCapacity, kDmaTailWords,
-                                              kSamplesPerWord, kSamplePeriodNs,
-                                              4000000u, 0u, 1225u),
+    FL_CHECK_EQ(validation::rpPioMaxWireBytes(
+                    kRpPioRxEdgeCapacity, kRpPioRxDmaTailWords,
+                    kRpPioRxSamplesPerDmaWord, kSamplePeriodNs, 4000000u, 0u,
+                    1225u),
                 0u);
 }
 


### PR DESCRIPTION
`runSingleTest` bounded `laneSizes` with `mState->rx_buffer.size() / 32`. That measures the wrong thing twice over: `rx_buffer` is the decode **output** buffer, and 32 has no relation to the capture. It advertised 103 LEDs — and 101, 102 and 103 were all *accepted* and then failed in capture with `bytes: 0` and no error, which is the outcome a bounds check exists to prevent (#4371).

## Two ceilings, each binding in its own regime

This is why no single constant — and no single model — fit both chipsets.

**1. Edge pool.** The capture appends one `EdgeTime` per signal phase into a fixed pool: two phases per bit, eight bits per wire byte. So `kRpPioRxEdgeCapacity / 16` = **300 wire bytes**.

**2. Sample-time budget.** The sampler packs 32 samples per DMA word at 20 MHz, and `mDmaWordCount = (mCapacity + 1) / 2 + kPioRxDmaTailWords` is pinned at **2465** for every frame large enough for either ceiling to matter. That is a constant quantity of *wall clock*, not of data:

```
2465 words x 32 samples x 50 ns = 3.944 ms
  - 100 us trailing idle (RxChannelConfig::signal_range_max_ns)
  -  64 us arm-to-first-edge gap
  = 3.78 ms for the frame
```

At a 1225 ns bit period the pool binds first (300 bytes, 2.9 ms). At 2500 ns the clock binds first (3.78 ms, 189 bytes). Each ceiling is invisible in the other's regime, which is why 800 kHz parts all reported 100 and the one 400 kHz part reported 63.

The two were measured apart: **192 wire bytes / 3072 phases passes 3/3 at 800 kHz and fails 3/3 at 400 kHz.** Same size, same phase count, opposite verdicts — so constraint 2 is about time and constraint 1 is about size.

## And it has to be encoder-aware

A UCS7604 lane is more than twice a WS2812 lane of the same length — 15-byte preamble, 16-bit channels, padding to a multiple of three — so it tops out at **47** LEDs where WS2812 tops out at 100. A guard phrased in LEDs cannot be right for both; one phrased in wire bytes is right for both.

## The change

- `fl::validation::rpPioMaxWireBytes()` returns the smaller of the two ceilings, from the sampler's own constants.
- The check moves to just after the timing and encoder are resolved, because it needs both. The old guard stays as a coarse pre-allocation backstop.
- `kPioRxClockHz`, `kPioRxSamplesPerDmaWord` and `kPioRxDmaTailWords` move into `rx_pio_channel.h` so the bound reads the real constants rather than copies; `collectDurations()` now uses the named samples-per-word constant instead of a bare `32`.
- `ucs7604FrameBytes()` joins the encoder header for the same reason — `encodeUCS7604()` derives its padding from it, so the length callers predict and the length written cannot drift.

## Measured

RP2350W `2DCB876B587EA334`, PIO0, GPIO0 → GPIO1. Every boundary is now the hardware's:

| timing | last accepted | first rejected |
|---|---|---|
| WS2812B-V5 | 100, 4/4 | 101 — 303 B > 300 |
| WS2818 | 100, 4/4 | 101 — 303 B > 300 |
| WS2814 | 100, 4/4 | 101 — 303 B > 300 |
| WS2811-400KHZ | 63, 4/4 | 64 — 192 B > 189 |
| UCS7604-800KHZ | 47 | 48 — 303 B > 300 |

The silent band is empty for all five. The rejection now says what happened:

```
LaneSizeTooLarge: laneSizes[0] = 64 puts 192 bytes on the wire at
WS2811-400KHZ; PIO RX capture holds 189 (63 LEDs)
```

Host tests assert the same five ceilings against the production function rather than re-deriving them.

> UCS7604 still compares as *failed* on this branch — that is #4373, fixed separately in #4377; this branch is off master. It captures 141 bytes at 47 LEDs, `47 x 3` raw pixel bytes, exactly that defect's signature. The guard behaviour under test here is unaffected.

Fixes #4371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RP2040 and RP2350 validation for LED configurations exceeding available capture capacity.
  * Correctly accounts for RGBW data when calculating wire usage and maximum LED counts.
  * Improved UCS7604 frame sizing for RGB and RGBW configurations, including protocol padding.
  * Added support for wider-source RGB output with improved color handling.

* **Tests**
  * Added coverage for RP PIO capture limits across 800 kHz and 400 kHz LED protocols.
  * Added validation for boundary conditions and insufficient capture budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->