### PR TITLE
fix(autoresearch): stop an inline pinRx capturing nothing while reporting success (#4374)

### DIFF
--- a/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
+++ b/examples/AutoResearch/AutoResearchRemoteRunSingleTest.cpp
@@ -60,6 +60,52 @@
 
 namespace {
 
+/// @brief Stand down the session's RX channel for the duration of one call.
+///
+/// A capture backend can own an exclusive, process-wide resource -- on RP the
+/// PIO capture buffer is a single global claimed in `begin()` and released
+/// only in `stop()`. A per-call channel built while the standing one is still
+/// alive therefore fails to arm. Releasing every reference destroys the
+/// standing device and frees the claim; the destructor rebuilds it on the pin
+/// the session is still configured for, so inline pins stay scoped to the call
+/// that asked for them however that call exits. See FastLED#4374.
+class StandingRxChannelSwap {
+  public:
+    explicit StandingRxChannelSwap(AutoResearchState* state)
+        : mState(state), mReleased(false) {}
+
+    /// @param alias The caller's own reference to the standing channel, which
+    ///              has to go too -- a surviving alias keeps the device, and
+    ///              its claim, alive.
+    void release(fl::shared_ptr<fl::RxChannel>* alias) {
+        if (mReleased || mState == nullptr) {
+            return;
+        }
+        if (alias != nullptr) {
+            alias->reset();
+        }
+        mState->rx_channel.reset();
+        mReleased = true;
+    }
+
+    ~StandingRxChannelSwap() {
+        if (!mReleased || mState == nullptr || mState->rx_factory == nullptr) {
+            return;
+        }
+        // Rebuild, do not restore: the previous device is gone. A failure here
+        // leaves rx_channel null, which the next call reports as a missing RX
+        // channel rather than as a mystery zero capture.
+        mState->rx_channel = mState->rx_factory(mState->pin_rx);
+    }
+
+    StandingRxChannelSwap(const StandingRxChannelSwap&) = delete;
+    StandingRxChannelSwap& operator=(const StandingRxChannelSwap&) = delete;
+
+  private:
+    AutoResearchState* mState;
+    bool mReleased;
+};
+
 uint32_t expectedClocklessWireUs(const fl::ChipsetTimingConfig& timing,
                                  uint32_t max_leds) {
     const uint64_t bit_period_ns = timing.total_period_ns();
@@ -923,7 +969,26 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
         have_backend_override = true;
     }
 
+    // A per-call RX channel has to displace the standing one, not sit
+    // alongside it.
+    //
+    // The RP PIO capture buffer is a single global, claimed by whichever
+    // device calls begin() first and released only in stop() -- so a standing
+    // channel that has already captured once still owns it. A second channel
+    // built next to it fails begin() with `dma_buffer_busy` and captures
+    // nothing, while the response echoes the requested pins back through
+    // actualRxPin as though the change took effect. `setPins` never hit this
+    // because it *replaces* mState->rx_channel, destroying the old device and
+    // releasing the claim. Confirmed on an RP2350W: the failing run reports
+    // rxBeginError='dma_buffer_busy'. See FastLED#4374.
+    //
+    // Restoring it afterwards keeps inline pins scoped to the one call, which
+    // is what a caller probing alternative wiring means by them -- adopting
+    // the pin as standing state would trade a silent failure for a silent
+    // reconfiguration.
+    StandingRxChannelSwap standing_rx_swap(mState.get());
     if (have_backend_override) {
+        standing_rx_swap.release(&rx_channel_to_use);
         fl::RxChannelConfig rx_cfg(pin_rx, rx_backend_override);
         rx_channel_to_use = FastLED.addRx(rx_cfg);
         if (!rx_channel_to_use) {
@@ -933,6 +998,7 @@ fl::json AutoResearchRemoteControl::runSingleTestImpl(const fl::json& args) {
             return response;
         }
     } else if (pin_rx != mState->pin_rx && mState->rx_factory) {
+        standing_rx_swap.release(&rx_channel_to_use);
         rx_channel_to_use = mState->rx_factory(pin_rx);
         if (!rx_channel_to_use) {
             response.set("success", false);


### PR DESCRIPTION
`runSingleTest` accepts `pinRx`, validates it, echoes it back through `actualRxPin`, and captured **nothing** whenever it differed from the standing configuration — `passed: false`, `captureEvidenceBytes: 0`, no error. The same pin pair passed when set through `setPins` (#4374).

## Cause: a resource claim, not a pin capability

The RP PIO capture buffer is a single global, claimed by whichever device calls `begin()` first and released only in `stop()`:

```cpp
bool claimPioRxCaptureBuffer(void* owner) {
    if (owner == nullptr || mPioRxCaptureOwner != nullptr) return false;
    ...
```

A standing channel that has already captured once still owns it. The inline path built a second channel **alongside** the standing one, and that channel's `begin()` failed with `dma_buffer_busy`. `setPins` never hit this because it *replaces* `mState->rx_channel`, destroying the old device and releasing the claim.

The diagnostic was already being collected and serialized — just never read:

```
inline rx=20, differs from standing:  evidence=0  rxBeginError='dma_buffer_busy'
```

Three rounds of black-box testing on the issue had eliminated the standing channel occupying the pin, the temporary channel being ignored in favour of the standing one, and resource accumulation across calls — narrowing it to "a temporary channel captures nothing" without reaching the cause. It is one field in the response.

## Fix

A per-call channel now **displaces** the standing one rather than sitting beside it. `StandingRxChannelSwap` releases every reference — the caller's alias as well as `mState->rx_channel`, since a surviving alias keeps the device and its claim alive — and rebuilds the standing channel on the session's pin when the call exits, however it exits.

Inline pins therefore stay scoped to the call that asked for them. Adopting the pin as standing state (the other option the issue floated) would have traded a silent failure for a silent reconfiguration. The `rxBackend` override path builds a second channel the same way and gets the same treatment.

## Measured

RP2350W `2DCB876B587EA334`, GPIO0 ↔ GPIO1:

| step | result |
|---|---|
| standing 1/0, no inline | 4/4, `actualRx=0`, 120 bytes |
| **inline `tx=0 rx=1` (differs)** | **4/4, `actualRx=1`, 120 bytes** — was 0/4, 0 bytes |
| standing 1/0 again | 4/4, `actualRx=0`, 120 bytes |
| inline `rx=20` (genuinely dead pin) | 0/4, 0 bytes, `rxBeginError=None` |

The dead-pin case still fails, which is correct — and it now fails with an *armed* channel and no begin error, so a zero capture there means what it says instead of hiding a resource conflict. The standing configuration is intact after every inline call, checked between each one.

Fixes #4374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-test runs using backend overrides or custom receive pins to prevent conflicts with shared capture resources.
  * The configured standing receive channel is now restored automatically after each test, preserving the session’s expected receive configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->