### PR TITLE
ci(color): actually run P9's TINY symbol check, and fail if it cannot (#4043)

### DIFF
--- a/.github/workflows/build_template_binary_size.yml
+++ b/.github/workflows/build_template_binary_size.yml
@@ -51,6 +51,21 @@ jobs:
       - name: Check Compiled Program Size for ${{ inputs.board }}
         run: uv run ci/ci-check-compiled-size.py ${{ inputs.board }} --max-size ${{ inputs.max_size }} --example Blink ${{ inputs.extra_args }}
 
+      # P9 (FastLED#4043) asks for the TINY tier's link-time property to be
+      # verified by symbol inspection. The test existed and skipped everywhere,
+      # because nothing built an ATtiny85 before it ran -- this job just did.
+      # FL_REQUIRE_TINY_ELF makes a missing build fail instead of skip, so the
+      # check cannot quietly go back to asserting nothing.
+      #
+      # Only the unmodified build: the sibling job compiles with
+      # FASTLED_NO_FORCE_INLINE, whose link-time symbol set is a separate
+      # question this does not claim to answer.
+      - name: TINY tier links no float and no solver (FastLED#4043)
+        if: inputs.board == 'attiny85' && inputs.extra_args == ''
+        env:
+          FL_REQUIRE_TINY_ELF: '1'
+        run: uv run python -m pytest ci/tests/test_tiny_links_no_float.py -v
+
       - name: Inspect Binary
         if: always()
         continue-on-error: true

--- a/ci/tests/test_tiny_links_no_float.py
+++ b/ci/tests/test_tiny_links_no_float.py
@@ -20,10 +20,20 @@ every pull request. Run
     bash compile attiny85 --examples Blink
 
 and this checks what it produced.
+
+Skipping is the right default and was, on its own, the whole problem: nothing
+built an ATtiny85 before this ran, so it skipped everywhere, every time, and
+P9's link-time half was asserted by a test that never executed a single
+assertion. `check_attiny85.yml` now runs it in the job that has just built
+the ELF, with `FL_REQUIRE_TINY_ELF=1` set -- which turns a missing build from
+a skip into a failure. Without that, wiring it up would be worth nothing: the
+first thing to move the ELF would return this file to passing vacuously, and
+nothing would say so.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import unittest
@@ -32,16 +42,34 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-ELF = (
-    PROJECT_ROOT
-    / ".build"
-    / "pio"
-    / "attiny85"
-    / ".fbuild"
-    / "build"
-    / "release"
-    / "firmware.elf"
+
+# Where an attiny85 build lands. Both roots and a recursive glob, rather than
+# one hardcoded path, because `ci/compiled_size.py` documents two fbuild
+# layouts -- `<build_dir>/.fbuild/build/release/firmware.elf` and
+# `<build_dir>/.fbuild/build/<env>/release/firmware.elf` -- and falls back
+# between two build roots. Pinning one of those spellings meant this file
+# silently found nothing whenever the other was produced.
+kBuildRoots = (
+    PROJECT_ROOT / ".build" / "pio" / "attiny85",
+    PROJECT_ROOT / ".build" / "attiny85",
 )
+
+
+def _find_elf() -> "Path | None":
+    """Newest attiny85 firmware ELF under either build root, or None."""
+
+    newest: Path | None = None
+    for root in kBuildRoots:
+        for candidate in root.glob(".fbuild/build/**/firmware.elf"):
+            if not candidate.is_file():
+                continue
+            # Newest wins, matching the rule `ci/bloat.py` settled on in
+            # FastLED#4386: two layouts can coexist under one board directory
+            # and a fixed preference reports on whichever is stale.
+            if newest is None or candidate.stat().st_mtime > newest.stat().st_mtime:
+                newest = candidate
+    return newest
+
 
 # avr-gcc's soft-float helpers. An ATtiny has no FPU, so any float arithmetic
 # that survives to link time arrives as a call to one of these -- which is what
@@ -87,23 +115,54 @@ def _avr_nm() -> str | None:
     return None
 
 
+# Set by the CI job that has just built the ELF. A skip there means the build
+# it was supposed to inspect is not where it expects, which is a failure of
+# that job, not a reason to report success.
+kRequireElfEnvVar = "FL_REQUIRE_TINY_ELF"
+
+
+def _elf_is_required() -> bool:
+    """Whether a missing build must fail rather than skip."""
+
+    return os.environ.get(kRequireElfEnvVar, "") not in ("", "0")
+
+
 class TestTinyLinksNoFloat(unittest.TestCase):
     def setUp(self: "TestTinyLinksNoFloat") -> None:
-        if not ELF.is_file():
+        required = _elf_is_required()
+        elf = _find_elf()
+        if elf is None:
+            searched = ", ".join(
+                str(root.relative_to(PROJECT_ROOT)) for root in kBuildRoots
+            )
+            if required:
+                self.fail(
+                    f"{kRequireElfEnvVar} is set, so this must inspect a real "
+                    f"build, but no firmware.elf was found under {searched}. "
+                    "Either the attiny85 build did not run before this step or "
+                    "it wrote somewhere else; skipping here would report P9's "
+                    "link-time check as satisfied without having read a single "
+                    "symbol."
+                )
             warnings.warn(
-                "Skipping TestTinyLinksNoFloat because "
-                f"{ELF.relative_to(PROJECT_ROOT)} does not exist. "
+                "Skipping TestTinyLinksNoFloat because no attiny85 "
+                f"firmware.elf was found under {searched}. "
                 "Run 'bash compile attiny85 --examples Blink' to generate it."
             )
             self.skipTest("attiny85 build missing")
         nm = _avr_nm()
         if nm is None:
+            if required:
+                self.fail(
+                    f"{kRequireElfEnvVar} is set but avr-nm was not found; the "
+                    "toolchain that produced the ELF should provide it."
+                )
             self.skipTest("avr-nm not found; build attiny85 to fetch the toolchain")
         # `subprocess.run` and not `RunningProcess.run`: the latter merges
         # stderr into stdout, and a symbol table is not something to parse out
         # of a merged stream.
         completed = subprocess.run(  # noqa: SRC001
-            [nm, str(ELF)],
+            [nm, str(elf)],
             capture_output=True,
             text=True,
             encoding="utf-8",


### PR DESCRIPTION
P9 (#4043) asks for the TINY tier's link-time property — no float helpers, no solver symbols — to be verified by **symbol-level inspection**. The test for it has existed since #4390 and **has never executed a single assertion.**

## Why it never ran

It reads an ATtiny85 ELF and skips when the build is absent, following `test_elf.py`. Nothing ever built an ATtiny85 before it ran:

- `pytest ci/tests` collects it in a job with no AVR build → skips
- neither `build_attiny85.yml` nor `check_attiny85.yml` invokes it — `grep` for `tiny_links` across `.github/` and `ci/` returns nothing but the file itself

A deliverable asserted by a test that always skips is not asserted.

## The fix

`check_attiny85.yml` already builds attiny85 Blink to check its size, so the ELF is right there. The test now runs in that job, immediately after the Blink build and before the Apa102 one.

**`FL_REQUIRE_TINY_ELF=1` is as much the point as the wiring.** Without it, the first thing to move the ELF would return this file to passing vacuously and nothing would say so — the exact failure being fixed, reintroduced. With it set, a missing build **fails** and names the roots it searched.

Scope is tight: guarded on `board == 'attiny85' && extra_args == ''`. The sibling job compiles with `FASTLED_NO_FORCE_INLINE`, whose link-time symbol set is a separate question this does not claim to answer. The other ten boards using the template are untouched.

## The hardcoded path went too

`ci/compiled_size.py` documents **two** fbuild layouts and **two** build roots. The test pinned one spelling of one of them:

```
.build/pio/attiny85/.fbuild/build/release/firmware.elf
```

so the other layout produced a silent skip. It now globs both roots for `.fbuild/build/**/firmware.elf` and takes the newest match — the rule `ci/bloat.py` settled on in #4386, for the same reason.

## Verification

All four states, locally:

| state | result |
|---|---|
| ELF present, variable unset | 3 passed |
| ELF present, variable set | 3 passed |
| ELF absent, variable set | **3 failed** |
| ELF absent, variable unset | 3 skipped |

Plus: with the ELF moved to the alternate `<env>/release` layout it is still found — where the old hardcoded path found nothing.

`bash lint` clean. `uv run pytest ci/tests` — 1502 passed, 41 skipped, 3215 subtests.

## Known limit, stated rather than implied

Both attiny85 workflows trigger on **push to master, not on pull_request**. So this catches a regression one merge after it lands rather than blocking it. Making it a PR gate means paying for an AVR build on every PR — a cost decision for the maintainer, not something to slip in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation for unmodified ATtiny85 builds by checking the latest generated ELF output across supported build layouts.
  - CI now treats missing ELF artifacts or required tooling as failures, while preserving skip behavior for local runs.
  - Added coverage to ensure TINY-tier builds continue to meet link-symbol requirements.

- **Documentation**
  - Clarified how the test runs in CI and which build workflow is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->