### PR TITLE
docs(lint): stop LegacyLogMacroChecker claiming a cost the suffix cannot control (#4297)

### DIFF
--- a/ci/lint_cpp_rs/src/checkers/bare_legacy.rs
+++ b/ci/lint_cpp_rs/src/checkers/bare_legacy.rs
@@ -254,10 +254,27 @@ impl FileContentChecker for FlNoUnderscoreChecker {
 
 // --- LegacyLogMacroChecker ---------------------------------------------------
 //
-// Bans legacy stream-style FastLED logging macros (FL_WARN, FL_PRINT, FL_DBG,
-// FL_ERROR, FL_LOG_*) in src/. Each call site should use the `_F` printf-style
-// variant so the formatter lives in fl::printf instead of a fresh fl::sstream
-// chain per call site. Origin: ci/lint_cpp/legacy_log_macro_checker.py.
+// Requires the `_F` spelling of the FastLED logging macros (FL_WARN, FL_PRINT,
+// FL_DBG, FL_ERROR, FL_LOG_*) in src/. Origin:
+// ci/lint_cpp/legacy_log_macro_checker.py.
+//
+// This used to say the `_F` form "puts the formatter in fl::printf instead of
+// a fresh fl::sstream chain per call site". That is not achievable by the
+// spelling, and saying so here sent readers looking for a cost that the
+// suffix does not control. `src/fl/log/log.h:330` is:
+//
+//     #define FL_WARN_F(...) FL_WARN(__VA_ARGS__)
+//
+// so the two are the same token sequence. What selects `log_emit_f` over
+// `log_emit` is the argument count -- one argument builds an `fl::sstream`,
+// two or more do not -- and the suffix has no bearing on it.
+//
+// So what this rule enforces is a spelling, for consistency. Whether that is
+// the right rule is open: `log.h` tells new code to drop the suffix and "rely
+// on argument-count dispatch", which is the opposite instruction, and more
+// than half the `_F` calls this rule approves are single-argument ones that
+// build the sstream anyway. FastLED#4297 has the counts and the options; do
+// not resolve that by editing this comment.
 
 struct LegacyLogMacroChecker;
 


### PR DESCRIPTION
Addresses the factual half of #4297 without taking its decision.

### The false claim

`LegacyLogMacroChecker`'s header said each call site

> should use the `_F` printf-style variant so the formatter lives in fl::printf instead of a fresh fl::sstream chain per call site

That is not achievable by the spelling. `src/fl/log/log.h:330`:

```cpp
#define FL_WARN_F(...) FL_WARN(__VA_ARGS__)
```

The two are the same token sequence. What selects `log_emit_f` over `log_emit` is the **argument count** — one argument builds an `fl::sstream`, two or more do not — and the suffix has no bearing on it. I verified the identity by preprocessing rather than by taking the issue's word for it.

Stating a false mechanism in the checker is worse than stating nothing: it sends the next reader looking for a cost the rule does not control, and it is the justification someone would cite when deciding whether to keep the rule.

### What this changes

The comment only. **Behaviour is unchanged** — the rule still enforces the `_F` spelling and still has no suppression.

The comment now says what the rule actually enforces, and records the contradiction at the place someone hits it: `log.h` tells new code to *drop* the suffix and "rely on argument-count dispatch", the opposite instruction, and per #4297 more than half the `_F` calls this rule approves are single-argument ones that build the sstream anyway.

### What it deliberately does not do

Resolve #4297. That issue's option (1) is a lint rewrite over 1,760 call sites, and its option (2) retires a rule with no suppression — both decisions, not cleanups. The comment says so explicitly so the next person does not mistake an accurate rationale for a settled question.

`bash lint` clean; the crate's own 105 tests pass.

Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected internal documentation describing how formatted logging macros select their logging behavior.
  * Clarified that argument count, rather than the macro suffix, determines the underlying logging path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->