### PR TITLE
feat(color): let HD108 consume the device drive too (P8, #4042/#4326)

### DIFF
--- a/src/fl/channels/channel.cpp.hpp
+++ b/src/fl/channels/channel.cpp.hpp
@@ -833,7 +833,7 @@ void Channel::showPixels(PixelController<RGB, 1, 0xFFFFFFFF> &pixels) {
                 break;
 
             case SpiChipset::HD108:
-                pixelIterator.writeHD108(&data);
+                pixelIterator.writeHD108(&data, iterator.isManaged());
                 break;
         }
         // No default case - compiler will error if any enum value is missing

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -430,9 +430,67 @@ class PixelIterator {
     /// @brief Encode pixels in HD108 format (zero allocation)
     /// @param out Output buffer to write encoded bytes
     /// @note Protocol: 16-bit RGB with gamma correction and brightness control
+    /// @param managed True when the source is the colour-managed one, i.e.
+    ///        `loadAndScaleRGB16` yields a device drive rather than a widened
+    ///        8-bit pixel. Then the fixed 2.8 gamma is skipped: it would be a
+    ///        second shaping stage after the device solve (#4326).
     template <typename CONTAINER_UIN8_T>
-    void writeHD108(CONTAINER_UIN8_T* out) FL_NO_EXCEPT {
+    void writeHD108(CONTAINER_UIN8_T* out, bool managed = false) FL_NO_EXCEPT {
         auto back_ins = fl::back_inserter(*out);
+
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+        if (managed) {
+            // Inline rather than an `encodeHD108_wide` in hd108.h: that header
+            // is included *by* this one, before `PixelIterator` exists, and a
+            // concrete `PixelIterator&` parameter is not a dependent type --
+            // so its body would be checked there and fail. Same reason the
+            // UCS7604 wide path had to be guarded for TINY (#4326).
+            //
+            // `hd108GammaCorrect` is skipped by construction. It exists to
+            // widen an 8-bit pixel to the 16 bits this chipset carries; the
+            // managed source has already quantized its device drive once, to
+            // 16 bits, so a fixed 2.8 curve on top is the second shaping stage
+            // B1 and section 6 of the spec forbid after the device solve. And
+            // unlike UCS7604's `mGamma.value_or(2.8f)`, this one is hardcoded
+            // -- no caller could have chosen otherwise.
+        #if FASTLED_HD_COLOR_MIXING
+            // Per-strip constant, which is why the brightness iterator loads
+            // without advancing the shared cursor (#4321).
+            auto brightness_it = makeScaledBrightness(this);
+            const u8 brightness = *brightness_it;
+        #else
+            const u8 brightness = 255;
+        #endif
+            for (int i = 0; i < 8; i++) {
+                *back_ins++ = 0x00;  // start frame
+            }
+            u8 f0, f1;
+            hd108BrightnessHeader(brightness, &f0, &f1);
+            fl::size num_leds = 0;
+            while (has(1)) {
+                u16 r16, g16, b16;
+                loadAndScaleRGB16(&r16, &g16, &b16);
+                *back_ins++ = f0;
+                *back_ins++ = f1;
+                *back_ins++ = static_cast<u8>(r16 >> 8);
+                *back_ins++ = static_cast<u8>(r16 & 0xFF);
+                *back_ins++ = static_cast<u8>(g16 >> 8);
+                *back_ins++ = static_cast<u8>(g16 & 0xFF);
+                *back_ins++ = static_cast<u8>(b16 >> 8);
+                *back_ins++ = static_cast<u8>(b16 & 0xFF);
+                stepDithering();
+                advanceData();
+                ++num_leds;
+            }
+            const fl::size latch = num_leds / 2 + 4;
+            for (fl::size i = 0; i < latch; i++) {
+                *back_ins++ = 0xFF;  // end frame
+            }
+            return;
+        }
+#else
+        FL_UNUSED(managed);
+#endif
 
         #if FASTLED_HD_COLOR_MIXING
         // HD mode: per-LED brightness

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,3 +1,33 @@
+# 2026-09-12, PR TBD (issue #4326, colour pipeline P8): +240 B,
+# 342714 -> 342954.
+#
+# HD108 joins UCS7604-16 in consuming the device drive rather than an 8-bit
+# copy of it widened by a gamma curve. #4326 called HD108 "the same shape and
+# worse": `hd108GammaCorrect` is a hardcoded 2.8 inside the encoder, so unlike
+# UCS7604's `mGamma.value_or(2.8f)` no caller could ever have chosen
+# otherwise. Measured on a managed channel it put the same 849 on the wire
+# where the solve asked for 13933; it now puts 13935.
+#
+# Where the 240 B is, from a symbol diff against master (`fbuild symbols` on
+# the ELF the build produced -- `bash bloat --build` used to analyse a
+# different one, fixed in #4386):
+#
+#   +255  PixelIterator::writeHD108<vector_psram<u8>>
+#    +72  PixelIterator::loadAndScaleRGB16
+#         (minus ~87 B recovered elsewhere)
+#
+# `loadAndScaleRGB16` was inlined into its single caller before; with a second
+# one it is emitted once and called twice, which is the cheaper of the two.
+#
+# The wide loop is inline in `writeHD108` rather than a function in hd108.h
+# because that header is included *by* pixel_iterator.h, before the class
+# exists, and a concrete `PixelIterator&` parameter is not a dependent type --
+# its body would be checked there and fail.
+#
+# A tiny-memory target pays 0 B: the branch sits behind
+# !FL_PLATFORM_HAS_TINY_MEMORY, verified by compiling the header with
+# FL_PLATFORM_HAS_TINY_MEMORY=1.
+#
 # 2026-09-12, PR #4368 (issue #4326, colour pipeline P8): +231 B,
 # 342483 -> 342714.
 #
@@ -52,4 +82,4 @@
 # showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
 # only ever spent where flash is not the binding constraint. On a target
 # that does compile it in, 305 B is 0.089% of the image.
-342714
+342954

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,4 +1,4 @@
-# 2026-09-12, PR TBD (issue #4326, colour pipeline P8): +240 B,
+# 2026-09-12, PR #4387 (issue #4326, colour pipeline P8): +240 B,
 # 342714 -> 342954.
 #
 # HD108 joins UCS7604-16 in consuming the device drive rather than an 8-bit

--- a/tests/fl/channels/channel.cpp
+++ b/tests/fl/channels/channel.cpp
@@ -973,6 +973,89 @@ FL_TEST_CASE("[#4326] the 16-bit encoder reaches 252 of 65536 levels") {
     FL_CHECK_EQ(widest_step, 717);
 }
 
+// ============ HD108 through the Channels encode path (#4326 / #4042) ============
+// The other native 16-bit chipset. #4326 called it "the same shape and worse":
+// `hd108GammaCorrect` is a hardcoded 2.8 inside the encoder, so unlike
+// UCS7604's `mGamma.value_or(2.8f)` no caller could ever have chosen
+// otherwise, and `writeHD108` took no settings at all -- the information
+// needed to suppress it was not in scope.
+
+namespace {
+
+/// Encode one HD108 frame through `fl::Channel` and hand back the bytes.
+fl::vector<u8> encodeHd108Once(CRGB colour, bool bindProfile, int pin) {
+    auto& mgr = ChannelManager::instance();
+    mgr.clearAllDrivers();
+    auto engine = fl::make_shared<ByteCapturingMockEngine>("HD108_CAPTURE");
+    mgr.addDriver(9200, engine);
+    auto cleanup = fl::make_scope_exit([&mgr]() { mgr.clearAllDrivers(); });
+
+    CRGB leds[1] = {colour};
+    ChannelOptions options;
+    options.mDitherMode = DISABLE_DITHER;
+    if (bindProfile) {
+        options.setColorProfile(kProfile, SourceProfile::linearSrgb());
+    }
+    SpiChipsetConfig spiConfig{pin, pin + 1, SpiEncoder::hd108()};
+    ChannelConfig config(spiConfig, fl::span<CRGB>(leds, 1), RGB, options);
+    ChannelPtr channel = Channel::create(config);
+    fl::vector<u8> out;
+    if (channel) {
+        channel->showLeds(255);
+        if (!engine->mCapturedChannels.empty()) {
+            ChannelDataPtr data = engine->mCapturedChannels[0];
+            if (data) {
+                for (fl::size i = 0; i < data->getData().size(); ++i) {
+                    out.push_back(data->getData()[i]);
+                }
+            }
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+FL_TEST_CASE("[#4326] HD108 puts the device drive on the wire when managed") {
+    // Same fixture and reasoning as the UCS7604 case above: all three emitters
+    // at luminance 1.0 with sRGB chromaticities and a linear sRGB source, so
+    // full red is a target of Y = 0.2126 against an emitter making Y = 1.0 at
+    // full drive, and the solve's answer is a red drive of 0.2126. A 16-bit
+    // encoder consuming that should put 0.2126 * 65535 = 13933 on the wire.
+    fl::vector<u8> bound = encodeHd108Once(CRGB(255, 0, 0), true, 30);
+    fl::vector<u8> unbound = encodeHd108Once(CRGB(255, 0, 0), false, 32);
+
+    // 8 start bytes, then 2 brightness header bytes, then RGB16 big-endian.
+    FL_REQUIRE_GT((int)bound.size(), 16);
+    FL_REQUIRE_EQ((int)bound.size(), (int)unbound.size());
+
+    const int bound_red = (bound[10] << 8) | bound[11];
+    const int unbound_red = (unbound[10] << 8) | unbound[11];
+
+    // Managed: the drive itself, within rounding.
+    FL_CHECK_GT(bound_red, 13900);
+    FL_CHECK_LT(bound_red, 13970);
+
+    // Unbound is the legacy path and must be untouched by this change: the
+    // hardcoded 2.8 curve still widens its 8-bit pixel, which at full scale
+    // saturates.
+    FL_CHECK_EQ(unbound_red, 65535);
+
+    // And the two differ, so the branch is actually taken.
+    FL_CHECK_NE(bound_red, unbound_red);
+}
+
+FL_TEST_CASE("[#4326] HD108 black stays black on both paths") {
+    // The gamma curve maps 0 to 0, and so does the drive, so this is the
+    // control: a difference above can only be shaping, not an offset.
+    fl::vector<u8> bound = encodeHd108Once(CRGB(0, 0, 0), true, 34);
+    fl::vector<u8> unbound = encodeHd108Once(CRGB(0, 0, 0), false, 36);
+    FL_REQUIRE_GT((int)bound.size(), 16);
+    FL_REQUIRE_GT((int)unbound.size(), 16);
+    FL_CHECK_EQ((int)((bound[10] << 8) | bound[11]), 0);
+    FL_CHECK_EQ((int)((unbound[10] << 8) | unbound[11]), 0);
+}
+
 // ============ Legacy output with colour management disabled (#4034) ============
 // The tracker lists "Legacy output byte-identical with CM disabled" as an
 // acceptance criterion and nothing verified it. The colour pipeline reaches


### PR DESCRIPTION
Completes the wide-output work #4368 started, for the other native 16-bit chipset. Part of #4034 P8 (#4042), "encoders consume wide output directly".

#4326 called HD108 "the same shape and worse". `hd108GammaCorrect` is a hardcoded 2.8 **inside the encoder**, so unlike UCS7604's `mGamma.value_or(2.8f)` no caller could ever have chosen otherwise — and `writeHD108` took no settings at all, so the information needed to suppress it was not in scope.

### Measured

On a managed channel HD108 put **849** on the wire where the device solve asked for **13933** — the identical number the UCS7604 path produced before #4368. It now puts **13935**.

Confirmed causally rather than by inspection: disabling the wide branch returns the case to `849 > 13900` failing.

### Notes

- **`isManaged()`, not `hasColorProfile()`** — the distinction established in #4368's review. A rejected binding leaves the legacy controller in place while the options still report a profile; taking the no-gamma path over its 8-bit pixels would drop a stage that path still needs.
- **The loop is inline in `writeHD108`** rather than an `encodeHD108_wide` in `hd108.h`. That header is included *by* `pixel_iterator.h`, before the class exists, and a concrete `PixelIterator&` parameter is not a dependent type — so the body would be checked there and fail. That is the same property that made the UCS7604 wide encoder a hard compile error on TINY until it was guarded, so it is worth stating rather than rediscovering.
- **TINY pays 0 B** — verified by compiling the header with `FL_PLATFORM_HAS_TINY_MEMORY=1`.

### Flash

**+240 B**, baseline moved to 342954 with the symbol diff recorded in the file:

```
+255  PixelIterator::writeHD108<vector_psram<u8>>
 +72  PixelIterator::loadAndScaleRGB16
      (minus ~87 B recovered elsewhere)
```

`loadAndScaleRGB16` was inlined into its single caller; with a second one it is emitted once and called twice, which is the cheaper arrangement. Measured with `fbuild symbols` on the ELF the build produced — `bash bloat --build` used to analyse a different one, fixed in #4386.

### Tests

Two cases: the managed path emits the drive while the unbound path still saturates at 65535 through the legacy curve, and black stays black on both — so a difference above can only be shaping, not an offset.

`bash lint` clean; 305/305 unit, 84/84 examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HD108 LED output for color-managed streams, providing more accurate brightness and color handling.
  - Preserved existing encoding behavior for unbound or legacy color streams.
  - Ensured black output remains correctly represented as zero across both color-processing paths.

- **Tests**
  - Added coverage validating HD108 output for managed, legacy, and black-pixel scenarios.
  - Updated embedded build-size tracking to reflect the encoding improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->