### PR TITLE
docs(mp3): the ledger path filter is gone; stop saying it is there (#4155)

### DIFF
--- a/agents/docs/mp3-decoder-performance.md
+++ b/agents/docs/mp3-decoder-performance.md
@@ -136,10 +136,14 @@ exactly, by the bit-identical case in the same test file: it compares every
 decoded sample against the scalar kernels, which is a machine-independent
 comparison in a way a ratio of times is not.
 
-There is also no `codec_cpu_ledger.md`, despite
-`.github/workflows/mp3_cpu_audit.yml` path-filtering on it. It has never
-existed. Do not conclude "Helix was never profiled" from grepping it -- that
-mistake was made once already; `grep -c` on a missing file returns 0.
+There is no `codec_cpu_ledger.md` and there never has been. The store is
+`codec_cpu_trend.json`. Do not conclude "Helix was never profiled" from
+grepping the former -- that mistake was made once already; `grep -c` on a
+missing file returns 0.
+
+`.github/workflows/mp3_cpu_audit.yml` used to path-filter on the missing name
+as well, which is how the confusion started. It no longer does (#4155, item 1);
+both its `push` and `pull_request` filters list `codec_cpu_trend.json` alone.
 
 ## Historical Helix numbers
 


### PR DESCRIPTION
#4155 item 1.

That issue asked for `.github/workflows/mp3_cpu_audit.yml` to stop path-filtering on `codec_cpu_ledger.md`, a file that has never existed. **That part is already done** — both its `push` and `pull_request` filters now list `codec_cpu_trend.json` alone, and `codec_cpu_ledger` appears nowhere in the workflows.

What was left behind is the documentation. `agents/docs/mp3-decoder-performance.md` still said:

> There is also no `codec_cpu_ledger.md`, despite `.github/workflows/mp3_cpu_audit.yml` path-filtering on it.

The second half is no longer true. A doc that tells you CI watches a file it does not watch is worse than one that says nothing — especially this paragraph, which exists because someone once concluded "Helix was never profiled" from `grep -c` on the missing name and got 0.

Kept that warning, which is still worth having, and corrected the claim around it.

### On the rest of #4155

- **Item 2** (the unexplained 1.6x huffman stage) is not touched here. Worth noting for whoever picks it up: my notes said Callgrind was unusable on this host, but that applies to `audit.py --check`, which passes `--instr-atstart=no` and makes NixOS valgrind 3.26 write `totals: 0`. `ci/codec_cpu/callgrind.py` passes `--instr-atstart=yes`, so it may well work locally.
- **Item 3** (upstreaming to `lieff/minimp3`) is outward-facing and needs a maintainer's go-ahead, not an agent's.

`bash lint` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected MP3 decoder performance documentation to identify the current CPU baseline data source.
  * Clarified that MP3 audit checks apply consistently to both pushes and pull requests.
  * Removed outdated workflow path-filtering information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->