### PR TITLE
feat(wasm): show real loop FPS and render FPS in the viewer

### DIFF
--- a/src/platforms/wasm/compiler/index.ts
+++ b/src/platforms/wasm/compiler/index.ts
@@ -660,13 +660,14 @@ async function FastLED_SetupAndLoop(moduleInstance, frame_rate) {
       FASTLED_DEBUG_LOG('INDEX_JS', 'Setting up performance monitoring...');
       setInterval(() => {
         const fps = fastLEDController.getFPS();
+        const renderFps = fastLEDController.getRenderFPS();
         const frameTime = fastLEDController.getAverageFrameTime();
 
         // Record performance metrics
         fastLEDPerformanceMonitor.recordFrameTime(frameTime);
 
         // Update display
-        fpsDisplay.textContent = `FPS: ${fps.toFixed(1)} | Frame: ${frameTime.toFixed(1)}ms`;
+        fpsDisplay.textContent = `FPS: ${fps.toFixed(1)} | Render: ${renderFps.toFixed(1)} fps | Loop: ${frameTime.toFixed(2)}ms`;
 
         // Monitor memory usage if available
         if (performance.memory) {

--- a/src/platforms/wasm/compiler/modules/core/fastled_async_controller.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_async_controller.ts
@@ -46,6 +46,7 @@ class FastLEDAsyncController {
     this.lastFrameTime = 0;
     this.frameInterval = 1000 / this.frameRate;
     this.lastSlowFrameWarningTime = 0; // Track last slow frame warning timestamp
+    this.renderTimes = []; // Timestamps of renders in the last second (legacy main-thread loop)
 
     // Worker integration properties
     this.isMainThread = typeof Worker !== 'undefined' && typeof window !== 'undefined';
@@ -430,6 +431,11 @@ class FastLEDAsyncController {
     if (globalThis.FastLED_onFrame) {
       await globalThis.FastLED_onFrame(frameData);
     }
+    const now = performance.now();
+    this.renderTimes.push(now);
+    while (this.renderTimes.length && now - this.renderTimes[0] > 1000) {
+      this.renderTimes.shift();
+    }
   }
 
   /**
@@ -540,7 +546,15 @@ class FastLEDAsyncController {
      * @returns {number} Render FPS
      */
   getRenderFPS() {
-    return this.workerMode ? fastLEDWorkerManager.getRenderFPS() : this.getFPS();
+    if (this.workerMode) {
+      return fastLEDWorkerManager.getRenderFPS();
+    }
+    // Legacy main-thread loop: count renderFrame() calls in the last second
+    const now = performance.now();
+    while (this.renderTimes.length && now - this.renderTimes[0] > 1000) {
+      this.renderTimes.shift();
+    }
+    return this.renderTimes.length;
   }
 
   /**

--- a/src/platforms/wasm/compiler/modules/core/fastled_async_controller.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_async_controller.ts
@@ -524,8 +524,23 @@ class FastLEDAsyncController {
      * @returns {number} Current FPS
      */
   getFPS() {
+    // Worker mode: wall-clock loop rate reported by the worker. The old
+    // 1000 / averageFrameTime figure is loop *cost*, not a rate (it read ~700
+    // while 60 frames/s were delivered), so it is only a fallback for the
+    // legacy main-thread loop, which has no other measurement.
+    if (this.workerMode) {
+      return fastLEDWorkerManager.getLoopFPS();
+    }
     const avgFrameTime = this.getAverageFrameTime();
     return avgFrameTime > 0 ? 1000 / avgFrameTime : 0;
+  }
+
+  /**
+     * Gets frames rendered per second (see FastLEDWorkerManager.getRenderFPS)
+     * @returns {number} Render FPS
+     */
+  getRenderFPS() {
+    return this.workerMode ? fastLEDWorkerManager.getRenderFPS() : this.getFPS();
   }
 
   /**
@@ -537,6 +552,7 @@ class FastLEDAsyncController {
       frameCount: this.frameCount,
       averageFrameTime: this.getAverageFrameTime(),
       fps: this.getFPS(),
+      renderFps: this.getRenderFPS(),
       running: this.running,
       setupCompleted: this.setupCompleted,
     };

--- a/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
@@ -590,6 +590,10 @@ async function handleStart(_payload) {
     workerState.running = true;
     workerState.startTime = performance.now();
     workerState.frameCount = 0;
+    // Rate counters measure from here, not from page load
+    workerState.loopCount = 0;
+    workerState.renderCount = 0;
+    performanceMonitor.lastStatsReport = workerState.startTime;
 
     startAnimationLoop();
 

--- a/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_background_worker.ts
@@ -91,6 +91,13 @@ const workerState = {
   // Dictionary format: { "0": {strips: {...}, absMin: [...], absMax: [...]}, "1": {...} }
   screenMaps: {},
   screenMapsDirty: false, // screenMaps changed and the main thread has not been told yet (main-thread rendering)
+  // Rate counters, reset every stats report. loopCount: extern_loop() iterations
+  // (the sketch frame rate). renderCount: frames handed to the renderer here;
+  // in main-thread rendering mode the main thread counts renders instead.
+  loopCount: 0,
+  renderCount: 0,
+  loopFps: 0,
+  renderFps: 0,
   renderOnMainThread: false, // frames are posted to the main thread instead of drawn on an OffscreenCanvas
 
   // Audio sample queue - samples buffered here from onmessage, flushed to WASM at frame start
@@ -1007,6 +1014,7 @@ async function executeFrameLoop(currentTime) {
 
   try {
     workerState.frameCount++;
+    workerState.loopCount++;
 
     // Flush buffered audio samples to WASM BEFORE running C++ loop.
     // This ensures Module.ccall('pushAudioSamples') happens in the same
@@ -1033,6 +1041,7 @@ async function executeFrameLoop(currentTime) {
       } else {
         // Render frame to OffscreenCanvas (automatically syncs to main thread canvas)
         workerState.graphicsManager.updateCanvas(frameData);
+        workerState.renderCount++;
 
         // Capture frame for main-thread recording if enabled
         if (workerState.isCapturingFrames) {
@@ -1174,6 +1183,13 @@ function updatePerformanceMetrics(frameTime) {
  * Reports performance statistics to main thread
  */
 function reportPerformanceStats() {
+  // Wall-clock rates over the interval since the last report
+  const now = performance.now();
+  const intervalSec = Math.max((now - performanceMonitor.lastStatsReport) / 1000, 0.001);
+  workerState.loopFps = workerState.loopCount / intervalSec;
+  workerState.renderFps = workerState.renderCount / intervalSec;
+  workerState.loopCount = 0;
+  workerState.renderCount = 0;
   const stats = getPerformanceStats();
 
   postMessage({
@@ -1192,8 +1208,11 @@ function getPerformanceStats() {
   const fps = workerState.frameCount / (runTime / 1000);
 
   return {
-    fps: fps || 0,
-    averageFrameTime: workerState.averageFrameTime,
+    fps: fps || 0, // cumulative loop iterations per second since start
+    loopFps: workerState.loopFps, // sketch frame rate over the last stats interval
+    renderFps: workerState.renderFps, // frames rendered here over the last interval (0 in main-thread rendering mode)
+    renderOnMainThread: workerState.renderOnMainThread,
+    averageFrameTime: workerState.averageFrameTime, // CPU cost of one loop iteration, ms
     frameCount: workerState.frameCount,
     runTime: runTime,
     memoryUsage: 'self' in globalThis && 'performance' in self && self.performance.memory ? {

--- a/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
@@ -452,6 +452,11 @@ export class FastLEDWorkerManager {
   recordMainThreadRender() {
     const now = performance.now();
     this.mainThreadRenderTimes.push(now);
+    this.pruneMainThreadRenderTimes(now);
+  }
+
+  /** Drops main-thread render timestamps older than one second. */
+  pruneMainThreadRenderTimes(now) {
     while (this.mainThreadRenderTimes.length && now - this.mainThreadRenderTimes[0] > 1000) {
       this.mainThreadRenderTimes.shift();
     }
@@ -466,10 +471,7 @@ export class FastLEDWorkerManager {
    */
   getRenderFPS() {
     if (this.renderOnMainThread) {
-      const now = performance.now();
-      while (this.mainThreadRenderTimes.length && now - this.mainThreadRenderTimes[0] > 1000) {
-        this.mainThreadRenderTimes.shift();
-      }
+      this.pruneMainThreadRenderTimes(performance.now());
       return this.mainThreadRenderTimes.length;
     }
     return this.lastWorkerStats ? (this.lastWorkerStats.renderFps || 0) : 0;

--- a/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
+++ b/src/platforms/wasm/compiler/modules/core/fastled_worker_manager.ts
@@ -61,6 +61,10 @@ export class FastLEDWorkerManager {
     this.lastScreenMaps = null;
     /** @type {Object|null} Graphics manager that already received lastScreenMaps */
     this.screenMapsTarget = null;
+    /** @type {number[]} Timestamps of frames drawn on the main thread in the last second */
+    this.mainThreadRenderTimes = [];
+    /** @type {Object|null} Last performance_stats payload from the worker */
+    this.lastWorkerStats = null;
 
     /** @type {WorkerCapabilities} Detected browser capabilities */
     this.capabilities = this.detectCapabilities();
@@ -441,6 +445,42 @@ export class FastLEDWorkerManager {
     pushScreenMaps(); // manager already exists: new layout applies to this frame
     window.updateCanvas(frameData);
     pushScreenMaps(); // manager was just created by updateCanvas()
+    this.recordMainThreadRender();
+  }
+
+  /** Records one frame drawn on the main thread (main-thread rendering mode). */
+  recordMainThreadRender() {
+    const now = performance.now();
+    this.mainThreadRenderTimes.push(now);
+    while (this.mainThreadRenderTimes.length && now - this.mainThreadRenderTimes[0] > 1000) {
+      this.mainThreadRenderTimes.shift();
+    }
+  }
+
+  /**
+   * Frames rendered per second. Comes from the worker when it draws on its
+   * OffscreenCanvas, and from the main-thread counter otherwise. Today a render
+   * happens for every loop iteration; once LED draw simulation throttles
+   * FastLED.show(), this rate will drop below the loop rate.
+   * @returns {number} Render frames per second
+   */
+  getRenderFPS() {
+    if (this.renderOnMainThread) {
+      const now = performance.now();
+      while (this.mainThreadRenderTimes.length && now - this.mainThreadRenderTimes[0] > 1000) {
+        this.mainThreadRenderTimes.shift();
+      }
+      return this.mainThreadRenderTimes.length;
+    }
+    return this.lastWorkerStats ? (this.lastWorkerStats.renderFps || 0) : 0;
+  }
+
+  /**
+   * Sketch loop iterations per second, measured wall-clock by the worker.
+   * @returns {number} Loop frames per second
+   */
+  getLoopFPS() {
+    return this.lastWorkerStats ? (this.lastWorkerStats.loopFps || 0) : 0;
   }
 
   handleWorkerMessage(event) {
@@ -551,6 +591,7 @@ export class FastLEDWorkerManager {
    * @param {Object} payload - Performance data
    */
   handlePerformanceStats(payload) {
+    this.lastWorkerStats = payload || null;
     // Emit performance data for monitoring
     fastLEDEvents.emit('performance:stats', {
       source: 'background_worker',


### PR DESCRIPTION
## Summary

The viewer's FPS readout was `1000 / averageFrameTime`, and `averageFrameTime` is the CPU cost of one worker loop iteration. It read about 700 while exactly 60 frames per second were delivered, so it measured cost, not rate.

- **Loop FPS**: the worker counts `extern_loop()` iterations per stats interval and reports a wall-clock `loopFps`.
- **Render FPS**: counted where a frame is handed to the renderer. In worker rendering mode the worker counts its `updateCanvas()` calls; in main-thread rendering mode (no OffscreenCanvas WebGL2, PR #4405) the worker manager counts the frames it draws.
- `FastLEDAsyncController.getFPS()` now returns the loop rate in worker mode and `getRenderFPS()` is new. The readout shows `FPS | Render | Loop cost`.
- The old `1000 / averageFrameTime` figure survives only as the fallback for the legacy main-thread loop, which has no other measurement.

Render FPS currently tracks loop FPS because every iteration renders. Once LED draw simulation throttles `FastLED.show()`, the render count is taken at the render step, so it will drop below the loop rate without further plumbing.

## Verification

Tauri viewer (WebKitGTK), MoodRing:

```
FPS: 58.8 | Render: 60.0 fps | Loop: 3.15ms
FPS: 59.2 | Render: 60.0 fps | Loop: 3.02ms
```

Headless Chromium, both render modes: readout and `getLoopFPS()` / `getRenderFPS()` agree with each other. `bash lint --js` passes (one pre-existing complexity warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9rUkvoW2gVKYurtQJpi4i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Performance displays now show separate render and loop frame rates.
  * Performance statistics include render FPS alongside existing timing information.
  * FPS calculations account for both worker-based and main-thread rendering.

* **Improvements**
  * Frame timing is displayed with greater precision.
  * Loop and render rates are measured over real elapsed time for more accurate results.
  * Performance counters reset when an animation starts, ensuring rates reflect the current session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->