### PR TITLE
fix(bloat): analyse the ELF the build produced, not the highest-priority one (#4384)

### DIFF
--- a/ci/bloat.py
+++ b/ci/bloat.py
@@ -61,6 +61,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -141,6 +142,29 @@ class ElfLocation:
     fbuild_native: bool
 
 
+def _assert_fresh(location: ElfLocation, build_started: float | None) -> None:
+    """Refuse to analyse an ELF older than the build that just ran.
+
+    `--build` promises "a fresh ELF"; without this the promise is unchecked,
+    and a layout the build did not write can be analysed instead while every
+    number looks plausible. FastLED#4384.
+    """
+
+    if build_started is None:
+        return
+    mtime = location.elf.stat().st_mtime
+    if mtime >= build_started:
+        return
+    age = build_started - mtime
+    raise SystemExit(
+        f"Bloat: --build ran, but the ELF selected for analysis predates it by "
+        f"{age / 3600:.1f} h:\n  {location.elf}\n"
+        "That is a stale artifact from another backend or an earlier build, so "
+        "the numbers would describe a binary this run did not produce. Remove "
+        "it, or build the layout it belongs to."
+    )
+
+
 def find_elf(board: str, build_root: Path) -> ElfLocation:
     """Auto-detect the firmware ELF for the given board.
 
@@ -153,24 +177,40 @@ def find_elf(board: str, build_root: Path) -> ElfLocation:
     """
     project_root = Path.cwd()
     fbuild_elf = project_root / ".fbuild" / "build" / board / "release" / "firmware.elf"
-    if fbuild_elf.is_file():
-        return ElfLocation(elf=fbuild_elf, fbuild_native=True)
-
     pio_fbuild_elf = (
         build_root / "pio" / board / ".fbuild" / "build" / "release" / "firmware.elf"
     )
-    if pio_fbuild_elf.is_file():
-        return ElfLocation(elf=pio_fbuild_elf, fbuild_native=True)
-
     candidates = [
         build_root / "pio" / board / ".pio" / "build" / board / "firmware.elf",
         build_root / board / "firmware.elf",
     ]
-    for c in candidates:
-        if c.is_file():
-            return ElfLocation(elf=c, fbuild_native=False)
 
-    paths = "\n  ".join(str(c) for c in [fbuild_elf, *candidates])
+    # Newest wins, with the documented order as the tie-break.
+    #
+    # It used to be priority alone, and that is how this command came to
+    # report five-day-old numbers for a change made minutes earlier: these
+    # layouts coexist under one board directory, `--build` writes the `.pio`
+    # one, and the `.fbuild` one outranked it whatever its age. Two runs
+    # across a real code change produced byte-identical output, including
+    # total_flash. FastLED#4384.
+    ranked = [
+        (fbuild_elf, True),
+        (pio_fbuild_elf, True),
+        (candidates[0], False),
+        (candidates[1], False),
+    ]
+    found = [
+        (path, native, path.stat().st_mtime)
+        for path, native in ranked
+        if path.is_file()
+    ]
+    if found:
+        newest = max(mtime for _, _, mtime in found)
+        for path, native, mtime in found:
+            if mtime == newest:
+                return ElfLocation(elf=path, fbuild_native=native)
+
+    paths = "\n  ".join(str(c) for c in [fbuild_elf, pio_fbuild_elf, *candidates])
     raise SystemExit(
         "Bloat: no firmware.elf found. Looked at:\n  "
         + paths
@@ -357,6 +397,7 @@ def main() -> int:
 
     assert_fbuild_has_symbols()
 
+    build_started: float | None = None
     if args.build:
         compile_script = "compile.bat" if os.name == "nt" else "./compile"
         if os.name != "nt" and not shutil.which("bash"):
@@ -369,10 +410,12 @@ def main() -> int:
             "--platformio",
         ]
         print(f"$ {' '.join(cmd)}")
+        build_started = time.time()
         subprocess.run(cmd, check=True)
 
     try:
         location = find_elf(args.board, Path(args.build_root))
+        _assert_fresh(location, build_started)
     except SystemExit:
         if not args.allow_overflow:
             raise

--- a/ci/bloat.py
+++ b/ci/bloat.py
@@ -142,6 +142,10 @@ class ElfLocation:
     fbuild_native: bool
 
 
+# See `_assert_fresh`: the coarsest common filesystem mtime granularity.
+_MTIME_GRANULARITY_SLACK_S = 2.0
+
+
 def _assert_fresh(location: ElfLocation, build_started: float | None) -> None:
     """Refuse to analyse an ELF older than the build that just ran.
 
@@ -153,7 +157,13 @@ def _assert_fresh(location: ElfLocation, build_started: float | None) -> None:
     if build_started is None:
         return
     mtime = location.elf.stat().st_mtime
-    if mtime >= build_started:
+    # Slack for coarse mtime granularity. `time.time()` is sub-microsecond,
+    # but a filesystem may store mtimes to the second (ext3, HFS+) or to two
+    # seconds (FAT/exFAT), so an ELF written moments after the build began can
+    # carry a timestamp rounded below it. Two seconds covers the coarsest of
+    # those while still refusing the artifact this guard exists for, which was
+    # five days stale.
+    if mtime >= build_started - _MTIME_GRANULARITY_SLACK_S:
         return
     age = build_started - mtime
     raise SystemExit(
@@ -199,11 +209,10 @@ def find_elf(board: str, build_root: Path) -> ElfLocation:
         (candidates[0], False),
         (candidates[1], False),
     ]
-    found = [
-        (path, native, path.stat().st_mtime)
-        for path, native in ranked
-        if path.is_file()
-    ]
+    found: list[tuple[Path, bool, float]] = []
+    for path, native in ranked:
+        if path.is_file():
+            found.append((path, native, path.stat().st_mtime))
     if found:
         newest = max(mtime for _, _, mtime in found)
         for path, native, mtime in found:
@@ -415,7 +424,6 @@ def main() -> int:
 
     try:
         location = find_elf(args.board, Path(args.build_root))
-        _assert_fresh(location, build_started)
     except SystemExit:
         if not args.allow_overflow:
             raise
@@ -431,6 +439,13 @@ def main() -> int:
                 "(expected for over-budget builds). Checking for ELF..."
             )
         location = find_elf(args.board, Path(args.build_root))
+
+    # Outside the block above on purpose. That `except SystemExit` means
+    # "no ELF was found, retry with --allow-overflow"; a stale-ELF refusal
+    # raised inside it would be caught and rebuilt as though the ELF were
+    # missing, which is the opposite of what it is. Checked here so it covers
+    # both the normal and the recovery selection.
+    _assert_fresh(location, build_started)
 
     # nm resolution:
     #   fbuild-native ELF → fbuild auto-resolves via build_info_<board>.json,

--- a/ci/tests/test_bloat_elf_selection.py
+++ b/ci/tests/test_bloat_elf_selection.py
@@ -1,0 +1,120 @@
+"""`bash bloat` must analyse the ELF the build produced, not an older one.
+
+`find_elf` used to pick by a fixed layout priority and ignore mtime. The
+layouts coexist under one board directory -- `--build` writes the `.pio` one
+while the `.fbuild` one outranked it -- so a stale artifact could be analysed
+with no indication anything was wrong.
+
+That is how the command reported five-day-old numbers for a change made
+minutes earlier: two runs across a real code change produced byte-identical
+output, `total_flash` included, and the totals did not even match CI's for the
+same board and example because they described different binaries.
+FastLED#4384.
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+from pathlib import Path
+
+from ci.bloat import ElfLocation, _assert_fresh, find_elf
+
+
+def _touch(path: Path, mtime: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x7fELF")
+    import os
+
+    os.utime(path, (mtime, mtime))
+
+
+class TestFindElfPrefersTheNewest(unittest.TestCase):
+    def _layouts(self: "TestFindElfPrefersTheNewest", root: Path) -> tuple[Path, Path]:
+        """The two that coexist in practice, and did here."""
+
+        fbuild = root / "pio" / "esp32s3" / ".fbuild" / "build" / "release"
+        pio = root / "pio" / "esp32s3" / ".pio" / "build" / "esp32s3"
+        return fbuild / "firmware.elf", pio / "firmware.elf"
+
+    def test_the_newer_pio_elf_wins_over_a_stale_fbuild_one(
+        self: "TestFindElfPrefersTheNewest",
+    ) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fbuild_elf, pio_elf = self._layouts(root)
+            now = time.time()
+            _touch(fbuild_elf, now - 5 * 86400)
+            _touch(pio_elf, now)
+
+            # Priority alone would return the fbuild one, which is the bug.
+            self.assertEqual(find_elf("esp32s3", root).elf, pio_elf)
+
+    def test_the_newer_fbuild_elf_still_wins_when_it_is_newer(
+        self: "TestFindElfPrefersTheNewest",
+    ) -> None:
+        """The change is "newest", not "always prefer PIO"."""
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fbuild_elf, pio_elf = self._layouts(root)
+            now = time.time()
+            _touch(pio_elf, now - 5 * 86400)
+            _touch(fbuild_elf, now)
+
+            location = find_elf("esp32s3", root)
+            self.assertEqual(location.elf, fbuild_elf)
+            self.assertTrue(location.fbuild_native)
+
+    def test_a_missing_build_still_reports_where_it_looked(
+        self: "TestFindElfPrefersTheNewest",
+    ) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit) as caught:
+                find_elf("esp32s3", Path(tmp))
+            self.assertIn("no firmware.elf found", str(caught.exception))
+
+
+class TestFreshnessGuard(unittest.TestCase):
+    """`--build` promises a fresh ELF; this is the promise being checked."""
+
+    def _location(self: "TestFreshnessGuard", tmp: str, mtime: float) -> ElfLocation:
+        elf = Path(tmp) / "firmware.elf"
+        _touch(elf, mtime)
+        return ElfLocation(elf=elf, fbuild_native=False)
+
+    def test_without_build_nothing_is_asserted(self: "TestFreshnessGuard") -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _assert_fresh(self._location(tmp, time.time() - 86400), None)
+
+    def test_an_elf_newer_than_the_build_passes(self: "TestFreshnessGuard") -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            started = time.time() - 60
+            _assert_fresh(self._location(tmp, time.time()), started)
+
+    def test_an_elf_older_than_the_build_is_refused(self: "TestFreshnessGuard") -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            location = self._location(tmp, time.time() - 5 * 86400)
+            with self.assertRaises(SystemExit) as caught:
+                _assert_fresh(location, time.time())
+            message = str(caught.exception)
+            # Says what happened and by how much, so the next person does not
+            # have to rediscover it from byte-identical reports.
+            self.assertIn("predates it", message)
+            self.assertIn("120.0 h", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_bloat_elf_selection.py
+++ b/ci/tests/test_bloat_elf_selection.py
@@ -14,6 +14,8 @@ FastLED#4384.
 
 from __future__ import annotations
 
+import os
+import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -24,8 +26,6 @@ from ci.bloat import ElfLocation, _assert_fresh, find_elf
 def _touch(path: Path, mtime: float) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"\x7fELF")
-    import os
-
     os.utime(path, (mtime, mtime))
 
 
@@ -40,8 +40,6 @@ class TestFindElfPrefersTheNewest(unittest.TestCase):
     def test_the_newer_pio_elf_wins_over_a_stale_fbuild_one(
         self: "TestFindElfPrefersTheNewest",
     ) -> None:
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             fbuild_elf, pio_elf = self._layouts(root)
@@ -57,8 +55,6 @@ class TestFindElfPrefersTheNewest(unittest.TestCase):
     ) -> None:
         """The change is "newest", not "always prefer PIO"."""
 
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             fbuild_elf, pio_elf = self._layouts(root)
@@ -73,8 +69,6 @@ class TestFindElfPrefersTheNewest(unittest.TestCase):
     def test_a_missing_build_still_reports_where_it_looked(
         self: "TestFindElfPrefersTheNewest",
     ) -> None:
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             with self.assertRaises(SystemExit) as caught:
                 find_elf("esp32s3", Path(tmp))
@@ -90,21 +84,31 @@ class TestFreshnessGuard(unittest.TestCase):
         return ElfLocation(elf=elf, fbuild_native=False)
 
     def test_without_build_nothing_is_asserted(self: "TestFreshnessGuard") -> None:
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             _assert_fresh(self._location(tmp, time.time() - 86400), None)
 
     def test_an_elf_newer_than_the_build_passes(self: "TestFreshnessGuard") -> None:
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmp:
             started = time.time() - 60
             _assert_fresh(self._location(tmp, time.time()), started)
 
-    def test_an_elf_older_than_the_build_is_refused(self: "TestFreshnessGuard") -> None:
-        import tempfile
+    def test_an_elf_rounded_just_below_the_build_still_passes(
+        self: "TestFreshnessGuard",
+    ) -> None:
+        """Coarse filesystem mtime must not read as stale.
 
+        `time.time()` is sub-microsecond; a filesystem may store mtimes to the
+        second (ext3, HFS+) or two seconds (FAT), so an ELF written moments
+        after the build began can carry a timestamp rounded below it. Refusing
+        that would turn this guard into a false alarm on exactly the fresh
+        build it is meant to accept.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            started = time.time()
+            _assert_fresh(self._location(tmp, started - 1.5), started)
+
+    def test_an_elf_older_than_the_build_is_refused(self: "TestFreshnessGuard") -> None:
         with tempfile.TemporaryDirectory() as tmp:
             location = self._location(tmp, time.time() - 5 * 86400)
             with self.assertRaises(SystemExit) as caught:

--- a/ci/tests/test_bloat_elf_selection.py
+++ b/ci/tests/test_bloat_elf_selection.py
@@ -18,7 +18,10 @@ import os
 import tempfile
 import time
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
+
+from typeguard import typechecked
 
 from ci.bloat import ElfLocation, _assert_fresh, find_elf
 
@@ -29,26 +32,35 @@ def _touch(path: Path, mtime: float) -> None:
     os.utime(path, (mtime, mtime))
 
 
+@typechecked
+@dataclass(frozen=True, slots=True)
+class Layouts:
+    """The two ELF layouts that coexist under one board directory."""
+
+    fbuild: Path
+    pio: Path
+
+
 class TestFindElfPrefersTheNewest(unittest.TestCase):
-    def _layouts(self: "TestFindElfPrefersTheNewest", root: Path) -> tuple[Path, Path]:
+    def _layouts(self: "TestFindElfPrefersTheNewest", root: Path) -> Layouts:
         """The two that coexist in practice, and did here."""
 
         fbuild = root / "pio" / "esp32s3" / ".fbuild" / "build" / "release"
         pio = root / "pio" / "esp32s3" / ".pio" / "build" / "esp32s3"
-        return fbuild / "firmware.elf", pio / "firmware.elf"
+        return Layouts(fbuild=fbuild / "firmware.elf", pio=pio / "firmware.elf")
 
     def test_the_newer_pio_elf_wins_over_a_stale_fbuild_one(
         self: "TestFindElfPrefersTheNewest",
     ) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fbuild_elf, pio_elf = self._layouts(root)
+            layouts = self._layouts(root)
             now = time.time()
-            _touch(fbuild_elf, now - 5 * 86400)
-            _touch(pio_elf, now)
+            _touch(layouts.fbuild, now - 5 * 86400)
+            _touch(layouts.pio, now)
 
             # Priority alone would return the fbuild one, which is the bug.
-            self.assertEqual(find_elf("esp32s3", root).elf, pio_elf)
+            self.assertEqual(find_elf("esp32s3", root).elf, layouts.pio)
 
     def test_the_newer_fbuild_elf_still_wins_when_it_is_newer(
         self: "TestFindElfPrefersTheNewest",
@@ -57,13 +69,13 @@ class TestFindElfPrefersTheNewest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fbuild_elf, pio_elf = self._layouts(root)
+            layouts = self._layouts(root)
             now = time.time()
-            _touch(pio_elf, now - 5 * 86400)
-            _touch(fbuild_elf, now)
+            _touch(layouts.pio, now - 5 * 86400)
+            _touch(layouts.fbuild, now)
 
             location = find_elf("esp32s3", root)
-            self.assertEqual(location.elf, fbuild_elf)
+            self.assertEqual(location.elf, layouts.fbuild)
             self.assertTrue(location.fbuild_native)
 
     def test_a_missing_build_still_reports_where_it_looked(


### PR DESCRIPTION
Closes #4384.

`bash bloat <board> --build` compiled one ELF and analysed another.

The layouts coexist under a single board directory. `--build` runs the platformio backend, which writes `.pio/build/<board>/firmware.elf`, while `find_elf` ranked `.fbuild/build/release/firmware.elf` above it by fixed priority, **regardless of age**. So a stale artifact was analysed, silently.

### How it presented

Diagnosing the bloat-gate failure on #4368, I ran `bash bloat esp32s3 --build --top 200` on `master`, then on the feature branch, and diffed the two `report.json` files. The diff was **empty** — identical symbols, identical `total_flash` (399,293 B) — across a change CI measured at +940 B. The local total did not match CI's for the same board and example (342,483 B), because they described different binaries:

```
2026-09-11 19:19  .build/pio/esp32s3/.pio/build/esp32s3/firmware.elf     <- just built
2026-09-06 16:12  .build/pio/esp32s3/.fbuild/build/release/firmware.elf  <- analysed
```

I nearly reported "the change costs nothing" from that. `fbuild symbols` on the freshly built ELF gave 297,597 B on master and 298,561 B on the branch — +964 B, matching CI, and it localised 750 B of the cost to six duplicated vtable thunks in one diff.

Both `agents/docs/binary-size-analysis.md` and the gate's own failure message send people to this command, so the failure mode was plausible output with the conclusion inverted.

### The fix

1. **`find_elf` takes the newest candidate**, keeping the documented layout order only as a tie-break. It can no longer prefer an older artifact over a newer one.
2. **`--build` refuses a stale ELF.** If the selected ELF predates the build that just ran, it exits with the age rather than analysing it — `--build` promises "a fresh ELF" and nothing checked that promise.

Verified against the real directory: `find_elf` now returns the Sep 11 ELF where it previously returned the Sep 6 one.

### Tests

Six, and both halves mutation-verified:

- reverting selection to priority order → `test_the_newer_pio_elf_wins_over_a_stale_fbuild_one` fails;
- making the guard never refuse → `test_an_elf_older_than_the_build_is_refused` fails.

There is also a case pinning that a *newer* `.fbuild` ELF still wins, so the change is "newest" rather than "always prefer PIO".

`bash lint` and `bash test --py --clean` both clean on exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented analysis of stale ELF build artifacts from earlier builds or alternate layouts.
  * Artifact selection now prioritizes the newest available build output, using layout order only when timestamps match.
  * Added clearer errors when a build artifact predates the current build.
  * Improved handling of coarse filesystem timestamps to avoid rejecting valid artifacts.
  * Corrected freshness validation during overflow recovery.

* **Tests**
  * Added coverage for artifact selection, freshness validation, skipped checks when no build is performed, and related error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->