### PR TITLE
fix(uart): stop 400 kHz picking a geometry whose '1' symbol nothing can decode (#4379)

### DIFF
--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -23,7 +23,11 @@
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
 #include "fl/stl/atomic.h"
 #include "fl/stl/isr.h"
+// lastActualBaud() identifies the UART geometry the transmitter actually ran,
+// which is what the capture has to be decoded against.
+#include "platforms/arm/rp/rpcommon/rp_uart_bus_traits.h"
 #endif
+#include "fl/channels/uart_wave_encoder.h"
 #include "LegacyClocklessProxy.h"
 #include "platforms/arm/teensy/teensy4_common/drivers/objectfled/objectfled_diagnostics.h"
 #include <FastLED.h>
@@ -691,22 +695,46 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
         AR_FL_WARN("[CAPTURE] UART: attempting decode with captured edges despite timeout");
     }
 
-    // UART with TX inversion at 4 Mbps produces a standard WS2812-compatible
-    // waveform on the wire. Each 10-bit UART frame (2500ns) encodes exactly 2
-    // LED bits with correct WS2812 timing:
-    //   T0H=250ns, T0L=1000ns (LED bit "0")
-    //   T1H=750ns, T1L=500ns  (LED bit "1")
-    // Use the standard WS2812 decoder with UART-specific timing thresholds.
+    // UART TX with inversion puts a WS2812-shaped waveform on the wire, but
+    // quantized onto the UART pulse grid -- exactly like the wave8 and wave3
+    // cases handled above, and for the same reason: the decoder has to be told
+    // what the transmitter actually emitted, not what the datasheet says.
+    //
+    // This used to hardcode T0H=250 / T1H=750 / T1L=500, the shape an ESP32
+    // UART produces at 4 Mbps for a WS2812. That is right for one chipset on
+    // one platform and wrong everywhere else. At 400 kHz the real wire is
+    // 625 / 1250 / 1250, every phase of which falls outside those hardcoded
+    // windows -- so a correct frame decoded to nothing. See FastLED#4379.
     if (is_uart_driver) {
         AR_FL_WARN("[CAPTURE] UART (inverted TX): using standard WS2812 decoder with UART timing...");
-        // UART timing at 4 Mbps: T0H=250ns, T1H-T0H=500ns, T0L=1000ns
-        fl::ChipsetTiming uart_timing{
-            250,   // T1 = T0H (1 UART bit = 250ns)
-            500,   // T2 = T1H - T0H (3 bits - 1 bit = 2 bits = 500ns)
-            500,   // T3 = T1L (2 UART bits = 500ns, stop + next start)
-            50,    // reset_us (WS2812 minimum)
-            "UART_4Mbps"
-        };
+        // Derive the geometry from the chipset under test. Pass the baud the
+        // engine reports when it reports one: uartWireTiming() re-runs the
+        // same P=5/P=4 selection the encoder ran, and handing it the baud that
+        // was used reproduces that choice rather than guessing it from a
+        // generic ceiling.
+        fl::u32 uart_max_baud = fl::kMaxUartBaudRate;
+#if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
+        if (fl::strcmp(driver_name, "UART0") == 0) {
+            const fl::u32 actual =
+                fl::BusTraits<fl::Bus::UART, 0>::instance().lastActualBaud();
+            if (actual != 0) { uart_max_baud = actual; }
+        } else if (fl::strcmp(driver_name, "UART1") == 0) {
+            const fl::u32 actual =
+                fl::BusTraits<fl::Bus::UART, 1>::instance().lastActualBaud();
+            if (actual != 0) { uart_max_baud = actual; }
+        }
+#endif
+        // uartWireTiming() carries timing.reset_us and names the result
+        // "uart_wire", so nothing further needs setting here.
+        const fl::ChipsetTiming uart_timing =
+            fl::uartWireTiming(timing, uart_max_baud);
+        if (uart_timing.T1 == 0 && uart_timing.T2 == 0) {
+            // No representable geometry. Decoding against zeros would reject
+            // every symbol and report it as a capture fault; say what it is.
+            AR_FL_WARN("[CAPTURE] UART: no representable wave geometry for "
+                       << timing.name << " at " << uart_max_baud << " baud");
+            return 0;
+        }
         // Use wider tolerance (250ns) for UART because the UART clock and RMT
         // sample clock are asynchronous, and GPIO matrix adds ~10-20ns jitter
         auto rx_timing = fl::make4PhaseTiming(uart_timing, 250);

--- a/examples/AutoResearch/AutoResearchTest.cpp
+++ b/examples/AutoResearch/AutoResearchTest.cpp
@@ -707,32 +707,34 @@ size_t capture(fl::shared_ptr<fl::RxChannel> rx_channel,
     // windows -- so a correct frame decoded to nothing. See FastLED#4379.
     if (is_uart_driver) {
         AR_FL_WARN("[CAPTURE] UART (inverted TX): using standard WS2812 decoder with UART timing...");
-        // Derive the geometry from the chipset under test. Pass the baud the
-        // engine reports when it reports one: uartWireTiming() re-runs the
-        // same P=5/P=4 selection the encoder ran, and handing it the baud that
-        // was used reproduces that choice rather than guessing it from a
-        // generic ceiling.
-        fl::u32 uart_max_baud = fl::kMaxUartBaudRate;
+        // Take the geometry the engine recorded when it transmitted, rather
+        // than re-deriving it. Which geometry gets chosen depends on the
+        // backend's *maximum* baud, not on anything visible here, and the
+        // achieved baud is the wrong input: it is allowed to sit up to 1%
+        // under the requested one, and fed back as a ceiling that shortfall
+        // makes the transmitted geometry look infeasible and selects the
+        // other. Re-deriving from the generic ceiling is the fallback for
+        // backends that do not report one.
+        fl::ChipsetTiming uart_timing{0, 0, 0, 0, nullptr};
 #if defined(FL_IS_RP2040) || defined(FL_IS_RP2350)
         if (fl::strcmp(driver_name, "UART0") == 0) {
-            const fl::u32 actual =
-                fl::BusTraits<fl::Bus::UART, 0>::instance().lastActualBaud();
-            if (actual != 0) { uart_max_baud = actual; }
+            uart_timing =
+                fl::BusTraits<fl::Bus::UART, 0>::instance().lastWireTiming();
         } else if (fl::strcmp(driver_name, "UART1") == 0) {
-            const fl::u32 actual =
-                fl::BusTraits<fl::Bus::UART, 1>::instance().lastActualBaud();
-            if (actual != 0) { uart_max_baud = actual; }
+            uart_timing =
+                fl::BusTraits<fl::Bus::UART, 1>::instance().lastWireTiming();
         }
 #endif
-        // uartWireTiming() carries timing.reset_us and names the result
-        // "uart_wire", so nothing further needs setting here.
-        const fl::ChipsetTiming uart_timing =
-            fl::uartWireTiming(timing, uart_max_baud);
+        if (uart_timing.T1 == 0) {
+            // uartWireTiming() carries timing.reset_us and names the result
+            // "uart_wire", so nothing further needs setting here.
+            uart_timing = fl::uartWireTiming(timing, fl::kMaxUartBaudRate);
+        }
         if (uart_timing.T1 == 0 && uart_timing.T2 == 0) {
             // No representable geometry. Decoding against zeros would reject
             // every symbol and report it as a capture fault; say what it is.
             AR_FL_WARN("[CAPTURE] UART: no representable wave geometry for "
-                       << timing.name << " at " << uart_max_baud << " baud");
+                       << timing.name);
             return 0;
         }
         // Use wider tolerance (250ns) for UART because the UART clock and RMT

--- a/src/fl/channels/uart_wave_encoder.cpp.hpp
+++ b/src/fl/channels/uart_wave_encoder.cpp.hpp
@@ -106,6 +106,17 @@ struct UartWaveFit {
     u8 pulses_0;
     u8 pulses_1;
     u32 total_err_ns; ///< |T0H err| + |T1H err| vs nominal, post-bump
+    /// @brief Worst single-symbol error, measured pre-bump.
+    ///
+    /// `total_err_ns` cannot distinguish 125 ns spread over two symbols from
+    /// 200 ns concentrated in one, and only the concentrated case leaves a
+    /// symbol outside what a receiver will classify (FastLED#4379).
+    ///
+    /// Pre-bump because the separation widening below is deliberate -- it
+    /// moves T1H away from T0H on purpose and a longer HIGH still reads as 1
+    /// -- so charging it as error would relitigate #3569/#3572 rather than
+    /// measure rounding.
+    u32 max_err_ns;
 };
 
 /// @brief Evaluate whether P pulses/LED-bit can represent the timing.
@@ -169,10 +180,14 @@ UartWaveFit fitUartWave(const ChipsetTimingConfig& timing,
     if (err_t0h > tolerance_ns) return fit;
     if (err_t1h > t1h_tolerance_ns) return fit;
 
+    const u32 raw_t1h = static_cast<u32>(pulses_1_raw) * pulse_width_ns;
+    const u32 err_t1h_raw = absDiff(raw_t1h, t1h_ns);
+
     fit.ok = true;
     fit.pulses_0 = pulses_0;
     fit.pulses_1 = pulses_1;
     fit.total_err_ns = err_t0h + err_t1h;
+    fit.max_err_ns = err_t0h > err_t1h_raw ? err_t0h : err_t1h_raw;
     return fit;
 }
 
@@ -221,8 +236,24 @@ Wave10Lut buildWave10LutForMaxBaud(const ChipsetTimingConfig& timing,
     u8 P = 0;
     UartWaveFit fit = {};
     constexpr u32 kHysteresisNs = 50;
+    // A symbol further than this from nominal is one a receiver may not
+    // classify at all. WS281x parts quote about +/-150 ns, and AutoResearch
+    // decodes at +/-170; `fitUartWave` on its own admits half a pulse width,
+    // which at a 2500 ns period is 250 ns -- wider than either, which is how a
+    // geometry emitting an unclassifiable symbol got selected. See #4379.
+    constexpr u32 kMaxSymbolErrorNs = 150;
     if (fit5.ok && fit4.ok) {
-        if (fit4.total_err_ns + kHysteresisNs < fit5.total_err_ns) {
+        const bool fit5_classifiable = fit5.max_err_ns <= kMaxSymbolErrorNs;
+        const bool fit4_classifiable = fit4.max_err_ns <= kMaxSymbolErrorNs;
+        if (fit5_classifiable != fit4_classifiable) {
+            // Exactly one geometry keeps every symbol inside a receiver's
+            // tolerance. Take it, whatever the totals say -- a smaller sum
+            // bought by putting one symbol out of range is not a better fit.
+            // WS2811 at 400 kHz is the case: P=5 nails T0H and misses T1H by
+            // 200 ns, P=4 spends 125 ns on T0H to bring T1H within 50 ns.
+            P = fit5_classifiable ? 5 : 4;
+            fit = fit5_classifiable ? fit5 : fit4;
+        } else if (fit4.total_err_ns + kHysteresisNs < fit5.total_err_ns) {
             P = 4;
             fit = fit4;
         } else {

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
@@ -13,7 +13,8 @@ ChannelEngineRpUart::ChannelEngineRpUart(
       mCurrentChannel(0), mLatchStartUs(0), mLatchDurationUs(0),
       mActive(false), mLatchPending(false), mFailed(false),
       mLastStartAttempted(false), mLastStartSucceeded(false),
-      mLastEncodedSize(0), mLastActualBaud(0) {}
+      mLastEncodedSize(0), mLastActualBaud(0),
+      mLastWireTiming{0, 0, 0, 0, nullptr} {}
 
 ChannelEngineRpUart::~ChannelEngineRpUart() {
     releaseInFlight();
@@ -83,6 +84,7 @@ void ChannelEngineRpUart::show() FL_NO_EXCEPT {
     mLastStartSucceeded = false;
     mLastEncodedSize = 0;
     mLastActualBaud = 0;
+    mLastWireTiming = ChipsetTiming{0, 0, 0, 0, nullptr};
     mLastError.clear();
     for (const ChannelDataPtr& channel : mInFlightChannels) {
         if (channel) {
@@ -186,6 +188,11 @@ bool ChannelEngineRpUart::beginTransmission(const ChannelDataPtr& channel) FL_NO
     mLastStartSucceeded = false;
     mLastEncodedSize = 0;
     mLastActualBaud = 0;
+    // Record the geometry under the same ceiling the LUT above was built
+    // with, so a decoder reads the shape that went on the wire rather than
+    // re-deriving it and getting the other one (FastLED#4379).
+    mLastWireTiming = uartWireTiming(channel->getTiming(),
+                                     mPeripheral->maxBaudRate());
     RpUartConfig config;
     config.uart_index = mUartIndex;
     config.tx_pin = static_cast<u8>(channel->getPin());

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.cpp.hpp
@@ -188,11 +188,7 @@ bool ChannelEngineRpUart::beginTransmission(const ChannelDataPtr& channel) FL_NO
     mLastStartSucceeded = false;
     mLastEncodedSize = 0;
     mLastActualBaud = 0;
-    // Record the geometry under the same ceiling the LUT above was built
-    // with, so a decoder reads the shape that went on the wire rather than
-    // re-deriving it and getting the other one (FastLED#4379).
-    mLastWireTiming = uartWireTiming(channel->getTiming(),
-                                     mPeripheral->maxBaudRate());
+    mLastWireTiming = ChipsetTiming{0, 0, 0, 0, nullptr};
     RpUartConfig config;
     config.uart_index = mUartIndex;
     config.tx_pin = static_cast<u8>(channel->getPin());
@@ -233,6 +229,14 @@ bool ChannelEngineRpUart::beginTransmission(const ChannelDataPtr& channel) FL_NO
         mLastError = mError;
         return false;
     }
+    // Only now, with a transmission actually running. Recorded before the
+    // start, a failed attempt would leave a non-zero geometry behind and break
+    // the `T1 == 0` sentinel lastWireTiming() documents -- a decoder would
+    // then be handed the shape of a frame that never went on the wire. The
+    // LUT above is what this reproduces; the ceiling is the same one it was
+    // built with (FastLED#4379).
+    mLastWireTiming = uartWireTiming(channel->getTiming(),
+                                     mPeripheral->maxBaudRate());
     mLastStartSucceeded = true;
     mError.clear();
     mLastError.clear();

--- a/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.h
+++ b/src/platforms/arm/rp/rpcommon/channel_engine_rp_uart.h
@@ -37,6 +37,22 @@ class ChannelEngineRpUart final : public IChannelDriver {
     bool lastStartSucceeded() const FL_NO_EXCEPT { return mLastStartSucceeded; }
     size_t lastEncodedSize() const FL_NO_EXCEPT { return mLastEncodedSize; }
     u32 lastActualBaud() const FL_NO_EXCEPT { return mLastActualBaud; }
+
+    /// @brief Wire timing of the geometry the last transmission actually used.
+    ///
+    /// Which geometry gets picked (P=5 vs P=4) depends on the backend's
+    /// *maximum* baud, so a caller that has to decode this waveform cannot
+    /// re-derive it from the chipset timing alone. Re-deriving it from
+    /// `lastActualBaud()` is worse than not having it: the achieved baud is
+    /// allowed to sit up to 1% under the requested one, and fed back in as a
+    /// ceiling that shortfall makes the transmitted geometry look infeasible
+    /// and selects the other one. Recorded here instead, from the same LUT the
+    /// encoder ran. `T1 == 0` means nothing has been transmitted yet.
+    /// See FastLED#4379.
+    const ChipsetTiming& lastWireTiming() const FL_NO_EXCEPT {
+        return mLastWireTiming;
+    }
+
     const fl::string& lastError() const FL_NO_EXCEPT { return mLastError; }
 
   private:
@@ -57,6 +73,7 @@ class ChannelEngineRpUart final : public IChannelDriver {
     bool mActive;
     bool mLatchPending;
     bool mFailed;
+    ChipsetTiming mLastWireTiming;
     fl::string mError;
     bool mLastStartAttempted;
     bool mLastStartSucceeded;

--- a/tests/fl/channels/uart_wave_encoder.cpp
+++ b/tests/fl/channels/uart_wave_encoder.cpp
@@ -509,6 +509,79 @@ FL_TEST_CASE("uartWireTiming reproduces the timing actually put on the wire") {
     FL_CHECK((t1h % (period / 5u) == 0u) || (t1h % (period / 4u) == 0u));
 }
 
+// Nominal-vs-wire distance for one symbol, the quantity a receiver's
+// tolerance is stated in.
+u32 symbolError(u32 wire_ns, u32 nominal_ns) {
+    return wire_ns > nominal_ns ? wire_ns - nominal_ns : nominal_ns - wire_ns;
+}
+
+FL_TEST_CASE("400 kHz UART geometry keeps both symbols classifiable") {
+    // FastLED#4379. P=5 fits T0H exactly (500 ns on a 500 ns pulse grid) and
+    // rounds T1H 1200 -> 2 pulses = 1000 ns, 200 ns low. That is outside the
+    // part's ~+/-150 ns spec and 30 ns outside the +/-170 window AutoResearch
+    // decodes with, so every '1' bit in the frame classified as neither
+    // symbol and UART0 failed the RP2350 loopback at every length while PIO0
+    // passed on the same wire.
+    //
+    // P=5 totals 200 ns of error and P=4 totals 175, so the summed-error rule
+    // kept P=5 (the difference is inside its 50 ns hysteresis). Summed error
+    // cannot see that all 200 sits on one symbol.
+    const auto ws2811 = fl::makeTimingConfig<fl::TIMING_WS2811_400KHZ>();
+    const fl::ChipsetTiming wire =
+        fl::uartWireTiming(ws2811, fl::kMaxUartBaudRate);
+    const u32 t0h = wire.T1;
+    const u32 t1h = wire.T1 + wire.T2;
+    FL_CHECK_EQ(t0h, 625u);   // P=4: 2500 / 4 = 625 ns pulses
+    FL_CHECK_EQ(t1h, 1250u);
+
+    // The property that matters, stated the way the decoder states it.
+    constexpr u32 kDecodeToleranceNs = 170;
+    FL_CHECK(symbolError(t0h, ws2811.t1_ns) <= kDecodeToleranceNs);
+    FL_CHECK(symbolError(t1h, ws2811.t1_ns + ws2811.t2_ns) <=
+             kDecodeToleranceNs);
+
+    // 1.6 Mbaud, which the RP PL011 reaches (clk_peri/16 = 3.0 Mbaud) where
+    // P=5's 2.0 Mbaud also fits -- so this is a choice, not a fallback.
+    const fl::Wave10Lut lut = fl::buildWave10Lut(ws2811);
+    FL_CHECK_EQ(static_cast<u32>(lut.pulses_per_bit), 4u);
+    FL_CHECK_EQ(fl::uartWireTiming(ws2811, 3000000u).T1, 625u);
+}
+
+FL_TEST_CASE("in-tolerance preference leaves settled geometries alone") {
+    // The criterion only intervenes when exactly one geometry keeps every
+    // symbol inside the receiver bound. Audited across all 37 chipset
+    // timings, WS2811-400KHZ is the only selection it moves; these are the
+    // ones most likely to drift if that ever stopped being true.
+    struct Expected {
+        fl::ChipsetTimingConfig timing;
+        u32 t0h;
+        u32 t1h;
+    };
+    const Expected cases[] = {
+        // P=5 stays: its worst symbol is inside the bound.
+        {fl::makeTimingConfig<fl::TIMING_WS2812_800KHZ>(), 250u, 750u},
+        {fl::makeTimingConfig<fl::TIMING_WS2811_800KHZ_LEGACY>(), 250u, 750u},
+        // P=5 stays because neither geometry qualifies, so the summed-error
+        // rule still decides -- the separation bump is not charged as error.
+        {fl::makeTimingConfig<fl::TIMING_WS2812B_V5>(), 245u, 735u},
+        {fl::makeTimingConfig<fl::TIMING_WS2814>(), 256u, 768u},
+        {fl::makeTimingConfig<fl::TIMING_GW6205_800KHZ>(), 480u, 960u},
+        {fl::makeTimingConfig<fl::TIMING_WS2815>(), 378u, 1512u},
+        // Both geometries agree; nothing to choose.
+        {fl::makeTimingConfig<fl::TIMING_SK6812>(), 300u, 900u},
+        {fl::makeTimingConfig<fl::TIMING_UCS7604_800KHZ>(), 312u, 936u},
+        // A 400 kHz part that was already exact stays exact.
+        {fl::makeTimingConfig<fl::TIMING_UCS1903_400KHZ>(), 500u, 2000u},
+        {fl::makeTimingConfig<fl::TIMING_DP1903_400KHZ>(), 800u, 2400u},
+    };
+    for (const Expected& c : cases) {
+        const fl::ChipsetTiming w =
+            fl::uartWireTiming(c.timing, fl::kMaxUartBaudRate);
+        FL_CHECK_EQ(w.T1, c.t0h);
+        FL_CHECK_EQ(w.T1 + w.T2, c.t1h);
+    }
+}
+
 FL_TEST_CASE("uartWireTiming reports infeasible timing rather than guessing") {
     // A baud ceiling below anything the chipset needs leaves no geometry.
     const auto ws2812 = fl::makeTimingConfig<fl::TIMING_WS2812B_V5>();


### PR DESCRIPTION
RP `UART0` failed the clockless loopback at **every** length while `PIO0` passed on the same wire, same pins, same timing (#4379). Two defects, one on each side of the loopback — and the second only became visible once the first was fixed.

## The wire

`buildWave10LutForMaxBaud()` picks the geometry with the smaller **summed** quantization error. Summed error cannot distinguish 125 ns spread over two symbols from 200 ns concentrated in one, and only the concentrated case leaves a symbol nothing downstream can classify.

At a 2500 ns period:

| geometry | baud | pulse | T0H | T1H | worst symbol |
|---|---|---|---|---|---|
| **P=5 (was selected)** | 2.0 M | 500 ns | 500 (exact) | **1000** (−200) | **200 ns** |
| P=4 | 1.6 M | 625 ns | 625 (+125) | 1250 (+50) | 125 ns |

P=5 totals 200 ns, P=4 totals 175 — a 25 ns difference, inside the 50 ns hysteresis favouring P=5. So the chosen geometry put T1H 200 ns low: outside the part's ~±150 ns spec and 30 ns outside the ±170 window AutoResearch decodes with. Every `1` bit classified as neither symbol, which is why 100% of bytes mismatched rather than a few.

`fitUartWave()` did not catch it because its own acceptance bound is half a pulse width — 250 ns at this period, wider than any decoder window.

Selection now prefers a geometry whose **worst single symbol** stays inside a receiver tolerance, falling back to the summed rule when both qualify or neither does. The worst-symbol figure is measured **pre-bump**: the #3569/#3572 separation widening moves T1H on purpose, and a longer HIGH still reads as `1`, so charging it as error would relitigate that work rather than measure rounding.

**Audited across all 37 chipset timings in `led_timing.h`.** Exactly one selection moves:

```
- WS2811_400KHZ period=2500 nom=500/1200 sel=500/1000
+ WS2811_400KHZ period=2500 nom=500/1200 sel=625/1250
```

Nothing else — WS2812, WS2812B-V5, WS2814, SK6812, GW6205, UCS7604 and the rest are byte-identical before and after. A test pins ten of them so that stays true.

## The decoder

`capture()` hardcoded `T0H=250 / T1H=750 / T1L=500` for *any* UART driver — the shape an ESP32 UART emits at 4 Mbps for a WS2812 — ignoring the chipset under test entirely. That is how the second half surfaced: with the wire corrected to 625/1250, **every phase fell outside those hardcoded windows and a correct frame decoded to nothing** (0 bytes, worse than the 119 the broken wire had produced).

It now derives the geometry from the timing under test via `fl::uartWireTiming()` — the same thing the `wave8` and `wave3` branches directly above it already do for SPI, PARLIO, I2S and LCD_CLOCKLESS — and passes the baud the engine reports, so the P=5/P=4 selection is *reproduced* rather than guessed from a generic ceiling.

## Measured

RP2350W `2DCB876B587EA334`, UART0, GPIO0 → GPIO1, 3/3 per row:

```
leds=  1   4/4 @ 1600000 baud      leds= 20   4/4
leds=  2   4/4                     leds= 40   4/4
leds=  5   4/4                     leds= 60   4/4
leds= 10   4/4                     leds= 63   4/4
```

Byte-exact at every length up to the PIO RX capture ceiling (#4371). **Every one of these was 0/4 before.** `PIO0` unchanged at 4/4. This is the first time the RP UART clockless loopback has passed byte-exact — relevant to #3899's driver matrix.

> `bash autoresearch rp2350w --uart` still exits 1: its default chipset is WS2812B-V5, whose 1225 ns needs a baud the PL011 cannot reach, so the engine declines. That is #4375 and correct behaviour, not this defect.

Fixes #4379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UART signal decoding on supported RP2040 and RP2350 devices by using the timing actually transmitted over the wire.
  - Improved timing selection for WS2811-400KHZ signals, helping both symbol types remain within receiver tolerance.
  - Decoding now stops when no representable UART timing is available.
  - Corrected timing state after unsuccessful transmissions to prevent stale signal information from affecting subsequent decoding.

- **Tests**
  - Expanded coverage for UART timing accuracy across multiple chipset configurations and validated expected wire timings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->