### PR TITLE
test(power): pin the draw the estimate misses when dithering is on (#4342)

### DIFF
--- a/tests/fl/power_estimation.cpp
+++ b/tests/fl/power_estimation.cpp
@@ -232,3 +232,137 @@ FL_TEST_CASE_FIXTURE(PowerEstimationFixture,"Power estimation - non linear scali
 
     FL_REQUIRE(nonlinear_power > linear_power);
 }
+
+// ---------------------------------------------------------------------------
+// #4342: the estimate reads pre-dither pixels, and dither only ever adds.
+//
+// `docs/color-pipeline-contracts.md` requires the prepass to "include response
+// inversion, current-field policy, and quantization reserve". The reserve is
+// unimplemented, and this measures what that costs while it stays that way.
+//
+// Nothing pinned it before. The figure in #4342 was a one-off measurement; a
+// regression that made the gap worse -- or a fix that closed it -- would move
+// silently either way.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+const int kDitherCycle = 8;
+
+const int kStripLen = 200;
+
+/// Power of a uniform strip as the limiter would score it.
+///
+/// A strip rather than one LED on purpose. `calculate_unscaled_power_mW`
+/// returns whole milliwatts, and a single dim pixel lands on 3 against 8 --
+/// a ratio whose precision is the estimator's rounding, not the effect. At
+/// 200 LEDs the quantum is a fraction of a percent.
+fl::u32 powerOfStrip(CRGB pixel) {
+    fl::vector<CRGB> strip;
+    for (int i = 0; i < kStripLen; ++i) {
+        strip.push_back(pixel);
+    }
+    return calculate_unscaled_power_mW(strip.data(), kStripLen);
+}
+
+/// The strip's draw with dithering off -- the pixel the estimate is built on.
+fl::u32 unditheredDraw(CRGB source, fl::u8 brightness) {
+    CRGB pixel = source;
+    ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+    adjustment.premixed = CRGB(brightness, brightness, brightness);
+    PixelController<RGB> pixels(&pixel, 1, adjustment, DISABLE_DITHER);
+    const CRGB emitted(pixels.loadAndScale0(), pixels.loadAndScale1(),
+                       pixels.loadAndScale2());
+    return powerOfStrip(emitted);
+}
+
+/// The largest single-frame draw over a full dither cycle at `brightness`.
+///
+/// The phase must advance between frames. Building a fresh `PixelController`
+/// without advancing it renders the same phase eight times and reports a
+/// milder gap -- #4342 records measuring +25% that way before finding +50%.
+fl::u32 worstDitheredFrame(CRGB source, fl::u8 brightness) {
+    fl::u32 worst = 0;
+    for (int frame = 0; frame < kDitherCycle; ++frame) {
+        fl::detail::advanceDitherFrame();
+        CRGB pixel = source;
+        ColorAdjustment adjustment = ColorAdjustment::noAdjustment();
+        adjustment.premixed = CRGB(brightness, brightness, brightness);
+        PixelController<RGB> pixels(&pixel, 1, adjustment, BINARY_DITHER);
+        const CRGB emitted(pixels.loadAndScale0(), pixels.loadAndScale1(),
+                           pixels.loadAndScale2());
+        // Every LED on the strip carries the same source, so the whole strip
+        // takes the same dither offset in a given frame.
+        const fl::u32 drawn = powerOfStrip(emitted);
+        if (drawn > worst) {
+            worst = drawn;
+        }
+    }
+    return worst;
+}
+
+}  // namespace
+
+FL_TEST_CASE("[#4342] the power estimate misses what dithering adds") {
+    // Both sides through `calculate_unscaled_power_mW`, dither off against
+    // dither on, on the same 200-LED strip. That is what makes it
+    // like-for-like. Powering the source and calling
+    // `scale_power_for_brightness` -- what the real limiter does -- treats the
+    // estimator's per-LED idle term differently from powering an already
+    // scaled pixel, and reports 2.4x where the dither accounts for a fraction
+    // of it. #4342 makes the same caveat about its own method.
+    const fl::u8 brightness = 16;
+
+    // Measured, at brightness 16, 200 LEDs:
+    //
+    //   source   dither off   worst frame   ratio
+    //        1         1000          1162   1.162
+    //        8         1000          1162   1.162
+    //       16         1162          1327   1.142
+    //       64         1655          1818   1.098
+    //
+    // The 1000 mW floor is the idle term for 200 dark LEDs, and the dither
+    // adds a near-constant ~162 mW on top -- it lifts channels off zero, and
+    // how far it lifts them does not depend much on how dim the source is.
+    // So the *relative* error is worst exactly where a limiter operates.
+    const CRGB dim(8, 8, 8);
+    const fl::u32 off = unditheredDraw(dim, brightness);
+    const fl::u32 on = worstDitheredFrame(dim, brightness);
+
+    // Dither only ever adds: `dither()` is `b ? qadd8(b, d) : 0`, so it raises
+    // a lit channel and never lowers one. The estimate cannot come out high.
+    FL_CHECK_GE(on, off);
+
+    // And the excess is not a rounding artifact. 15% of the strip's draw is
+    // unaccounted for at this operating point.
+    FL_CHECK_GT(on * 100, off * 115);
+
+    // Non-zero, or the comparison is two zeroes agreeing.
+    FL_CHECK_GT(off, 0u);
+}
+
+FL_TEST_CASE("[#4342] the unaccounted draw matters most where the signal is small") {
+    // The shape, and why this is a low-light problem. The dither's addition is
+    // roughly fixed; the signal it sits on is not. So the fraction it
+    // represents falls as the source rises -- 1.162 at source 8 against 1.098
+    // at source 64 -- and a limiter pushing brightness down is walking toward
+    // the worse end, not away from it.
+    const fl::u8 brightness = 16;
+
+    const fl::u32 dim_off = unditheredDraw(CRGB(8, 8, 8), brightness);
+    const fl::u32 dim_on = worstDitheredFrame(CRGB(8, 8, 8), brightness);
+    const fl::u32 bright_off = unditheredDraw(CRGB(64, 64, 64), brightness);
+    const fl::u32 bright_on = worstDitheredFrame(CRGB(64, 64, 64), brightness);
+
+    const double dim_ratio =
+        static_cast<double>(dim_on) / static_cast<double>(dim_off);
+    const double bright_ratio =
+        static_cast<double>(bright_on) / static_cast<double>(bright_off);
+
+    FL_CHECK_GT(dim_ratio, bright_ratio);
+
+    // Both above one, so the ordering above is between two real excesses
+    // rather than between two roundings.
+    FL_CHECK_GT(dim_ratio, 1.10);
+    FL_CHECK_GT(bright_ratio, 1.05);
+}


### PR DESCRIPTION
Pins the exposure #4342 measured. Does **not** close it — the fix (a quantization reserve in the estimate, which `docs/color-pipeline-contracts.md` names directly) is still unimplemented.

### Measured

Brightness 16, 200-LED strip, dither off against the worst frame of a full cycle, both sides through `calculate_unscaled_power_mW`:

| source | dither off | worst frame | ratio |
|---:|---:|---:|---:|
| 1 | 1000 | 1162 | **1.162** |
| 8 | 1000 | 1162 | **1.162** |
| 16 | 1162 | 1327 | 1.142 |
| 64 | 1655 | 1818 | 1.098 |

The 1000 mW floor is the idle term for 200 dark LEDs. The dither adds a near-constant ~162 mW on top — what it does is lift channels off zero, and how far barely depends on how dim the source is. So the *relative* error is worst exactly where a limiter operates, and a limiter pushing brightness down walks toward that end rather than away from it.

### Method, and two things that change the answer

**Both sides go through the same estimator.** Powering the source and calling `scale_power_for_brightness` — what the real limiter does — treats the per-LED idle term differently from powering an already-scaled pixel, and reports **2.4x** where the dither accounts for a fraction of it. That is an artifact of the comparison, not of the dither. #4342 makes the same caveat about its own figures, which is what prompted me to check.

**The dither phase has to advance between frames.** Rebuilding the `PixelController` without `advanceDitherFrame()` renders one phase eight times and misses the worst one. #4342 records measuring a milder gap that way before finding it.

### It does not reproduce the +50% headline

Under a like-for-like comparison that includes the idle term, the worst case here is **+16%**, not +50%. I have recorded what this method measures rather than asserting agreement I cannot demonstrate — I do not know the strip length or source the original figure used, and the idle term alone is enough to explain a difference of that size.

### Verification

Making the dither contribute nothing (`d[i] = 0`) fails both cases.

`bash lint` clean; 305/305 unit, 84/84 examples.

Test-only; no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9