### PR TITLE
fix(wasm): render on the main thread when OffscreenCanvas has no WebGL2

### DIFF
--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -112,25 +112,37 @@ console.log(`⭐ index.js loading, URL: ${window.location.href}`);
 
 /**
  * Browser Compatibility Check
- * FastLED WASM requires OffscreenCanvas and WebGL2 support for Web Worker mode
+ *
+ * WebGL2 on a regular canvas is required. WebGL2 on an OffscreenCanvas lets
+ * the Web Worker render directly; when it is missing (WebKitGTK, which backs
+ * the Tauri viewer on Linux, has OffscreenCanvas but no WebGL on it) the
+ * worker still runs the sketch and posts frames to the main thread, which
+ * draws them. FastLEDWorkerManager detects that itself; this only warns.
  */
 (function checkBrowserCompatibility() {
   const errors = [];
 
-  // Check OffscreenCanvas support
-  if (typeof OffscreenCanvas === 'undefined') {
-    errors.push('OffscreenCanvas not supported');
-  } else {
-    // Check WebGL2 support with OffscreenCanvas
-    try {
-      const testCanvas = new OffscreenCanvas(1, 1);
-      const ctx = testCanvas.getContext('webgl2');
-      if (!ctx) {
-        errors.push('WebGL2 not supported with OffscreenCanvas');
-      }
-    } catch (error) {
-      errors.push(`OffscreenCanvas WebGL2 test failed: ${error.message}`);
+  // WebGL2 on a regular canvas is the hard requirement
+  try {
+    const ctx = document.createElement('canvas').getContext('webgl2');
+    if (!ctx) {
+      errors.push('WebGL2 not supported');
     }
+  } catch (error) {
+    errors.push(`WebGL2 test failed: ${error.message}`);
+  }
+
+  // WebGL2 on an OffscreenCanvas is optional: without it frames are drawn on the main thread
+  let offscreenWebGL2 = false;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    try {
+      offscreenWebGL2 = !!new OffscreenCanvas(1, 1).getContext('webgl2');
+    } catch (error) {
+      offscreenWebGL2 = false;
+    }
+  }
+  if (!offscreenWebGL2) {
+    console.warn('WebGL2 on OffscreenCanvas is unavailable; frames will be rendered on the main thread');
   }
 
   if (errors.length > 0) {
@@ -582,12 +594,14 @@ async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
 
     FASTLED_DEBUG_LOG('INDEX_JS', 'Controller setup completed, initializing worker mode...');
 
-    // Initialize Web Worker mode for background thread rendering (always enabled)
     const canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('myCanvas'));
     if (!canvas) {
       throw new Error('Canvas element not found');
     }
 
+    // Web Worker mode for background thread rendering (always enabled). When
+    // the browser has no WebGL2 on OffscreenCanvas the worker still runs the
+    // sketch and posts frames back for main-thread rendering.
     FASTLED_DEBUG_LOG('INDEX_JS', 'Initializing Web Worker mode with OffscreenCanvas...');
     await fastLEDController.initializeWorkerMode(canvas, {
       maxRetries: 3

--- a/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
@@ -90,6 +90,8 @@ const workerState = {
   // Zero polling overhead - completely event-driven
   // Dictionary format: { "0": {strips: {...}, absMin: [...], absMax: [...]}, "1": {...} }
   screenMaps: {},
+  screenMapsDirty: false, // screenMaps changed and the main thread has not been told yet (main-thread rendering)
+  renderOnMainThread: false, // frames are posted to the main thread instead of drawn on an OffscreenCanvas
 
   // Audio sample queue - samples buffered here from onmessage, flushed to WASM at frame start
   audioSampleQueue: [],
@@ -276,11 +278,18 @@ async function handleInitialize(payload) {
     workerState.capabilities = payload.capabilities;
     workerState.frameRate = payload.frameRate || 60;
     workerState.urlParams = payload.urlParams || {}; // Store URL parameters from main thread
+    // When the browser cannot create WebGL2 on an OffscreenCanvas (WebKitGTK
+    // behind the Tauri viewer on Linux), the sketch still runs here — blocking
+    // calls must stay off the main thread — and each frame is posted back to
+    // the main thread, which draws it on the real canvas.
+    workerState.renderOnMainThread = !!payload.renderOnMainThread;
 
     workerLog('LOG', 'BACKGROUND_WORKER', 'URL parameters received from main thread', workerState.urlParams);
 
     // Validate OffscreenCanvas
-    if (!workerState.canvas || !(workerState.canvas instanceof OffscreenCanvas)) {
+    if (workerState.renderOnMainThread) {
+      workerLog('LOG', 'BACKGROUND_WORKER', 'Main-thread rendering: no OffscreenCanvas, frames will be posted to the main thread');
+    } else if (!workerState.canvas || !(workerState.canvas instanceof OffscreenCanvas)) {
       throw new Error('Invalid OffscreenCanvas provided to worker');
     }
 
@@ -290,18 +299,20 @@ async function handleInitialize(payload) {
     await initializeFastLEDModule();
 
     // Set up graphics manager for OffscreenCanvas
-    await initializeGraphicsManager();
+    if (!workerState.renderOnMainThread) {
+      await initializeGraphicsManager();
+    }
 
     workerState.initialized = true;
 
     const result = {
       success: true,
       capabilities: workerState.capabilities,
-      canvas: {
+      canvas: workerState.canvas ? {
         width: workerState.canvas.width,
         height: workerState.canvas.height
-      },
-      contextType: 'webgl2'
+      } : null,
+      contextType: workerState.renderOnMainThread ? 'main_thread' : 'webgl2'
     };
 
     workerLog('LOG', 'BACKGROUND_WORKER', 'Worker initialized successfully', result);
@@ -548,6 +559,7 @@ async function handleStart(_payload) {
 
         // Update worker state and notify graphics manager
         workerState.screenMaps = screenMapData;
+        workerState.screenMapsDirty = true;
         if (workerState.graphicsManager && workerState.graphicsManager.updateScreenMap) {
           workerState.graphicsManager.updateScreenMap(screenMapData);
           workerLog('LOG', 'BACKGROUND_WORKER', 'ScreenMaps fetched and sent to graphics manager', {
@@ -760,6 +772,9 @@ async function handleStartRecording(payload) {
 
   try {
     // Check if canvas is available
+    if (workerState.renderOnMainThread) {
+      throw new Error('Frame capture is unavailable in main-thread rendering mode (no OffscreenCanvas WebGL2)');
+    }
     if (!workerState.canvas) {
       throw new Error('Canvas not available for frame capture');
     }
@@ -830,6 +845,7 @@ function handleScreenMapUpdate(payload) {
     // Cache the screenmap data (dictionary format)
     // This is sent from C++ only when screenmaps change (strip added, layout updated)
     workerState.screenMaps = payload.screenMapData;
+    workerState.screenMapsDirty = true;
 
     workerLog('LOG', 'BACKGROUND_WORKER', 'Screenmap cache updated', {
       screenMapCount: Object.keys(workerState.screenMaps || {}).length
@@ -961,6 +977,28 @@ function startAnimationLoop() {
 }
 
 /**
+ * Posts one frame to the main thread for rendering (no OffscreenCanvas mode).
+ * Pixel buffers are transferred, not copied; the screenmap dictionary rides
+ * along only when it changed since the last post.
+ * @param {Array} frameData - Strip data with pixel_data copies from extractFrameData()
+ */
+function postFrameToMainThread(frameData) {
+  const transfer = [];
+  for (const strip of frameData) {
+    if (strip.pixel_data && strip.pixel_data.buffer) {
+      transfer.push(strip.pixel_data.buffer);
+    }
+  }
+  const payload = {
+    frameData,
+    frameNumber: workerState.frameCount,
+    screenMaps: workerState.screenMapsDirty ? workerState.screenMaps : undefined
+  };
+  workerState.screenMapsDirty = false;
+  postMessage({ type: 'frame_data', payload }, /** @type {*} */ (transfer));
+}
+
+/**
  * Executes a single frame of the animation loop
  * @param {number} currentTime - Current timestamp
  */
@@ -989,14 +1027,19 @@ async function executeFrameLoop(currentTime) {
     const frameData = extractFrameData();
 
     if (frameData) {
-      // Render frame to OffscreenCanvas (automatically syncs to main thread canvas)
-      workerState.graphicsManager.updateCanvas(frameData);
+      if (workerState.renderOnMainThread) {
+        // No OffscreenCanvas here: hand the frame to the main thread to draw
+        postFrameToMainThread(frameData);
+      } else {
+        // Render frame to OffscreenCanvas (automatically syncs to main thread canvas)
+        workerState.graphicsManager.updateCanvas(frameData);
 
-      // Capture frame for main-thread recording if enabled
-      if (workerState.isCapturingFrames) {
-        captureAndTransferFrame().catch((err) => {
-          workerLog('ERROR', 'BACKGROUND_WORKER', 'Frame capture error', err);
-        });
+        // Capture frame for main-thread recording if enabled
+        if (workerState.isCapturingFrames) {
+          captureAndTransferFrame().catch((err) => {
+            workerLog('ERROR', 'BACKGROUND_WORKER', 'Frame capture error', err);
+          });
+        }
       }
 
       // Send lightweight performance telemetry to main thread

--- a/src/platforms/wasm/compiler/modules/core/fastled_callbacks.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_callbacks.ts
@@ -110,12 +110,12 @@ globalThis.FastLED_onFrame = async function (frameData) {
       }
     }
 
-    // Final defensive check: ensure screenMap has proper structure
-    if (frameData.screenMap && (!frameData.screenMap.strips || typeof frameData.screenMap.strips !== 'object')) {
-      console.warn('FastLED_onFrame: screenMap exists but has invalid structure, using fallback:', frameData.screenMap);
-      frameData.screenMap = {
-        strips: {},
-      };
+    // Final defensive check: screenMap is a dictionary keyed by strip id
+    // ({ "0": { strips, absMin, absMax }, ... }), the same shape the graphics
+    // managers' updateScreenMap() consumes. Drop anything that is not an object.
+    if (frameData.screenMap && typeof frameData.screenMap !== 'object') {
+      console.warn('FastLED_onFrame: screenMap has invalid structure, dropping it:', frameData.screenMap);
+      delete frameData.screenMap;
     }
 
     // Render to canvas using existing graphics manager (main thread)

--- a/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
@@ -55,6 +55,13 @@ export class FastLEDWorkerManager {
     /** @type {HTMLCanvasElement|null} Original main thread canvas */
     this.mainCanvas = null;
 
+    /** @type {boolean} Worker posts frames here when OffscreenCanvas WebGL2 is unavailable */
+    this.renderOnMainThread = false;
+    /** @type {Object|null} Last screenmap dictionary received from the worker */
+    this.lastScreenMaps = null;
+    /** @type {Object|null} Graphics manager that already received lastScreenMaps */
+    this.screenMapsTarget = null;
+
     /** @type {WorkerCapabilities} Detected browser capabilities */
     this.capabilities = this.detectCapabilities();
 
@@ -148,11 +155,20 @@ export class FastLEDWorkerManager {
       this.mainCanvas = config.canvas;
       this.maxRetries = config.maxRetries || 3;
 
-      // Transfer canvas control to OffscreenCanvas
-      console.log('🔧 About to transfer canvas to offscreen...');
-      this.offscreenCanvas = this.mainCanvas.transferControlToOffscreen();
-      console.log('🔧 Canvas transferred successfully');
-      FASTLED_DEBUG_LOG('WORKER_MANAGER', `Canvas control transferred to OffscreenCanvas`);
+      // Transfer canvas control to OffscreenCanvas — unless this browser cannot
+      // create WebGL2 on one (WebKitGTK behind the Tauri viewer on Linux). Then
+      // the worker still runs the sketch, so blocking calls stay off the main
+      // thread, and posts every frame back here to draw on the real canvas.
+      this.renderOnMainThread = !this.capabilities.webgl2;
+      if (this.renderOnMainThread) {
+        console.log('🔧 No WebGL2 on OffscreenCanvas: worker will post frames for main-thread rendering');
+        this.offscreenCanvas = null;
+      } else {
+        console.log('🔧 About to transfer canvas to offscreen...');
+        this.offscreenCanvas = this.mainCanvas.transferControlToOffscreen();
+        console.log('🔧 Canvas transferred successfully');
+        FASTLED_DEBUG_LOG('WORKER_MANAGER', `Canvas control transferred to OffscreenCanvas`);
+      }
 
       // Create and configure worker
       console.log('🔧 About to create worker...');
@@ -175,7 +191,8 @@ export class FastLEDWorkerManager {
       fastLEDEvents.emit('worker:initialized', {
         mode: 'background_worker',
         capabilities: this.capabilities,
-        canvas: { width: this.offscreenCanvas.width, height: this.offscreenCanvas.height }
+        renderOnMainThread: this.renderOnMainThread,
+        canvas: { width: this.mainCanvas.width, height: this.mainCanvas.height }
       });
 
       FASTLED_DEBUG_LOG('WORKER_MANAGER', 'Background worker initialized successfully');
@@ -239,6 +256,7 @@ export class FastLEDWorkerManager {
         id: this.generateMessageId(),
         payload: {
           canvas: this.offscreenCanvas,
+          renderOnMainThread: this.renderOnMainThread,
           capabilities: this.capabilities,
           frameRate: config.frameRate,
           urlParams: urlParamsObject, // Pass URL parameters to worker
@@ -253,7 +271,7 @@ export class FastLEDWorkerManager {
 
       console.log('🔧 createWorker: About to call sendMessageWithResponse...');
       console.log('🔧 createWorker: isWorkerActive BEFORE send:', this.isWorkerActive);
-      const success = await this.sendMessageWithResponse(initMessage, [this.offscreenCanvas]);
+      const success = await this.sendMessageWithResponse(initMessage, this.offscreenCanvas ? [this.offscreenCanvas] : null);
       console.log('🔧 createWorker: sendMessageWithResponse returned:', success);
       if (!success) {
         throw new Error('Worker initialization message failed');
@@ -397,6 +415,34 @@ export class FastLEDWorkerManager {
    * Handles messages received from the worker
    * @param {MessageEvent} event - Worker message event
    */
+  /**
+   * Draws a frame the worker posted because it has no OffscreenCanvas
+   * (main-thread rendering). The screenmap dictionary arrives only when it
+   * changed; it is cached and pushed to whichever graphics manager is current.
+   * @param {{frameData: Array, frameNumber: number, screenMaps?: Object}} payload
+   */
+  handleFrameData(payload) {
+    if (!payload || typeof window.updateCanvas !== 'function') return;
+    if (payload.screenMaps) {
+      this.lastScreenMaps = payload.screenMaps;
+      this.screenMapsTarget = null;
+    }
+    const pushScreenMaps = () => {
+      const gm = window.graphicsManager;
+      if (this.lastScreenMaps && gm && typeof gm.updateScreenMap === 'function' && this.screenMapsTarget !== gm) {
+        gm.updateScreenMap(this.lastScreenMaps);
+        this.screenMapsTarget = gm;
+      }
+    };
+    const frameData = payload.frameData || [];
+    // null, not undefined: updateCanvas() treats undefined as "no screenmap yet"
+    // and skips the frame; the screenmap is pushed separately.
+    frameData.screenMap = null;
+    pushScreenMaps(); // manager already exists: new layout applies to this frame
+    window.updateCanvas(frameData);
+    pushScreenMaps(); // manager was just created by updateCanvas()
+  }
+
   handleWorkerMessage(event) {
     const { data } = event;
     FASTLED_DEBUG_TRACE('WORKER_MANAGER', 'handleWorkerMessage', 'ENTER', { messageType: data.type });
@@ -423,6 +469,10 @@ export class FastLEDWorkerManager {
       switch (data.type) {
         case 'frame_rendered':
           this.handleFrameRendered(data.payload);
+          break;
+
+        case 'frame_data':
+          this.handleFrameData(data.payload);
           break;
 
         case 'error':


### PR DESCRIPTION
## Summary

The `fastled` Tauri viewer on Linux uses WebKitGTK, which has OffscreenCanvas but cannot create a WebGL2 context on it. The viewer failed the browser compatibility check ("WebGL2 not supported with OffscreenCanvas") and never ran the sketch.

- The sketch stays in the background worker. Running it on the main thread deadlocks: the pthread build blocks inside `extern_setup()`/`extern_loop()`, and the main thread cannot wait.
- When OffscreenCanvas WebGL2 is missing, `FastLEDWorkerManager` keeps the real canvas, the worker skips its graphics manager, and each frame's pixel buffers are transferred to the main thread, which draws them with the regular-canvas WebGL2 graphics manager (`window.updateCanvas`).
- The screenmap dictionary is posted only when it changes and pushed to whichever graphics manager is current, before the frame that uses it.
- Frame recording needs the worker canvas, so `start_recording` now fails with an explicit message in this mode.
- The compatibility check requires WebGL2 on a regular canvas and only warns about OffscreenCanvas.
- `FastLED_onFrame`'s stale screenMap guard expected a single `{strips}` object and replaced the strip-id dictionary with an empty map; it now accepts the dictionary the graphics managers consume.

## Verification

- Tauri viewer (WebKitGTK 2.52.6, NixOS): MoodRing runs in worker mode with main-thread rendering, strip registers, Animartrix bank cycles, no console errors over 70+ s.
- Headless Chromium (Brave) with OffscreenCanvas WebGL2 forced off: same path renders the ring and UI (screenshot checked).
- Chromium with WebGL2 available: unchanged worker rendering path.
- `bash lint --js` passes (one pre-existing complexity warning in `graphics_manager.ts`).

Note for the fastled-wasm side: on this host the viewer also needed `JSC_useSharedArrayBuffer=1` in the environment, because JavaScriptCore hides the `SharedArrayBuffer` global even when the page is cross-origin isolated, which broke the pthread worker bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9rUkvoW2gVKYurtQJpi4i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a rendering fallback for browsers that do not support WebGL2 on OffscreenCanvas.
  - Frames can now render on the main thread, allowing the application to continue working in more browser environments.
  - Screen map updates are synchronized efficiently during fallback rendering.

- **Bug Fixes**
  - Browsers without OffscreenCanvas WebGL2 no longer incorrectly display a “Browser Not Supported” error.
  - Invalid screen map data is handled more safely during frame updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->