### PR TITLE
fix(test): answer the OTA peer run's apply criterion in its success-path mock

### DIFF
--- a/ci/tests/test_autoresearch_net.py
+++ b/ci/tests/test_autoresearch_net.py
@@ -243,7 +243,20 @@ def test_ota_peer_stages_artifact_without_a_host_wifi_manager(tmp_path) -> None:
         return _response(responses[method])
 
     async def primary_after_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
-        return _response({"success": True})
+        responses = {
+            # The run's final criterion asks the board whether it applied the
+            # image, because the C6 having served it only proves a download
+            # (#3956). A blanket success for every method answered that with
+            # `{"success": True}`, which `ota_applied_ok` reads as "not proven"
+            # -- correctly, since neither flag is there. Answer the question the
+            # success path is meant to be asserting.
+            "rpOtaUpdateStatus": {
+                "success": True,
+                "attempted": True,
+                "succeeded": True,
+            },
+        }
+        return _response(responses.get(method, {"success": True}))
 
     async def peer_send(method: str, *_args: Any, **_kwargs: Any) -> MagicMock:
         responses = {


### PR DESCRIPTION
`master` is red: `ci/tests/test_autoresearch_net.py::test_ota_peer_stages_artifact_without_a_host_wifi_manager` has failed on every push since #4318 merged.

## Cause

#4318 added the run's final criterion — ask the RP whether it applied the image, because the C6 having served it only proves a download happened (#3956):

```python
applied = await rpc_data(primary, "rpOtaUpdateStatus", {})
if not ota_applied_ok(applied):
    raise RuntimeError(f"RP2350W did not apply the artifact it fetched: {applied}; ...")
```

It did not update this test. The `primary_after` mock answers *every* method with a blanket `{"success": True}`, and `ota_applied_ok` requires `attempted is True and succeeded is True` — neither is present, so it reads "not proven" and fails. Which is the criterion working as designed; the fixture simply never answered the new question.

Note the shape: a mock that says yes to everything is exactly what #4318 exists to stop counting as proof, so the right fix is to make it dispatch on method rather than to loosen the criterion.

## Fix

`primary_after_send` now dispatches, answering `rpOtaUpdateStatus` the way a board that applied the image would, and keeping the blanket success for the other calls.

## Verification

- `uv run pytest ci/tests/test_autoresearch_net.py` — 25 passed (was 24 passed, 1 failed).
- Load-bearing: flipping `succeeded` to `False` in the new mock fails the test, so it still exercises the criterion rather than papering over it.
- `bash lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated OTA update test behavior to correctly represent successful update results.
  - Preserved fallback success handling for other update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->