### PR TITLE
test(color): derive the per-pixel solver guard's forbidden set (#4041)

### DIFF
--- a/ci/tests/test_no_iterative_solver_per_pixel.py
+++ b/ci/tests/test_no_iterative_solver_per_pixel.py
@@ -79,10 +79,9 @@ KNOWN_REACHING_WRAPPERS = (
 )
 
 # C++ constructs that look like a call or a definition to a regex and are not.
-# Without these, `if (...) { ... }` parses as a function named `if` whose body
-# is the block, every branch in the tree becomes a call edge, and the fixpoint
-# swallows the whole namespace -- measured 230 names including `blur1d` and
-# `fill_solid` before this list existed.
+# Without these, `if (...) { ... }` parses as a function named `if`, every
+# branch in the tree becomes a call edge, and the fixpoint swallows the whole
+# namespace -- measured 230 names including `blur1d` and `fill_solid`.
 NOT_FUNCTIONS = frozenset(
     (
         "if",
@@ -114,21 +113,90 @@ NOT_FUNCTIONS = frozenset(
     )
 )
 
-# `name(params)` followed by trailing specifiers and an opening brace. Ctor
-# initialiser lists and trailing return types are not matched on purpose: a
-# definition this misses simply contributes no call edges, which loses
-# coverage rather than inventing it. The vacuity test below is what keeps that
-# honest.
 _TRAILER = r"(?:\s|const|noexcept|FL_NO_EXCEPT|override|final|mutable|volatile)*"
+# A constructor initialiser list, narrowly: `: name(...), name(...)`. Anchored
+# on the colon and on `name(` entries rather than "anything up to the brace".
+# The permissive form was tried and is wrong -- a ternary `f(x) : g(y)` then
+# matches and runs to a distant brace, swallowing the real definition that
+# follows. Measured: the closure collapsed from 21 names to 5 and lost
+# `project_to_hull` itself.
+_INIT_ENTRY = r"[A-Za-z_]\w*\s*\([^;{}()]*\)"
+_CTOR_INIT = r"(?::\s*" + _INIT_ENTRY + r"(?:\s*,\s*" + _INIT_ENTRY + r")*\s*)?"
+
 DEFINITION = re.compile(
-    r"\b(?P<name>[A-Za-z_]\w*)\s*\((?P<args>[^;{}()]*)\)" + _TRAILER + r"\{"
+    r"\b(?P<name>[A-Za-z_]\w*)\s*\((?P<args>[^;{}()]*)\)"
+    + _TRAILER
+    + _CTOR_INIT
+    + r"\{"
 )
 CALLED_NAME = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
 
-# Measured 455 on the tree that introduced this check. A parser change that
+# Definition syntax `DEFINITION` cannot parse. A function written this way
+# contributes no call edges, so a solver wrapper spelled
+# `auto wrap(...) -> bool { nnls3(...); }` would never enter the derived set
+# and a stage could call it freely. The vacuity floor below does not catch
+# that -- one missed definition out of hundreds moves no count. So the forms
+# are detected and the test fails, rather than silently losing coverage:
+# extend `DEFINITION` to cover the form, then drop it from here.
+UNSUPPORTED_DEFINITION_SYNTAX = (
+    ("trailing return type", re.compile(r"\)" + _TRAILER + r"->[^;{}]*\{")),
+    ("requires clause", re.compile(r"\)" + _TRAILER + r"requires\b[^;{}]*\{")),
+    ("attribute before body", re.compile(r"\)" + _TRAILER + r"\[\[[^\]]*\]\]\s*\{")),
+)
+
+# Measured 461 on the tree that introduced this check. A parser change that
 # drops most definitions would make the fixpoint find nothing and the scan
 # pass vacuously, so the floor is asserted rather than trusted.
 MIN_PARSED_DEFINITIONS = 300
+
+
+def scanned_sources() -> "list[Path]":
+    """The translation units the call graph is built from."""
+
+    return sorted(GFX.glob("*.cpp.hpp")) + sorted(GFX.glob("*.h"))
+
+
+def strip_comments_and_literals(text: str) -> str:
+    """Blank out comments and string/char literals, preserving offsets loosely.
+
+    Necessary, not cosmetic. Prose is full of things that read as code: the
+    arrow diagram `(R,0,0)->(R,0,0,0)` in `rgbw_colorimetric.h` made the
+    trailing-return detector fire on a file that has no trailing-return
+    definition, and a comment in `lookup_lut` mentioning `build_lut()` put
+    `lookup_lut` in the forbidden set -- a per-pixel LUT lookup, which A3
+    explicitly permits ("matrix + clamp/compress, optionally LUT-backed").
+    Forbidding it would have blocked the very thing P7 asks for.
+    """
+
+    out: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "/" and index + 1 < length and text[index + 1] == "*":
+            close = text.find("*/", index + 2)
+            index = length if close < 0 else close + 2
+            out.append(" ")
+        elif char == "/" and index + 1 < length and text[index + 1] == "/":
+            close = text.find("\n", index)
+            index = length if close < 0 else close
+            out.append(" ")
+        elif char == '"' or char == "'":
+            quote = char
+            index += 1
+            while index < length:
+                if text[index] == "\\":
+                    index += 2
+                    continue
+                if text[index] == quote:
+                    index += 1
+                    break
+                index += 1
+            out.append('""')
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
 
 
 def _end_of_block(text: str, open_index: int) -> int:
@@ -151,9 +219,8 @@ def call_edges() -> "dict[str, set[str]]":
     """Map every function defined under `src/fl/gfx` to the names it calls."""
 
     edges: dict[str, set[str]] = {}
-    sources = sorted(GFX.glob("*.cpp.hpp")) + sorted(GFX.glob("*.h"))
-    for source in sources:
-        text = source.read_text(encoding="utf-8")
+    for source in scanned_sources():
+        text = strip_comments_and_literals(source.read_text(encoding="utf-8"))
         for match in DEFINITION.finditer(text):
             name = match.group("name")
             if name in NOT_FUNCTIONS:
@@ -193,16 +260,13 @@ def call_pattern(symbol: str) -> re.Pattern[str]:
 
     So this matches the identifier followed by an open paren, allowing
     whitespace and block or line comments in between -- which covers
-    `nnls3 /* why */ (args)`. Two known limits:
+    `nnls3 /* why */ (args)`. One known limit:
 
-    * A comment or string literal that itself contains `nnls3(` fails the
-      test. That is a false positive, so it fails closed; the fix is obvious
-      to whoever hits it.
-    * Preprocessor tricks that split the identifier would evade it. Anyone
-      doing that is deliberately defeating the guard, not tripping over it.
-
-    Prose naming the symbol without a following paren -- as the comments in
-    these files do -- does not match.
+    Callers pass text with comments and literals already stripped, so
+    prose mentioning a symbol cannot trip it either way. One known limit
+    remains: preprocessor tricks that split the identifier would evade
+    it, and anyone doing that is deliberately defeating the guard, not
+    tripping over it.
     """
 
     gap = r"(?:\s|/\*.*?\*/|//[^\n]*\n)*"
@@ -250,12 +314,33 @@ class TestNoIterativeSolverPerPixel(unittest.TestCase):
                     "say why in the same commit",
                 )
 
+    def test_every_definition_form_present_is_parseable(
+        self: "TestNoIterativeSolverPerPixel",
+    ) -> None:
+        # A definition the parser cannot see contributes no call edges, so a
+        # solver wrapper written that way never joins the forbidden set and a
+        # stage may call it freely. The vacuity floor does not catch this --
+        # one missed definition out of hundreds moves no count. Fail loudly
+        # instead of losing coverage quietly.
+        for label, pattern in UNSUPPORTED_DEFINITION_SYNTAX:
+            for source in scanned_sources():
+                text = strip_comments_and_literals(source.read_text(encoding="utf-8"))
+                with self.subTest(form=label, source=source.name):
+                    self.assertIsNone(
+                        pattern.search(text),
+                        f"{source.name} defines a function using a {label}, "
+                        "which DEFINITION cannot parse -- its call edges are "
+                        "invisible to the forbidden-set derivation. Extend "
+                        "DEFINITION to cover the form, then remove it from "
+                        "UNSUPPORTED_DEFINITION_SYNTAX.",
+                    )
+
     def test_no_iterative_solver_on_the_per_pixel_path(
         self: "TestNoIterativeSolverPerPixel",
     ) -> None:
         forbidden = sorted(forbidden_symbols())
         for name in PER_PIXEL_STAGES:
-            text = (GFX / name).read_text(encoding="utf-8")
+            text = strip_comments_and_literals((GFX / name).read_text(encoding="utf-8"))
             for symbol in forbidden:
                 with self.subTest(stage=name, symbol=symbol):
                     self.assertIsNone(

--- a/ci/tests/test_no_iterative_solver_per_pixel.py
+++ b/ci/tests/test_no_iterative_solver_per_pixel.py
@@ -5,6 +5,26 @@ profile/cache build time and catastrophic per pixel, and #4041 asks for a
 structural test rather than a convention. This asserts the streaming stages
 never reference it, so a future edit that wires one in fails here rather than
 in a frame-rate report on someone's bench.
+
+The forbidden set is **derived, not listed**. It used to be three names --
+`nnls3`, `solve_rgb_colorimetric`, `build_rgb_colorimetric_cache` -- and
+naming the solver was the only way to trip it. But `nnls3` is private
+(`static bool project_to_hull` at `rgbw_colorimetric.cpp.hpp:183` is its only
+caller), and the way anyone actually reaches it is through the *public*
+wrappers over that: `solve_strict_subgamut_xy`, `solve_wx_overdrive` and
+`solve_rgbcct`, all declared in `rgbw_colorimetric.h`. None of those three was
+on the list. A stage calling `solve_rgbcct(...)` ran a 500-iteration solve per
+pixel and this guard passed it.
+
+So the seeds below name the iterative primitives, and the check forbids every
+function that can reach one of them -- computed by walking call edges across
+`src/fl/gfx` to a fixpoint. Wrapping a solver in a new name now extends the
+forbidden set instead of escaping it.
+
+This is FastLED#4335's lesson one level down. That issue was "the guard's list
+of files was itself a thing nothing checked"; this was the guard's list of
+*symbols*, with the same shape and the same fix -- derive it, then assert the
+derivation is not vacuous.
 """
 
 from __future__ import annotations
@@ -40,9 +60,126 @@ PER_PIXEL_STAGES = (
     "flux_scalar.cpp.hpp",
 )
 
-# Names whose presence on a per-pixel path would mean an unbounded or
-# iterative computation per frame.
-FORBIDDEN = ("nnls3", "solve_rgb_colorimetric", "build_rgb_colorimetric_cache")
+# The iterative primitives themselves. Everything that can reach one of these
+# is derived from them; this tuple is the only hand-maintained part.
+ITERATIVE_PRIMITIVES = (
+    "nnls3",
+    "solve_rgb_colorimetric",
+    "build_rgb_colorimetric_cache",
+)
+
+# Public wrappers that reach `nnls3` and were absent from the old hand-written
+# list. Asserted to be in the derived set, so the derivation cannot quietly
+# stop finding them -- which is the whole defect this file now guards against.
+KNOWN_REACHING_WRAPPERS = (
+    "project_to_hull",
+    "solve_strict_subgamut_xy",
+    "solve_wx_overdrive",
+    "solve_rgbcct",
+)
+
+# C++ constructs that look like a call or a definition to a regex and are not.
+# Without these, `if (...) { ... }` parses as a function named `if` whose body
+# is the block, every branch in the tree becomes a call edge, and the fixpoint
+# swallows the whole namespace -- measured 230 names including `blur1d` and
+# `fill_solid` before this list existed.
+NOT_FUNCTIONS = frozenset(
+    (
+        "if",
+        "for",
+        "while",
+        "switch",
+        "catch",
+        "return",
+        "sizeof",
+        "do",
+        "else",
+        "operator",
+        "decltype",
+        "static_cast",
+        "reinterpret_cast",
+        "const_cast",
+        "dynamic_cast",
+        "alignof",
+        "noexcept",
+        "throw",
+        "new",
+        "delete",
+        "and",
+        "or",
+        "not",
+        "typeid",
+        "constexpr",
+        "static_assert",
+    )
+)
+
+# `name(params)` followed by trailing specifiers and an opening brace. Ctor
+# initialiser lists and trailing return types are not matched on purpose: a
+# definition this misses simply contributes no call edges, which loses
+# coverage rather than inventing it. The vacuity test below is what keeps that
+# honest.
+_TRAILER = r"(?:\s|const|noexcept|FL_NO_EXCEPT|override|final|mutable|volatile)*"
+DEFINITION = re.compile(
+    r"\b(?P<name>[A-Za-z_]\w*)\s*\((?P<args>[^;{}()]*)\)" + _TRAILER + r"\{"
+)
+CALLED_NAME = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
+
+# Measured 455 on the tree that introduced this check. A parser change that
+# drops most definitions would make the fixpoint find nothing and the scan
+# pass vacuously, so the floor is asserted rather than trusted.
+MIN_PARSED_DEFINITIONS = 300
+
+
+def _end_of_block(text: str, open_index: int) -> int:
+    """Index of the brace closing the one at `open_index`."""
+
+    depth = 0
+    index = open_index
+    while index < len(text):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return len(text)
+
+
+def call_edges() -> "dict[str, set[str]]":
+    """Map every function defined under `src/fl/gfx` to the names it calls."""
+
+    edges: dict[str, set[str]] = {}
+    sources = sorted(GFX.glob("*.cpp.hpp")) + sorted(GFX.glob("*.h"))
+    for source in sources:
+        text = source.read_text(encoding="utf-8")
+        for match in DEFINITION.finditer(text):
+            name = match.group("name")
+            if name in NOT_FUNCTIONS:
+                continue
+            open_index = text.index("{", match.end() - 1)
+            body = text[open_index : _end_of_block(text, open_index)]
+            called = edges.setdefault(name, set())
+            for candidate in CALLED_NAME.findall(body):
+                if candidate not in NOT_FUNCTIONS:
+                    called.add(candidate)
+    return edges
+
+
+def forbidden_symbols() -> "set[str]":
+    """Every name that can reach an iterative primitive, primitives included."""
+
+    reaching = set(ITERATIVE_PRIMITIVES)
+    edges = call_edges()
+    grew = True
+    while grew:
+        grew = False
+        for name, called in edges.items():
+            if name not in reaching and (called & reaching):
+                reaching.add(name)
+                grew = True
+    return reaching
 
 
 def call_pattern(symbol: str) -> re.Pattern[str]:
@@ -80,12 +217,46 @@ class TestNoIterativeSolverPerPixel(unittest.TestCase):
             with self.subTest(stage=name):
                 self.assertTrue((GFX / name).is_file(), f"{name} not found in {GFX}")
 
+    def test_the_call_graph_is_not_vacuous(
+        self: "TestNoIterativeSolverPerPixel",
+    ) -> None:
+        # A parser that matches nothing forbids nothing and passes everything.
+        edges = call_edges()
+        self.assertGreaterEqual(
+            len(edges),
+            MIN_PARSED_DEFINITIONS,
+            f"only {len(edges)} function definitions parsed under {GFX}; the "
+            "scan below would pass vacuously",
+        )
+
+    def test_the_derived_set_reaches_the_public_wrappers(
+        self: "TestNoIterativeSolverPerPixel",
+    ) -> None:
+        # The defect this file exists to close. `nnls3` is private; these are
+        # the names a caller can actually write, and the old hand-written list
+        # had none of them.
+        forbidden = forbidden_symbols()
+        for symbol in ITERATIVE_PRIMITIVES:
+            with self.subTest(symbol=symbol):
+                self.assertIn(symbol, forbidden)
+        for symbol in KNOWN_REACHING_WRAPPERS:
+            with self.subTest(symbol=symbol):
+                self.assertIn(
+                    symbol,
+                    forbidden,
+                    f"{symbol} reaches an iterative solver and must be "
+                    "forbidden on the per-pixel path; if it genuinely no "
+                    "longer does, remove it from KNOWN_REACHING_WRAPPERS and "
+                    "say why in the same commit",
+                )
+
     def test_no_iterative_solver_on_the_per_pixel_path(
         self: "TestNoIterativeSolverPerPixel",
     ) -> None:
+        forbidden = sorted(forbidden_symbols())
         for name in PER_PIXEL_STAGES:
             text = (GFX / name).read_text(encoding="utf-8")
-            for symbol in FORBIDDEN:
+            for symbol in forbidden:
                 with self.subTest(stage=name, symbol=symbol):
                     self.assertIsNone(
                         call_pattern(symbol).search(text),

--- a/ci/tests/test_no_iterative_solver_per_pixel.py
+++ b/ci/tests/test_no_iterative_solver_per_pixel.py
@@ -126,7 +126,8 @@ _TRAILER = r"(?:\s|const|noexcept|FL_NO_EXCEPT|override|final|mutable|volatile)*
 # does not match, the whole definition does not match, and the constructor
 # contributes no edges at all; a mutation covers this.
 _INIT_ARG = r"[^;{}()]*(?:\([^;{}()]*\)[^;{}()]*)*"
-_INIT_ENTRY = r"[A-Za-z_]\w*\s*\(" + _INIT_ARG + r"\)"
+# `: member(expr)` and `: member{expr}` both initialise, so both are entries.
+_INIT_ENTRY = r"[A-Za-z_]\w*\s*(?:\(" + _INIT_ARG + r"\)|\{" + _INIT_ARG + r"\})"
 _CTOR_INIT = r"(?::\s*" + _INIT_ENTRY + r"(?:\s*,\s*" + _INIT_ENTRY + r")*\s*)?"
 
 DEFINITION = re.compile(
@@ -287,8 +288,15 @@ def call_pattern(symbol: str) -> re.Pattern[str]:
     # constructor is usually reached and which `Name(` alone does not match --
     # found by a mutation that the first version of this guard let through.
     declarator = r"(?:[A-Za-z_]\w*" + gap + r")?"
+    # `(` or `{`: `InitProbe probe{args}` constructs exactly as
+    # `InitProbe probe(args)` does, and matching only the paren let a stage
+    # build a forbidden type unchallenged.
+    #
+    # `symbol` comes from the derived set -- names parsed out of this repo's
+    # own sources -- not from anything a caller supplies, and it is escaped
+    # regardless. The surrounding parts are fixed literals.
     return re.compile(
-        r"\b" + re.escape(symbol) + r"(?:\s+|" + gap + r")" + declarator + r"\(",
+        r"\b" + re.escape(symbol) + r"(?:\s+|" + gap + r")" + declarator + r"[({]",
         re.S,
     )
 

--- a/ci/tests/test_no_iterative_solver_per_pixel.py
+++ b/ci/tests/test_no_iterative_solver_per_pixel.py
@@ -120,13 +120,21 @@ _TRAILER = r"(?:\s|const|noexcept|FL_NO_EXCEPT|override|final|mutable|volatile)*
 # matches and runs to a distant brace, swallowing the real definition that
 # follows. Measured: the closure collapsed from 21 names to 5 and lost
 # `project_to_hull` itself.
-_INIT_ENTRY = r"[A-Za-z_]\w*\s*\([^;{}()]*\)"
+# One level of nesting inside an entry, because the interesting case is
+# exactly `: ok(solve_wx_overdrive(o))` -- a solver reached from an
+# initialiser and never mentioned in the body. Without the nesting the entry
+# does not match, the whole definition does not match, and the constructor
+# contributes no edges at all; a mutation covers this.
+_INIT_ARG = r"[^;{}()]*(?:\([^;{}()]*\)[^;{}()]*)*"
+_INIT_ENTRY = r"[A-Za-z_]\w*\s*\(" + _INIT_ARG + r"\)"
 _CTOR_INIT = r"(?::\s*" + _INIT_ENTRY + r"(?:\s*,\s*" + _INIT_ENTRY + r")*\s*)?"
 
 DEFINITION = re.compile(
     r"\b(?P<name>[A-Za-z_]\w*)\s*\((?P<args>[^;{}()]*)\)"
     + _TRAILER
+    + r"(?P<init>"
     + _CTOR_INIT
+    + r")"
     + r"\{"
 )
 CALLED_NAME = re.compile(r"\b([A-Za-z_]\w*)\s*\(")
@@ -227,8 +235,12 @@ def call_edges() -> "dict[str, set[str]]":
                 continue
             open_index = text.index("{", match.end() - 1)
             body = text[open_index : _end_of_block(text, open_index)]
+            # The initialiser list counts as part of the constructor: a call
+            # in `Foo(x) : mResult(solve_rgbcct(...)) {}` runs every time the
+            # object is built, and scanning only from the brace would miss it.
+            initialiser = match.group("init") or ""
             called = edges.setdefault(name, set())
-            for candidate in CALLED_NAME.findall(body):
+            for candidate in CALLED_NAME.findall(initialiser + body):
                 if candidate not in NOT_FUNCTIONS:
                     called.add(candidate)
     return edges
@@ -270,7 +282,15 @@ def call_pattern(symbol: str) -> re.Pattern[str]:
     """
 
     gap = r"(?:\s|/\*.*?\*/|//[^\n]*\n)*"
-    return re.compile(r"\b" + re.escape(symbol) + gap + r"\(", re.S)
+    # `Name(` covers a call and a temporary. The optional identifier covers a
+    # variable declaration, `InitProbe probe(args)`, which is how a
+    # constructor is usually reached and which `Name(` alone does not match --
+    # found by a mutation that the first version of this guard let through.
+    declarator = r"(?:[A-Za-z_]\w*" + gap + r")?"
+    return re.compile(
+        r"\b" + re.escape(symbol) + r"(?:\s+|" + gap + r")" + declarator + r"\(",
+        re.S,
+    )
 
 
 class TestNoIterativeSolverPerPixel(unittest.TestCase):


### PR DESCRIPTION
P7 (#4041) names a structural test enforcing that iterative solves never run per pixel (A3/B11). It existed, and it could be walked straight past.

## The hole

The guard forbade three names: `nnls3`, `solve_rgb_colorimetric`, `build_rgb_colorimetric_cache`.

But `nnls3` is private — `static bool project_to_hull` (`rgbw_colorimetric.cpp.hpp:183`) is its only caller. The way a stage actually reaches a 500-iteration projected-gradient solve is through the **public** wrappers over that call, all declared in `rgbw_colorimetric.h`:

| wrapper | declared | reaches |
|---|---|---|
| `solve_strict_subgamut_xy` | `rgbw_colorimetric.h:245` | → `project_to_hull` → `nnls3` |
| `solve_wx_overdrive` | `rgbw_colorimetric.h:272` | → `solve_strict_subgamut_xy` → … |
| `solve_rgbcct` | `rgbw_colorimetric.h:300` | → `solve_strict_subgamut_xy` → … |

None of the three was on the list.

## Demonstrated, not argued

Injecting `solve_rgbcct(...)` into `gamut_map.cpp.hpp` — the stage A3 is actually about, and the one #4335 already had to add to this guard's *file* list:

```
=== OLD guard (HEAD), against the mutation ===
2 passed, 32 subtests passed          <- reports success

=== NEW guard, same mutation ===
SUBFAILED(stage='gamut_map.cpp.hpp', symbol='solve_rgbcct')
SUBFAILED(stage='gamut_map.cpp.hpp', symbol='mutation_probe')
2 failed, 4 passed, 189 subtests passed
```

It catches the wrapper the probe itself introduced, too — the set is self-extending.

## The fix

Stop listing the forbidden set; derive it. The three primitives become seeds, and the check forbids every function that can reach one of them, computed by walking call edges across `src/fl/gfx` to a fixpoint. Wrapping a solver in a new name now joins the forbidden set instead of escaping it.

Currently 21 names, and **none appears in the eight per-pixel stages — no production code changes here.**

## Keeping a self-derived guard honest

A guard that computes its own criterion can fail open, so two things are asserted:

- the call graph parses **≥ 300** definitions (measured 455). A parser that matched nothing would forbid nothing and pass everything.
- the four wrappers above are asserted **present in the derived set**, so the derivation cannot quietly stop finding the exact hole this closes.

The regex needs a keyword blacklist to be usable: without it `if (...) { ... }` parses as a function named `if`, every branch becomes a call edge, and the fixpoint swallows the namespace — measured **230** names including `blur1d` and `fill_solid` before that list existed.

`PER_PIXEL_STAGES` is unchanged, so `test_per_pixel_stage_lists_agree.py` still holds.

## Verification

- `uv run pytest ci/tests` — **1501 passed, 41 skipped, 2968 subtests**.
- `bash lint` clean.
- Mutation evidence above.

This is #4335's lesson one level down: that issue was *"the guard's list of files was itself a thing nothing checked"*; this was its list of symbols — same shape, same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of iterative solver usage in per-pixel processing, including calls made through constructors, member or base initialization, and nested arguments.
  * Expanded validation to recognize both parenthesized and braced construction patterns.
  * Strengthened safeguards against computationally intensive iterative operations being used during per-pixel processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->