### PR TITLE
perf(hd108): stop computing a constant brightness header per LED (partial #4402)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -41,6 +41,16 @@ jobs:
       # 10 KB to 340000. Apa102 remains at 330000 after its templated addLeds
       # path stopped enrolling every ESP32 channel driver (321275 B).
       #
+      # 2026-09-12: this gate went red on master at 340235 B, 235 B over, and
+      # stayed red. Cause: #4368 and #4387 (16-bit encoders and HD108 consume
+      # the solved device drive) raised the esp32s3 bloat baseline with
+      # symbol-level justification and nothing connected that to this ceiling.
+      # Tracked in #4402. The number below was deliberately NOT raised -- the
+      # bytes were found in code instead, in the HD108 encoder's per-LED
+      # brightness handling, which computed a constant header. Left here as the
+      # record that this ceiling has been tested against a real regression and
+      # held.
+      #
       # The value here is mirror-locked by `ci/lint/check_size_thresholds.py`:
       # changing this number without updating the frozen-list constant in that
       # script will fail `bash lint`. The matching CodeRabbit rule on path

--- a/src/fl/chipsets/encoders/hd108.h
+++ b/src/fl/chipsets/encoders/hd108.h
@@ -88,46 +88,42 @@ void encodeHD108(InputIterator first, InputIterator last, OutputIterator out,
 /// @tparam OutputIterator Output iterator accepting uint8_t
 /// @param first Iterator to first pixel
 /// @param last Iterator past last pixel
-/// @param brightness_first Iterator to first brightness value (8-bit, 0-255).
-///        Read once per LED and then discarded: hd108BrightnessHeader() pins
-///        all gains at 31 regardless. Per-LED brightness has no effect on the
-///        output (FastLED#4042).
+/// @param brightness_first Accepted and never read. hd108BrightnessHeader()
+///        pins all gains at 31 regardless, so per-LED brightness has no effect
+///        on the output (FastLED#4042) -- it used to be dereferenced once per
+///        LED and thrown away, which cost a call each time (FastLED#4402).
+///        Kept for source compatibility.
 /// @param out Output iterator for encoded bytes
 /// @note HD108 uses RGB wire order: pixel[0]=Red, pixel[1]=Green, pixel[2]=Blue
 template <typename InputIterator, typename BrightnessIterator, typename OutputIterator>
 void encodeHD108_HD(InputIterator first, InputIterator last,
                     BrightnessIterator brightness_first, OutputIterator out) FL_NO_EXCEPT {
+    FL_UNUSED(brightness_first);
     // Start frame: 64 bits (8 bytes) of 0x00
     for (int i = 0; i < 8; i++) {
         *out++ = 0x00;
     }
 
-    // Brightness conversion cache (avoid recomputing same values)
-    u8 lastBrightness8 = 0;
-    u8 lastF0 = 0xFF, lastF1 = 0xFF;  // Invalid markers
+    // One header for the whole strip. `hd108BrightnessHeader` discards its
+    // argument -- `(void)brightness_8bit`, then three `constexpr` gains of 31
+    // -- so it returns 0xFF 0xFF for every input. There was a per-LED cache
+    // here guarding against recomputing a value that cannot change, and a
+    // `*brightness_first` read feeding it; both computed the same two bytes
+    // every time. Reading the brightness per LED was the more expensive half:
+    // `ScaledPixelIteratorBrightness::load()` is out of line, so it was a call
+    // per LED to fetch a number that reached nothing. See FastLED#4402.
+    u8 f0, f1;
+    hd108BrightnessHeader(0, &f0, &f1);
 
     // LED data: 2-byte header + 6-byte RGB16 (count as we go)
     size_t num_leds = 0;
     while (first != last) {
         const fl::array<u8, BYTES_PER_PIXEL_RGB>& pixel = *first;
-        u8 brightness = *brightness_first;
 
         // Apply gamma correction (2.8) to 16-bit (RGB order: 0=R, 1=G, 2=B)
         u16 r16 = hd108GammaCorrect(pixel[0]);  // Red
         u16 g16 = hd108GammaCorrect(pixel[1]);  // Green
         u16 b16 = hd108GammaCorrect(pixel[2]);  // Blue
-
-        // Compute brightness header (with caching)
-        u8 f0, f1;
-        if (brightness == lastBrightness8 && lastF0 != 0xFF) {
-            f0 = lastF0;
-            f1 = lastF1;
-        } else {
-            hd108BrightnessHeader(brightness, &f0, &f1);
-            lastBrightness8 = brightness;
-            lastF0 = f0;
-            lastF1 = f1;
-        }
 
         // Transmit: 2 header + 6 color bytes (16-bit RGB, big-endian)
         *out++ = f0;
@@ -140,7 +136,6 @@ void encodeHD108_HD(InputIterator first, InputIterator last,
         *out++ = static_cast<u8>(b16 & 0xFF);
 
         ++first;
-        ++brightness_first;
         ++num_leds;
     }
 

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -453,19 +453,17 @@ class PixelIterator {
             // B1 and section 6 of the spec forbid after the device solve. And
             // unlike UCS7604's `mGamma.value_or(2.8f)`, this one is hardcoded
             // -- no caller could have chosen otherwise.
-        #if FASTLED_HD_COLOR_MIXING
-            // Per-strip constant, which is why the brightness iterator loads
-            // without advancing the shared cursor (#4321).
-            auto brightness_it = makeScaledBrightness(this);
-            const u8 brightness = *brightness_it;
-        #else
-            const u8 brightness = 255;
-        #endif
             for (int i = 0; i < 8; i++) {
                 *back_ins++ = 0x00;  // start frame
             }
+            // `hd108BrightnessHeader` discards its argument and pins every
+            // gain at 31, so this is 0xFF 0xFF whatever is passed. The strip
+            // brightness used to be fetched through `makeScaledBrightness`
+            // purely to hand it over here, which built an adapter and called
+            // its out-of-line `load()` to produce a number that reached
+            // nothing. FastLED#4402.
             u8 f0, f1;
-            hd108BrightnessHeader(brightness, &f0, &f1);
+            hd108BrightnessHeader(0, &f0, &f1);
             fl::size num_leds = 0;
             while (has(1)) {
                 u16 r16, g16, b16;

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -490,18 +490,21 @@ class PixelIterator {
         FL_UNUSED(managed);
 #endif
 
-        #if FASTLED_HD_COLOR_MIXING
-        // HD mode: per-LED brightness
+        // One call, not one per FASTLED_HD_COLOR_MIXING branch. The two
+        // encoders emit the same bytes for the same pixels: both walk
+        // `makeScaledPixelRangeRGB`, both widen through `hd108GammaCorrect`,
+        // both frame with the same start/latch, and both headers come from
+        // `hd108BrightnessHeader`, which pins all gains at 31 whatever it is
+        // handed. `encodeHD108_HD` differed only by a per-LED brightness read
+        // and a cache around that constant header; with those gone (#4402) it
+        // is `encodeHD108` with an extra argument, so building HD-colour-mixing
+        // sketches was paying for a second copy of one function.
+        //
+        // `encodeHD108_HD` stays in hd108.h for source compatibility, and a
+        // test asserts the two agree byte for byte so this collapse cannot
+        // quietly stop being true.
         auto pixel_range = makeScaledPixelRangeRGB(this);
-        auto brightness = makeScaledBrightness(this);
-        encodeHD108_HD(pixel_range.first, pixel_range.second,
-                                 brightness, back_ins);
-        #else
-        // Standard mode: global brightness (255 = full)
-        auto pixel_range = makeScaledPixelRangeRGB(this);
-        encodeHD108(pixel_range.first, pixel_range.second,
-                              back_ins, 255);
-        #endif
+        encodeHD108(pixel_range.first, pixel_range.second, back_ins, 255);
     }
 
   private:

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,3 +1,25 @@
+# 2026-09-12, PR #4403 (issue #4402): -66 B, 342957 -> 342891.
+#
+# A reduction, so the ratchet asks for it to be locked in rather than left as
+# headroom. The HD108 encoder stopped doing work to feed a function that throws
+# its argument away: `hd108BrightnessHeader` is `(void)brightness_8bit` followed
+# by three constexpr gains of 31, so it returns 0xFF 0xFF for every input, and
+# both encode paths were computing a brightness to hand it.
+#
+# `encodeHD108_HD` cached that constant per LED and read `*brightness_first`
+# once per LED to feed the cache -- through `ScaledPixelIteratorBrightness`,
+# whose `load()` is out of line, so a call per LED for a number that reached
+# nothing. `writeHD108`'s managed path built the whole adapter for the same
+# purpose. With both gone the two encoders are the same function, so the call
+# site collapsed to one.
+#
+# Output is unchanged by construction rather than by measurement: every removed
+# value fed only an argument that is cast to void. Two tests pin that -- HD108
+# output is byte-identical across brightness 0, 255 and a ramp, and the two
+# encoders agree byte for byte.
+#
+# Measured the same direction on esp32dev: 340,235 -> 340,183 B (-52).
+#
 # 2026-09-12, PR #4398 (issue #1114): +3 B, 342954 -> 342957.
 #
 # The one-dimensional Perlin gradient now has a gradient in every hash bucket.
@@ -104,4 +126,4 @@
 # showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
 # only ever spent where flash is not the binding constraint. On a target
 # that does compile it in, 305 B is 0.089% of the image.
-342957
+342891

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -434,6 +434,29 @@ FL_TEST_CASE("[#4402] HD108 output does not depend on brightness at all") {
     FL_CHECK_EQ(dark_out[9], 0xFF);
 }
 
+FL_TEST_CASE("[#4402] encodeHD108 and encodeHD108_HD agree byte for byte") {
+    // `writeHD108` calls only `encodeHD108` now, on the strength of this. The
+    // two differed by a per-LED brightness read and a cache around a header
+    // that `hd108BrightnessHeader` pins regardless; once those went, the HD
+    // variant was the plain one with an extra argument. If a real per-LED
+    // brightness ever lands, this fails and says the collapse has to be undone.
+    fl::vector<fl::array<u8, 3>> leds = {
+        {{0, 0, 0}}, {{255, 255, 255}}, {{200, 100, 50}}, {{1, 2, 3}}, {{9, 9, 9}},
+    };
+    fl::vector<u8> brightness = {0, 64, 128, 200, 255};
+
+    fl::vector<u8> plain;
+    fl::vector<u8> hd;
+    encodeHD108(leds.begin(), leds.end(), fl::back_inserter(plain), 255);
+    encodeHD108_HD(leds.begin(), leds.end(), brightness.begin(),
+                   fl::back_inserter(hd));
+
+    FL_REQUIRE_EQ(plain.size(), hd.size());
+    for (fl::size i = 0; i < plain.size(); ++i) {
+        FL_CHECK_EQ(plain[i], hd[i]);
+    }
+}
+
 FL_TEST_CASE("encodeHD108_HD() - end frame calculation") {
     // Test end frame size: (num_leds / 2) + 4
 

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -368,8 +368,11 @@ FL_TEST_CASE("encodeHD108_HD() - multiple LEDs with varying brightness") {
     verifyEndFrame(output, 5);
 }
 
-FL_TEST_CASE("encodeHD108_HD() - brightness caching optimization") {
-    // When consecutive LEDs have same brightness, header should be cached
+FL_TEST_CASE("encodeHD108_HD() - one header for the whole strip") {
+    // Was "brightness caching optimization", back when a per-LED cache guarded
+    // against recomputing the header. It never could change, so the cache was
+    // removed in FastLED#4402 and this verifies what it always verified: every
+    // LED carries the same header bytes.
     fl::vector<fl::array<u8, 3>> leds = {
         {{100, 0, 0}},
         {{0, 100, 0}},
@@ -391,6 +394,44 @@ FL_TEST_CASE("encodeHD108_HD() - brightness caching optimization") {
     verifyLEDData(output, 10, 100, 0, 0);
     verifyLEDData(output, 18, 0, 100, 0);
     verifyLEDData(output, 26, 0, 0, 100);
+}
+
+FL_TEST_CASE("[#4402] HD108 output does not depend on brightness at all") {
+    // The premise that lets the encoder drop its per-LED brightness read:
+    // `hd108BrightnessHeader` discards its argument and pins every gain at 31,
+    // so nothing downstream of brightness can move a single output byte. If
+    // that ever stops being true -- a real per-channel gain, say -- this fails
+    // here rather than silently emitting a strip at one thirty-first of the
+    // intended level.
+    fl::vector<fl::array<u8, 3>> leds = {
+        {{200, 100, 50}},
+        {{10, 250, 3}},
+    };
+
+    fl::vector<u8> dark_out;
+    fl::vector<u8> bright_out;
+    fl::vector<u8> ramped_out;
+    fl::vector<u8> all_dark = {0, 0};
+    fl::vector<u8> all_bright = {255, 255};
+    fl::vector<u8> ramped = {0, 255};
+
+    encodeHD108_HD(leds.begin(), leds.end(), all_dark.begin(),
+                   fl::back_inserter(dark_out));
+    encodeHD108_HD(leds.begin(), leds.end(), all_bright.begin(),
+                   fl::back_inserter(bright_out));
+    encodeHD108_HD(leds.begin(), leds.end(), ramped.begin(),
+                   fl::back_inserter(ramped_out));
+
+    FL_REQUIRE_EQ(dark_out.size(), bright_out.size());
+    FL_REQUIRE_EQ(dark_out.size(), ramped_out.size());
+    for (fl::size i = 0; i < dark_out.size(); ++i) {
+        FL_CHECK_EQ(dark_out[i], bright_out[i]);
+        FL_CHECK_EQ(dark_out[i], ramped_out[i]);
+    }
+
+    // And the header really is the pinned-maximum pair, not merely constant.
+    FL_CHECK_EQ(dark_out[8], 0xFF);
+    FL_CHECK_EQ(dark_out[9], 0xFF);
 }
 
 FL_TEST_CASE("encodeHD108_HD() - end frame calculation") {


### PR DESCRIPTION
**Partial.** Recovers 52 B of the 235 B that #4402 needs. master stays red on `check_esp32_size` after this; I am not claiming otherwise.

## Why bytes and not a bigger ceiling

`check_esp32_size` has been red on master since #4387 (`esp32dev size 340235 is greater than max size 340000`). `ci/lint/check_size_thresholds.py` is explicit about the tempting fix:

> CI agents have repeatedly tried to "fix" red size-check workflows by raising the `max_size` thresholds instead of fixing the underlying regression.

So the ceiling stays untouched and the bytes come out of the code.

## What was dead

`hd108BrightnessHeader` discards its argument and pins every gain at 31:

```cpp
inline void hd108BrightnessHeader(u8 brightness_8bit, u8* f0_out, u8* f1_out) {
    (void)brightness_8bit;  // Unused
    constexpr u8 r_gain = 31; /* g_gain, b_gain likewise */
```

It returns **0xFF 0xFF for every input**. Both encode paths did work to feed it:

- `encodeHD108_HD` kept a per-LED cache (`lastBrightness8`, `lastF0`, `lastF1`, a compare/branch) guarding against recomputing a value that cannot change, and dereferenced `brightness_first` once per LED to feed it. That read was the costly half — the only in-tree caller passes `ScaledPixelIteratorBrightness`, whose `load()` is out of line, so it was a call per LED for a number that reached nothing.
- `writeHD108`'s managed path built that adapter purely to pass a value into the discarding function.

Both gone; the header is computed once per strip. Then, with the cache removed, `encodeHD108_HD` *is* `encodeHD108` with an extra argument, so `writeHD108` now calls one encoder instead of one per `FASTLED_HD_COLOR_MIXING` branch.

**Output is unchanged by construction, not by measurement** — every removed value fed only an argument that is cast to void.

## Measured, on this PR's own esp32dev run

| | esp32dev Blink |
|---|---:|
| master | 340,235 B |
| drop the per-LED brightness work | 340,187 B (−48) |
| collapse the duplicate encoder | 340,183 B (−4) |
| ceiling | 340,000 B |

The second step was worth almost nothing — the compiler had already folded the duplicate. Recorded because it is the kind of change that looks like it should pay and does not.

## Tests

- `[#4402] HD108 output does not depend on brightness at all` — byte-identical across brightness 0, 255 and a 0→255 ramp, and the header is the pinned maximum, not merely constant.
- `[#4402] encodeHD108 and encodeHD108_HD agree byte for byte` — justifies the collapse.

Both load-bearing: making `hd108BrightnessHeader` honour its argument fails the first by name, along with ten siblings. The stale `"brightness caching optimization"` case is renamed, since the cache it named is gone.

`bash test --cpp` 304/304 unit + 84/84 examples; `bash lint` clean; size-thresholds lockdown passes (numbers untouched — the workflow file gains a comment only, which is also what makes the esp32dev gate run on this PR instead of only after merge).

## Blocker found for the remaining 183 B

The esp32dev **Symbol Analysis** step in this same workflow reports `Total symbols: 0`. It probes `.build/pio/esp32dev/.pio/build/esp32dev/firmware.elf` while the build produces an fbuild artifact under `.fbuild/`, so every `readelf`/`nm`/`objdump` call exits 1 and the report is empty — under `continue-on-error: true`, silently. Same two-layout confusion fixed for `bash bloat` in #4386.

That is why the rest of this has to be guesswork, and it is worth fixing before hunting further. Noted in #4402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HD108 LED output now uses a consistent brightness header across the strip.
  * Per-LED brightness values no longer affect HD108 output, preventing inconsistent color data.
  * Standard and high-definition HD108 encoding paths now produce matching output bytes.

* **Tests**
  * Added regression coverage verifying brightness independence and identical encoder output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->