### PR TITLE
perf(channels): one PixelController per channel, not one per colour order (#4402)

### DIFF
--- a/.github/workflows/check_esp32_size.yml
+++ b/.github/workflows/check_esp32_size.yml
@@ -50,7 +50,8 @@ jobs:
       # brightness handling, which computed a constant header. Left here as the
       # record that this ceiling has been tested against a real regression and
       # held. Follow-ups: #4403 (-52 B), #4404 (diagnostics), and the one-loop
-      # HD108 encoder that landed after them.
+      # HD108 encoder that landed after them (#4407), then one PixelController
+      # per channel instead of six (#4402 follow-up).
       #
       # The value here is mirror-locked by `ci/lint/check_size_thresholds.py`:
       # changing this number without updating the frozen-list constant in that

--- a/src/fl/chipsets/encoders/pixel_iterator.h
+++ b/src/fl/chipsets/encoders/pixel_iterator.h
@@ -61,6 +61,19 @@ struct PixelControllerVtable {
     pc->loadAndScaleRGBWW(rgbww, b0_out, b1_out, b2_out, b3_out, b4_out);
   }
 
+  // Order-free loads, bound only for the RGB instantiation (see
+  // RgbwLoadBinder). PixelIterator applies the colour order itself, so one
+  // PixelController<RGB> serves every order and the other five instantiations
+  // -- a full vtable set each -- are never referenced (FastLED#4402).
+  static void loadAndScaleRGBWUnordered(void* pixel_controller, const Rgbw& rgbw, u8* r_out, u8* g_out, u8* b_out, u8* w_out) FL_NO_EXCEPT {
+    PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
+    pc->loadAndScaleRGBWUnordered(rgbw, r_out, g_out, b_out, w_out);
+  }
+  static void loadAndScaleRGBWWUnordered(void* pixel_controller, Rgbww rgbww, u8* r_out, u8* g_out, u8* b_out, u8* ww_out, u8* wc_out) FL_NO_EXCEPT {
+    PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
+    pc->loadAndScaleRGBWWUnordered(rgbww, r_out, g_out, b_out, ww_out, wc_out);
+  }
+
   static void loadAndScaleRGB(void* pixel_controller, u8* r_out, u8* g_out, u8* b_out) FL_NO_EXCEPT {
     PixelControllerT* pc = static_cast<PixelControllerT*>(pixel_controller);
     pc->loadAndScaleRGB(r_out, g_out, b_out);
@@ -145,6 +158,39 @@ struct WideLoadBinder<T, decltype(static_cast<void>(
 #endif
 // NOTE: loadAndScale_APA102_HDFunction removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
 // NOTE: loadAndScale_WS2816_HDFunction removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
+typedef void (*loadAndScaleRGBWUnorderedFunction)(void* pixel_controller, const Rgbw& rgbw, u8* r_out, u8* g_out, u8* b_out, u8* w_out);
+typedef void (*loadAndScaleRGBWWUnorderedFunction)(void* pixel_controller, Rgbww rgbww, u8* r_out, u8* g_out, u8* b_out, u8* ww_out, u8* wc_out);
+
+namespace detail {
+/// `type` exists only when `B` is true: a self-contained enable_if so the
+/// binder below can key on a constant that only PixelController declares.
+template <bool B> struct OnlyIf {};
+template <> struct OnlyIf<true> { typedef void type; };
+}  // namespace detail
+
+/// Binds exactly one RGBW thunk and one RGBWW thunk per source type, and
+/// names only that one, so the other is never linked for that instantiation.
+///
+/// A `PixelController<RGB>` gets the order-free pair: PixelIterator permutes
+/// their output itself, which is how one instantiation serves all six colour
+/// orders. Anything else -- another order, used directly by a templated
+/// driver, or a colour-managed source with no `kColorOrder` at all -- keeps
+/// the fully ordered thunks it always had, and its bytes are untouched.
+template <typename T, typename = void>
+struct RgbwLoadBinder {
+    static loadAndScaleRGBWFunction ordered() FL_NO_EXCEPT { return &PixelControllerVtable<T>::loadAndScaleRGBW; }
+    static loadAndScaleRGBWWFunction orderedWW() FL_NO_EXCEPT { return &PixelControllerVtable<T>::loadAndScaleRGBWW; }
+    static loadAndScaleRGBWUnorderedFunction unordered() FL_NO_EXCEPT { return nullptr; }
+    static loadAndScaleRGBWWUnorderedFunction unorderedWW() FL_NO_EXCEPT { return nullptr; }
+};
+template <typename T>
+struct RgbwLoadBinder<T, typename detail::OnlyIf<(T::kColorOrder == RGB)>::type> {
+    static loadAndScaleRGBWFunction ordered() FL_NO_EXCEPT { return nullptr; }
+    static loadAndScaleRGBWWFunction orderedWW() FL_NO_EXCEPT { return nullptr; }
+    static loadAndScaleRGBWUnorderedFunction unordered() FL_NO_EXCEPT { return &PixelControllerVtable<T>::loadAndScaleRGBWUnordered; }
+    static loadAndScaleRGBWWUnorderedFunction unorderedWW() FL_NO_EXCEPT { return &PixelControllerVtable<T>::loadAndScaleRGBWWUnordered; }
+};
+
 typedef void (*stepDitheringFunction)(void* pixel_controller);
 typedef void (*advanceDataFunction)(void* pixel_controller);
 typedef int (*sizeFunction)(void* pixel_controller);
@@ -191,8 +237,10 @@ class PixelIterator {
       // Btw, this pattern in C++ is called the "type-erasure pattern". It allows non virtual
       // polymorphism by leveraging the C++ template system to ensure type safety.
       typedef PixelControllerVtable<PixelControllerT> Vtable;
-      mLoadAndScaleRGBW = &Vtable::loadAndScaleRGBW;
-      mLoadAndScaleRGBWW = &Vtable::loadAndScaleRGBWW;
+      mLoadAndScaleRGBW = RgbwLoadBinder<PixelControllerT>::ordered();
+      mLoadAndScaleRGBWW = RgbwLoadBinder<PixelControllerT>::orderedWW();
+      mLoadAndScaleRGBWUnordered = RgbwLoadBinder<PixelControllerT>::unordered();
+      mLoadAndScaleRGBWWUnordered = RgbwLoadBinder<PixelControllerT>::unorderedWW();
       mLoadAndScaleRGB = &Vtable::loadAndScaleRGB;
 #if !FL_PLATFORM_HAS_TINY_MEMORY
       mLoadAndScaleRGB16 = WideLoadBinder<PixelControllerT>::get();
@@ -210,15 +258,53 @@ class PixelIterator {
     }
 
     bool has(int n) FL_NO_EXCEPT { return mHas(mPixelController, n); }
+    /// Wire colour order, applied here rather than by instantiating a
+    /// `PixelController` per order. Identity by default, so a templated driver
+    /// wrapping its own `PixelController<ORDER>` is unaffected: the bytes it
+    /// gets are the ones that controller already ordered (FastLED#4402).
+    void setColorOrder(EOrder order) FL_NO_EXCEPT {
+      // Same bit layout as RGB_BYTE(order, i) in pixel_controller.h.
+      for (int i = 0; i < 3; ++i) {
+        mOrder[i] = static_cast<u8>((static_cast<int>(order) >> (3 * (2 - i))) & 0x3);
+      }
+    }
+
     void loadAndScaleRGBW(u8 *b0_out, u8 *b1_out, u8 *b2_out, u8 *w_out) FL_NO_EXCEPT {
+      if (mLoadAndScaleRGBWUnordered != nullptr) {
+        // Source-order RGB plus W, then the same two steps the templated
+        // `loadAndScaleRGBW` takes: permute RGB, place W.
+        u8 c[3];
+        u8 w = 0;
+        mLoadAndScaleRGBWUnordered(mPixelController, mRgbw, &c[0], &c[1], &c[2], &w);
+        rgbw_partial_reorder(mRgbw.w_placement, c[mOrder[0]], c[mOrder[1]], c[mOrder[2]], w,
+                             b0_out, b1_out, b2_out, w_out);
+        return;
+      }
       mLoadAndScaleRGBW(mPixelController, mRgbw, b0_out, b1_out, b2_out, w_out);
     }
     void loadAndScaleRGBWW(u8 *b0_out, u8 *b1_out, u8 *b2_out,
                            u8 *b3_out, u8 *b4_out) FL_NO_EXCEPT {
+      if (mLoadAndScaleRGBWWUnordered != nullptr) {
+        u8 c[3];
+        u8 ww = 0;
+        u8 wc = 0;
+        mLoadAndScaleRGBWWUnordered(mPixelController, mRgbww, &c[0], &c[1], &c[2], &ww, &wc);
+        rgbww_partial_reorder(mRgbww.w_placement, c[mOrder[0]], c[mOrder[1]], c[mOrder[2]], ww, wc,
+                              b0_out, b1_out, b2_out, b3_out, b4_out);
+        return;
+      }
       mLoadAndScaleRGBWW(mPixelController, mRgbww, b0_out, b1_out, b2_out, b3_out, b4_out);
     }
     void loadAndScaleRGB(u8 *r_out, u8 *g_out, u8 *b_out) FL_NO_EXCEPT {
-      mLoadAndScaleRGB(mPixelController, r_out, g_out, b_out);
+      // The source's own order first (identity for PixelController<RGB>),
+      // then this iterator's. `loadAndScale<SLOT>` is per source channel --
+      // data, dither table and scale all indexed by the same channel -- so
+      // reordering after the fact is the same bytes.
+      u8 c[3];
+      mLoadAndScaleRGB(mPixelController, &c[0], &c[1], &c[2]);
+      *r_out = c[mOrder[0]];
+      *g_out = c[mOrder[1]];
+      *b_out = c[mOrder[2]];
     }
 #if !FL_PLATFORM_HAS_TINY_MEMORY
     /// One pixel at the source's own precision, wire-ordered.
@@ -254,7 +340,12 @@ class PixelIterator {
 
     #if FASTLED_HD_COLOR_MIXING
     void loadRGBScaleAndBrightness(u8* c0, u8* c1, u8* c2, u8* brightness) FL_NO_EXCEPT {
-      mLoadRGBScaleAndBrightness(mPixelController, c0, c1, c2, brightness);
+      // Per-slot scale, so it takes the same permutation as the pixel.
+      u8 c[3];
+      mLoadRGBScaleAndBrightness(mPixelController, &c[0], &c[1], &c[2], brightness);
+      *c0 = c[mOrder[0]];
+      *c1 = c[mOrder[1]];
+      *c2 = c[mOrder[2]];
     }
 
     FL_DEPRECATED("Use loadRGBScaleAndBrightness() instead") FL_NO_EXCEPT
@@ -517,9 +608,14 @@ class PixelIterator {
     loadAndScaleRGBWFunction mLoadAndScaleRGBW = nullptr;
     loadAndScaleRGBWWFunction mLoadAndScaleRGBWW = nullptr;
     loadAndScaleRGBFunction mLoadAndScaleRGB = nullptr;
+    loadAndScaleRGBWUnorderedFunction mLoadAndScaleRGBWUnordered = nullptr;
+    loadAndScaleRGBWWUnorderedFunction mLoadAndScaleRGBWWUnordered = nullptr;
 #if !FL_PLATFORM_HAS_TINY_MEMORY
     loadAndScaleRGB16Function mLoadAndScaleRGB16 = nullptr;
 #endif
+    // Wire byte i comes from source channel mOrder[i]. Identity unless
+    // setColorOrder() is called; PixelIteratorAny is the caller.
+    u8 mOrder[3] = {0, 1, 2};
     // NOTE: mLoadAndScale_APA102_HD removed - use fl::loadAndScale_APA102_HD<RGB_ORDER>() from apa102.h encoder
     // NOTE: mLoadAndScale_WS2816_HD removed - use fl::loadAndScale_WS2816_HD<RGB_ORDER>() from ws2816.h encoder
     stepDitheringFunction mStepDithering = nullptr;

--- a/src/fl/gfx/pixel_iterator_any.h
+++ b/src/fl/gfx/pixel_iterator_any.h
@@ -5,7 +5,6 @@
 
 #include "fl/chipsets/encoders/pixel_iterator.h"
 #include "pixel_controller.h"
-#include "fl/stl/variant.h"
 #include "fl/stl/optional.h"
 #include "fl/stl/vector.h"
 #include "rgbw.h"
@@ -30,22 +29,16 @@ class PixelIteratorAny {
     /// @param rgbw RGBW conversion settings
     PixelIteratorAny(PixelController<RGB> &controller, EOrder newOrder, Rgbw rgbw,
                      Rgbww rgbww = RgbwwInvalid::value())
-        : mRgbw(rgbw), mRgbww(rgbww) {
-        init(controller, newOrder);
+        : mController(controller), mOrder(newOrder), mRgbw(rgbw), mRgbww(rgbww) {
+        bindIterator();
     }
 
     template<typename PIXEL_CONTROLLER>
     PixelIteratorAny(PIXEL_CONTROLLER &controller, EOrder newOrder, Rgbw rgbw,
                      Rgbww rgbww = RgbwwInvalid::value())
-        : mRgbw(rgbw), mRgbww(rgbww) {
-        // (#2558) Bugfix surfaced by CodeRabbit on PR #2560: the previous
-        // implementation constructed rgbController for normalization but then
-        // called init(controller, ...) — passing the un-normalized original
-        // controller. init() takes a PixelController<RGB>&, so a non-RGB
-        // PIXEL_CONTROLLER would have failed to compile if this branch was
-        // ever instantiated; the bug stayed latent until now.
-        PixelController<RGB> rgbController(controller);  // Normalize to RGB order.
-        init(rgbController, newOrder);
+        : mController(controller),  // Normalize to RGB order (#2558).
+          mOrder(newOrder), mRgbw(rgbw), mRgbww(rgbww) {
+        bindIterator();
     }
 
     /// @brief Get the type-erased PixelIterator
@@ -64,27 +57,28 @@ class PixelIteratorAny {
     /// @brief Copy: the iterator must be re-aimed, not copied.
     ///
     /// This class is self-referential -- `mPixelIterator` is a type-erased
-    /// `PixelIterator` holding a `void*` into `mAnyController`, a member of
-    /// the same object. The compiler-generated copy carried that pointer
-    /// across unchanged, so the copy's iterator kept reading the *source*
-    /// object's controller. Where the source was a temporary, as in
+    /// `PixelIterator` holding a `void*` into `mController`, a member of the
+    /// same object. The compiler-generated copy carried that pointer across
+    /// unchanged, so the copy's iterator kept reading the *source* object's
+    /// controller. Where the source was a temporary, as in
     /// `ReorderingPixelIteratorAny`'s addressing branch, that was a read of
     /// dead stack on every addressed frame (#4201).
     PixelIteratorAny(const PixelIteratorAny& other) FL_NO_EXCEPT
-        : mAnyController(other.mAnyController), mRgbw(other.mRgbw),
-          mRgbww(other.mRgbww), mXyMap(other.mXyMap) {
+        : mController(other.mController), mOrder(other.mOrder),
+          mRgbw(other.mRgbw), mRgbww(other.mRgbww), mXyMap(other.mXyMap) {
         bindIterator();
     }
 
     PixelIteratorAny(PixelIteratorAny&& other) FL_NO_EXCEPT
-        : mAnyController(fl::move(other.mAnyController)), mRgbw(other.mRgbw),
-          mRgbww(other.mRgbww), mXyMap(fl::move(other.mXyMap)) {
+        : mController(other.mController), mOrder(other.mOrder),
+          mRgbw(other.mRgbw), mRgbww(other.mRgbww), mXyMap(fl::move(other.mXyMap)) {
         bindIterator();
     }
 
     PixelIteratorAny& operator=(const PixelIteratorAny& other) FL_NO_EXCEPT {
         if (this != &other) {
-            mAnyController = other.mAnyController;
+            mController = other.mController;
+            mOrder = other.mOrder;
             mRgbw = other.mRgbw;
             mRgbww = other.mRgbww;
             mXyMap = other.mXyMap;
@@ -95,7 +89,8 @@ class PixelIteratorAny {
 
     PixelIteratorAny& operator=(PixelIteratorAny&& other) FL_NO_EXCEPT {
         if (this != &other) {
-            mAnyController = fl::move(other.mAnyController);
+            mController = other.mController;
+            mOrder = other.mOrder;
             mRgbw = other.mRgbw;
             mRgbww = other.mRgbww;
             mXyMap = fl::move(other.mXyMap);
@@ -104,79 +99,26 @@ class PixelIteratorAny {
         return *this;
     }
 
-    /// @brief Initialize the adapter with color order conversion
-    void init(PixelController<RGB> &controller, EOrder newOrder) {
-        // Step 1: Create the appropriate PixelController variant based on color order
-        switch (newOrder) {
-        case RGB:
-            mAnyController = controller;
-            break;
-        case RBG:
-            mAnyController = PixelController<RBG>(controller);
-            break;
-        case GRB:
-            mAnyController = PixelController<GRB>(controller);
-            break;
-        case GBR:
-            mAnyController = PixelController<GBR>(controller);
-            break;
-        case BRG:
-            mAnyController = PixelController<BRG>(controller);
-            break;
-        case BGR:
-            mAnyController = PixelController<BGR>(controller);
-            break;
-        }
-
-        // Step 2: aim the type-erased iterator at whichever alternative
-        // `mAnyController` now holds.
-        bindIterator();
-    }
-
   private:
     /// @brief Point `mPixelIterator` at this object's own controller.
     ///
-    /// Every path that changes `mAnyController` has to end here, because the
+    /// Every path that changes `mController` has to end here, because the
     /// iterator holds a raw pointer into it and nothing else fixes that up.
+    ///
+    /// One `PixelController<RGB>` for every order. This used to hold a
+    /// `variant` of six `PixelController<EOrder>` instantiations and visit it
+    /// -- six copies of a ~870 B vtable set plus a 127 B visit thunk each, of
+    /// which a sketch uses one, measured at ~5.9 KB on an esp32dev Blink
+    /// build. A colour order is a pure permutation of the three per-channel
+    /// values, so the iterator applies it and the other five instantiations
+    /// are never referenced (FastLED#4402).
     void bindIterator() {
-        // Note: fl::Optional::emplace takes a constructed object, not constructor args
-        struct PixelIteratorInitVisitor {
-            PixelIteratorInitVisitor(Rgbw rgbw, Rgbww rgbww)
-                : rgbw(rgbw), rgbww(rgbww) {}
-            fl::Optional<PixelIterator>* pixelIteratorPtr;
-            Rgbw rgbw;
-            Rgbww rgbww;
-
-            // Need concrete overloads for each type in the variant
-            void accept(PixelController<RGB>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-            void accept(PixelController<RBG>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-            void accept(PixelController<GRB>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-            void accept(PixelController<GBR>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-            void accept(PixelController<BRG>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-            void accept(PixelController<BGR>& controller) {
-                pixelIteratorPtr->emplace(PixelIterator(&controller, rgbw, rgbww));
-            }
-        };
-
-        PixelIteratorInitVisitor visitor(mRgbw, mRgbww);
-        visitor.pixelIteratorPtr = &mPixelIterator;
-        mAnyController.visit(visitor);
+        mPixelIterator.emplace(PixelIterator(&mController, mRgbw, mRgbww));
+        mPixelIterator->setColorOrder(mOrder);
     }
 
-    fl::variant<PixelController<RGB>, PixelController<RBG>,
-                PixelController<GRB>, PixelController<GBR>,
-                PixelController<BRG>, PixelController<BGR>>
-        mAnyController;
+    PixelController<RGB> mController;
+    EOrder mOrder;
 
     // fl::optional used just as a way to defer construction.
     fl::Optional<PixelIterator> mPixelIterator;

--- a/src/pixel_controller.h
+++ b/src/pixel_controller.h
@@ -114,6 +114,10 @@ struct PixelController {
         kLanes = LANES,
         kMask = MASK
     };
+    /// The colour order this instantiation writes, as a value. Lets the
+    /// type-erased `PixelIterator` bind order-free loads only for the RGB
+    /// instantiation and permute at runtime (FastLED#4402).
+    static constexpr EOrder kColorOrder = RGB_ORDER;
 
     FASTLED_FORCE_INLINE fl::PixelIterator as_iterator(const Rgbw& rgbw) {
         return fl::PixelIterator(this, rgbw);
@@ -594,6 +598,67 @@ struct PixelController {
     // NOTE: loadAndScale_WS2816_HD() has been moved to src/fl/chipsets/encoders/ws2816.h
     // Use fl::loadAndScale_WS2816_HD<RGB_ORDER>(pixels, ...) instead
 
+    /// One source channel, loaded, dithered and scaled -- `loadAndScale<SLOT>`
+    /// with `RO(SLOT)` replaced by a runtime channel index. Same arithmetic,
+    /// same tables: `d[c]` and `premixed.raw[c]` are indexed by source channel
+    /// in both, which is what makes a colour order a pure permutation of these
+    /// three values (FastLED#4402).
+    FASTLED_FORCE_INLINE fl::u8 loadAndScaleChannel(fl::u8 c) {
+        const fl::u8 b = mData[c];
+        return fl::scale8(b ? fl::qadd8(b, d[c]) : 0, mColorAdjustment.premixed.raw[c]);
+    }
+
+    /// `loadAndScaleRGBW` before its wire reorder: RGB in source order plus W.
+    /// The templated `loadAndScaleRGBW` is this followed by the reorder, so
+    /// the two cannot drift; the type-erased path calls this directly and
+    /// applies its own order (FastLED#4402).
+    FASTLED_FORCE_INLINE void loadAndScaleRGBWUnordered(
+        const Rgbw& rgbw, fl::u8 *r_out, fl::u8 *g_out, fl::u8 *b_out,
+        fl::u8 *w_out) {
+#ifdef FL_IS_AVR
+        FL_UNUSED(rgbw);
+        // No RGBW conversion on AVR; W stays black, as in loadAndScaleRGBW.
+        *r_out = loadAndScaleChannel(0);
+        *g_out = loadAndScaleChannel(1);
+        *b_out = loadAndScaleChannel(2);
+        *w_out = 0;
+#else
+        const CRGB rgb(mData[0], mData[1], mData[2]);
+        *w_out = 0;
+        fl::rgb_2_rgbw(rgbw,
+                   rgb.r, rgb.g, rgb.b,
+                   mColorAdjustment.premixed.r, mColorAdjustment.premixed.g, mColorAdjustment.premixed.b,
+                   r_out, g_out, b_out, w_out);
+#endif
+    }
+
+    /// `loadAndScaleRGBWW` before its wire reorder. See loadAndScaleRGBWUnordered.
+    FASTLED_FORCE_INLINE void loadAndScaleRGBWWUnordered(
+        fl::Rgbww rgbww, fl::u8 *r_out, fl::u8 *g_out, fl::u8 *b_out,
+        fl::u8 *ww_out, fl::u8 *wc_out) {
+#ifdef FL_IS_AVR
+        FL_UNUSED(rgbww);
+        FL_WARN_F_ONCE("RGBWW colorimetric is not supported on AVR -- the warm "
+                     "and cool white channels will be black. Use an ESP32 / "
+                     "Teensy / RP2040 target for full RGBWW support.");
+        *r_out = loadAndScaleChannel(0);
+        *g_out = loadAndScaleChannel(1);
+        *b_out = loadAndScaleChannel(2);
+        *ww_out = 0;
+        *wc_out = 0;
+#else
+        const CRGB rgb(mData[0], mData[1], mData[2]);
+        *ww_out = 0;
+        *wc_out = 0;
+        fl::rgb_2_rgbww(rgbww,
+                        rgb.r, rgb.g, rgb.b,
+                        mColorAdjustment.premixed.r,
+                        mColorAdjustment.premixed.g,
+                        mColorAdjustment.premixed.b,
+                        r_out, g_out, b_out, ww_out, wc_out);
+#endif
+    }
+
     FASTLED_FORCE_INLINE void loadAndScaleRGBW(
         const Rgbw& rgbw, fl::u8 *b0_out, fl::u8 *b1_out,
         fl::u8 *b2_out, fl::u8 *b3_out) {
@@ -616,13 +681,10 @@ struct PixelController {
         const fl::u8 b0_index = RGB_BYTE0(RGB_ORDER);  // Needed to re-order RGB back into led native order.
         const fl::u8 b1_index = RGB_BYTE1(RGB_ORDER);
         const fl::u8 b2_index = RGB_BYTE2(RGB_ORDER);
-        // Get the naive RGB data order in r,g,b order.
-        CRGB rgb(mData[0], mData[1], mData[2]);
+        // Source-order RGB after white extraction, then the wire reorder.
+        CRGB rgb;
         fl::u8 w = 0;
-        fl::rgb_2_rgbw(rgbw,
-                   rgb.r, rgb.g, rgb.b,  // Input colors
-                   mColorAdjustment.premixed.r, mColorAdjustment.premixed.g, mColorAdjustment.premixed.b,  // How these colors are scaled for color balance.
-                   &rgb.r, &rgb.g, &rgb.b, &w);
+        loadAndScaleRGBWUnordered(rgbw, &rgb.r, &rgb.g, &rgb.b, &w);
         // Now finish the ordering so that the output is in the native led order for all of RGBW.
         fl::rgbw_partial_reorder(
             rgbw.w_placement,
@@ -663,15 +725,10 @@ struct PixelController {
         const fl::u8 b0_index = RGB_BYTE0(RGB_ORDER);
         const fl::u8 b1_index = RGB_BYTE1(RGB_ORDER);
         const fl::u8 b2_index = RGB_BYTE2(RGB_ORDER);
-        CRGB rgb(mData[0], mData[1], mData[2]);
+        CRGB rgb;
         fl::u8 ww = 0;
         fl::u8 wc = 0;
-        fl::rgb_2_rgbww(rgbww,
-                        rgb.r, rgb.g, rgb.b,
-                        mColorAdjustment.premixed.r,
-                        mColorAdjustment.premixed.g,
-                        mColorAdjustment.premixed.b,
-                        &rgb.r, &rgb.g, &rgb.b, &ww, &wc);
+        loadAndScaleRGBWWUnordered(rgbww, &rgb.r, &rgb.g, &rgb.b, &ww, &wc);
         fl::rgbww_partial_reorder(
             rgbww.w_placement,
             rgb.raw[b0_index],

--- a/tests/data/esp32s3_bloat_baseline.txt
+++ b/tests/data/esp32s3_bloat_baseline.txt
@@ -1,3 +1,23 @@
+# 2026-09-12, PR #4409 (issue #4402 follow-up): -6245 B, 342709 -> 336464.
+#
+# A reduction, locked in by the ratchet. `PixelIteratorAny` held a variant of
+# six `PixelController<EOrder>` instantiations and visited it, so every
+# sketch linked six full type-erasure vtable sets -- loadAndScaleRGBW 300 B,
+# loadAndScaleRGBWW 227 B, loadAndScaleRGB 116 B, ctor 60 B, dither/advance/
+# has/size ~100 B -- plus a 127 B visit thunk each, of which the sketch used
+# one order. It now holds one `PixelController<RGB>` and `PixelIterator`
+# applies the colour order as a three-byte permutation. A colour order is a
+# pure permutation: `loadByte`, `dither` and `scale` all index by source
+# channel, and the RGBW/RGBWW loads reorder after computing in source order.
+#
+# Proven against the legacy path, still in the tree: byte-for-byte across all
+# six orders for RGB, RGBW at every W placement, RGBWW and the HD per-slot
+# scale, with binary dither on and lopsided per-channel scales. Templated
+# drivers wrapping their own `PixelController<ORDER>` keep identity and the
+# thunks they always had; their bytes are untouched.
+#
+# esp32dev Blink measured the same way: 339,955 -> 334,147 B (-5,808).
+#
 # 2026-09-12, PR #4407 (issue #4402): -182 B, 342891 -> 342709.
 #
 # A reduction, locked in by the ratchet. `writeHD108` was two complete loops
@@ -140,4 +160,4 @@
 # showPixels block. A tiny-memory target pays 0 B of this, so the 305 B is
 # only ever spent where flash is not the binding constraint. On a target
 # that does compile it in, 305 B is 0.089% of the image.
-342709
+336464

--- a/tests/fl/gfx/pixel_iterator_any.cpp
+++ b/tests/fl/gfx/pixel_iterator_any.cpp
@@ -123,7 +123,10 @@ const EOrder kAllOrders[6] = {RGB, RBG, GRB, GBR, BRG, BGR};
 ColorAdjustment lopsidedAdjustment() {
     ColorAdjustment adj = ColorAdjustment::noAdjustment();
     adj.premixed = CRGB(230, 140, 60);
+#if FASTLED_HD_COLOR_MIXING
+    // `color` only exists in the HD build; premixed is the one every build has.
     adj.color = CRGB(230, 140, 60);
+#endif
     return adj;
 }
 

--- a/tests/fl/gfx/pixel_iterator_any.cpp
+++ b/tests/fl/gfx/pixel_iterator_any.cpp
@@ -105,4 +105,156 @@ FL_TEST_CASE("[#4201] Colour order survives the copy") {
     FL_CHECK_EQ(static_cast<int>(bytes[2]), 10);
 }
 
+
+// ===========================================================================
+// One PixelController<RGB> for every order must equal six of them (#4402).
+//
+// The oracle is the legacy path itself: a PixelIterator over a real
+// PixelController<ORDER>, which is what PixelIteratorAny used to build and
+// what every templated driver still builds. Binary dither on, and per-channel
+// scales that are all different, so a wrong permutation cannot hide behind a
+// symmetric input.
+// ===========================================================================
+
+namespace {
+
+const EOrder kAllOrders[6] = {RGB, RBG, GRB, GBR, BRG, BGR};
+
+ColorAdjustment lopsidedAdjustment() {
+    ColorAdjustment adj = ColorAdjustment::noAdjustment();
+    adj.premixed = CRGB(230, 140, 60);
+    adj.color = CRGB(230, 140, 60);
+    return adj;
+}
+
+CRGB* fixture(CRGB (&leds)[6]) {
+    leds[0] = CRGB(10, 200, 33);
+    leds[1] = CRGB(0, 0, 0);
+    leds[2] = CRGB(255, 255, 255);
+    leds[3] = CRGB(7, 8, 9);
+    leds[4] = CRGB(128, 64, 32);
+    leds[5] = CRGB(1, 2, 254);
+    return leds;
+}
+
+void drainRGB(PixelIterator& it, fl::vector<u8>* out) {
+    while (it.has(1)) {
+        u8 c[3];
+        it.loadAndScaleRGB(&c[0], &c[1], &c[2]);
+        for (int i = 0; i < 3; ++i) { out->push_back(c[i]); }
+        it.stepDithering();
+        it.advanceData();
+    }
+}
+void drainRGBW(PixelIterator& it, fl::vector<u8>* out) {
+    while (it.has(1)) {
+        u8 c[4];
+        it.loadAndScaleRGBW(&c[0], &c[1], &c[2], &c[3]);
+        for (int i = 0; i < 4; ++i) { out->push_back(c[i]); }
+        it.stepDithering();
+        it.advanceData();
+    }
+}
+void drainRGBWW(PixelIterator& it, fl::vector<u8>* out) {
+    while (it.has(1)) {
+        u8 c[5];
+        it.loadAndScaleRGBWW(&c[0], &c[1], &c[2], &c[3], &c[4]);
+        for (int i = 0; i < 5; ++i) { out->push_back(c[i]); }
+        it.stepDithering();
+        it.advanceData();
+    }
+}
+
+template <EOrder ORDER, typename Drain>
+fl::vector<u8> oracle(PixelController<RGB>& source, Rgbw rgbw, Rgbww rgbww, Drain drain) {
+    PixelController<ORDER> ordered(source);   // the legacy route
+    PixelIterator it(&ordered, rgbw, rgbww);  // identity permutation
+    fl::vector<u8> out;
+    drain(it, &out);
+    return out;
+}
+
+template <typename Drain>
+fl::vector<u8> oracleFor(EOrder order, PixelController<RGB>& source, Rgbw rgbw, Rgbww rgbww, Drain drain) {
+    switch (order) {
+        case RGB: return oracle<RGB>(source, rgbw, rgbww, drain);
+        case RBG: return oracle<RBG>(source, rgbw, rgbww, drain);
+        case GRB: return oracle<GRB>(source, rgbw, rgbww, drain);
+        case GBR: return oracle<GBR>(source, rgbw, rgbww, drain);
+        case BRG: return oracle<BRG>(source, rgbw, rgbww, drain);
+        case BGR: return oracle<BGR>(source, rgbw, rgbww, drain);
+    }
+    return fl::vector<u8>();
+}
+
+template <typename Drain>
+void checkAllOrders(Rgbw rgbw, Rgbww rgbww, Drain drain, const char* what) {
+    CRGB leds[6];
+    fixture(leds);
+    for (int oi = 0; oi < 6; ++oi) {
+        const EOrder order = kAllOrders[oi];
+        PixelController<RGB> a(leds, 6, lopsidedAdjustment(), BINARY_DITHER);
+        PixelController<RGB> b(leds, 6, lopsidedAdjustment(), BINARY_DITHER);
+
+        PixelIteratorAny any(a, order, rgbw, rgbww);
+        fl::vector<u8> got;
+        drain(any.get(), &got);
+
+        const fl::vector<u8> want = oracleFor(order, b, rgbw, rgbww, drain);
+
+        FL_INFO(what << " order=" << static_cast<int>(order));
+        FL_REQUIRE_EQ(got.size(), want.size());
+        FL_REQUIRE(got.size() > 0u);
+        for (fl::size i = 0; i < got.size(); ++i) {
+            FL_CHECK_EQ(static_cast<int>(got[i]), static_cast<int>(want[i]));
+        }
+    }
+}
+
+}  // namespace
+
+FL_TEST_CASE("[#4402] one PixelController<RGB> equals PixelController<ORDER> for RGB, all six orders") {
+    checkAllOrders(Rgbw(), RgbwwInvalid::value(), drainRGB, "rgb");
+}
+
+FL_TEST_CASE("[#4402] ... and for RGBW, every W placement") {
+    const EOrderW placements[4] = {EOrderW::W3, EOrderW::W2, EOrderW::W1, EOrderW::W0};
+    for (int pi = 0; pi < 4; ++pi) {
+        Rgbw rgbw(fl::kRGBWDefaultColorTemp, fl::RGBW_MODE::kRGBWExactColors, placements[pi]);
+        checkAllOrders(rgbw, RgbwwInvalid::value(), drainRGBW, "rgbw");
+    }
+}
+
+FL_TEST_CASE("[#4402] ... and for RGBWW") {
+    checkAllOrders(Rgbw(), Rgbww(), drainRGBWW, "rgbww");
+}
+
+#if FASTLED_HD_COLOR_MIXING
+FL_TEST_CASE("[#4402] ... and the HD per-slot scale follows the same permutation") {
+    CRGB leds[6];
+    fixture(leds);
+    for (int oi = 0; oi < 6; ++oi) {
+        const EOrder order = kAllOrders[oi];
+        PixelController<RGB> a(leds, 6, lopsidedAdjustment(), BINARY_DITHER);
+        PixelIteratorAny any(a, order, Rgbw());
+        u8 got[4];
+        any.get().loadRGBScaleAndBrightness(&got[0], &got[1], &got[2], &got[3]);
+
+        PixelController<RGB> b(leds, 6, lopsidedAdjustment(), BINARY_DITHER);
+        u8 want[4];
+        switch (order) {
+            case RGB: { PixelController<RGB> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+            case RBG: { PixelController<RBG> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+            case GRB: { PixelController<GRB> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+            case GBR: { PixelController<GBR> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+            case BRG: { PixelController<BRG> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+            case BGR: { PixelController<BGR> o(b); PixelIterator it(&o, Rgbw()); it.loadRGBScaleAndBrightness(&want[0], &want[1], &want[2], &want[3]); break; }
+        }
+        for (int i = 0; i < 4; ++i) {
+            FL_CHECK_EQ(static_cast<int>(got[i]), static_cast<int>(want[i]));
+        }
+    }
+}
+#endif
+
 }  // FL_TEST_FILE


### PR DESCRIPTION
Step (2) of the #4402 plan. The (now working) esp32dev symbol report showed **~5.9 KB of per-colour-order code, of which a sketch uses one order**: `PixelIteratorAny` held a `variant` of six `PixelController<EOrder>` instantiations and visited it, so every sketch linked six full vtable sets plus a visit thunk each.

## Why one instantiation is the same bytes

A colour order is a pure permutation. `loadByte<SLOT>`, `dither<SLOT>` and `scale<SLOT>` all index by `RO(SLOT)` — the *source* channel — so the data byte, the dither table and the premixed scale for wire slot S are all channel RO(S). `loadAndScaleRGBW`/`RGBWW` compute in source order and reorder before placing W. Compute once in RGB, permute three bytes: identical output.

## Change

- `PixelController`: `kColorOrder`, `loadAndScaleChannel(c)`, and order-free `loadAndScaleRGBWUnordered` / `loadAndScaleRGBWWUnordered`. The templated `loadAndScaleRGBW`/`RGBWW` now *call* the order-free forms then reorder — the legacy path is the same code factored, not a second implementation.
- `PixelIterator`: runtime `mOrder[3]` (identity by default) + `setColorOrder()`, applied in `loadAndScaleRGB`, the HD scale accessor, and RGBW/RGBWW before W placement. `RgbwLoadBinder` names exactly one RGBW and one RGBWW thunk per source type — the order-free pair for `PixelController<RGB>`, the ordered pair for everything else — so no instantiation links both. **Templated drivers wrapping their own `PixelController<ORDER>` keep identity and the thunks they always had; their bytes are untouched.**
- `PixelIteratorAny`: one `PixelController<RGB>` + an `EOrder`. The variant, the six-way switch and the visitor are gone.

## Proof, against the legacy path (still in the tree)

For all six orders, a `PixelIteratorAny` is held **byte-for-byte** to a `PixelIterator` over a real `PixelController<ORDER>`:

- RGB
- RGBW at each of the four W placements (`W3`, `W2`, `W1`, `W0`)
- RGBWW
- the HD per-slot scale (`FASTLED_HD_COLOR_MIXING`)

Binary dither **on**, per-channel scales all different (230/140/60), so a wrong permutation cannot hide behind a symmetric input.

Mutations: scrambling the permutation table fails every order-sensitive case (6 of 7); dropping the permutation from the RGBW path alone fails **exactly** the RGBW case (1 of 7).

`bash test --cpp` 305/305 + 84/84. `bash lint` clean. Size thresholds untouched (`check_esp32_size.yml` gains a comment line — which is what runs the esp32dev gate on this PR; **its number, and the esp32s3 gate's, are the verification**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLhWkMfzLjrnLTDMBE6Fj9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of RGB, RGBW, and RGBWW color orders.
  * Corrected color-channel output consistency across supported orderings, including HD108 configurations.
  * Preserved RGBW white-channel conversion and brightness-scaling behavior across color orders.

* **Performance**
  * Reduced duplicated color-order processing while maintaining equivalent output across supported configurations.
  * Reduced the ESP32-S3 build size by approximately 6 KB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->