### PR TITLE
docs(lessons): record diagnostic provenance and mutually-masking constraints

### DIFF
--- a/agents/tasks/lessons.md
+++ b/agents/tasks/lessons.md
@@ -325,3 +325,28 @@
   content, not state, and
   when commits are stranded rebuild them onto current master as a fresh PR
   rather than reopening the merged one.
+- A diagnostic field named after the subsystem you are testing may be sourced
+  from the other side of the loopback. Chasing the RP PIO capture ceiling in
+  #4371 I used `rpPioWordCount` as evidence about the RX DMA and wrote on the
+  issue that "the DMA is not the constraint", because the field read exactly
+  `8 * wire_bytes` in every row, passing and failing alike. It comes from
+  `fl::BusTraits<fl::Bus::FLEX_IO, N>::instance().lastWordCount()` -- the
+  **transmitter**. Eight words per byte is one TX word per bit, which is
+  precisely why it tracked byte count so cleanly and said nothing at all about
+  capture. The tell was there in the data: a number that is an exact linear
+  function of the input, with no variation between the cases you are trying to
+  tell apart, is usually not measuring the thing that separates them. Grep the
+  field back to where the response sets it before drawing a conclusion from it.
+  The pass/fail boundaries themselves were unaffected, which is the reason the
+  rest of that analysis survived the correction -- prefer evidence from the
+  behaviour you are measuring over evidence from a field that claims to explain
+  it.
+- Two constraints can hide each other completely. The same capture had an edge
+  pool bounding fast chipsets at 300 wire bytes and a fixed sample-time budget
+  bounding slow ones at 3.8 ms, and each ceiling is unreachable in the other's
+  regime -- so every 800 kHz part reported 100 LEDs, the one 400 kHz part
+  reported 63, and no single model fit. Separating them took constructing a
+  case where one variable was held equal: 192 wire bytes and 3072 phases passes
+  at 800 kHz and fails at 400 kHz. When measurements refuse to collapse into
+  one model, stop fitting curves and look for the input you have never varied
+  independently.


### PR DESCRIPTION
Two corrections from the RP2350 PIO capture-ceiling work (#4371), recorded in `agents/tasks/lessons.md`.

**Diagnostic provenance.** I used `rpPioWordCount` as evidence about the RX DMA and stated on the issue that "the DMA is not the constraint". It comes from `fl::BusTraits<fl::Bus::FLEX_IO, N>::instance().lastWordCount()` — the transmitter. The generalisable tell was visible in the data: a field that is an exact linear function of the input, with no variation between the cases you are trying to separate, is usually not measuring what separates them.

**Mutually-masking constraints.** The same capture has an edge pool bounding fast chipsets at 300 wire bytes and a fixed sample-time budget bounding slow ones at 3.8 ms. Each is unreachable in the other's regime, so no single model fit until a case was constructed holding one variable equal across both — 192 wire bytes passes at 800 kHz and fails at 400 kHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance to verify that diagnostic fields measure the intended subsystem and data source.
  - Documented how independent resource and timing constraints can mask one another, including a method for isolating each constraint during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->