### PR TITLE
fix(ci): point the binary-size diagnostics at the ELF the build wrote (#4402)

### DIFF
--- a/ci/ci-check-compiled-size.py
+++ b/ci/ci-check-compiled-size.py
@@ -99,6 +99,14 @@ def main():
         ],
         capture_output=True,
     )
+    # Echo it. `ci.compiled_size` reports which ELF it measured -- "measured
+    # fbuild ELF: <path>" or "no fbuild ELF found ...; falling through to pio
+    # size" -- and capturing without printing threw that away, so the log
+    # recorded a number with no way to tell which backend's binary produced it.
+    # Both write under `.build/pio/<board>/`, so the path is the only thing
+    # that distinguishes them (FastLED#4402).
+    if output:
+        print(output)
     size_match = re.search(r": *(\d+)", output)  # type: ignore
 
     if not size_match:

--- a/ci/compiled_size.py
+++ b/ci/compiled_size.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from ci.util.firmware_elf import find_fbuild_elf
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.pio_runner import run_pio_command
 
@@ -193,51 +194,6 @@ def _find_size_tool(board_info: dict[str, Any]) -> Path | None:
     return None
 
 
-def _find_fbuild_elf(board_info: dict[str, Any], build_dir: Path) -> Path | None:
-    """Locate the ELF that fbuild produced for this build, if any.
-
-    Checks (in order):
-      1. `prog_path` from `build_info.json` if it lives under a `.fbuild/`
-         directory — covers builds where `_override_prog_path_for_fbuild`
-         already rewrote the metadata (or where fbuild emitted the
-         metadata itself).
-      2. A recursive glob under `<build_dir>/.fbuild/build/**/firmware.elf`
-         covering both fbuild layouts:
-           - `<build_dir>/.fbuild/build/release/firmware.elf` (used by
-             `bash compile <arm-board>` on the standalone driver path)
-           - `<build_dir>/.fbuild/build/<env>/release/firmware.elf` (used
-             by `PioCompiler._build_fbuild_sync` on the PIO-wrapper path
-             that handles ESP32 boards) — see `ci/compiler/pio.py`
-             `_artifacts_dir`.
-
-    Returns the resolved ELF path, or None if no fbuild artifact is present
-    (i.e. the build was driven by PlatformIO and the old `_run_pio_size`
-    path should win).
-    """
-    prog_path_raw = board_info.get("prog_path")
-    if isinstance(prog_path_raw, str) and prog_path_raw:
-        prog_path = Path(prog_path_raw)
-        if ".fbuild" in prog_path.parts:
-            # prog_path may end in .bin (what fbuild emits as `prog_path`)
-            # or .elf (what `_override_prog_path_for_fbuild` writes). The
-            # size tool only takes ELF, so normalise to .elf.
-            elf_candidate = prog_path.with_suffix(".elf")
-            if elf_candidate.exists():
-                return elf_candidate
-
-    fbuild_root = build_dir / ".fbuild" / "build"
-    if not fbuild_root.is_dir():
-        return None
-
-    # Glob both `release/firmware.elf` and `<env>/release/firmware.elf` plus
-    # their `debug/` siblings. Picking the newest mtime handles the case
-    # where a `--release` build was followed by `--quick`.
-    candidates: list[Path] = list(fbuild_root.glob("**/firmware.elf"))
-    if not candidates:
-        return None
-    return max(candidates, key=lambda p: p.stat().st_mtime)
-
-
 def check_firmware_size(board: str, example: str | None = None) -> int:
     build_info_json = _find_build_info(board, example)
     board_info = _create_board_info(build_info_json)
@@ -251,7 +207,7 @@ def check_firmware_size(board: str, example: str | None = None) -> int:
     # (e.g. `-Wl,--gc-sections`, `.eh_frame` stripping) and (b) report the
     # PIO binary which is ~169 KB larger on esp32dev. Without this branch
     # the CI size-check measures the wrong build.
-    fbuild_elf = _find_fbuild_elf(board_info, build_dir)
+    fbuild_elf = find_fbuild_elf(board_info, build_dir)
     size_tool = _find_size_tool(board_info)
     if fbuild_elf is not None and size_tool is not None:
         size = _run_size_on_elf(size_tool, fbuild_elf)

--- a/ci/inspect_binary.py
+++ b/ci/inspect_binary.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ci.util.bin_2_elf import bin_to_elf
 from ci.util.elf import dump_symbol_sizes
+from ci.util.firmware_elf import resolve_firmware_elf
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 from ci.util.map_dump import map_dump
 from ci.util.symbol_analysis import SymbolInfo, analyze_symbols
@@ -224,13 +225,18 @@ def main() -> int:
     board = board_dir.name
     board_info = build_info.get(board) or build_info[next(iter(build_info))]
 
-    # Validate paths from build_info.json
-    elf_path = Path(board_info.get("prog_path", ""))
-    if not elf_path.exists():
+    # Resolve via the shared helper, not `prog_path` alone: on an fbuild board
+    # `prog_path` names a PlatformIO location that was never written, and every
+    # tool below then fails one at a time against it (FastLED#4402).
+    resolved_elf = resolve_firmware_elf(board_info, board_dir)
+    if resolved_elf is None:
         print(
-            f"Error: ELF path '{elf_path}' does not exist. Check the 'prog_path' in build_info.json."
+            f"Error: no firmware ELF found for '{board}'. Looked for an fbuild "
+            f"artifact under {board_dir / '.fbuild' / 'build'} and at "
+            f"prog_path '{board_info.get('prog_path', '')}'."
         )
         return 1
+    elf_path = resolved_elf
 
     bin_file = elf_path.with_suffix(".bin")
     if not bin_file.exists():

--- a/ci/inspect_elf.py
+++ b/ci/inspect_elf.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from ci.util.elf import dump_symbol_sizes
+from ci.util.firmware_elf import resolve_firmware_elf
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
@@ -73,7 +74,15 @@ def main() -> int:
     build_info = json.loads(build_info_json.read_text())
     board_info = build_info.get(board) or build_info[next(iter(build_info))]
 
-    firmware_path = Path(board_info["prog_path"])
+    # See ci/util/firmware_elf.py: `prog_path` is not where fbuild writes.
+    firmware_path = resolve_firmware_elf(board_info, board_dir)
+    if firmware_path is None:
+        print(
+            f"Error: no firmware ELF found for {board}. Looked for an fbuild "
+            f"artifact under {board_dir / '.fbuild' / 'build'} and at "
+            f"prog_path '{board_info.get('prog_path', '')}'."
+        )
+        return 1
     cpp_filt_path = Path(board_info["aliases"]["c++filt"])
 
     print(f"Dumping symbol sizes for {board} firmware: {firmware_path}")

--- a/ci/tests/test_compiled_size_fbuild.py
+++ b/ci/tests/test_compiled_size_fbuild.py
@@ -15,10 +15,10 @@ from typing import Any
 import pytest
 
 from ci.compiled_size import (
-    _find_fbuild_elf,
     _find_size_tool,
     _parse_size_tool_text,
 )
+from ci.util.firmware_elf import find_fbuild_elf as _find_fbuild_elf
 
 
 def test_parse_size_tool_text_berkeley_format() -> None:

--- a/ci/tests/test_firmware_elf_resolution.py
+++ b/ci/tests/test_firmware_elf_resolution.py
@@ -1,0 +1,104 @@
+"""`resolve_firmware_elf` picks the ELF a build actually wrote. FastLED#4402.
+
+`find_fbuild_elf` is covered by `test_compiled_size_fbuild.py`, which is where
+it used to live. These cover the layer the binary-size diagnostics added on top
+of it: the fallback to `prog_path` for PlatformIO builds, and returning None
+instead of a path that does not exist.
+
+The last one is the whole point. `ci/inspect_binary.py`, `ci/inspect_elf.py`
+and `ci/util/symbol_analysis.py` used to read `prog_path` and hand it to
+`readelf`, `nm` and `objdump` in turn. On an fbuild board that path is never
+written, so each tool failed separately and the symbol report came out empty --
+under `continue-on-error: true`, so the log showed a wall of tool errors and a
+report of `Total symbols: 0` while the actual ELF sat under `.fbuild/`.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ci.util.firmware_elf import find_fbuild_elf, resolve_firmware_elf
+
+
+class TestResolveFirmwareElf(unittest.TestCase):
+    def setUp(self: "TestResolveFirmwareElf") -> None:
+        self._tmp = TemporaryDirectory()
+        self.build_dir = Path(self._tmp.name)
+
+    def tearDown(self: "TestResolveFirmwareElf") -> None:
+        self._tmp.cleanup()
+
+    def _write(self: "TestResolveFirmwareElf", relative: str) -> Path:
+        path = self.build_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x7fELF")
+        return path
+
+    def test_the_fbuild_artifact_wins_over_a_stale_prog_path(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        # The esp32dev case: `prog_path` names a PlatformIO location that the
+        # fbuild build never wrote, and the real ELF is under `.fbuild/`.
+        elf = self._write(".fbuild/build/esp32dev/release/firmware.elf")
+        board_info = {
+            "prog_path": str(
+                self.build_dir / ".pio" / "build" / "esp32dev" / "firmware.elf"
+            )
+        }
+        self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), elf)
+
+    def test_prog_path_is_used_when_there_is_no_fbuild_build(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        # A PlatformIO-driven board must keep working exactly as before.
+        elf = self._write(".pio/build/uno/firmware.elf")
+        board_info = {"prog_path": str(elf)}
+        self.assertIsNone(find_fbuild_elf(board_info, self.build_dir))
+        self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), elf)
+
+    def test_a_bin_prog_path_falls_back_to_its_elf_sibling(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        elf = self._write(".pio/build/uno/firmware.elf")
+        board_info = {"prog_path": str(elf.with_suffix(".bin"))}
+        self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), elf)
+
+    def test_nothing_on_disk_returns_none_rather_than_a_bad_path(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        # Returning the non-existent path is what produced a wall of separate
+        # tool failures and an empty report instead of one clear message.
+        board_info = {
+            "prog_path": str(self.build_dir / ".pio" / "build" / "x" / "firmware.elf")
+        }
+        self.assertIsNone(resolve_firmware_elf(board_info, self.build_dir))
+
+    def test_a_missing_prog_path_key_is_not_an_exception(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        self.assertIsNone(resolve_firmware_elf({}, self.build_dir))
+        elf = self._write(".fbuild/build/release/firmware.elf")
+        self.assertEqual(resolve_firmware_elf({}, self.build_dir), elf)
+
+    def test_the_newest_fbuild_layout_wins(self: "TestResolveFirmwareElf") -> None:
+        import os
+        import time
+
+        old = self._write(".fbuild/build/release/firmware.elf")
+        new = self._write(".fbuild/build/esp32dev/release/firmware.elf")
+        # Explicit mtimes rather than write order: a same-second filesystem
+        # makes write order prove nothing.
+        now = time.time()
+        os.utime(old, (now - 100, now - 100))
+        os.utime(new, (now, now))
+        self.assertEqual(resolve_firmware_elf({}, self.build_dir), new)
+
+        os.utime(old, (now, now))
+        os.utime(new, (now - 100, now - 100))
+        self.assertEqual(resolve_firmware_elf({}, self.build_dir), old)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_firmware_elf_resolution.py
+++ b/ci/tests/test_firmware_elf_resolution.py
@@ -65,6 +65,25 @@ class TestResolveFirmwareElf(unittest.TestCase):
         board_info = {"prog_path": str(elf.with_suffix(".bin"))}
         self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), elf)
 
+    def test_an_existing_bin_does_not_beat_its_existing_elf_sibling(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        # Both on disk. Returning the `.bin` resolves to a real file and is
+        # still wrong: every caller runs readelf/nm/objdump, so it would trade
+        # one silent empty report for another.
+        elf = self._write(".pio/build/uno/firmware.elf")
+        self._write(".pio/build/uno/firmware.bin")
+        board_info = {"prog_path": str(elf.with_suffix(".bin"))}
+        self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), elf)
+
+    def test_a_suffixless_prog_path_is_still_returned_when_it_is_the_binary(
+        self: "TestResolveFirmwareElf",
+    ) -> None:
+        # No `.elf` sibling to prefer; the path itself is all there is.
+        binary = self._write(".pio/build/uno/firmware")
+        board_info = {"prog_path": str(binary)}
+        self.assertEqual(resolve_firmware_elf(board_info, self.build_dir), binary)
+
     def test_nothing_on_disk_returns_none_rather_than_a_bad_path(
         self: "TestResolveFirmwareElf",
     ) -> None:

--- a/ci/util/firmware_elf.py
+++ b/ci/util/firmware_elf.py
@@ -1,0 +1,93 @@
+"""Locate the firmware ELF a build actually produced.
+
+Two build backends write to one board directory and they do not agree on where
+the ELF goes. PlatformIO leaves it at `prog_path` from `build_info.json`
+(`<build_dir>/.pio/build/<env>/firmware.elf`); fbuild writes under
+`<build_dir>/.fbuild/build/...` and leaves `prog_path` pointing at the
+PlatformIO location or at a `.bin`.
+
+`ci/compiled_size.py` learned this and got it right. The binary-size
+diagnostics did not: `ci/inspect_binary.py`, `ci/inspect_elf.py` and
+`ci/util/symbol_analysis.py` each read `board_info["prog_path"]` directly, so
+on an fbuild board every `readelf`/`nm`/`objdump` call ran against a path that
+does not exist and exited 1. The symbol report came out as
+
+    Found 0 total symbols using enhanced analysis
+      Total symbol size: 0 bytes (0.0 KB)
+
+and, because those steps run `continue-on-error: true`, nothing said so. The
+esp32dev size gate has been red since FastLED#4387 with no usable symbol data
+to find the regression with (FastLED#4402). `bash bloat` had the same defect
+and it was fixed for that tool alone in FastLED#4386; this is the shared
+version, so the next tool to need it does not reinvent it a fourth time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def find_fbuild_elf(board_info: dict[str, Any], build_dir: Path) -> Path | None:
+    """Locate the ELF that fbuild produced for this build, if any.
+
+    Checks (in order):
+      1. `prog_path` from `build_info.json` if it lives under a `.fbuild/`
+         directory -- covers builds where the metadata already points there.
+         Normalised to `.elf`: fbuild emits `prog_path` as `.bin`.
+      2. A recursive glob under `<build_dir>/.fbuild/build/**/firmware.elf`,
+         covering both fbuild layouts:
+           - `<build_dir>/.fbuild/build/release/firmware.elf`
+           - `<build_dir>/.fbuild/build/<env>/release/firmware.elf`
+
+    Returns None when no fbuild artifact is present, which is the signal that
+    the build was driven by PlatformIO and `prog_path` is authoritative.
+    """
+
+    prog_path_raw = board_info.get("prog_path")
+    if isinstance(prog_path_raw, str) and prog_path_raw:
+        prog_path = Path(prog_path_raw)
+        if ".fbuild" in prog_path.parts:
+            elf_candidate = prog_path.with_suffix(".elf")
+            if elf_candidate.exists():
+                return elf_candidate
+
+    fbuild_root = build_dir / ".fbuild" / "build"
+    if not fbuild_root.is_dir():
+        return None
+
+    candidates: list[Path] = []
+    for candidate in fbuild_root.glob("**/firmware.elf"):
+        if candidate.is_file():
+            candidates.append(candidate)
+    if not candidates:
+        return None
+    # Newest wins. Two layouts can coexist under one board directory, and a
+    # fixed preference reports on whichever one is stale -- the rule
+    # `ci/bloat.py` settled on in FastLED#4386.
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def resolve_firmware_elf(board_info: dict[str, Any], build_dir: Path) -> Path | None:
+    """The ELF a diagnostic should read, fbuild artifact first.
+
+    Falls back to `prog_path` so PlatformIO-driven builds keep working
+    unchanged, and returns None when neither exists rather than handing back a
+    path that every tool downstream will fail on one at a time.
+    """
+
+    fbuild_elf = find_fbuild_elf(board_info, build_dir)
+    if fbuild_elf is not None:
+        return fbuild_elf
+
+    prog_path_raw = board_info.get("prog_path")
+    if not isinstance(prog_path_raw, str) or not prog_path_raw:
+        return None
+
+    prog_path = Path(prog_path_raw)
+    if prog_path.is_file():
+        return prog_path
+    elf_candidate = prog_path.with_suffix(".elf")
+    if elf_candidate.is_file():
+        return elf_candidate
+    return None

--- a/ci/util/firmware_elf.py
+++ b/ci/util/firmware_elf.py
@@ -84,10 +84,16 @@ def resolve_firmware_elf(board_info: dict[str, Any], build_dir: Path) -> Path | 
     if not isinstance(prog_path_raw, str) or not prog_path_raw:
         return None
 
+    # The `.elf` sibling first when `prog_path` is not already one. Every
+    # caller here runs `readelf`/`nm`/`objdump`, so an existing `.bin` next to
+    # an existing `.elf` is the wrong answer even though the path resolves --
+    # it would swap one silent empty report for another.
     prog_path = Path(prog_path_raw)
-    if prog_path.is_file():
-        return prog_path
-    elf_candidate = prog_path.with_suffix(".elf")
-    if elf_candidate.is_file():
-        return elf_candidate
+    candidates: list[Path] = []
+    if prog_path.suffix != ".elf":
+        candidates.append(prog_path.with_suffix(".elf"))
+    candidates.append(prog_path)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
     return None

--- a/ci/util/symbol_analysis.py
+++ b/ci/util/symbol_analysis.py
@@ -1,3 +1,4 @@
+from ci.util.firmware_elf import resolve_firmware_elf
 from ci.util.global_interrupt_handler import handle_keyboard_interrupt
 
 
@@ -930,7 +931,20 @@ def main():
 
     nm_path = board_info["aliases"]["nm"]
     cppfilt_path = board_info["aliases"]["c++filt"]
-    elf_file = board_info["prog_path"]
+    # `prog_path` names the PlatformIO location, which an fbuild board never
+    # writes. Reading it directly is why this report came out with
+    # `Total symbols: 0` on esp32dev while the build sat under `.fbuild/`
+    # (FastLED#4402); the resolver checks there first.
+    resolved_elf = resolve_firmware_elf(board_info, build_info_path.parent)
+    if resolved_elf is None:
+        print(
+            f"Error: no firmware ELF found for {board_name}. Looked for an "
+            f"fbuild artifact under "
+            f"{build_info_path.parent / '.fbuild' / 'build'} and at prog_path "
+            f"'{board_info.get('prog_path', '')}'."
+        )
+        sys.exit(1)
+    elf_file = str(resolved_elf)
 
     # Get readelf path (derive from nm path if not in aliases)
     if "readelf" in board_info["aliases"]:


### PR DESCRIPTION
The esp32dev symbol report has been coming out empty. Not sparse — empty:

```
Analyzing ELF file: .../.build/pio/esp32dev/.pio/build/esp32dev/firmware.elf
Error running command: ...-readelf -s ...                    Exit code: 1
Error running command: ...-nm --print-size --size-sort ...   Exit code: 1
Error running command: ...-objdump -t ...                    Exit code: 1
Found 0 total symbols using enhanced analysis
  Total symbol size: 0 bytes (0.0 KB)
```

`ci/inspect_binary.py`, `ci/inspect_elf.py` and `ci/util/symbol_analysis.py` each read `board_info["prog_path"]` and hand it straight to `readelf`, `nm` and `objdump`. On an fbuild board that path names a PlatformIO location nothing ever wrote, so each tool fails separately against it. Those steps run `continue-on-error: true`, so nothing reports it.

Two consequences, both live:

1. **The report is useless on every fbuild board**, and it is the tool for finding the 183 B #4402 still needs.
2. **Its errors disguise real failures.** The esp32dev size-cap breach is buried under ~20 lines of `Error: ELF path … does not exist`, which read like a broken toolchain and are not.

## Fix

`ci/compiled_size.py` already had this right, and `bash bloat` was fixed for itself alone in #4386. Rather than write a fourth copy, the resolution moves to `ci/util/firmware_elf.py` and all four callers use it:

- `find_fbuild_elf` — unchanged behaviour, including returning `None` to mean "PlatformIO build, `prog_path` is authoritative".
- `resolve_firmware_elf` — adds the fallback the diagnostics need, and returns `None` rather than a path that does not exist, so a missing build is **one clear message** instead of three tool failures and an empty report.

`ci/compiled_size.py` loses its private copy (−45 lines) and imports the shared one.

## Tests

Six new cases for the added layer:

- the fbuild artifact wins over a stale `prog_path` (the esp32dev case)
- `prog_path` still wins when there is no fbuild build (PlatformIO unchanged)
- a `.bin` `prog_path` falls back to its `.elf` sibling
- nothing on disk returns `None`, not a bad path
- a missing `prog_path` key is not an exception
- the newest fbuild layout wins — with mtimes set **explicitly**, since a same-second filesystem makes write order prove nothing

`test_compiled_size_fbuild.py` follows `find_fbuild_elf` to its new home; its 9 cases are unchanged.

`uv run pytest ci/tests` — 1508 passed, 41 skipped, 3215 subtests. `bash lint` clean.

## Verification

This PR touches `ci/compiled_size.py`, which is on `check_esp32_size.yml`'s `pull_request` path list — so the esp32dev job runs **here**, and its Symbol Analysis step is the proof. Before this change that step printed `Total symbols: 0`.

Behaviour for PlatformIO-driven boards is unchanged by construction: the fbuild probe returns `None` for them and the `prog_path` fallback is what runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware analysis and size checks to locate generated ELF files across supported build layouts.
  * Added fallback handling for alternate firmware paths and binary-to-ELF artifact resolution.
  * Enhanced error messages to identify locations checked when firmware files cannot be found.
  * Build logs now indicate which firmware size measurement was used.

* **Tests**
  * Added coverage for artifact discovery, fallback behavior, missing paths, and multiple build layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->