### PR TITLE
perf(hd108): one loop for both sources, not two copies of the framing (#4402)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -49,7 +49,8 @@ jobs:
       # bytes were found in code instead, in the HD108 encoder's per-LED
       # brightness handling, which computed a constant header. Left here as the
       # record that this ceiling has been tested against a real regression and
-      # held.
+      # held. Follow-ups: #4403 (-52 B), #4404 (diagnostics), and the one-loop
+      # HD108 encoder that landed after them.
       #
       # The value here is mirror-locked by `ci/lint/check_size_thresholds.py`:
       # changing this number without updating the frozen-list constant in that

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -438,73 +438,75 @@ class PixelIterator {
     void writeHD108(CONTAINER_UIN8_T* out, bool managed = false) FL_NO_EXCEPT {
         auto back_ins = fl::back_inserter(*out);
 
-#if !FL_PLATFORM_HAS_TINY_MEMORY
-        if (managed) {
-            // Inline rather than an `encodeHD108_wide` in hd108.h: that header
-            // is included *by* this one, before `PixelIterator` exists, and a
-            // concrete `PixelIterator&` parameter is not a dependent type --
-            // so its body would be checked there and fail. Same reason the
-            // UCS7604 wide path had to be guarded for TINY (#4326).
-            //
-            // `hd108GammaCorrect` is skipped by construction. It exists to
-            // widen an 8-bit pixel to the 16 bits this chipset carries; the
-            // managed source has already quantized its device drive once, to
-            // 16 bits, so a fixed 2.8 curve on top is the second shaping stage
-            // B1 and section 6 of the spec forbid after the device solve. And
-            // unlike UCS7604's `mGamma.value_or(2.8f)`, this one is hardcoded
-            // -- no caller could have chosen otherwise.
-            for (int i = 0; i < 8; i++) {
-                *back_ins++ = 0x00;  // start frame
-            }
-            // `hd108BrightnessHeader` discards its argument and pins every
-            // gain at 31, so this is 0xFF 0xFF whatever is passed. The strip
-            // brightness used to be fetched through `makeScaledBrightness`
-            // purely to hand it over here, which built an adapter and called
-            // its out-of-line `load()` to produce a number that reached
-            // nothing. FastLED#4402.
-            u8 f0, f1;
-            hd108BrightnessHeader(0, &f0, &f1);
-            fl::size num_leds = 0;
-            while (has(1)) {
-                u16 r16, g16, b16;
-                loadAndScaleRGB16(&r16, &g16, &b16);
-                *back_ins++ = f0;
-                *back_ins++ = f1;
-                *back_ins++ = static_cast<u8>(r16 >> 8);
-                *back_ins++ = static_cast<u8>(r16 & 0xFF);
-                *back_ins++ = static_cast<u8>(g16 >> 8);
-                *back_ins++ = static_cast<u8>(g16 & 0xFF);
-                *back_ins++ = static_cast<u8>(b16 >> 8);
-                *back_ins++ = static_cast<u8>(b16 & 0xFF);
-                stepDithering();
-                advanceData();
-                ++num_leds;
-            }
-            const fl::size latch = num_leds / 2 + 4;
-            for (fl::size i = 0; i < latch; i++) {
-                *back_ins++ = 0xFF;  // end frame
-            }
-            return;
-        }
-#else
+        // One loop for both sources. This used to be two: the managed path
+        // written out by hand here, and the 8-bit path routed through
+        // `encodeHD108` over `makeScaledPixelRangeRGB`. Each carried its own
+        // copy of the framing -- the 8-byte start frame, the per-LED emit of
+        // header + three big-endian channels, the latch -- and together they
+        // made this the largest encoder body in a Blink build (481 B on
+        // esp32dev, ahead of `writeWS2812`, the only one Blink runs). The only
+        // thing that differed was where the 16-bit channels came from, so
+        // that is now the only branch (FastLED#4402).
+        //
+        // Byte-identical to the iterator path by construction:
+        // `ScaledPixelIteratorRGB::advance()` is exactly `has(1)`,
+        // `loadAndScaleRGB` into wire order, `stepDithering`, `advanceData`,
+        // once per pixel; the bytes it hands `encodeHD108` are captured before
+        // the step, which is what this loop does too.
+        //
+        // Inline rather than an `encodeHD108_wide` in hd108.h: that header is
+        // included *by* this one, before `PixelIterator` exists, and a
+        // concrete `PixelIterator&` parameter is not a dependent type -- so
+        // its body would be checked there and fail (#4326).
+#if FL_PLATFORM_HAS_TINY_MEMORY
+        // No wide source exists on TINY, so the flag selects nothing there.
         FL_UNUSED(managed);
 #endif
-
-        // One call, not one per FASTLED_HD_COLOR_MIXING branch. The two
-        // encoders emit the same bytes for the same pixels: both walk
-        // `makeScaledPixelRangeRGB`, both widen through `hd108GammaCorrect`,
-        // both frame with the same start/latch, and both headers come from
-        // `hd108BrightnessHeader`, which pins all gains at 31 whatever it is
-        // handed. `encodeHD108_HD` differed only by a per-LED brightness read
-        // and a cache around that constant header; with those gone (#4402) it
-        // is `encodeHD108` with an extra argument, so building HD-colour-mixing
-        // sketches was paying for a second copy of one function.
-        //
-        // `encodeHD108_HD` stays in hd108.h for source compatibility, and a
-        // test asserts the two agree byte for byte so this collapse cannot
-        // quietly stop being true.
-        auto pixel_range = makeScaledPixelRangeRGB(this);
-        encodeHD108(pixel_range.first, pixel_range.second, back_ins, 255);
+        for (int i = 0; i < 8; i++) {
+            *back_ins++ = 0x00;  // start frame
+        }
+        // `hd108BrightnessHeader` discards its argument and pins every gain
+        // at 31, so this is 0xFF 0xFF whatever is passed (#4402).
+        u8 f0, f1;
+        hd108BrightnessHeader(0, &f0, &f1);
+        fl::size num_leds = 0;
+        while (has(1)) {
+            u16 r16, g16, b16;
+#if !FL_PLATFORM_HAS_TINY_MEMORY
+            if (managed) {
+                // The managed source has already quantized its device drive
+                // once, to 16 bits. `hd108GammaCorrect` exists to widen an
+                // 8-bit pixel to the 16 this chipset carries; a fixed 2.8
+                // curve on top of a solved drive is the second shaping stage
+                // B1 and section 6 of the spec forbid after the device
+                // solve, and unlike UCS7604's `mGamma.value_or(2.8f)` this
+                // one is hardcoded -- no caller could have chosen otherwise.
+                loadAndScaleRGB16(&r16, &g16, &b16);
+            } else
+#endif
+            {
+                u8 b0, b1, b2;
+                loadAndScaleRGB(&b0, &b1, &b2);  // wire order
+                r16 = hd108GammaCorrect(b0);
+                g16 = hd108GammaCorrect(b1);
+                b16 = hd108GammaCorrect(b2);
+            }
+            *back_ins++ = f0;
+            *back_ins++ = f1;
+            *back_ins++ = static_cast<u8>(r16 >> 8);
+            *back_ins++ = static_cast<u8>(r16 & 0xFF);
+            *back_ins++ = static_cast<u8>(g16 >> 8);
+            *back_ins++ = static_cast<u8>(g16 & 0xFF);
+            *back_ins++ = static_cast<u8>(b16 >> 8);
+            *back_ins++ = static_cast<u8>(b16 & 0xFF);
+            stepDithering();
+            advanceData();
+            ++num_leds;
+        }
+        const fl::size latch = num_leds / 2 + 4;
+        for (fl::size i = 0; i < latch; i++) {
+            *back_ins++ = 0xFF;  // end frame
+        }
     }
 
   private:

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,3 +1,17 @@
+# 2026-09-12, PR #4407 (issue #4402): -182 B, 342891 -> 342709.
+#
+# A reduction, locked in by the ratchet. `writeHD108` was two complete loops
+# -- the managed path written by hand, the 8-bit path routed through
+# `encodeHD108` -- each with its own copy of the start frame, per-LED emit and
+# latch. On esp32dev it was the largest encoder body in a Blink build (481 B,
+# ahead of `writeWS2812`, the only encoder Blink runs). One loop now, the
+# source being the only branch: 481 -> 280 B there, esp32dev Blink
+# 340,183 -> 339,955 B, back under its 340,000 B ceiling.
+#
+# Byte-identical to the iterator path by construction and by test: a case
+# drives both through a real PixelIterator with binary dither on and a GRB
+# order and holds them to the same bytes.
+#
 # 2026-09-12, PR #4403 (issue #4402): -66 B, 342957 -> 342891.
 #
 # A reduction, so the ratchet asks for it to be locked in rather than left as
@@ -126,4 +140,4 @@
 # showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
 # only ever spent where flash is not the binding constraint. On a target
 # that does compile it in, 305 B is 0.089% of the image.
-342891
+342709

--- a/tests/fl/chipsets/encoders/hd108.hpp
+++ b/tests/fl/chipsets/encoders/hd108.hpp
@@ -616,6 +616,36 @@ FL_TEST_CASE("[#4321] writeHD108 emits one LED per source pixel") {
     }
 }
 
+FL_TEST_CASE("[#4402] writeHD108 through a real PixelIterator equals encodeHD108 byte for byte") {
+    // `writeHD108` no longer routes the 8-bit path through `encodeHD108`; it
+    // walks the source itself in one loop shared with the managed path. This
+    // holds the two to the same bytes on the real adapter, with binary dither
+    // ON and a non-trivial colour order, so the dither-step and wire-order
+    // bookkeeping the iterator used to do is proven, not assumed.
+    fl::CRGB leds[5] = {fl::CRGB(10, 200, 33), fl::CRGB(0, 0, 0),
+                        fl::CRGB(255, 255, 255), fl::CRGB(7, 8, 9),
+                        fl::CRGB(128, 64, 32)};
+
+    PixelController<GRB> via_writer(leds, 5, ColorAdjustment::noAdjustment(),
+                                    BINARY_DITHER);
+    fl::PixelIteratorAny writer_adapter(via_writer, GRB, fl::Rgbw());
+    fl::vector<fl::u8> from_writer;
+    writer_adapter.get().writeHD108(&from_writer);
+
+    PixelController<GRB> via_encoder(leds, 5, ColorAdjustment::noAdjustment(),
+                                     BINARY_DITHER);
+    fl::PixelIteratorAny encoder_adapter(via_encoder, GRB, fl::Rgbw());
+    auto range = fl::makeScaledPixelRangeRGB(&encoder_adapter.get());
+    fl::vector<fl::u8> from_encoder;
+    fl::encodeHD108(range.first, range.second, fl::back_inserter(from_encoder), 255);
+
+    FL_REQUIRE_EQ(from_writer.size(), from_encoder.size());
+    FL_REQUIRE_EQ((int)from_writer.size(), 8 + 5 * 8 + (5 / 2 + 4));
+    for (fl::size i = 0; i < from_writer.size(); ++i) {
+        FL_CHECK_EQ(from_writer[i], from_encoder[i]);
+    }
+}
+
 FL_TEST_CASE("[#4321] writeAPA102 and writeSK9822 emit one LED per source pixel in HD mode") {
     // 4 start bytes + 4 per LED + ((N/32)+1)*4 end.  N=4 -> 4 + 16 + 4.
     FL_SUBCASE("APA102") {


### PR DESCRIPTION
Step (1) of the #4402 plan, from the now-working esp32dev symbol report.

## What the report showed

`writeHD108` was the **largest encoder body in a Blink build — 481 B**, ahead of `writeWS2812` (309 B), the only encoder Blink actually runs. It was two complete loops: the managed path written out by hand, and the 8-bit path routed through `encodeHD108` over `makeScaledPixelRangeRGB`. Each carried its own start frame, per-LED emit, and latch. The only difference was where the 16-bit channels came from.

## Change

One loop; the source is the only branch. `ScaledPixelIteratorRGB::advance()` is exactly `has(1)` → `loadAndScaleRGB` (wire order) → `stepDithering` → `advanceData`, once per pixel, bytes captured before the step — so the manual loop is byte-identical by construction.

## Test

`[#4402] writeHD108 through a real PixelIterator equals encodeHD108 byte for byte` — both paths driven through a real `PixelIteratorAny`, **binary dither on, GRB order**, held to the same bytes. A wrong-channel mutation fails it by name (`194 | 191 passed | 3 failed`).

`bash test --cpp` 305/305 + 84/84. `bash lint` clean. Size thresholds untouched (workflow gains a comment line — which is what makes the esp32dev gate run on this PR; **its number is the verification**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved consistency of HD108 LED encoding across color-managed and standard 8-bit pixel configurations.
  - Reduced memory usage for ESP32-S3 builds through a more efficient encoding path.

- **Tests**
  - Added coverage verifying byte-for-byte HD108 output for real pixel-strip rendering, including dithering and multi-LED configurations.

- **Documentation**
  - Updated ESP32 build-size records with the latest measured binary-size results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->