### PR TITLE
fix(task): bound fl::platforms::await() so an unresolvable promise returns (#4369)

### DIFF
--- a/src/fl/system/timeout.h
+++ b/src/fl/system/timeout.h
@@ -44,14 +44,14 @@ public:
     /// @brief Construct a timeout with specified start time and duration
     /// @param start_time Start timestamp (in any consistent units)
     /// @param duration Duration (in same units as start_time)
-    Timeout(u32 start_time, u32 duration)
+    Timeout(u32 start_time, u32 duration) FL_NO_EXCEPT
         : mStartTime(start_time), mDuration(duration) {}
 
     /// @brief Check if the timeout has completed
     /// @param current_time Current timestamp (in same units as constructor)
     /// @return true if elapsed time >= duration, false otherwise
     /// @note Handles uint32_t rollover correctly via unsigned arithmetic
-    bool done(u32 current_time) const {
+    bool done(u32 current_time) const FL_NO_EXCEPT {
         u32 elapsed_time = current_time - mStartTime;  // Rollover-safe
         return elapsed_time >= mDuration;
     }
@@ -59,20 +59,20 @@ public:
     /// @brief Get elapsed time since timeout started
     /// @param current_time Current timestamp (in same units as constructor)
     /// @return Elapsed time (in same units as constructor)
-    u32 elapsed(u32 current_time) const {
+    u32 elapsed(u32 current_time) const FL_NO_EXCEPT {
         return current_time - mStartTime;  // Rollover-safe
     }
 
     /// @brief Reset the timeout to start counting from specified time
     /// @param start_time New start timestamp
-    void reset(u32 start_time) {
+    void reset(u32 start_time) FL_NO_EXCEPT {
         mStartTime = start_time;
     }
 
     /// @brief Reset with a new start time and duration
     /// @param start_time New start timestamp
     /// @param duration New duration (in same units as start_time)
-    void reset(u32 start_time, u32 duration) {
+    void reset(u32 start_time, u32 duration) FL_NO_EXCEPT {
         mStartTime = start_time;
         mDuration = duration;
     }

--- a/src/fl/task/executor.h
+++ b/src/fl/task/executor.h
@@ -299,9 +299,15 @@ namespace task {
 ///     }
 /// });
 /// @endcode
+/// @param timeout_ms Wall-clock budget before the wait returns an error rather
+///        than continuing to poll. Defaults to
+///        `fl::platforms::kAwaitDefaultTimeoutMs`; see FastLED#4369 for why
+///        the wait is bounded at all.
 template<typename T>
-inline PromiseResult<T> await(Promise<T> p) {
-    return fl::platforms::await(p);
+inline PromiseResult<T> await(
+    Promise<T> p,
+    fl::u32 timeout_ms = fl::platforms::kAwaitDefaultTimeoutMs) FL_NO_EXCEPT {
+    return fl::platforms::await(p, timeout_ms);
 }
 
 } // namespace task

--- a/src/platforms/await.h
+++ b/src/platforms/await.h
@@ -18,21 +18,52 @@
 #include "fl/task/promise.h"
 #include "fl/task/promise_result.h"
 #include "platforms/coroutine_runtime.h"
+#include "fl/stl/chrono.h"
 #include "fl/stl/noexcept.h"
+#include "fl/system/timeout.h"
 
 namespace fl {
 namespace platforms {
 
+/// @brief Default wall-clock bound for `await()`, in milliseconds.
+///
+/// `fl::task::await_top_level` caps the same kind of wait at 10000 pump
+/// iterations, which at that loop's ~1 ms yield is about ten seconds. This is
+/// the same budget stated as wall clock, which is what it is really bounding:
+/// an iteration count buys a different amount of time on every platform,
+/// depending on what `suspendMainthread()` does with its microsecond budget.
+///
+/// Generous on purpose. `await()` exists to block on genuinely slow work --
+/// `fl::task::await(fl::fetch_get(...))` is the documented use -- so the
+/// default has to cover a real network round trip. A caller that needs longer
+/// passes a larger budget.
+constexpr fl::u32 kAwaitDefaultTimeoutMs = 10000;
+
 /// @brief Await promise completion using platform-agnostic polling
 /// @tparam T The type of value the promise resolves to
 /// @param promise The promise to await
+/// @param timeout_ms Wall-clock budget before the wait gives up and returns an
+///        error. There is deliberately no "wait forever" value: a caller with
+///        slow work passes a larger budget, which keeps the failure mode a
+///        reported error rather than a hang.
 /// @return A PromiseResult<T> containing either the resolved value or an error
 ///
 /// Polls the promise in a loop, yielding to the platform scheduler between
 /// checks via ICoroutineRuntime::suspendMainthread(). This method is safe to call
 /// from any execution context (main thread, coroutine, worker thread).
+///
+/// The wait is bounded. It used to have no cap of any kind, so a promise that
+/// could not be resolved -- the easiest way in being a platform whose
+/// coroutine backend is the null one, where the coroutine that would resolve
+/// it never runs -- never returned to its caller. On a microcontroller that
+/// stops the sketch until the watchdog resets the board. `PromiseResult<T>`
+/// already carries an error and `fl::task::await_top_level` already returns
+/// one on exhaustion; this is the same policy on the same kind of wait.
+/// See FastLED#4369.
 template<typename T>
-fl::task::PromiseResult<T> await(fl::task::Promise<T> promise) FL_NO_EXCEPT {
+fl::task::PromiseResult<T> await(
+    fl::task::Promise<T> promise,
+    fl::u32 timeout_ms = kAwaitDefaultTimeoutMs) FL_NO_EXCEPT {
     // Validate promise
     if (!promise.valid()) {
         return fl::task::PromiseResult<T>(fl::task::Error("Invalid promise"));
@@ -47,10 +78,18 @@ fl::task::PromiseResult<T> await(fl::task::Promise<T> promise) FL_NO_EXCEPT {
 
     auto& runtime = ICoroutineRuntime::instance();
 
-    // Poll until promise completes, yielding to platform scheduler
+    // Poll until the promise completes or the budget runs out, yielding to the
+    // platform scheduler in between. The deadline is checked after update()
+    // and before the yield, so a zero budget still gets one poll rather than
+    // failing a promise that was about to complete.
+    const fl::Timeout deadline(fl::millis(), timeout_ms);
     while (!promise.is_completed()) {
         promise.update();
         if (promise.is_completed()) break;
+        if (deadline.done(fl::millis())) {
+            return fl::task::PromiseResult<T>(
+                fl::task::Error("await timeout - promise did not complete"));
+        }
         runtime.suspendMainthread(1000);  // Yield ~1ms
     }
 

--- a/tests/fl/task/executor.cpp
+++ b/tests/fl/task/executor.cpp
@@ -295,6 +295,81 @@ FL_TEST_CASE("fl::task::run with ms") {
     }
 }
 
+FL_TEST_CASE("fl::task::await - an unresolvable promise returns, and returns an error") {
+    // The wait used to have no cap of any kind, so a promise nothing can
+    // resolve never returned to its caller. On a microcontroller that stops
+    // the sketch until the watchdog resets the board. FastLED#4369.
+    FL_SUBCASE("a promise that never resolves gives up inside its budget") {
+        auto promise = fl::task::Promise<int>::create();  // nothing will resolve it
+        const u32 budget_ms = 50;
+        const u32 start = fl::millis();
+        auto result = fl::task::await(promise, budget_ms);
+        const u32 elapsed = fl::millis() - start;
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message,
+                    "await timeout - promise did not complete");
+        // The point is that it returned at all. Bound the upper end loosely --
+        // the loop yields ~1 ms per turn and the scheduler decides how long
+        // that really takes -- but it must not be the old behaviour, which
+        // never came back.
+        FL_CHECK(elapsed < 5000u);
+    }
+
+    FL_SUBCASE("a zero budget still polls once before giving up") {
+        // A promise that is resolvable by update() alone must not be failed
+        // by a budget that has already expired: the deadline is checked after
+        // the poll, not before it.
+        auto promise = fl::task::Promise<int>::resolve(7);
+        auto result = fl::task::await(promise, 0);
+
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 7);
+    }
+
+    FL_SUBCASE("an already-resolved promise is unaffected by the budget") {
+        auto promise = fl::task::Promise<int>::resolve(42);
+        auto result = fl::task::await(promise, 1);
+
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 42);
+    }
+
+    FL_SUBCASE("an already-rejected promise still reports its own error") {
+        // The timeout error must not displace the promise's.
+        auto promise =
+            fl::task::Promise<int>::reject(fl::task::Error("Original error"));
+        auto result = fl::task::await(promise, 1);
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message, "Original error");
+    }
+
+    FL_SUBCASE("an invalid promise is rejected before the wait") {
+        fl::task::Promise<int> invalid_promise;
+        auto result = fl::task::await(invalid_promise, 1);
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message, "Invalid promise");
+    }
+
+    FL_SUBCASE("the budget is a bound, not a delay") {
+        // A resolvable promise must return as soon as it completes. If the
+        // deadline were waited on rather than checked, this would take the
+        // whole budget.
+        auto promise = fl::task::Promise<int>::create();
+        promise.complete_with_value(123);
+
+        const u32 start = fl::millis();
+        auto result = fl::task::await(promise, 5000);
+        const u32 elapsed = fl::millis() - start;
+
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 123);
+        FL_CHECK(elapsed < 1000u);
+    }
+}
+
 FL_TEST_CASE("fl::task::await_top_level - Basic Operations") {
     FL_SUBCASE("await_top_level resolved promise returns value") {
         auto promise = fl::task::Promise<int>::resolve(42);

--- a/tests/fl/task/executor.cpp
+++ b/tests/fl/task/executor.cpp
@@ -683,10 +683,18 @@ FL_TEST_CASE("fl::task::await - the wait is bounded") {
         auto result = fl::task::await(promise, 20);
         const u32 elapsed = fl::millis() - start;
 
+        // The error is the proof: had the call waited for resolution it would
+        // have returned ok() with 99, whatever the clock said.
         FL_CHECK(!result.ok());
         FL_CHECK_EQ(result.error().message,
                     "await timeout - promise did not complete");
-        FL_CHECK(elapsed < 400u);
+        // Deliberately far above the 400 ms resolver delay rather than under
+        // it. A descheduled host can stretch a correctly-timed-out 20 ms wait
+        // past 400 ms, which would make a tighter bound flaky without adding
+        // anything the error assertion does not already establish -- see the
+        // measurements under load in FastLED#3772. This is a sanity ceiling,
+        // not the discriminator.
+        FL_CHECK(elapsed < 5000u);
         fl::platforms::cleanup_background_threads();
     }
 

--- a/tests/fl/task/executor.cpp
+++ b/tests/fl/task/executor.cpp
@@ -295,81 +295,6 @@ FL_TEST_CASE("fl::task::run with ms") {
     }
 }
 
-FL_TEST_CASE("fl::task::await - an unresolvable promise returns, and returns an error") {
-    // The wait used to have no cap of any kind, so a promise nothing can
-    // resolve never returned to its caller. On a microcontroller that stops
-    // the sketch until the watchdog resets the board. FastLED#4369.
-    FL_SUBCASE("a promise that never resolves gives up inside its budget") {
-        auto promise = fl::task::Promise<int>::create();  // nothing will resolve it
-        const u32 budget_ms = 50;
-        const u32 start = fl::millis();
-        auto result = fl::task::await(promise, budget_ms);
-        const u32 elapsed = fl::millis() - start;
-
-        FL_CHECK(!result.ok());
-        FL_CHECK_EQ(result.error().message,
-                    "await timeout - promise did not complete");
-        // The point is that it returned at all. Bound the upper end loosely --
-        // the loop yields ~1 ms per turn and the scheduler decides how long
-        // that really takes -- but it must not be the old behaviour, which
-        // never came back.
-        FL_CHECK(elapsed < 5000u);
-    }
-
-    FL_SUBCASE("a zero budget still polls once before giving up") {
-        // A promise that is resolvable by update() alone must not be failed
-        // by a budget that has already expired: the deadline is checked after
-        // the poll, not before it.
-        auto promise = fl::task::Promise<int>::resolve(7);
-        auto result = fl::task::await(promise, 0);
-
-        FL_CHECK(result.ok());
-        FL_CHECK_EQ(result.value(), 7);
-    }
-
-    FL_SUBCASE("an already-resolved promise is unaffected by the budget") {
-        auto promise = fl::task::Promise<int>::resolve(42);
-        auto result = fl::task::await(promise, 1);
-
-        FL_CHECK(result.ok());
-        FL_CHECK_EQ(result.value(), 42);
-    }
-
-    FL_SUBCASE("an already-rejected promise still reports its own error") {
-        // The timeout error must not displace the promise's.
-        auto promise =
-            fl::task::Promise<int>::reject(fl::task::Error("Original error"));
-        auto result = fl::task::await(promise, 1);
-
-        FL_CHECK(!result.ok());
-        FL_CHECK_EQ(result.error().message, "Original error");
-    }
-
-    FL_SUBCASE("an invalid promise is rejected before the wait") {
-        fl::task::Promise<int> invalid_promise;
-        auto result = fl::task::await(invalid_promise, 1);
-
-        FL_CHECK(!result.ok());
-        FL_CHECK_EQ(result.error().message, "Invalid promise");
-    }
-
-    FL_SUBCASE("the budget is a bound, not a delay") {
-        // A resolvable promise must return as soon as it completes. If the
-        // deadline were waited on rather than checked, this would take the
-        // whole budget.
-        auto promise = fl::task::Promise<int>::create();
-        promise.complete_with_value(123);
-
-        const u32 start = fl::millis();
-        auto result = fl::task::await(promise, 5000);
-        const u32 elapsed = fl::millis() - start;
-
-        FL_CHECK(result.ok());
-        FL_CHECK_EQ(result.value(), 123);
-        FL_CHECK(elapsed < 1000u);
-    }
-}
-
 FL_TEST_CASE("fl::task::await_top_level - Basic Operations") {
     FL_SUBCASE("await_top_level resolved promise returns value") {
         auto promise = fl::task::Promise<int>::resolve(42);
@@ -716,6 +641,101 @@ fl::task::Promise<T> delayed_reject(const fl::task::Error& error, uint32_t delay
 
     fl::platforms::register_background_thread(fl::move(t));
     return p;
+}
+
+FL_TEST_CASE("fl::task::await - the wait is bounded") {
+    // The wait used to have no cap of any kind, so a promise nothing can
+    // resolve never returned to its caller. On a microcontroller that stops
+    // the sketch until the watchdog resets the board. FastLED#4369.
+    FL_SUBCASE("a promise that never resolves gives up inside its budget") {
+        auto promise = fl::task::Promise<int>::create();  // nothing will resolve it
+        const u32 budget_ms = 50;
+        const u32 start = fl::millis();
+        auto result = fl::task::await(promise, budget_ms);
+        const u32 elapsed = fl::millis() - start;
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message,
+                    "await timeout - promise did not complete");
+        // The point is that it returned at all. Bound the upper end loosely --
+        // the loop yields ~1 ms per turn and the scheduler decides how long
+        // that really takes -- but it must not be the old behaviour, which
+        // never came back.
+        FL_CHECK(elapsed < 5000u);
+    }
+
+    FL_SUBCASE("a pending promise resolved during the wait returns its value") {
+        // Reaches the polling loop, unlike the completed cases below, and
+        // proves the bound does not cost a legitimate wait its result.
+        auto promise = delayed_resolve<int>(99, 20);
+        auto result = fl::task::await(promise, 5000);
+
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 99);
+        fl::platforms::cleanup_background_threads();
+    }
+
+    FL_SUBCASE("a pending promise outliving its budget times out") {
+        // Same promise, a budget too small for it. The loop exits on the
+        // deadline rather than on completion.
+        auto promise = delayed_resolve<int>(99, 400);
+        const u32 start = fl::millis();
+        auto result = fl::task::await(promise, 20);
+        const u32 elapsed = fl::millis() - start;
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message,
+                    "await timeout - promise did not complete");
+        FL_CHECK(elapsed < 400u);
+        fl::platforms::cleanup_background_threads();
+    }
+
+    FL_SUBCASE("an already-completed promise returns whatever the budget") {
+        // Returns before the loop, so no budget applies -- including zero.
+        auto resolved = fl::task::Promise<int>::resolve(7);
+        auto result = fl::task::await(resolved, 0);
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 7);
+
+        auto resolved_again = fl::task::Promise<int>::resolve(42);
+        auto result_again = fl::task::await(resolved_again, 1);
+        FL_CHECK(result_again.ok());
+        FL_CHECK_EQ(result_again.value(), 42);
+    }
+
+    FL_SUBCASE("an already-rejected promise still reports its own error") {
+        // The timeout error must not displace the promise's.
+        auto promise =
+            fl::task::Promise<int>::reject(fl::task::Error("Original error"));
+        auto result = fl::task::await(promise, 1);
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message, "Original error");
+    }
+
+    FL_SUBCASE("an invalid promise is rejected before the wait") {
+        fl::task::Promise<int> invalid_promise;
+        auto result = fl::task::await(invalid_promise, 1);
+
+        FL_CHECK(!result.ok());
+        FL_CHECK_EQ(result.error().message, "Invalid promise");
+    }
+
+    FL_SUBCASE("the budget is a bound, not a delay") {
+        // A resolvable promise must return as soon as it completes. If the
+        // deadline were waited on rather than checked, this would take the
+        // whole budget.
+        auto promise = fl::task::Promise<int>::create();
+        promise.complete_with_value(123);
+
+        const u32 start = fl::millis();
+        auto result = fl::task::await(promise, 5000);
+        const u32 elapsed = fl::millis() - start;
+
+        FL_CHECK(result.ok());
+        FL_CHECK_EQ(result.value(), 123);
+        FL_CHECK(elapsed < 1000u);
+    }
 }
 
 FL_TEST_CASE("await in coroutine - basic resolution") {


### PR DESCRIPTION
`fl::platforms::await()` polled a promise with no iteration cap, no deadline and no escape. A promise that cannot be resolved never returned to its caller — on a microcontroller that stops the sketch until the watchdog resets the board (#4369).

The easiest way in is a platform whose coroutine backend is the null one, where the coroutine that would resolve the promise never runs. But the hazard is not platform-specific: `await()` is documented for blocking on real async work (`fl::task::await(fl::fetch_get(...))`), and any promise that never resolves and whose `update()` never errors hangs the caller the same way.

## The policy already exists

`fl::task::await_top_level` guards the same kind of wait and returns `PromiseResult<T>(Error(...))` on exhaustion. `PromiseResult<T>` already carries the error. `platforms::await()` just never got the same treatment — so this is applying a decision the codebase has already made, not inventing one.

## Wall clock, not a pump count

The issue left the bound open as an owner's call. Taking it:

- **The number** matches its sibling. `await_top_level`'s 10000 iterations at its ~1 ms yield is about ten seconds, so `kAwaitDefaultTimeoutMs = 10000`. Generous on purpose — `await()` exists to block on genuinely slow work, so the default has to cover a real network round trip.
- **The unit** is wall clock, because that is what it actually bounds. An iteration count buys a different amount of time on every platform, depending on what `suspendMainthread()` does with its microsecond budget. `fl::Timeout` already does the rollover-safe arithmetic.
- **No "wait forever" value.** A caller with slow work passes a larger budget, which keeps the failure mode a reported error rather than a hang.
- **The deadline is checked after `update()` and before the yield**, so a zero budget still gets one poll rather than failing a promise that was about to complete.

On the issue's second open question — whether a null backend should refuse earlier — I left it alone, for the reason the issue itself gives: `promise.update()` runs inside the loop, so a promise driven by polling rather than by a coroutine can legitimately complete on a null backend.

## Tests

Host tests cover the timeout path, the zero budget, an already-resolved and an already-rejected promise (the timeout error must not displace the promise's own), an invalid promise, and that the budget **bounds rather than delays** — a resolvable promise must return immediately, not wait out its budget.

## Scope — what this does not fix

AutoResearch arms a 5 s watchdog, so on RP it still fires before this 10 s budget. **#4367's declines stay the guard there** until the harness passes an explicit budget of its own; that is a follow-up in a file this PR does not touch. What this removes is the unbounded wait, on every platform, which is what the issue reports:

> #4367 declines those three on `FL_IS_RP` — that guards the symptom on one platform, not the hazard.

## Verified

Host suite 305/305 unit + 84/84 examples. `bash autoresearch rp2350w --flex-io` passes on an RP2350W with the change in.

> Also adds the missing `FL_NO_EXCEPT` to `fl::Timeout`'s five members, which the AST ratchet flags once the header is pulled in here.

Fixes #4369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkufoNxfnNRU9psT3R9F51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable time limits for asynchronous waits, with a default timeout of 10 seconds.
  - Wait operations now stop and return an error when the configured limit is exceeded, preventing indefinite polling.
  - Existing behavior remains unchanged for completed, rejected, or invalid operations.
  - A zero-timeout wait still performs one initial check before timing out.

- **Bug Fixes**
  - Improved timeout handling for wait and timer operations, including safe behavior around timer rollover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->